### PR TITLE
Fix tsc error; fixes build failures

### DIFF
--- a/packages/esm-config/src/navigation/navigate.test.ts
+++ b/packages/esm-config/src/navigation/navigate.test.ts
@@ -9,7 +9,7 @@ describe("navigate", () => {
   let mockLocationAssign;
 
   beforeAll(() => {
-    delete window.location;
+    delete (window as any).location;
     //@ts-ignore
     window.location = { assign: jest.fn() };
     mockLocationAssign = window.location.assign as jest.Mock;


### PR DESCRIPTION
Fixes build failures arising from `tsc` failing with this error:

![Screenshot 2020-09-15 at 12 03 57](https://user-images.githubusercontent.com/8509731/93190088-9c977180-f74b-11ea-93ac-af3979b2deb9.png)

Which is, more specifically:

![Screenshot 2020-09-15 at 11 56 37](https://user-images.githubusercontent.com/8509731/93190204-bd5fc700-f74b-11ea-89f0-0b55f8496560.png)

Ultimately, per @FlorianRappl, we should disable type checking / compilation errors for test files. Developers have it hard enough already 😄
