### PR TITLE
MF-382 Update initial script to support -widgets

### DIFF
--- a/packages/esm-app-shell/src/index.ts
+++ b/packages/esm-app-shell/src/index.ts
@@ -15,7 +15,9 @@ import type { SpaConfig } from "./types";
  * import maps.
  */
 function getApps(maps: Record<string, string>) {
-  return Object.keys(maps).filter((m) => m.endsWith("-app"));
+  return Object.keys(maps).filter(
+    (m) => m.endsWith("-app") || m.endsWith("-widgets")
+  );
 }
 
 /**


### PR DESCRIPTION
At the moment '-widgets' does not get loaded to enable the use of extension for the vital widgets 
[MF-382](https://issues.openmrs.org/projects/MF/issues/MF-382?filter=allissues)﻿
