### PR TITLE
Create activePage element in global app state

### DIFF
--- a/packages/esm-api/src/state.ts
+++ b/packages/esm-api/src/state.ts
@@ -54,12 +54,23 @@ export function getGlobalStore<TState = any>(
   return available.value;
 }
 
-export interface AppState {}
+export interface AppState {
+  /**
+   * The simplified route of the currently active page.
+   * Pages are declared in `setupOpenMRS`, as a `pages` array.
+   *
+   * For example, for route `/^patient\/.+\/chart/` the activePage
+   * will be `patient-chart`.
+   */
+  activePage: string | null;
+}
 
 export function createAppState(initialState: AppState) {
   return createGlobalStore("app", initialState);
 }
 
 export function getAppState() {
-  return getGlobalStore<AppState>("app", {});
+  return getGlobalStore<AppState>("app", {
+    activePage: null,
+  });
 }

--- a/packages/esm-app-shell/src/run.ts
+++ b/packages/esm-app-shell/src/run.ts
@@ -95,6 +95,6 @@ function clearDevOverrides() {
 export function run() {
   registerModules(sharedDependencies);
   setupApiModule();
-  createAppState({});
+  createAppState({ activePage: null });
   return loadApps().then(setupApps).then(runShell).catch(handleInitFailure);
 }


### PR DESCRIPTION
This creates an app state variable `activePage` which changes according to what page is active.

By "page" I mean a page defined in `setupOpenMRS`. I have adjusted the app registration code to only update the `activePage` when the page has been declared using the `pages` array in `setupOpenMRS`. This allows that we can declare things like esm-primary-navigation which should not affect `activePage` by declaring them with the `lifecycle` and `activate` parameters.

What this allows immediately is to declare slots whose name depends on the active page. This allows the extension framework to stay completely declarative while being sensitive to routes.

After [updating the left nav slot](https://github.com/openmrs/openmrs-esm-primary-navigation/pull/44) and doing

```
attach("nav-menu-home", "active-visits-link");
attach("nav-menu-patient-chart", "reports-link");
```

we obtain

![home-ext](https://user-images.githubusercontent.com/1031876/100683667-b188a780-332d-11eb-93e6-9398bdbf9223.png)
![pt-chart-ext](https://user-images.githubusercontent.com/1031876/100683672-b4839800-332d-11eb-9f28-1dc0557e1125.png)
