### PR TITLE
Fix typescript error from esm-login

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "raw-loader": "^3.1.0",
     "style-loader": "^1.0.0",
     "ts-loader": "^8.0.3",
-    "typescript": "^4.0.2",
+    "typescript": "^4.0.5",
     "webpack": "^4.44.1",
     "webpack-cli": "^3.3.12",
     "webpack-dev-server": "^3.11.0"

--- a/packages/esm-config/package.json
+++ b/packages/esm-config/package.json
@@ -49,8 +49,7 @@
     "@types/systemjs": "^6.1.0",
     "babel-plugin-ramda": "^2.0.0",
     "react": "^16.13.1",
-    "single-spa": "^4.4.1",
-    "typescript": "^4.0.3"
+    "single-spa": "^4.4.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/esm-config/src/module-config/module-config.ts
+++ b/packages/esm-config/src/module-config/module-config.ts
@@ -588,14 +588,14 @@ const setDefaults = (schema: ConfigSchema, inputConfig: Config) => {
       const elements = schemaPart._elements;
       if (hasObjectSchema(elements)) {
         if (schemaPart._type == Type.Array) {
-          const configWithDefaults = config[key].map((conf) =>
+          const configWithDefaults = config[key].map((conf: Config) =>
             setDefaults(elements, conf)
           );
           config[key] = configWithDefaults;
         } else if (schemaPart._type == Type.Object) {
-          const configWithDefaults = Object.values(config[key]).map((conf) =>
-            setDefaults(elements, conf)
-          );
+          const configWithDefaults = Object.values(
+            config[key]
+          ).map((conf: Config) => setDefaults(elements, conf));
           config[key] = configWithDefaults;
         }
       }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14430,10 +14430,15 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.0.2, typescript@^4.0.3:
+typescript@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
   integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+
+typescript@^4.0.5:
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
A much more conservative change than https://github.com/openmrs/openmrs-esm-core/pull/34 , which should allow esm-login to build.

Right now, `npm run typescript` in esm-login fails with

```
node_modules/@openmrs/esm-config/src/module-config/module-config.ts:597:35 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'Config'.
  Index signature is missing in type '{}'.

597             setDefaults(elements, conf)
                                      ~~~~
```

I don't know why Typescript in esm-core itself works fine, but it does. This same failure causes `npm run build` in esm-login to fail.
