### PR TITLE
Rework extension contexts to work based on the extensionSlotName instead of the extensionId / Improve extension registration in the app shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ci:publish": "lerna publish from-package --yes",
     "ci:release": "lerna version --no-git-tag-version",
     "verify": "lerna run lint && lerna run test && lerna run typescript",
-    "prettier": "prettier 'packages/**/src/**/*' --write"
+    "prettier": "prettier \"packages/**/src/**/*\" --write"
   },
   "devDependencies": {
     "@babel/core": "^7.11.4",

--- a/packages/esm-app-shell/src/apps.ts
+++ b/packages/esm-app-shell/src/apps.ts
@@ -29,12 +29,19 @@ function preprocessActivator(
   }
 }
 
-interface AppExtensionDefinition {
-  id?: string;
-  name?: string;
-  slot?: string;
+interface ModernAppExtensionDefinition {
+  id: string;
+  slot: string;
   load(): Promise<any>;
 }
+
+interface LegacyAppExtensionDefinition {
+  name: string;
+  load(): Promise<any>;
+}
+
+type AppExtensionDefinition = ModernAppExtensionDefinition &
+  LegacyAppExtensionDefinition;
 
 export function registerApp(appName: string, appExports: System.Module) {
   const setup = appExports.setupOpenMRS;
@@ -43,7 +50,7 @@ export function registerApp(appName: string, appExports: System.Module) {
     const result = setup();
 
     if (result && typeof result === "object") {
-      const availableExtensions: Array<AppExtensionDefinition> =
+      const availableExtensions: Array<Partial<AppExtensionDefinition>> =
         result.extensions ?? [];
 
       const availablePages: Array<PageDefinition> = result.pages ?? [];
@@ -66,7 +73,10 @@ export function registerApp(appName: string, appExports: System.Module) {
   }
 }
 
-function tryRegisterExtension(appName: string, ext: AppExtensionDefinition) {
+function tryRegisterExtension(
+  appName: string,
+  ext: Partial<AppExtensionDefinition>
+) {
   const name = ext.id ?? ext.name;
   const slot = ext.slot;
 

--- a/packages/esm-app-shell/src/apps.ts
+++ b/packages/esm-app-shell/src/apps.ts
@@ -33,7 +33,7 @@ interface AppExtensionDefinition {
   id?: string;
   name?: string;
   slot?: string;
-  load?(): Promise<any>;
+  load(): Promise<any>;
 }
 
 export function registerApp(appName: string, appExports: System.Module) {

--- a/packages/esm-config/src/react-hook/use-extension-config.test.tsx
+++ b/packages/esm-config/src/react-hook/use-extension-config.test.tsx
@@ -28,7 +28,8 @@ describe(`useExtensionConfig`, () => {
           <ExtensionContext.Provider
             value={{
               extensionModuleName: "ext-module",
-              extensionSlotName: "fooSlot",
+              actualExtensionSlotName: "fooSlot",
+              attachedExtensionSlotName: "fooSlot",
               extensionId: "barExt#id1",
             }}
           >
@@ -59,7 +60,8 @@ describe(`useExtensionConfig`, () => {
         <ModuleNameContext.Provider value="slot-module">
           <ExtensionContext.Provider
             value={{
-              extensionSlotName: "fooSlot",
+              actualExtensionSlotName: "fooSlot",
+              attachedExtensionSlotName: "fooSlot",
               extensionModuleName: "foo-module",
               extensionId: "fooExt#id1",
             }}
@@ -68,7 +70,8 @@ describe(`useExtensionConfig`, () => {
           </ExtensionContext.Provider>
           <ExtensionContext.Provider
             value={{
-              extensionSlotName: "fooSlot",
+              actualExtensionSlotName: "fooSlot",
+              attachedExtensionSlotName: "fooSlot",
               extensionModuleName: "bar-module",
               extensionId: "barExt",
             }}
@@ -107,7 +110,8 @@ describe(`useExtensionConfig`, () => {
         <ModuleNameContext.Provider value="slot-1-module">
           <ExtensionContext.Provider
             value={{
-              extensionSlotName: "slot1",
+              actualExtensionSlotName: "slot1",
+              attachedExtensionSlotName: "slot1",
               extensionModuleName: "foo-module",
               extensionId: "fooExt",
             }}
@@ -118,7 +122,8 @@ describe(`useExtensionConfig`, () => {
         <ModuleNameContext.Provider value="slot-2-module">
           <ExtensionContext.Provider
             value={{
-              extensionSlotName: "slot2",
+              actualExtensionSlotName: "slot2",
+              attachedExtensionSlotName: "slot2",
               extensionModuleName: "foo-module",
               extensionId: "fooExt",
             }}
@@ -145,8 +150,9 @@ describe(`useExtensionConfig`, () => {
         <ModuleNameContext.Provider value="slot-module">
           <ExtensionContext.Provider
             value={{
+              actualExtensionSlotName: "fooSlot",
+              attachedExtensionSlotName: "fooSlot",
               extensionModuleName: "ext-module",
-              extensionSlotName: "fooSlot",
               extensionId: "barExt#id1",
             }}
           >

--- a/packages/esm-config/src/react-hook/use-extension-config.tsx
+++ b/packages/esm-config/src/react-hook/use-extension-config.tsx
@@ -22,7 +22,7 @@ export function useExtensionConfig() {
       "Slot ModuleNameContext has not been provided. This should come from openmrs-react-root-decorator in the module defining the extension slot."
     );
   }
-  const { extensionSlotName, extensionId, extensionModuleName } = useContext(
+  const { actualExtensionSlotName, extensionId, extensionModuleName } = useContext(
     ExtensionContext
   );
   const forceUpdate = useForceUpdate();
@@ -31,7 +31,7 @@ export function useExtensionConfig() {
     return Config.getExtensionConfig(
       slotModuleName,
       extensionModuleName,
-      extensionSlotName,
+      actualExtensionSlotName,
       extensionId
     )
       .then((res) => {
@@ -55,7 +55,7 @@ export function useExtensionConfig() {
     // So we check ahead of time and avoid creating a new promise.
     throw error;
   }
-  const uniqueExtensionLookupId = `${extensionSlotName}-${extensionId}`;
+  const uniqueExtensionLookupId = `${actualExtensionSlotName}-${extensionId}`;
   if (!configCache[uniqueExtensionLookupId]) {
     // React will prevent the client component from rendering until the promise resolves
     throw getConfigAndSetCache(slotModuleName);

--- a/packages/esm-config/src/react-hook/use-extension-config.tsx
+++ b/packages/esm-config/src/react-hook/use-extension-config.tsx
@@ -22,16 +22,18 @@ export function useExtensionConfig() {
       "Slot ModuleNameContext has not been provided. This should come from openmrs-react-root-decorator in the module defining the extension slot."
     );
   }
-  const { actualExtensionSlotName, extensionId, extensionModuleName } = useContext(
-    ExtensionContext
-  );
+  const {
+    attachedExtensionSlotName,
+    extensionId,
+    extensionModuleName,
+  } = useContext(ExtensionContext);
   const forceUpdate = useForceUpdate();
 
   function getConfigAndSetCache(slotModuleName: string) {
     return Config.getExtensionConfig(
       slotModuleName,
       extensionModuleName,
-      actualExtensionSlotName,
+      attachedExtensionSlotName,
       extensionId
     )
       .then((res) => {
@@ -55,7 +57,7 @@ export function useExtensionConfig() {
     // So we check ahead of time and avoid creating a new promise.
     throw error;
   }
-  const uniqueExtensionLookupId = `${actualExtensionSlotName}-${extensionId}`;
+  const uniqueExtensionLookupId = `${attachedExtensionSlotName}-${extensionId}`;
   if (!configCache[uniqueExtensionLookupId]) {
     // React will prevent the client component from rendering until the promise resolves
     throw getConfigAndSetCache(slotModuleName);

--- a/packages/esm-context/src/context.ts
+++ b/packages/esm-context/src/context.ts
@@ -1,13 +1,15 @@
 import React from "react";
 
 export interface ExtensionContextData {
-  extensionSlotName: string;
+  actualExtensionSlotName: string;
+  attachedExtensionSlotName: string;
   extensionId: string;
   extensionModuleName: string;
 }
 
 export const ExtensionContext = React.createContext<ExtensionContextData>({
-  extensionSlotName: "",
+  actualExtensionSlotName: "",
+  attachedExtensionSlotName: "",
   extensionId: "",
   extensionModuleName: "",
 });

--- a/packages/esm-devtools/webpack.config.js
+++ b/packages/esm-devtools/webpack.config.js
@@ -33,7 +33,7 @@ module.exports = {
         use: ["style-loader", "css-loader"],
       },
       {
-        test: /src\/.+\.css$/i,
+        test: /\.css$/,
         use: [
           "style-loader",
           {

--- a/packages/esm-extensions/src/extension-slot-react.component.tsx
+++ b/packages/esm-extensions/src/extension-slot-react.component.tsx
@@ -33,7 +33,7 @@ export const ExtensionSlotReact: React.FC<ExtensionSlotReactProps> = ({
   state,
   ...divProps
 }: ExtensionSlotReactProps) => {
-  const [extensionIds, setExtensionIds] = useState<Array<string>>([]);
+  const [extensionIds, setExtensionIds] = useState<Array<{attachedExtensionSlotName: string, extensionId: string}>>([]);
   const slotModuleName = useContext(ModuleNameContext);
 
   if (!slotModuleName) {
@@ -72,13 +72,14 @@ export const ExtensionSlotReact: React.FC<ExtensionSlotReactProps> = ({
   return (
     <div style={divStyle} {...divProps}>
       {extensionIds.map((extensionId) => {
-        const extensionRegistration = getExtensionRegistration(extensionId);
+        const extensionRegistration = getExtensionRegistration(extensionId.extensionId);
         return (
           <ExtensionContext.Provider
-            key={extensionId}
+            key={extensionId.extensionId}
             value={{
-              extensionSlotName,
-              extensionId,
+              actualExtensionSlotName: extensionSlotName,
+              attachedExtensionSlotName: extensionId.attachedExtensionSlotName,
+              extensionId: extensionId.extensionId,
               extensionModuleName: extensionRegistration.moduleName,
             }}
           >
@@ -96,20 +97,21 @@ export interface ExtensionReactProps {
 
 export const ExtensionReact: React.FC<ExtensionReactProps> = ({ state }) => {
   const ref = React.useRef<HTMLSlotElement>(null);
-  const { extensionSlotName, extensionId } = useContext(ExtensionContext);
+  const { actualExtensionSlotName, attachedExtensionSlotName, extensionId } = useContext(ExtensionContext);
   // TODO: handle error if Extension not wrapped in ExtensionSlot
 
   React.useEffect(() => {
     if (ref.current) {
       return renderExtension(
         ref.current,
-        extensionSlotName,
+        actualExtensionSlotName,
+        attachedExtensionSlotName,
         extensionId,
         undefined,
         state
       );
     }
-  }, [extensionSlotName, extensionId]);
+  }, [actualExtensionSlotName, attachedExtensionSlotName, extensionId]);
 
   return getIsUIEditorEnabled() ? (
     <div style={{ outline: "0.125rem solid yellow" }}>

--- a/packages/esm-extensions/src/extensions.test.ts
+++ b/packages/esm-extensions/src/extensions.test.ts
@@ -1,9 +1,13 @@
 import { getExtensionSlotConfig } from "@openmrs/esm-config";
-import { attach, getExtensionIdsForExtensionSlot, reset } from "./extensions";
+import {
+  attach,
+  getAttachedExtensionInfoForSlotAndConfig,
+  reset,
+} from "./extensions";
 
 const mockGetExtensionSlotConfig = getExtensionSlotConfig as jest.Mock;
 
-describe("getExtensionIdsForExtensionSlot", () => {
+describe("getAttachedExtensionInfoForSlotAndConfig", () => {
   afterEach(() => {
     reset();
   });
@@ -12,10 +16,35 @@ describe("getExtensionIdsForExtensionSlot", () => {
     attach("slotski", "foo");
     attach("slotski", "bar");
     attach("slotso", "foo");
-    const res1 = await getExtensionIdsForExtensionSlot("slotski", "moddy");
-    expect(res1).toStrictEqual(["foo", "bar"]);
-    const res2 = await getExtensionIdsForExtensionSlot("slotso", "moddy");
-    expect(res2).toStrictEqual(["foo"]);
+
+    const res1 = await getAttachedExtensionInfoForSlotAndConfig(
+      "slotski",
+      "moddy"
+    );
+    expect(res1).toStrictEqual([
+      {
+        actualExtensionSlotName: "slotski",
+        attachedExtensionSlotName: "slotski",
+        extensionId: "foo",
+      },
+      {
+        actualExtensionSlotName: "slotski",
+        attachedExtensionSlotName: "slotski",
+        extensionId: "bar",
+      },
+    ]);
+
+    const res2 = await getAttachedExtensionInfoForSlotAndConfig(
+      "slotso",
+      "moddy"
+    );
+    expect(res2).toStrictEqual([
+      {
+        extensionId: "foo",
+        attachedExtensionSlotName: "slotso",
+        actualExtensionSlotName: "slotso",
+      },
+    ]);
   });
 
   it("respects add, remove, and order elements of configuration", async () => {
@@ -32,7 +61,15 @@ describe("getExtensionIdsForExtensionSlot", () => {
           }
         : {}
     );
-    const res = await getExtensionIdsForExtensionSlot("slotski", "moddy");
-    expect(res).toStrictEqual(["baz", "quinn", "qux", "foo"]);
+    const res = await getAttachedExtensionInfoForSlotAndConfig(
+      "slotski",
+      "moddy"
+    );
+    expect(res.map((x) => x.extensionId)).toStrictEqual([
+      "baz",
+      "quinn",
+      "qux",
+      "foo",
+    ]);
   });
 });

--- a/packages/esm-extensions/src/extensions.ts
+++ b/packages/esm-extensions/src/extensions.ts
@@ -125,6 +125,13 @@ export async function getExtensionIdsForExtensionSlot(
   let extensionIds =
     attachedExtensionsForExtensionSlot[extensionSlotName] ?? [];
 
+  const extensionsMatchingUrlPattern = Object.keys(
+    extensions
+  ).filter((extensionId) =>
+    getExtensionComponent(extensionId).component?.matcher(extensionSlotName)
+  );
+  extensionIds.push(...extensionsMatchingUrlPattern);
+
   if (config.add) {
     extensionIds = extensionIds.concat(config.add);
   }
@@ -156,7 +163,7 @@ function getExtensionComponent(extensionName: string) {
       const routeProps = extensions[name].matcher(extensionName);
 
       if (routeProps) {
-        return { component: extensionName[name], routeProps };
+        return { component: extensions[name], routeProps };
       }
     }
   }

--- a/packages/esm-extensions/src/extensions.ts
+++ b/packages/esm-extensions/src/extensions.ts
@@ -19,8 +19,29 @@ export interface ExtensionDefinition {
 }
 
 export interface AttachedExtensionInfo {
+  /** The ID of the extension which is attached to the slot. */
   extensionId: string;
+  /**
+   * The *actual* name of the extension slot which is defined when the slot is created.
+   *
+   * If the extension slot has a "normal" name (e.g. `my-extension-slot`), this is equal to `attachedExtensionSlot`.
+   *
+   * If the extension slot has a URL-like name, this `actualExtensionSlotName`'s path parameters have
+   * actual values (e.g. `/mySlot/213da954-87a2-432d-91f6-a3c441851726`).
+   * This is in contrast to the `attachedExtensionSlotName` which defines the path parameters
+   * (`e.g. `/mySlot/:uuidParameter`).
+   */
   actualExtensionSlotName: string;
+  /**
+   * The name which has been used to attach the extension to the extension slot.
+   *
+   * If the extension slot has a "normal" name (e.g. `my-extension-slot`), this is equal to `actualExtensionSlotName`.
+   *
+   * If the extension slot has a URL-like name, this `attachedExtensionSlotName`'s defines the path parameters
+   * (`e.g. `/mySlot/:uuidParameter`).
+   * This is in contrast to the `actualExtensionSlotName` where the parameters have been replaced with actual values
+   * (e.g. `/mySlot/213da954-87a2-432d-91f6-a3c441851726`).
+   */
   attachedExtensionSlotName: string;
 }
 
@@ -93,6 +114,16 @@ export function getExtensionRegistration(
   return extensions[extensionName];
 }
 
+/**
+ * Returns information describing all extensions which can be rendered into an extension slot with
+ * the specified name.
+ * The returned information describe the extension itself, as well as the extension slot name(s)
+ * with which it has been attached.
+ * @param actualExtensionSlotName The extension slot name for which matching extension info should be returned.
+ * For URL like extension slots, this should be the name where parameters have been replaced with actual values
+ * (e.g. `/mySlot/213da954-87a2-432d-91f6-a3c441851726`).
+ * @param moduleName The module name. Used for applying extension-specific config values to the result.
+ */
 export async function getAttachedExtensionInfoForSlotAndConfig(
   actualExtensionSlotName: string,
   moduleName: string

--- a/packages/esm-implementer-tools/src/configuration/extensions-config-tree.tsx
+++ b/packages/esm-implementer-tools/src/configuration/extensions-config-tree.tsx
@@ -2,7 +2,7 @@ import React, { useMemo, useState, useEffect } from "react";
 import { ExtensionSlotConfig } from "@openmrs/esm-config";
 import {
   getExtensionSlotsForModule,
-  getExtensionIdsForExtensionSlot,
+  getAttachedExtensionInfoForSlotAndConfig,
 } from "@openmrs/esm-extensions";
 import styles from "./configuration.styles.css";
 import EditableValue from "./editable-value.component";
@@ -23,16 +23,19 @@ export function ExtensionsConfigTree({
   const [
     extensionIdsForExtensionSlot,
     setExtensionIdsForExtensionSlot,
-  ] = useState({});
+  ] = useState<Record<string, Array<string>>>({});
 
   useEffect(() => {
     Promise.all(
       extensionSlotNames.map((slotName) =>
-        getExtensionIdsForExtensionSlot(slotName, moduleName)
+        getAttachedExtensionInfoForSlotAndConfig(slotName, moduleName)
       )
-    ).then((extensionIdsArr) => {
+    ).then((attachedExtensionInfos) => {
       const idsForExtSlot = Object.fromEntries(
-        extensionSlotNames.map((name, i) => [name, extensionIdsArr[i]])
+        extensionSlotNames.map((name, i) => [
+          name,
+          attachedExtensionInfos[i].map((x) => x.extensionId),
+        ])
       );
       setExtensionIdsForExtensionSlot(idsForExtSlot);
     });

--- a/packages/esm-implementer-tools/webpack.config.js
+++ b/packages/esm-implementer-tools/webpack.config.js
@@ -32,7 +32,7 @@ module.exports = {
         use: ["style-loader", "css-loader"],
       },
       {
-        test: /src\/.+\.css$/i,
+        test: /\.css$/,
         use: [
           "style-loader",
           {

--- a/packages/openmrs/src/utils/debugger.ts
+++ b/packages/openmrs/src/utils/debugger.ts
@@ -1,10 +1,27 @@
 import { dirname } from "path";
 import { logInfo, logWarn } from "./logger";
 
+function getWebpackEnv() {
+  return {
+    ...process.env,
+    analyze: process.env.BUNDLE_ANALYZE === "true",
+    production: process.env.NODE_ENV === "production",
+    development: process.env.NODE_ENV === "development",
+  };
+}
+
+function loadConfig(configPath: string) {
+  const content = require(configPath);
+  if (typeof content === "function") {
+    return content(getWebpackEnv());
+  }
+  return content;
+}
+
 function debug(configPath: string, port: number) {
   const webpack = require("webpack");
   const WebpackDevServer = require("webpack-dev-server");
-  const config = require(configPath);
+  const config = loadConfig(configPath);
 
   const options = {
     ...config.devServer,


### PR DESCRIPTION
* Allows auto-attaching extensions in `setupOpenMRS` via a `slot` property (see example below).
* Adds console warnings when an extension registration is incorrect.
* Fixes/Enables the extension context: It now works without having to manually attach the extension to the actual extension slot.

`setupOpenMRS` example:
```ts
function setupOpenMRS() {
  return {
    pages: [
      {
        load: () => import('./spa-order-basket-app'),
        route: /^patient\/.+\/drugorder\/basket/,
      },
    ],
    extensions: [
      {
        id: 'drugorder-widget',
        slot: 'patient-chart-dashboard-medications',
        load: () => import('./spa-medication-summary-extension'),
      },
      {
        id: 'order-basket-workspace',
        slot: '/patient/:patientUuid/drugorder/basket',
        load: () => import('./spa-order-basket-extension'),
      },
    ],
  };
}
```