### PR TITLE
MF-366 	Config elements should have `type` 

### DIFF
--- a/packages/esm-api/package.json
+++ b/packages/esm-api/package.json
@@ -10,7 +10,8 @@
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
     "typescript": "tsc",
-    "lint": "eslint src --ext ts,tsx"
+    "lint": "eslint src --ext ts,tsx",
+    "format": "prettier --write src/**"
   },
   "keywords": [
     "openmrs",

--- a/packages/esm-api/src/setup.ts
+++ b/packages/esm-api/src/setup.ts
@@ -1,21 +1,34 @@
-import { defineConfigSchema } from "@openmrs/esm-config";
+import { defineConfigSchema, Type, validators } from "@openmrs/esm-config";
 import { refetchCurrentUser } from "./shared-api-objects/current-user";
 
 export function setupApiModule() {
   defineConfigSchema("@openmrs/esm-api", {
     redirectAuthFailure: {
       enabled: {
-        default: true,
+        _type: Type.Boolean,
+        _default: true,
+        _description:
+          "Whether to redirect logged-out users to `redirectAuthFailure.url`",
       },
       url: {
-        //@ts-ignore
-        default: window.getOpenmrsSpaBase() + "login",
+        _type: Type.String,
+        _default: "${openmrsSpaBase}/login",
+        _validators: [validators.isUrl],
       },
       errors: {
-        default: [401],
+        _type: Type.Array,
+        _default: [401],
+        _elements: {
+          _type: Type.Number,
+          _validators: [validators.inRange(100, 600)],
+        },
+        _description: "The HTTP error codes for which users will be redirected",
       },
       resolvePromise: {
-        default: false,
+        _type: Type.Boolean,
+        _default: false,
+        _description:
+          "Changes how requests that fail authentication are handled. Try messing with this if redirects to the login page aren't working correctly.",
       },
     },
   });

--- a/packages/esm-config/package.json
+++ b/packages/esm-config/package.json
@@ -11,7 +11,8 @@
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
     "typescript": "tsc",
-    "lint": "eslint src --ext ts,tsx"
+    "lint": "eslint src --ext ts,tsx",
+    "format": "prettier --write src/**"
   },
   "keywords": [
     "openmrs",

--- a/packages/esm-config/src/module-config/module-config.test.ts
+++ b/packages/esm-config/src/module-config/module-config.test.ts
@@ -33,7 +33,7 @@ describe("defineConfigSchema", () => {
 
   it("logs an error if an invalid type is provided", () => {
     const schema = {
-      bar: { default: 0, type: "numeral" },
+      bar: { _default: 0, _type: "numeral" },
     };
     //@ts-ignore
     Config.defineConfigSchema("foo-module", schema);
@@ -45,15 +45,15 @@ describe("defineConfigSchema", () => {
   it("doesn't mind higher-level description and validator keys", () => {
     const schema = {
       foo: {
-        description: "Composed of bar and baz.",
-        validators: [
+        _description: "Composed of bar and baz.",
+        _validators: [
           validator((f) => f.bar != f.baz, "bar and baz must not be equal"),
         ],
         bar: {
-          default: 0,
+          _default: 0,
         },
         baz: {
-          default: 1,
+          _default: 1,
         },
       },
     };
@@ -63,7 +63,7 @@ describe("defineConfigSchema", () => {
 
   it("logs an error if a non-function validator is provided", () => {
     const schema = {
-      bar: { default: [], validators: [false] },
+      bar: { _default: [], _validators: [false] },
     };
     //@ts-ignore
     Config.defineConfigSchema("foo-module", schema);
@@ -77,9 +77,9 @@ describe("defineConfigSchema", () => {
   it("logs an error if non-object value is provided as a config element definition within an array", () => {
     const schema = {
       foo: {
-        default: [],
-        type: Config.Type.Array,
-        elements: { bar: "bad" },
+        _default: [],
+        _type: Config.Type.Array,
+        _elements: { bar: "bad" },
       },
     };
     Config.defineConfigSchema("mod-mod", schema);
@@ -91,9 +91,9 @@ describe("defineConfigSchema", () => {
   it("logs an error if elements key is provided without type being 'Array' or 'Object'", () => {
     const schema = {
       foo: {
-        default: [],
-        type: Config.Type.Boolean,
-        elements: {},
+        _default: [],
+        _type: Config.Type.Boolean,
+        _elements: {},
       },
     };
     Config.defineConfigSchema("mod-mod", schema);
@@ -104,7 +104,7 @@ describe("defineConfigSchema", () => {
 
   it("logs an error if any key does not include a default", () => {
     const schema = {
-      foo: { bar: { description: "lol idk" } },
+      foo: { bar: { _description: "lol idk" } },
     };
     Config.defineConfigSchema("mod-mod", schema);
     expect(console.error).toHaveBeenCalledWith(
@@ -125,9 +125,9 @@ describe("defineConfigSchema", () => {
   it("does not log an error if an array elements object has a key without a default", () => {
     const schema = {
       foo: {
-        default: [],
-        type: Config.Type.Array,
-        elements: {
+        _default: [],
+        _type: Config.Type.Array,
+        _elements: {
           bar: {},
         },
       },
@@ -147,7 +147,7 @@ describe("getConfig", () => {
   });
 
   it("uses config values from the provided config file", async () => {
-    Config.defineConfigSchema("foo-module", { foo: { default: "qux" } });
+    Config.defineConfigSchema("foo-module", { foo: { _default: "qux" } });
     const testConfig = { "foo-module": { foo: "bar" } };
     Config.provide(testConfig);
     const config = await Config.getConfig("foo-module");
@@ -158,7 +158,7 @@ describe("getConfig", () => {
   it("returns default values from the schema", async () => {
     Config.defineConfigSchema("testmod", {
       foo: {
-        default: "qux",
+        _default: "qux",
       },
     });
     const config = await Config.getConfig("testmod");
@@ -169,11 +169,11 @@ describe("getConfig", () => {
     Config.setAreDevDefaultsOn(true);
     Config.defineConfigSchema("testmod", {
       foo: {
-        default: "qux",
+        _default: "qux",
       },
       bar: {
-        default: "pub",
-        devDefault: "barcade",
+        _default: "pub",
+        _devDefault: "barcade",
       },
     });
     const config = await Config.getConfig("testmod");
@@ -184,7 +184,7 @@ describe("getConfig", () => {
   });
 
   it("logs an error if config values not defined in the schema", async () => {
-    Config.defineConfigSchema("foo-module", { foo: { default: "qux" } });
+    Config.defineConfigSchema("foo-module", { foo: { _default: "qux" } });
     Config.provide({ "foo-module": { bar: "baz" } });
     await Config.getConfig("foo-module");
     expect(console.error).toHaveBeenCalledWith(
@@ -194,7 +194,7 @@ describe("getConfig", () => {
 
   it("validates the structure of the config tree", async () => {
     Config.defineConfigSchema("foo-module", {
-      foo: { bar: { default: "qux" } },
+      foo: { bar: { _default: "qux" } },
     });
     Config.provide({ "foo-module": { foo: { doof: "nope" } } });
     await Config.getConfig("foo-module");
@@ -206,10 +206,10 @@ describe("getConfig", () => {
   it("supports running validators on nested objects", async () => {
     const fooSchema = {
       bar: {
-        a: { default: { b: 1 } },
-        c: { default: 2 },
-        diff: { default: 1 },
-        validators: [
+        a: { _default: { b: 1 } },
+        c: { _default: 2 },
+        diff: { _default: 1 },
+        _validators: [
           validator((o) => o.a.b + o.diff == o.c, "c must equal a.b + diff"),
         ],
       },
@@ -240,8 +240,8 @@ describe("getConfig", () => {
   it("supports freeform object elements, which have no structural validation", async () => {
     const fooSchema = {
       baz: {
-        default: {},
-        validators: [
+        _default: {},
+        _validators: [
           validator(
             (o) => typeof o === "object" && !Array.isArray(o),
             "Must be an object"
@@ -284,14 +284,14 @@ describe("getConfig", () => {
     Config.defineConfigSchema("foo-module", {
       foo: {
         bar: {
-          default: -1,
+          _default: -1,
         },
         baz: {
           qux: {
-            default: "N/A",
+            _default: "N/A",
           },
           quy: {
-            default: "",
+            _default: "",
           },
         },
       },
@@ -315,9 +315,9 @@ describe("getConfig", () => {
   });
 
   it("works for multiple modules and multiple provides", async () => {
-    Config.defineConfigSchema("foo-module", { foo: { default: "qux" } });
-    Config.defineConfigSchema("bar-module", { bar: { default: "quinn" } });
-    Config.defineConfigSchema("baz-module", { baz: { default: "quip" } });
+    Config.defineConfigSchema("foo-module", { foo: { _default: "qux" } });
+    Config.defineConfigSchema("bar-module", { bar: { _default: "quinn" } });
+    Config.defineConfigSchema("baz-module", { baz: { _default: "quip" } });
     const barTestConfig = { "bar-module": { bar: "barrr" } };
     const bazTestConfig = { "baz-module": { baz: "bazzz" } };
     Config.provide(barTestConfig);
@@ -334,8 +334,8 @@ describe("getConfig", () => {
   it("validates config values", async () => {
     Config.defineConfigSchema("foo-module", {
       foo: {
-        default: "thing",
-        validators: [
+        _default: "thing",
+        _validators: [
           validator((val) => val.startsWith("thi"), "must start with 'thi'"),
         ],
       },
@@ -355,8 +355,8 @@ describe("getConfig", () => {
   it("validators pass", async () => {
     Config.defineConfigSchema("foo-module", {
       foo: {
-        default: "thing",
-        validators: [
+        _default: "thing",
+        _validators: [
           validator((val) => val.startsWith("thi"), "must start with 'thi'"),
         ],
       },
@@ -375,11 +375,11 @@ describe("getConfig", () => {
   it("supports freeform object elements validations", async () => {
     Config.defineConfigSchema("foo-module", {
       foo: {
-        type: Config.Type.Object,
-        elements: {
-          name: { validators: [isUrl] },
+        _type: Config.Type.Object,
+        _elements: {
+          name: { _validators: [isUrl] },
         },
-        default: {},
+        _default: {},
       },
     });
     const testConfig = {
@@ -404,7 +404,7 @@ describe("getConfig", () => {
   it("supports array elements", async () => {
     Config.defineConfigSchema("foo-module", {
       foo: {
-        default: [1, 2, 3],
+        _default: [1, 2, 3],
       },
     });
     const testConfig = {
@@ -421,10 +421,10 @@ describe("getConfig", () => {
   it("supports validation of array elements", async () => {
     Config.defineConfigSchema("foo-module", {
       foo: {
-        type: Config.Type.Array,
-        default: [1, 2, 3],
-        elements: {
-          validators: [validator(Number.isInteger, "must be an integer")],
+        _type: Config.Type.Array,
+        _default: [1, 2, 3],
+        _elements: {
+          _validators: [validator(Number.isInteger, "must be an integer")],
         },
       },
     });
@@ -444,9 +444,9 @@ describe("getConfig", () => {
     Config.defineConfigSchema("foo-module", {
       bar: {
         baz: {
-          default: [{ a: 0, b: 1 }],
-          type: Config.Type.Array,
-          elements: {
+          _default: [{ a: 0, b: 1 }],
+          _type: Config.Type.Array,
+          _elements: {
             a: {},
             b: {},
           },
@@ -474,9 +474,9 @@ describe("getConfig", () => {
     const configSchema = {
       yoshi: {
         nori: {
-          default: [{ a: 0, b: { c: 2 } }],
-          type: Config.Type.Array,
-          elements: {
+          _default: [{ a: 0, b: { c: 2 } }],
+          _type: Config.Type.Array,
+          _elements: {
             a: {},
             b: { c: {} },
           },
@@ -504,12 +504,12 @@ describe("getConfig", () => {
   it("supports validation of nested array element objects elements", async () => {
     Config.defineConfigSchema("foo-module", {
       foo: {
-        default: [{ a: { b: 1 } }],
-        type: Config.Type.Array,
-        elements: {
+        _default: [{ a: { b: 1 } }],
+        _type: Config.Type.Array,
+        _elements: {
           a: {
             b: {
-              validators: [validator(Number.isInteger, "must be an integer")],
+              _validators: [validator(Number.isInteger, "must be an integer")],
             },
           },
         },
@@ -530,10 +530,10 @@ describe("getConfig", () => {
   it("supports validation of array element objects", async () => {
     const fooSchema = {
       bar: {
-        default: [{ a: { b: 1 }, c: 2 }],
-        type: Config.Type.Array,
-        elements: {
-          validators: [
+        _default: [{ a: { b: 1 }, c: 2 }],
+        _type: Config.Type.Array,
+        _elements: {
+          _validators: [
             validator((o) => o.a.b + 1 == o.c, "c must equal a.b + 1"),
           ],
         },
@@ -566,12 +566,12 @@ describe("getConfig", () => {
   it("fills array element object elements with defaults", async () => {
     Config.defineConfigSchema("array-def", {
       foo: {
-        default: [{ a: { b: "arrayDefaultB", filler: "arrayDefault" } }],
-        type: Config.Type.Array,
-        elements: {
+        _default: [{ a: { b: "arrayDefaultB", filler: "arrayDefault" } }],
+        _type: Config.Type.Array,
+        _elements: {
           a: {
-            b: { validators: [] },
-            filler: { default: "defaultFiller", validators: [isUrl] },
+            b: { _validators: [] },
+            filler: { _default: "defaultFiller", _validators: [isUrl] },
           },
         },
       },
@@ -613,7 +613,7 @@ describe("type validations", () => {
     [Config.Type.UUID, "not-valid"],
   ])("validates %s type", async (configType, badValue) => {
     Config.defineConfigSchema("foo-module", {
-      foo: { default: "qux", type: configType },
+      foo: { _default: "qux", _type: configType },
     });
     Config.provide({ "foo-module": { foo: badValue } });
     await Config.getConfig("foo-module");
@@ -637,7 +637,7 @@ describe("resolveImportMapConfig", () => {
   });
 
   it("gets config file from import map", async () => {
-    Config.defineConfigSchema("foo-module", { foo: { default: "qux" } });
+    Config.defineConfigSchema("foo-module", { foo: { _default: "qux" } });
     const testConfig = importableConfig({ "foo-module": { foo: "bar" } });
     (<any>window).System.resolve.mockReturnValue(true);
     (<any>window).System.import.mockResolvedValue(testConfig);
@@ -646,7 +646,7 @@ describe("resolveImportMapConfig", () => {
   });
 
   it("always puts config file from import map at highest priority", async () => {
-    Config.defineConfigSchema("foo-module", { foo: { default: "qux" } });
+    Config.defineConfigSchema("foo-module", { foo: { _default: "qux" } });
     const importedConfig = importableConfig({ "foo-module": { foo: "bar" } });
     (<any>window).System.resolve.mockReturnValue(true);
     (<any>window).System.import.mockResolvedValue(importedConfig);
@@ -657,7 +657,7 @@ describe("resolveImportMapConfig", () => {
   });
 
   it("does not 404 when no config file is in the import map", () => {
-    Config.defineConfigSchema("foo-module", { foo: { default: "qux" } });
+    Config.defineConfigSchema("foo-module", { foo: { _default: "qux" } });
     // this line below is actually all that the test requires, the rest is sanity checking
     expect(() => Config.getConfig("foo-module")).not.toThrow();
   });
@@ -675,8 +675,8 @@ describe("processConfig", () => {
   it("validates a config object", () => {
     const schema = {
       abe: {
-        default: "www.google.com",
-        validators: [validators.isUrl],
+        _default: "www.google.com",
+        _validators: [validators.isUrl],
       },
     };
     const inputConfig = {
@@ -691,7 +691,7 @@ describe("processConfig", () => {
 
   it("interpolates defaults", () => {
     const schema = {
-      foo: { default: false },
+      foo: { _default: false },
     };
     const inputConfig = {};
     const config = Config.processConfig(schema, inputConfig, "nowhere");
@@ -707,9 +707,9 @@ describe("getImplementerToolsConfig", () => {
 
   it("returns all config schemas, with values and sources interpolated", async () => {
     Config.defineConfigSchema("foo-module", {
-      foo: { default: "qux", description: "All the foo", validators: [] },
+      foo: { _default: "qux", _description: "All the foo", _validators: [] },
     });
-    Config.defineConfigSchema("bar-module", { bar: { default: "quinn" } });
+    Config.defineConfigSchema("bar-module", { bar: { _default: "quinn" } });
     const testConfig = { "bar-module": { bar: "baz" } };
     Config.provide(testConfig, "my config source");
     const devConfig = await Config.getImplementerToolsConfig();
@@ -718,13 +718,13 @@ describe("getImplementerToolsConfig", () => {
         foo: {
           _value: "qux",
           _source: "default",
-          default: "qux",
-          description: "All the foo",
-          validators: [],
+          _default: "qux",
+          _description: "All the foo",
+          _validators: [],
         },
       },
       "bar-module": {
-        bar: { _value: "baz", _source: "my config source", default: "quinn" },
+        bar: { _value: "baz", _source: "my config source", _default: "quinn" },
       },
     });
   });
@@ -736,7 +736,7 @@ describe("temporary config", () => {
   });
 
   it("allows overriding the existing config", async () => {
-    Config.defineConfigSchema("foo-module", { foo: { default: "qux" } });
+    Config.defineConfigSchema("foo-module", { foo: { _default: "qux" } });
     const testConfig = { "foo-module": { foo: "baz" } };
     Config.provide(testConfig);
     Config.setTemporaryConfigValue(["foo-module", "foo"], 3);
@@ -751,7 +751,7 @@ describe("temporary config", () => {
   });
 
   it("can be gotten and cleared", async () => {
-    Config.defineConfigSchema("foo-module", { foo: { default: "qux" } });
+    Config.defineConfigSchema("foo-module", { foo: { _default: "qux" } });
     Config.setTemporaryConfigValue(["foo-module", "foo"], 3);
     expect(Config.getTemporaryConfig()).toStrictEqual({
       "foo-module": { foo: 3 },
@@ -765,8 +765,8 @@ describe("temporary config", () => {
   it("is not mutated by getConfig", async () => {
     Config.defineConfigSchema("foo-module", {
       foo: {
-        bar: { default: "qux" },
-        baz: { default: "also qux" },
+        bar: { _default: "qux" },
+        baz: { _default: "also qux" },
       },
     });
     await Config.getConfig("foo-module");
@@ -819,7 +819,7 @@ describe("extension slot config", () => {
 
   it("doesn't get returned by getConfig", async () => {
     Config.defineConfigSchema("foo-module", {
-      foo: { default: 0 },
+      foo: { _default: 0 },
     });
     Config.provide({
       "foo-module": {
@@ -833,7 +833,7 @@ describe("extension slot config", () => {
 
   it("isn't mutated by getConfig", async () => {
     Config.defineConfigSchema("foo-module", {
-      foo: { default: 0 },
+      foo: { _default: 0 },
     });
     Config.provide({
       "foo-module": {
@@ -850,7 +850,7 @@ describe("extension slot config", () => {
 
   it("is included in getImplementerToolsConfig", async () => {
     Config.defineConfigSchema("foo-module", {
-      foo: { default: 0 },
+      foo: { _default: 0 },
     });
     Config.provide({
       "foo-module": {
@@ -860,7 +860,7 @@ describe("extension slot config", () => {
     const config = await Config.getImplementerToolsConfig();
     expect(config).toStrictEqual({
       "foo-module": {
-        foo: { default: 0, _value: 0, _source: "default" },
+        foo: { _default: 0, _value: 0, _source: "default" },
         extensions: {
           fooSlot: {
             remove: { _value: ["bar"], _source: "provided" },
@@ -894,8 +894,8 @@ describe("extension config", () => {
 
   it("returns the module config", async () => {
     Config.defineConfigSchema("ext-mod", {
-      bar: { default: "barry" },
-      baz: { default: "bazzy" },
+      bar: { _default: "barry" },
+      baz: { _default: "bazzy" },
     });
     const testConfig = { "ext-mod": { bar: "qux" } };
     Config.provide(testConfig);
@@ -911,8 +911,8 @@ describe("extension config", () => {
 
   it("uses the 'add' config if one is present", async () => {
     Config.defineConfigSchema("ext-mod", {
-      bar: { default: "barry" },
-      baz: { default: "bazzy" },
+      bar: { _default: "barry" },
+      baz: { _default: "bazzy" },
     });
     const testConfig = {
       "ext-mod": { bar: "qux" },
@@ -937,8 +937,8 @@ describe("extension config", () => {
 
   it("uses the 'configure' config if one is present", async () => {
     Config.defineConfigSchema("ext-mod", {
-      bar: { default: "barry" },
-      baz: { default: "bazzy" },
+      bar: { _default: "barry" },
+      baz: { _default: "bazzy" },
     });
     const testConfig = {
       "ext-mod": { bar: "qux" },
@@ -963,8 +963,8 @@ describe("extension config", () => {
 
   it("validates the extension slot config", async () => {
     Config.defineConfigSchema("ext-mod", {
-      bar: { default: "barry" },
-      baz: { default: "bazzy" },
+      bar: { _default: "barry" },
+      baz: { _default: "bazzy" },
     });
     const testConfig = {
       "ext-mod": { bar: "qux" },

--- a/packages/esm-config/src/module-config/module-config.test.ts
+++ b/packages/esm-config/src/module-config/module-config.test.ts
@@ -35,6 +35,7 @@ describe("defineConfigSchema", () => {
     const schema = {
       bar: { default: 0, type: "numeral" },
     };
+    //@ts-ignore
     Config.defineConfigSchema("foo-module", schema);
     expect(console.error).toHaveBeenCalledWith(
       expect.stringMatching(/foo-module.*bar[\s\S]*Number.*numeral/i)
@@ -64,6 +65,7 @@ describe("defineConfigSchema", () => {
     const schema = {
       bar: { default: [], validators: [false] },
     };
+    //@ts-ignore
     Config.defineConfigSchema("foo-module", schema);
     expect(console.error).toHaveBeenCalledWith(
       expect.stringMatching(
@@ -76,7 +78,7 @@ describe("defineConfigSchema", () => {
     const schema = {
       foo: {
         default: [],
-        type: "Array",
+        type: Config.Type.Array,
         elements: { bar: "bad" },
       },
     };
@@ -90,7 +92,7 @@ describe("defineConfigSchema", () => {
     const schema = {
       foo: {
         default: [],
-        type: "Boolean",
+        type: Config.Type.Boolean,
         elements: {},
       },
     };
@@ -124,7 +126,7 @@ describe("defineConfigSchema", () => {
     const schema = {
       foo: {
         default: [],
-        type: "Array",
+        type: Config.Type.Array,
         elements: {
           bar: {},
         },
@@ -373,7 +375,7 @@ describe("getConfig", () => {
   it("supports freeform object elements validations", async () => {
     Config.defineConfigSchema("foo-module", {
       foo: {
-        type: "Object",
+        type: Config.Type.Object,
         elements: {
           name: { validators: [isUrl] },
         },
@@ -419,7 +421,7 @@ describe("getConfig", () => {
   it("supports validation of array elements", async () => {
     Config.defineConfigSchema("foo-module", {
       foo: {
-        type: "Array",
+        type: Config.Type.Array,
         default: [1, 2, 3],
         elements: {
           validators: [validator(Number.isInteger, "must be an integer")],
@@ -443,7 +445,7 @@ describe("getConfig", () => {
       bar: {
         baz: {
           default: [{ a: 0, b: 1 }],
-          type: "Array",
+          type: Config.Type.Array,
           elements: {
             a: {},
             b: {},
@@ -473,7 +475,7 @@ describe("getConfig", () => {
       yoshi: {
         nori: {
           default: [{ a: 0, b: { c: 2 } }],
-          type: "Array",
+          type: Config.Type.Array,
           elements: {
             a: {},
             b: { c: {} },
@@ -503,7 +505,7 @@ describe("getConfig", () => {
     Config.defineConfigSchema("foo-module", {
       foo: {
         default: [{ a: { b: 1 } }],
-        type: "Array",
+        type: Config.Type.Array,
         elements: {
           a: {
             b: {
@@ -529,7 +531,7 @@ describe("getConfig", () => {
     const fooSchema = {
       bar: {
         default: [{ a: { b: 1 }, c: 2 }],
-        type: "Array",
+        type: Config.Type.Array,
         elements: {
           validators: [
             validator((o) => o.a.b + 1 == o.c, "c must equal a.b + 1"),
@@ -565,7 +567,7 @@ describe("getConfig", () => {
     Config.defineConfigSchema("array-def", {
       foo: {
         default: [{ a: { b: "arrayDefaultB", filler: "arrayDefault" } }],
-        type: "Array",
+        type: Config.Type.Array,
         elements: {
           a: {
             b: { validators: [] },
@@ -602,13 +604,13 @@ describe("type validations", () => {
   });
 
   test.each([
-    ["Array", "doop"],
-    ["Boolean", 0],
-    ["ConceptUuid", "Weight"],
-    ["Number", "foo"],
-    ["Object", []],
-    ["String", 0],
-    ["UUID", "not-valid"],
+    [Config.Type.Array, "doop"],
+    [Config.Type.Boolean, 0],
+    [Config.Type.ConceptUuid, "Weight"],
+    [Config.Type.Number, "foo"],
+    [Config.Type.Object, []],
+    [Config.Type.String, 0],
+    [Config.Type.UUID, "not-valid"],
   ])("validates %s type", async (configType, badValue) => {
     Config.defineConfigSchema("foo-module", {
       foo: { default: "qux", type: configType },

--- a/packages/esm-config/src/module-config/module-config.ts
+++ b/packages/esm-config/src/module-config/module-config.ts
@@ -8,6 +8,7 @@ import {
   isObject,
   isString,
 } from "../validators/type-validators";
+import { Validator } from "../validators/validator";
 
 // The input configs
 type ProvidedConfig = {
@@ -644,11 +645,11 @@ export function clearAll() {
 // Full-powered typing for Config and Schema trees depends on being able to
 // have types like `string not "_default"`. There is an experimental PR
 // for this feature, https://github.com/microsoft/TypeScript/pull/29317
-// But it is not likely to be merged any time terribly soon.
+// But it is not likely to be merged any time terribly soon. (Nov 11, 2020)
 export interface ConfigSchema {
   [key: string]: ConfigSchema | ConfigValue;
   _type?: Type;
-  _validators?: Function[];
+  _validators?: Array<Validator>;
   _elements?: ConfigSchema;
 }
 

--- a/packages/esm-config/src/react-hook/use-config.test.tsx
+++ b/packages/esm-config/src/react-hook/use-config.test.tsx
@@ -17,7 +17,7 @@ describe(`useConfig`, () => {
   it(`can return config as a react hook`, async () => {
     defineConfigSchema("foo-module", {
       thing: {
-        default: "The first thing",
+        _default: "The first thing",
       },
     });
 
@@ -35,13 +35,13 @@ describe(`useConfig`, () => {
   it(`can handle multiple calls to useConfig from different modules`, async () => {
     defineConfigSchema("foo-module", {
       thing: {
-        default: "foo thing",
+        _default: "foo thing",
       },
     });
 
     defineConfigSchema("bar-module", {
       thing: {
-        default: "bar thing",
+        _default: "bar thing",
       },
     });
 
@@ -71,7 +71,7 @@ describe(`useConfig`, () => {
   it("updates with a new value when the temporary config is updated", async () => {
     defineConfigSchema("foo-module", {
       thing: {
-        default: "The first thing",
+        _default: "The first thing",
       },
     });
 

--- a/packages/esm-config/src/react-hook/use-extension-config.test.tsx
+++ b/packages/esm-config/src/react-hook/use-extension-config.test.tsx
@@ -18,7 +18,7 @@ describe(`useExtensionConfig`, () => {
   it(`can return extension config as a react hook`, async () => {
     defineConfigSchema("ext-module", {
       thing: {
-        default: "The first thing",
+        _default: "The first thing",
       },
     });
 
@@ -44,13 +44,13 @@ describe(`useExtensionConfig`, () => {
   it(`can handle multiple extensions`, async () => {
     defineConfigSchema("foo-module", {
       thing: {
-        default: "foo thing",
+        _default: "foo thing",
       },
     });
 
     defineConfigSchema("bar-module", {
       thing: {
-        default: "bar thing",
+        _default: "bar thing",
       },
     });
 
@@ -86,7 +86,7 @@ describe(`useExtensionConfig`, () => {
   it("can handle multiple extension slots", async () => {
     defineConfigSchema("foo-module", {
       thing: {
-        default: "foo thing",
+        _default: "foo thing",
       },
     });
 
@@ -136,7 +136,7 @@ describe(`useExtensionConfig`, () => {
   it("updates with a new value when the temporary config is updated", async () => {
     defineConfigSchema("ext-module", {
       thing: {
-        default: "The first thing",
+        _default: "The first thing",
       },
     });
 

--- a/packages/esm-config/src/validators/type-validators.test.ts
+++ b/packages/esm-config/src/validators/type-validators.test.ts
@@ -1,0 +1,84 @@
+import {
+  isString,
+  isBoolean,
+  isUuid,
+  isObject,
+  isNumber,
+} from "./type-validators";
+
+describe("all validators", () => {
+  it("fail on undefined", () => {
+    expect(isString(undefined)).toMatch(/.*/);
+    expect(isBoolean(undefined)).toMatch(/.*/);
+    expect(isUuid(undefined)).toMatch(/.*/);
+    expect(isObject(undefined)).toMatch(/.*/);
+    expect(isNumber(undefined)).toMatch(/.*/);
+  });
+});
+
+describe("isString", () => {
+  it("accepts strings", () => {
+    expect(isString("")).toBeUndefined();
+  });
+
+  it("rejects non-strings", () => {
+    expect(isString([""])).toMatch("must be a string");
+  });
+});
+
+describe("isNumber", () => {
+  it("accepts numbers", () => {
+    expect(isNumber(10)).toBeUndefined();
+  });
+
+  it("rejects non-numbers", () => {
+    expect(isNumber("Not a Number")).toMatch("must be a number");
+  });
+});
+
+describe("isBoolean", () => {
+  it("accepts bools", () => {
+    expect(isBoolean(false)).toBeUndefined();
+  });
+
+  it("rejects non-bools", () => {
+    expect(isBoolean(1)).toMatch("must be a bool");
+  });
+});
+
+describe("isUuid", () => {
+  it("accepts a CIEL External ID", () => {
+    expect(isUuid("123118AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")).toBeUndefined();
+  });
+
+  it("accepts a valid UUID with dashes", () => {
+    expect(isUuid("28c37ff6-0079-4fa7-b803-5d547ac454e0")).toBeUndefined();
+  });
+
+  it("rejects a bad UUID", () => {
+    expect(isUuid("28c37ff6-0079-4fa7-b803-5d547ac454e")).toMatch(
+      "must be a valid UUID"
+    );
+  });
+
+  it("rejects a bad CIEL External ID", () => {
+    expect(isUuid("123118AAAAAAAAAAAAAAAAAAAAAAAAAAAAA")).toMatch(
+      "must be a valid UUID"
+    );
+  });
+});
+
+describe("isObject", () => {
+  it("accepts plain objects", () => {
+    expect(isObject({})).toBeUndefined();
+    expect(isObject({ foo: 0 })).toBeUndefined();
+  });
+
+  it("rejects arrays", () => {
+    expect(isObject([])).toMatch(/must be an object/i);
+  });
+
+  it("rejects null", () => {
+    expect(isObject(null)).toMatch(/must be an object/i);
+  });
+});

--- a/packages/esm-config/src/validators/type-validators.ts
+++ b/packages/esm-config/src/validators/type-validators.ts
@@ -1,0 +1,34 @@
+import { validator } from "./validator";
+
+export const isArray = validator(
+  (val) => Array.isArray(val),
+  "must be an array"
+);
+
+export const isBoolean = validator(
+  (val) => typeof val === "boolean",
+  "must be a boolean"
+);
+
+export const isNumber = validator(
+  (val) => typeof val === "number",
+  "must be a number"
+);
+
+export const isString = validator(
+  (val) => typeof val === "string",
+  "must be a string"
+);
+
+export const isObject = validator(
+  (val) => typeof val === "object" && !Array.isArray(val) && val !== null,
+  "must be an object (not an array or null)"
+);
+
+export const isUuid = validator(
+  (val) =>
+    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+      val
+    ) || /^[0-9a-f]{36}$/i.test(val),
+  "must be a valid UUID or a 36-character hexadecimal string"
+);

--- a/packages/esm-config/src/validators/validators.test.ts
+++ b/packages/esm-config/src/validators/validators.test.ts
@@ -1,89 +1,9 @@
-import {
-  isString,
-  isBoolean,
-  isUuid,
-  isObject,
-  isUrl,
-  isUrlWithTemplateParameters,
-  isNumber,
-} from "./validators";
+import { isUrl, isUrlWithTemplateParameters } from "./validators";
 
 describe("all validators", () => {
   it("fail on undefined", () => {
-    expect(isString(undefined)).toMatch(/.*/);
-    expect(isBoolean(undefined)).toMatch(/.*/);
-    expect(isUuid(undefined)).toMatch(/.*/);
-    expect(isObject(undefined)).toMatch(/.*/);
     expect(isUrl(undefined)).toMatch(/.*/);
     expect(isUrlWithTemplateParameters(["foo"])(undefined)).toMatch(/.*/);
-    expect(isNumber(undefined)).toMatch(/.*/);
-  });
-});
-
-describe("isString", () => {
-  it("accepts strings", () => {
-    expect(isString("")).toBeUndefined();
-  });
-
-  it("rejects non-strings", () => {
-    expect(isString([""])).toMatch("must be a string");
-  });
-});
-
-describe("isNumber", () => {
-  it("accepts numbers", () => {
-    expect(isNumber(10)).toBeUndefined();
-  });
-
-  it("rejects non-numbers", () => {
-    expect(isNumber("Not a Number")).toMatch("must be a number");
-  });
-});
-
-describe("isBoolean", () => {
-  it("accepts bools", () => {
-    expect(isBoolean(false)).toBeUndefined();
-  });
-
-  it("rejects non-bools", () => {
-    expect(isBoolean(1)).toMatch("must be a bool");
-  });
-});
-
-describe("isUuid", () => {
-  it("accepts a CIEL External ID", () => {
-    expect(isUuid("123118AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA")).toBeUndefined();
-  });
-
-  it("accepts a valid UUID with dashes", () => {
-    expect(isUuid("28c37ff6-0079-4fa7-b803-5d547ac454e0")).toBeUndefined();
-  });
-
-  it("rejects a bad UUID", () => {
-    expect(isUuid("28c37ff6-0079-4fa7-b803-5d547ac454e")).toMatch(
-      "must be a valid UUID"
-    );
-  });
-
-  it("rejects a bad CIEL External ID", () => {
-    expect(isUuid("123118AAAAAAAAAAAAAAAAAAAAAAAAAAAAA")).toMatch(
-      "must be a valid UUID"
-    );
-  });
-});
-
-describe("isObject", () => {
-  it("accepts plain objects", () => {
-    expect(isObject({})).toBeUndefined();
-    expect(isObject({ foo: 0 })).toBeUndefined();
-  });
-
-  it("rejects arrays", () => {
-    expect(isObject([])).toMatch(/must be an object/i);
-  });
-
-  it("rejects null", () => {
-    expect(isObject(null)).toMatch(/must be an object/i);
   });
 });
 

--- a/packages/esm-config/src/validators/validators.ts
+++ b/packages/esm-config/src/validators/validators.ts
@@ -1,33 +1,5 @@
 import { validator } from "./validator";
 
-export const isString = validator(
-  (val) => typeof val === "string",
-  "must be a string"
-);
-
-export const isNumber = validator(
-  (val) => typeof val === "number",
-  "must be a number"
-);
-
-export const isBoolean = validator(
-  (val) => typeof val === "boolean",
-  "must be a boolean"
-);
-
-export const isUuid = validator(
-  (val) =>
-    /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
-      val
-    ) || /^[0-9a-f]{36}$/i.test(val),
-  "must be a valid UUID or a 36-character hexadecimal string"
-);
-
-export const isObject = validator(
-  (val) => typeof val === "object" && !Array.isArray(val) && val !== null,
-  "must be an object (not an array or null)"
-);
-
 /**
  * Verifies that a string contains only the default URL template
  * parameters, plus any specified in `allowedTemplateParameters`.
@@ -43,19 +15,18 @@ export const isUrlWithTemplateParameters = (
     "openmrsSpaBase",
   ]);
   return validator((val) => {
-    if (!val) {
+    if (!val || typeof val != "string") {
       return false;
     }
 
     const matches = val.matchAll(/\${(.*?)}/g);
-
-    for (let match of matches) {
+    for (let match of Array.from(matches)) {
       if (!allowedParams.includes(match[1])) {
         return false;
       }
     }
     return true;
-  }, "the allowed template parameters are " + allowedParams.map((p) => "${" + p + "}").join(", "));
+  }, "should be a URL or path. The allowed template parameters are " + allowedParams.map((p) => "${" + p + "}").join(", "));
 };
 
 /**
@@ -66,11 +37,6 @@ export const isUrlWithTemplateParameters = (
 export const isUrl = isUrlWithTemplateParameters([]);
 
 export const validators = {
-  isString,
-  isNumber,
-  isBoolean,
-  isUuid,
-  isObject,
   isUrl,
   isUrlWithTemplateParameters,
 };

--- a/packages/esm-config/src/validators/validators.ts
+++ b/packages/esm-config/src/validators/validators.ts
@@ -1,6 +1,19 @@
 import { validator } from "./validator";
 
 /**
+ * Verifies that the value is between the provided minimum and maximum
+ *
+ * @param min Minimum acceptable value
+ * @param max Maximum acceptable value
+ */
+export const inRange = (min: number, max: number) => {
+  return validator(
+    (val) => min <= val && val <= max,
+    `must be between ${min} and ${max}`
+  );
+};
+
+/**
  * Verifies that a string contains only the default URL template
  * parameters, plus any specified in `allowedTemplateParameters`.
  *
@@ -37,6 +50,7 @@ export const isUrlWithTemplateParameters = (
 export const isUrl = isUrlWithTemplateParameters([]);
 
 export const validators = {
+  inRange,
   isUrl,
   isUrlWithTemplateParameters,
 };

--- a/packages/esm-implementer-tools/src/configuration/configuration.component.tsx
+++ b/packages/esm-implementer-tools/src/configuration/configuration.component.tsx
@@ -22,8 +22,9 @@ export default function Configuration(props: ConfigurationProps) {
   const [isUIEditorActive, setIsUIEditorActive] = React.useState(
     getIsUIEditorEnabled()
   );
+  const tempConfig = getTemporaryConfig();
   const tempConfigObjUrl = new Blob(
-    [JSON.stringify(getTemporaryConfig(), undefined, 2)],
+    [JSON.stringify(tempConfig, undefined, 2)],
     {
       type: "application/json",
     }

--- a/packages/esm-implementer-tools/src/configuration/editable-value.component.tsx
+++ b/packages/esm-implementer-tools/src/configuration/editable-value.component.tsx
@@ -1,10 +1,13 @@
 import React, { useState, useEffect, useRef } from "react";
 import { isEqual } from "lodash";
-import { setTemporaryConfigValue, ConfigValue } from "@openmrs/esm-config";
+import {
+  setTemporaryConfigValue,
+  ConfigValue,
+  Validator,
+} from "@openmrs/esm-config";
 import styles from "./editable-value.styles.css";
 import ValueEditor from "./value-editor";
 import { useGlobalState } from "../global-state";
-import { ConceptSearchBox } from "./concept-search";
 
 export interface EditableValueProps {
   path: string[];
@@ -16,7 +19,7 @@ export interface ConfigValueDescriptor {
   _source: string;
   _default: ConfigValue;
   _description?: string;
-  _validators?: Array<Function>;
+  _validators?: Array<Validator>;
 }
 
 export default function EditableValue({ path, element }: EditableValueProps) {

--- a/packages/esm-implementer-tools/src/configuration/editable-value.component.tsx
+++ b/packages/esm-implementer-tools/src/configuration/editable-value.component.tsx
@@ -14,9 +14,9 @@ export interface EditableValueProps {
 export interface ConfigValueDescriptor {
   _value: ConfigValue;
   _source: string;
-  default: ConfigValue;
-  description?: string;
-  validators?: Array<Function>;
+  _default: ConfigValue;
+  _description?: string;
+  _validators?: Array<Function>;
 }
 
 export default function EditableValue({ path, element }: EditableValueProps) {


### PR DESCRIPTION
https://issues.openmrs.org/browse/MF-366

This removes support for the `is****` validators, replacing them with `type` declarations in the schema.

All modules' configs must be updated simultaneously because this will break everything. I will change this to a normal PR once PRs against all the other modules are ready.