### PR TITLE
Fixed Extension Config

### DIFF
--- a/packages/esm-app-shell/src/index.ts
+++ b/packages/esm-app-shell/src/index.ts
@@ -1,6 +1,8 @@
 import "./style";
 import type { SpaConfig } from "./types";
 
+declare var __webpack_public_path__: string;
+
 function wireSpaPaths() {
   const baseElement = document.createElement("base");
   baseElement.href = window.getOpenmrsSpaBase();

--- a/packages/esm-config/src/module-config/module-config.test.ts
+++ b/packages/esm-config/src/module-config/module-config.test.ts
@@ -803,10 +803,13 @@ describe("extension slot config", () => {
     });
     const config = await Config.getExtensionSlotConfig("fooSlot", "foo-module");
     expect(config).toStrictEqual({
-      fooSlot: {
-        add: ["bar", "baz"],
-        remove: ["zap"],
-        order: ["qux", "baz", "bar"],
+      add: ["bar", "baz"],
+      remove: ["zap"],
+      order: ["qux", "baz", "bar"],
+      configure: {
+        bar: {
+          a: 0,
+        },
       },
     });
     expect(console.error).not.toHaveBeenCalled();
@@ -840,7 +843,7 @@ describe("extension slot config", () => {
       "fooSlot",
       "foo-module"
     );
-    expect(extConfig).toStrictEqual({ fooSlot: { remove: ["bar"] } });
+    expect(extConfig).toStrictEqual({ remove: ["bar"] });
   });
 
   it("is included in getImplementerToolsConfig", async () => {

--- a/packages/esm-config/src/module-config/module-config.ts
+++ b/packages/esm-config/src/module-config/module-config.ts
@@ -219,17 +219,14 @@ export function clearTemporaryConfig(): void {
 export async function getExtensionSlotConfig(
   slotName: string,
   moduleName: string
-): Promise<Record<string, ExtensionSlotConfigObject>> {
+): Promise<ExtensionSlotConfigObject> {
   await loadConfigs();
   const moduleConfig = mergeConfigsFor(moduleName, getProvidedConfigs());
   const allExtensionSlotConfigs: Record<string, ExtensionSlotConfig> =
     moduleConfig?.extensions ?? {};
-
-  for (const configKey of Object.keys(allExtensionSlotConfigs)) {
-    const config = allExtensionSlotConfigs[configKey];
-    validateExtensionSlotConfig(config, moduleName, slotName);
-  }
-  return processExtensionSlotConfigs(allExtensionSlotConfigs);
+  const config = allExtensionSlotConfigs[slotName] || {};
+  validateExtensionSlotConfig(config, moduleName, slotName);
+  return config;
 }
 
 function validateExtensionSlotConfig(
@@ -287,31 +284,6 @@ function validateExtensionSlotConfig(
       );
     }
   }
-}
-
-function processExtensionSlotConfigs(
-  allExtensionSlotConfigs: Record<string, ExtensionSlotConfig>
-): Record<string, ExtensionSlotConfigObject> {
-  const result: Record<string, ExtensionSlotConfigObject> = {};
-
-  for (const key of Object.keys(allExtensionSlotConfigs)) {
-    const config = allExtensionSlotConfigs[key];
-    result[key] = {};
-
-    if (config.remove) {
-      result[key].remove = config.remove;
-    }
-
-    if (config.order) {
-      result[key].order = config.order;
-    }
-
-    if (config.add) {
-      result[key].add = config.add;
-    }
-  }
-
-  return result;
 }
 
 /*
@@ -715,7 +687,7 @@ export interface ExtensionSlotConfigureValueObject {
   [key: string]: object;
 }
 
-interface ExtensionSlotConfigObject {
+export interface ExtensionSlotConfigObject {
   add?: string[];
   remove?: string[];
   order?: string[];

--- a/packages/esm-react-utils/src/ExtensionSlot.tsx
+++ b/packages/esm-react-utils/src/ExtensionSlot.tsx
@@ -7,6 +7,7 @@ import {
   ExtensionSlotInfo,
   extensionStore,
   ExtensionStore,
+  updateExtensionSlotInfo,
 } from "@openmrs/esm-extensions";
 import { ExtensionContext } from "./ExtensionContext";
 import { ModuleNameContext } from "./ModuleNameContext";
@@ -32,6 +33,7 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
   ...divProps
 }: ExtensionSlotProps) => {
   const slotModuleName = useContext(ModuleNameContext);
+
   if (!slotModuleName) {
     throw Error(
       "ModuleNameContext has not been provided. This should come from openmrs-react-root-decorator"
@@ -57,6 +59,7 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
 
   useEffect(() => {
     registerExtensionSlot(slotModuleName, extensionSlotName);
+    updateExtensionSlotInfo(extensionSlotName);
     return () => unregisterExtensionSlot(slotModuleName, extensionSlotName);
   }, []);
 

--- a/packages/esm-react-utils/src/ExtensionSlot.tsx
+++ b/packages/esm-react-utils/src/ExtensionSlot.tsx
@@ -1,17 +1,11 @@
-import React, { useContext, ReactNode, useEffect, useState } from "react";
+import React, { ReactNode } from "react";
 import {
   getIsUIEditorEnabled,
   getExtensionRegistration,
-  registerExtensionSlot,
-  unregisterExtensionSlot,
-  ExtensionSlotInfo,
-  extensionStore,
-  ExtensionStore,
-  updateExtensionSlotInfo,
 } from "@openmrs/esm-extensions";
 import { ExtensionContext } from "./ExtensionContext";
-import { ModuleNameContext } from "./ModuleNameContext";
 import { Extension } from "./Extension";
+import { useExtensionSlot } from "./useExtensionSlot";
 
 export interface ExtensionSlotBaseProps {
   extensionSlotName: string;
@@ -25,43 +19,18 @@ export interface ExtensionSlotBaseProps {
 export type ExtensionSlotProps<T = {}> = ExtensionSlotBaseProps & T;
 
 export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
-  extensionSlotName,
+  extensionSlotName: actualExtensionSlotName,
   children,
   state,
   style,
   className,
   ...divProps
 }: ExtensionSlotProps) => {
-  const slotModuleName = useContext(ModuleNameContext);
-
-  if (!slotModuleName) {
-    throw Error(
-      "ModuleNameContext has not been provided. This should come from openmrs-react-root-decorator"
-    );
-  }
-
-  const [slotInfo, setSlotInfo] = useState<ExtensionSlotInfo | undefined>(
-    undefined
-  );
-
-  const extensionIdsToRender = slotInfo?.assignedIds ?? [];
-
-  useEffect(() => {
-    const update = (state: ExtensionStore) => {
-      const matchingSlotInfo = Object.values(state.slots).find((slotDef) =>
-        slotDef.matches(extensionSlotName)
-      );
-      setSlotInfo(matchingSlotInfo);
-    };
-    update(extensionStore.getState());
-    return extensionStore.subscribe((state) => update(state));
-  }, []);
-
-  useEffect(() => {
-    registerExtensionSlot(slotModuleName, extensionSlotName);
-    updateExtensionSlotInfo(extensionSlotName);
-    return () => unregisterExtensionSlot(slotModuleName, extensionSlotName);
-  }, []);
+  const {
+    attachedExtensionSlotName,
+    extensionIdsToRender,
+    extensionSlotModuleName,
+  } = useExtensionSlot(actualExtensionSlotName);
 
   const divStyle = getIsUIEditorEnabled()
     ? { ...style, backgroundColor: "cyan" }
@@ -71,15 +40,16 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
     <div style={divStyle} {...divProps}>
       {extensionIdsToRender.map((extensionId) => {
         const extensionRegistration = getExtensionRegistration(extensionId);
+
         return (
-          slotInfo &&
+          attachedExtensionSlotName &&
           extensionRegistration && (
             <ExtensionContext.Provider
               key={extensionId}
               value={{
-                actualExtensionSlotName: extensionSlotName,
-                attachedExtensionSlotName: slotInfo.name,
-                extensionSlotModuleName: slotModuleName,
+                actualExtensionSlotName,
+                attachedExtensionSlotName,
+                extensionSlotModuleName,
                 extensionId,
                 extensionModuleName: extensionRegistration.moduleName,
               }}

--- a/packages/esm-react-utils/src/useConfig.test.tsx
+++ b/packages/esm-react-utils/src/useConfig.test.tsx
@@ -11,6 +11,12 @@ import { ModuleNameContext } from "./ModuleNameContext";
 import { useConfig } from "./useConfig";
 import { ExtensionContext } from "./ExtensionContext";
 
+function RenderConfig(props) {
+  const config = useConfig();
+
+  return <button>{config[props.configKey]}</button>;
+}
+
 describe(`useConfig in root context`, () => {
   afterEach(clearAll);
   afterEach(cleanup);
@@ -31,7 +37,7 @@ describe(`useConfig in root context`, () => {
       </React.Suspense>
     );
 
-    expect(screen.findByText("The first thing")).toBeTruthy();
+    expect(await screen.findByText("The first thing")).toBeTruthy();
   });
 
   it(`can handle multiple calls to useConfig from different modules`, async () => {
@@ -57,7 +63,7 @@ describe(`useConfig in root context`, () => {
 
     expect(await screen.findByText("foo thing")).toBeTruthy();
 
-    cleanup();
+    await cleanup();
 
     render(
       <React.Suspense fallback={<div>Suspense!</div>}>
@@ -67,7 +73,7 @@ describe(`useConfig in root context`, () => {
       </React.Suspense>
     );
 
-    expect(screen.findByText("bar thing")).toBeTruthy();
+    expect(await screen.findByText("bar thing")).toBeTruthy();
   });
 
   it("updates with a new value when the temporary config is updated", async () => {
@@ -85,11 +91,11 @@ describe(`useConfig in root context`, () => {
       </React.Suspense>
     );
 
-    expect(screen.findByText("The first thing")).toBeTruthy();
+    expect(await screen.findByText("The first thing")).toBeTruthy();
 
     setTemporaryConfigValue(["foo-module", "thing"], "A new thing");
 
-    expect(screen.findByText("A new thing")).toBeTruthy();
+    expect(await screen.findByText("A new thing")).toBeTruthy();
   });
 });
 
@@ -121,7 +127,7 @@ describe(`useConfig in an extension`, () => {
       </React.Suspense>
     );
 
-    expect(screen.findByText("The basics")).toBeTruthy();
+    expect(await screen.findByText("The basics")).toBeTruthy();
   });
 
   it(`can handle multiple extensions`, async () => {
@@ -165,7 +171,7 @@ describe(`useConfig in an extension`, () => {
     );
 
     expect(await screen.findByText("first thing")).toBeTruthy();
-    expect(screen.findByText("second thing")).toBeTruthy();
+    expect(await screen.findByText("second thing")).toBeTruthy();
   });
 
   it("can handle multiple extension slots", async () => {
@@ -215,7 +221,7 @@ describe(`useConfig in an extension`, () => {
     );
 
     expect(await screen.findByText("old extension thing")).toBeTruthy();
-    expect(screen.findByText("a different thing")).toBeTruthy();
+    expect(await screen.findByText("a different thing")).toBeTruthy();
   });
 
   it("updates with a new value when the temporary config is updated", async () => {
@@ -262,9 +268,3 @@ describe(`useConfig in an extension`, () => {
     expect(await screen.findByText("Yet another thing")).toBeTruthy();
   });
 });
-
-function RenderConfig(props) {
-  const config = useConfig();
-
-  return <button>{config[props.configKey]}</button>;
-}

--- a/packages/esm-react-utils/src/useExtensionSlot.ts
+++ b/packages/esm-react-utils/src/useExtensionSlot.ts
@@ -1,0 +1,56 @@
+import { useContext, useEffect, useState } from "react";
+import {
+  registerExtensionSlot,
+  unregisterExtensionSlot,
+  ExtensionSlotInfo,
+  extensionStore,
+  ExtensionStore,
+  updateExtensionSlotInfo,
+} from "@openmrs/esm-extensions";
+import { ModuleNameContext } from "./ModuleNameContext";
+
+export function useExtensionSlot(actualExtensionSlotName: string) {
+  const extensionSlotModuleName = useContext(ModuleNameContext);
+
+  if (!extensionSlotModuleName) {
+    throw Error(
+      "ModuleNameContext has not been provided. This should come from openmrs-react-root-decorator"
+    );
+  }
+
+  const [
+    [attachedExtensionSlotName, extensionIdsToRender],
+    setState,
+  ] = useState<[string | undefined, Array<string>]>([undefined, []]);
+
+  useEffect(() => {
+    registerExtensionSlot(extensionSlotModuleName, actualExtensionSlotName);
+    updateExtensionSlotInfo(actualExtensionSlotName);
+    return () =>
+      unregisterExtensionSlot(extensionSlotModuleName, actualExtensionSlotName);
+  }, []);
+
+  useEffect(() => {
+    const update = (state: ExtensionStore) => {
+      const slotInfo = Object.values(state.slots).find((slotDef) =>
+        slotDef.matches(actualExtensionSlotName)
+      );
+
+      if (
+        slotInfo &&
+        (attachedExtensionSlotName !== slotInfo.name ||
+          extensionIdsToRender !== slotInfo.assignedIds)
+      ) {
+        setState([slotInfo.name, slotInfo.assignedIds]);
+      }
+    };
+    update(extensionStore.getState());
+    return extensionStore.subscribe((state) => update(state));
+  }, [attachedExtensionSlotName, extensionIdsToRender]);
+
+  return {
+    extensionSlotModuleName,
+    attachedExtensionSlotName,
+    extensionIdsToRender,
+  };
+}


### PR DESCRIPTION
There is something larger that I have been working on locally, but I first want to get the config reestablished.

After all, this introduces the `useExtensionSlot` hook and tries to avoid rerenders quite a bit. It seems to work fine so far, but I don't know how dynamically we change (or expected changes) to a configuration. Presumably, it would be good to have the config also in a state container to allow listening to changes. Then config changes can reactively trigger extension slot updates. But I first wanted to hear an opinion on this one / plus get feedback if this is working at all as you expect.