### PR TITLE
MF-315: UI Editor Extension slots and extension show name on hover

### DIFF
--- a/packages/esm-extensions/package.json
+++ b/packages/esm-extensions/package.json
@@ -32,10 +32,13 @@
   },
   "homepage": "https://github.com/openmrs/openmrs-esm-core#readme",
   "dependencies": {
+    "carbon-components-react": "^7.23.2",
     "path-to-regexp": "6.1.0",
     "systemjs-webpack-interop": "^2.1.2"
   },
   "peerDependencies": {
+    "carbon-icons": "^7.0.7",
+    "carbon-components": "^10.23.2",
     "@openmrs/esm-config": "3.x",
     "@openmrs/esm-context": "3.x",
     "react": "16.x",
@@ -44,6 +47,9 @@
   "devDependencies": {
     "@openmrs/esm-config": "^3.0.8",
     "@openmrs/esm-context": "^3.0.8",
+    "@types/carbon-components": "^10.23.0",
+    "@types/carbon-components-react": "^7.23.0",
+    "@types/carbon__icons-react": "^10.20.0",
     "@types/react": "^16.9.46",
     "react": "^16.13.1",
     "single-spa": "^4.4.1"

--- a/packages/esm-extensions/src/extension-slot-react.component.tsx
+++ b/packages/esm-extensions/src/extension-slot-react.component.tsx
@@ -16,6 +16,7 @@ import {
   unregisterExtensionSlot,
   AttachedExtensionInfo,
 } from "./extensions";
+import { TooltipIcon } from "carbon-components-react";
 
 interface ExtensionSlotBaseProps {
   extensionSlotName: string;
@@ -131,9 +132,15 @@ export const ExtensionReact: React.FC<ExtensionReactProps> = ({ state }) => {
   }, [actualExtensionSlotName, attachedExtensionSlotName, extensionId]);
 
   return getIsUIEditorEnabled() ? (
-    <div style={{ outline: "0.125rem solid yellow" }}>
-      <slot ref={ref} />
-    </div>
+    <TooltipIcon
+      tooltipText={`Slot Name: ${actualExtensionSlotName} Extension: ${attachedExtensionSlotName}`}
+      align="center"
+      direction="top"
+    >
+      <div style={{ outline: "0.125rem solid yellow" }}>
+        <slot ref={ref} />
+      </div>
+    </TooltipIcon>
   ) : (
     <slot ref={ref} />
   );


### PR DESCRIPTION
### What does this PR do?

It implements a UI Tooltip that displays the Extension Slot name and the extension  
See [MF-315](https://issues.openmrs.org/projects/MF/issues/MF-325)

### Screenshots﻿

![2020-11-10 14 54 55](https://user-images.githubusercontent.com/28008754/98671163-e1fba800-2364-11eb-850b-ed71ca438ee9.gif)


