### PR TITLE
MF-314: Create minimal UI editor mode

### DIFF
--- a/packages/esm-extension-manager/src/extension-slot-react.component.tsx
+++ b/packages/esm-extension-manager/src/extension-slot-react.component.tsx
@@ -2,6 +2,7 @@ import React, { useState, useContext, ReactNode } from "react";
 import {
   renderExtension,
   getExtensionNamesForExtensionSlot,
+  getIsUIEditorEnabled,
 } from "./extensions";
 
 export interface ExtensionSlotReactProps {
@@ -30,7 +31,7 @@ export const ExtensionSlotReact: React.FC<ExtensionSlotReactProps> = ({
   }, [extensionSlotName]);
 
   return (
-    <>
+    <div style={{ backgroundColor: getIsUIEditorEnabled() ? "cyan" : "" }}>
       {extensionNames.map((extensionName) => (
         <ExtensionContext.Provider
           key={extensionName}
@@ -42,7 +43,7 @@ export const ExtensionSlotReact: React.FC<ExtensionSlotReactProps> = ({
           {children ?? <ExtensionReact />}
         </ExtensionContext.Provider>
       ))}
-    </>
+    </div>
   );
 };
 
@@ -57,5 +58,11 @@ export const ExtensionReact: React.FC = (props) => {
     }
   }, []);
 
-  return <slot ref={ref} />;
+  return getIsUIEditorEnabled() ? (
+    <div style={{ outline: "0.125rem solid yellow" }}>
+      <slot ref={ref} />
+    </div>
+  ) : (
+    <slot ref={ref} />
+  );
 };

--- a/packages/esm-extension-manager/src/extensions.ts
+++ b/packages/esm-extension-manager/src/extensions.ts
@@ -74,6 +74,16 @@ export function renderExtension(
   };
 }
 
+export function getIsUIEditorEnabled(): boolean {
+  return JSON.parse(
+    localStorage.getItem("openmrs:isUIEditorEnabled") ?? "false"
+  );
+}
+
+export function setIsUIEditorEnabled(enabled: boolean): void {
+  localStorage.setItem("openmrs:isUIEditorEnabled", JSON.stringify(enabled));
+}
+
 interface Lifecycle {
   bootstrap: () => void;
   mount: () => void;

--- a/packages/esm-extension-manager/src/openmrs-esm-extension-manager.ts
+++ b/packages/esm-extension-manager/src/openmrs-esm-extension-manager.ts
@@ -7,6 +7,8 @@ export {
   registerExtension,
   getExtensionNamesForExtensionSlot,
   attach,
+  setIsUIEditorEnabled,
+  getIsUIEditorEnabled,
 } from "./extensions";
 
 export {


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-314

Paired with @brandones. Thanks, Brandon!

When the UI editor is toggled on:

![Screenshot 2020-09-21 at 10 38 40](https://user-images.githubusercontent.com/8509731/93742356-a19a6c00-fbf6-11ea-85b0-5dbedd18741c.png)


The UI editor becomes aware of **extensions** and **extension slots** and applies a **yellow outline to the extension slot** and a **cyan background to the extension within it**.

![Screenshot 2020-09-21 at 10 24 10](https://user-images.githubusercontent.com/8509731/93741237-ae1dc500-fbf4-11ea-9f17-511195ca556e.png)

