### PR TITLE
Allow passing style and class props intended for the top-level div of an extension slot

### DIFF
--- a/packages/esm-extension-manager/src/extension-slot-react.component.tsx
+++ b/packages/esm-extension-manager/src/extension-slot-react.component.tsx
@@ -6,12 +6,14 @@ import {
   getIsUIEditorEnabled,
 } from "./extensions";
 
-export interface ExtensionSlotReactProps {
+interface ExtensionSlotBaseProps {
   extensionSlotName: string;
   children?: ReactNode;
-  style?: {};
-  [key: string]: any; // rest of params passed to div
+  style?: React.CSSProperties;
 }
+
+// remainder of props are for the top-level <div>
+export type ExtensionSlotReactProps<T = {}> = ExtensionSlotBaseProps & T;
 
 interface ExtensionContextData {
   extensionSlotName: string;
@@ -45,7 +47,7 @@ export const ExtensionSlotReact: React.FC<ExtensionSlotReactProps> = ({
   }, [extensionSlotName, moduleName]);
 
   const divStyle = getIsUIEditorEnabled()
-    ? Object.assign(style || {}, { backgroundColor: "cyan" })
+    ? { ...style, backgroundColor: "cyan" }
     : style;
 
   return (

--- a/packages/esm-extension-manager/src/extension-slot-react.component.tsx
+++ b/packages/esm-extension-manager/src/extension-slot-react.component.tsx
@@ -9,6 +9,8 @@ import {
 export interface ExtensionSlotReactProps {
   extensionSlotName: string;
   children?: ReactNode;
+  style?: {};
+  [key: string]: any; // rest of params passed to div
 }
 
 interface ExtensionContextData {
@@ -24,6 +26,8 @@ const ExtensionContext = React.createContext<ExtensionContextData>({
 export const ExtensionSlotReact: React.FC<ExtensionSlotReactProps> = ({
   extensionSlotName,
   children,
+  style,
+  ...divProps
 }: ExtensionSlotReactProps) => {
   const [extensionNames, setExtensionNames] = useState<Array<string>>([]);
   const moduleName = useContext<string>(ModuleNameContext);
@@ -40,8 +44,12 @@ export const ExtensionSlotReact: React.FC<ExtensionSlotReactProps> = ({
     ).then((names) => setExtensionNames(names));
   }, [extensionSlotName, moduleName]);
 
+  const divStyle = getIsUIEditorEnabled()
+    ? Object.assign(style || {}, { backgroundColor: "cyan" })
+    : style;
+
   return (
-    <div style={{ backgroundColor: getIsUIEditorEnabled() ? "cyan" : "" }}>
+    <div style={divStyle} {...divProps}>
       {extensionNames.map((extensionName) => (
         <ExtensionContext.Provider
           key={extensionName}


### PR DESCRIPTION
This makes it so there's no weird intermediate div you can't style