### PR TITLE
MF-221 Migrate deprecated i18next-xhr-backend to i18next-http-bakend

### DIFF
--- a/packages/esm-app-shell/package.json
+++ b/packages/esm-app-shell/package.json
@@ -21,12 +21,13 @@
     "@openmrs/esm-extension-manager": "^0.2.0",
     "@openmrs/esm-module-config": "^0.2.0",
     "i18next-browser-languagedetector": "^4.3.1",
+    "i18next-http-backend": "^1.0.21",
     "i18next-icu": "^1.4.2",
-    "i18next-xhr-backend": "^3.2.2",
     "import-map-overrides": "^1.15.2",
     "systemjs": "^6.3.3"
   },
   "devDependencies": {
+    "@openmrs/esm-extension-manager": "^0.2.0",
     "@types/systemjs": "^6.1.0",
     "browser-sync": "^2.26.7",
     "concurrently": "^5.2.0",

--- a/packages/esm-app-shell/src/locale.ts
+++ b/packages/esm-app-shell/src/locale.ts
@@ -1,5 +1,5 @@
 import ICU from "i18next-icu";
-import i18nextXhrBackend from "i18next-xhr-backend";
+import HttpApi from "i18next-http-backend";
 import LanguageDetector from "i18next-browser-languagedetector";
 import { i18n } from "i18next";
 
@@ -37,18 +37,18 @@ export function setupI18n() {
 
     return window.i18next
       .use(LanguageDetector)
-      .use(i18nextXhrBackend)
+      .use(HttpApi)
       .use(initReactI18next)
       .use(ICU)
       .init({
         backend: {
           parse: (data) => data,
           loadPath: "{{lng}}|{{ns}}",
-          ajax(url, _, callback) {
+          request: (options, url, payload, callback) => {
             const [language, namespace] = url.split("|");
 
             if (namespace === "translation") {
-              callback(null, { status: 404 });
+              callback(null, { status: 404, data: null });
             } else {
               System.import(decodeHtmlEntity(namespace))
                 .then((m) => {
@@ -70,10 +70,10 @@ export function setupI18n() {
 
                   return importPromise;
                 })
-                .then((json) => callback(json, { status: 200 }))
+                .then((json) => callback(null, { status: 200, data: json }))
                 .catch((err) => {
                   console.error(err);
-                  callback(null, { status: 404 });
+                  callback(err, { status: 404, data: null });
                 });
             }
           },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6128,19 +6128,19 @@ i18next-browser-languagedetector@^4.3.1:
   dependencies:
     "@babel/runtime" "^7.5.5"
 
+i18next-http-backend@^1.0.21:
+  version "1.0.21"
+  resolved "https://registry.yarnpkg.com/i18next-http-backend/-/i18next-http-backend-1.0.21.tgz#cee901b3527dad5165fa91de973b6aa6404c1c37"
+  integrity sha512-UDeHoV2B+31Gr++0KFAVjM5l+SEwePpF6sfDyaDq5ennM9QNJ78PBEMPStwkreEm4h5C8sT7M1JdNQrLcU1Wdg==
+  dependencies:
+    node-fetch "2.6.1"
+
 i18next-icu@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/i18next-icu/-/i18next-icu-1.4.2.tgz#2b79d1ac2c2d542725219beac34a74db15cd2ff9"
   integrity sha512-EqHafx/sL8eoEowwqi5P6cXtLrzJXBKI4RmV+UaMXlpIJNfckVsq873F2KkMKkApxiw2ATj46C8MurmhMsHQGw==
   dependencies:
     intl-messageformat "2.2.0"
-
-i18next-xhr-backend@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/i18next-xhr-backend/-/i18next-xhr-backend-3.2.2.tgz#769124441461b085291f539d91864e3691199178"
-  integrity sha512-OtRf2Vo3IqAxsttQbpjYnmMML12IMB5e0fc5B7qKJFLScitYaXa1OhMX0n0X/3vrfFlpHL9Ro/H+ps4Ej2j7QQ==
-  dependencies:
-    "@babel/runtime" "^7.5.5"
 
 i18next@^19.6.0:
   version "19.7.0"
@@ -8072,7 +8072,7 @@ node-fetch-npm@^2.0.2:
     json-parse-better-errors "^1.0.0"
     safe-buffer "^5.1.1"
 
-node-fetch@^2.3.0, node-fetch@^2.5.0:
+node-fetch@2.6.1, node-fetch@^2.3.0, node-fetch@^2.5.0:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
#### What does this PR do?

Migrate from deprecated [18next-xhr-backend](https://github.com/i18next/i18next-xhr-backend) to [i18next-http-backend](https://github.com/i18next/i18next-http-backend)

#### Description of Task completed?

At the moment translation is loaded using ajax function of the i18next-xhr-backend to the new i18next-http-backend request function.

The old i18next-xhr-back is deprecated for reasons explained [here](https://github.com/i18next/i18next-xhr-backend/issues/348#issuecomment-663060275)

#### Screenshots

![MF-221](https://user-images.githubusercontent.com/28008754/94819400-e187fd00-0407-11eb-977b-e4b75ff5d4bc.gif)

