### PR TITLE
[WIP] Rework the extension slot config to use the attached extension slot name

### DIFF
--- a/packages/esm-config/src/module-config/module-config.ts
+++ b/packages/esm-config/src/module-config/module-config.ts
@@ -198,16 +198,17 @@ export function clearTemporaryConfig(): void {
 /**
  * @internal
  */
-export async function getExtensionSlotConfig(
+export async function getExtensionSlotConfigs(
   slotName: string,
   moduleName: string
-): Promise<ExtensionSlotConfigObject> {
+): Promise<Record<string, ExtensionSlotConfigObject>> {
   await loadConfigs();
   const moduleConfig = mergeConfigsFor(moduleName, getProvidedConfigs());
-  const inputConfig = moduleConfig?.extensions?.[slotName] ?? {};
-  validateExtensionSlotConfig(inputConfig, moduleName, slotName);
-  const config = processExtensionSlotConfig(inputConfig);
-  return config;
+  const allExtensionSlotConfigs: Record<string, ExtensionSlotConfig> = moduleConfig?.extensions ?? {};
+  for (const config of Object.values(allExtensionSlotConfigs)) {
+    validateExtensionSlotConfig(config, moduleName, slotName);
+  }
+  return processExtensionSlotConfigs(allExtensionSlotConfigs);
 }
 
 function validateExtensionSlotConfig(
@@ -285,18 +286,21 @@ function validateExtensionSlotConfig(
   }
 }
 
-function processExtensionSlotConfig(
-  config: ExtensionSlotConfig
-): ExtensionSlotConfigObject {
-  const result: ExtensionSlotConfigObject = {};
-  if (config.remove) {
-    result.remove = config.remove;
-  }
-  if (config.order) {
-    result.order = config.order;
-  }
-  if (config.add) {
-    result.add = config.add.map((e) => e.extension);
+function processExtensionSlotConfigs(
+  allExtensionSlotConfigs: Record<string, ExtensionSlotConfig>
+): Record<string, ExtensionSlotConfigObject> {
+  const result: Record<string, ExtensionSlotConfigObject> = {};
+  for (const [key, config] of Object.entries(allExtensionSlotConfigs)) {
+    result[key] = {};
+    if (config.remove) {
+      result[key].remove = config.remove;
+    }
+    if (config.order) {
+      result[key].order = config.order;
+    }
+    if (config.add) {
+      result[key].add = config.add.map((e) => e.extension);
+    }
   }
   return result;
 }


### PR DESCRIPTION
**This is WIP. The draft PR is only here to discuss the general idea. Checklist of missing things:**

- [ ] Feedback
- [ ] Adapt tests
- [ ] Code cleanup of the changes (quite rough atm)

As a follow-up to https://github.com/openmrs/openmrs-esm-core/pull/26#discussion_r520139010_, this PR updates how the extension slot config is handled. After looking at the situation, I came to the conclusion that it's not possible to pass an `attachedExtensionSlotName` to the config's `getExtensionSlotConfig` function. This is because we don't have any attached slot name at this point in time ([this function](https://github.com/openmrs/openmrs-esm-core/pull/26/files/969da03fe318d56ad1ce88f730514355b430e777#diff-5acad908a3628b9641be28a5c4767b2279c16245b6106b344c82febba61e21f1R127) is atm called in the root of the `ExtensionSlotReact`, a point where we only have the `actualExtensionSlotName` - finding out what the corresponding `attachedExtensionSlotName`s are is exactly the point of `getAttachedExtensionInfoForSlotAndConfig`).

My initial approach to handle such situations is a slight rework of how the config is handled. Instead of handling **one** `ExtensionSlotConfig` which matches the extension slot name _exactly_, I'd from now on iterate through **all** extension slot configs and check whether their name pattern match the `actualExtensionSlotName`. If so, continue with the previous logic.

I'd love some feedback on this approach as I'm not sure whether this is the ideal way to do this.
The whole scenario also creates a new situation where it is theoretically possible to have multiple extension slots matching the current `actualExtensionSlotName` (e.g. `/slot/:foo` and `/slot/:bar`). For now, I simply allow both of these to render their extensions in order, but I guess that this is up for debate...

CC @FlorianRappl @brandones 