### PR TITLE
Make the UI Editor work through portals

### DIFF
--- a/packages/esm-extensions/src/extensions.ts
+++ b/packages/esm-extensions/src/extensions.ts
@@ -15,6 +15,7 @@ function createNewExtensionSlotInstance(): ExtensionSlotInstance {
     idOrder: [],
     removedIds: [],
     registered: 1,
+    domElement: null,
   };
 }
 
@@ -48,6 +49,7 @@ export const registerExtension: (
       name,
       load,
       moduleName,
+      instances: {},
     };
   }
 );
@@ -204,10 +206,12 @@ function getUpdatedExtensionSlotInfoForUnregistration(
  *
  * @param moduleName The name of the module that contains the extension slot
  * @param actualExtensionSlotName The extension slot name that is actually used
+ * @param domElement The HTML element of the extension slot
  */
 export function registerExtensionSlot(
   moduleName: string,
-  actualExtensionSlotName: string
+  actualExtensionSlotName: string,
+  domElement: HTMLElement
 ) {
   updateExtensionStore(async (state) => {
     const slotName =
@@ -224,7 +228,16 @@ export function registerExtensionSlot(
       ...state,
       slots: {
         ...state.slots,
-        [slotName]: updatedSlot,
+        [slotName]: {
+          ...updatedSlot,
+          instances: {
+            ...updatedSlot.instances,
+            [moduleName]: {
+              ...updatedSlot.instances[moduleName],
+              domElement,
+            },
+          },
+        },
       },
     };
   });
@@ -266,20 +279,6 @@ export function getExtensionSlotsForModule(moduleName: string) {
   return Object.keys(state.slots).filter(
     (name) => moduleName in state.slots[name].instances
   );
-}
-
-const uiEditorSettingKey = "openmrs:isUIEditorEnabled";
-
-export function getIsUIEditorEnabled(): boolean {
-  try {
-    return JSON.parse(localStorage.getItem(uiEditorSettingKey) ?? "false");
-  } catch {
-    return false;
-  }
-}
-
-export function setIsUIEditorEnabled(enabled: boolean) {
-  localStorage.setItem(uiEditorSettingKey, JSON.stringify(enabled));
 }
 
 /**

--- a/packages/esm-extensions/src/render.ts
+++ b/packages/esm-extensions/src/render.ts
@@ -1,6 +1,8 @@
 import { mountRootParcel } from "single-spa";
+import { cloneDeep, set } from "lodash-es";
 import { getExtensionRegistration } from "./extensions";
 import { getActualRouteProps } from "./route";
+import { updateExtensionStore } from "./store";
 
 export interface Lifecycle {
   bootstrap(): void;
@@ -56,6 +58,21 @@ export function renderExtension(
             ...routeProps,
             domElement,
           })
+      );
+
+      updateExtensionStore((state) =>
+        set(
+          cloneDeep(state),
+          [
+            "extensions",
+            extensionName,
+            "instances",
+            extensionSlotModuleName,
+            actualExtensionSlotName,
+            "domElement",
+          ],
+          domElement
+        )
       );
     } else {
       throw Error(

--- a/packages/esm-extensions/src/store.ts
+++ b/packages/esm-extensions/src/store.ts
@@ -9,9 +9,21 @@ export interface ExtensionRegistration extends ExtensionDefinition {
   moduleName: string;
 }
 
+export interface ExtensionInfo extends ExtensionRegistration {
+  /**
+   * The instances where the extension has been rendered using `renderExtension`,
+   * indexed by slotModuleName and actualExtensionSlotName
+   */
+  instances: Record<string, Record<string, ExtensionInstance>>;
+}
+
+export interface ExtensionInstance {
+  domElement: HTMLElement;
+}
+
 export interface ExtensionStore {
   slots: Record<string, ExtensionSlotInfo>;
-  extensions: Record<string, ExtensionRegistration>;
+  extensions: Record<string, ExtensionInfo>;
 }
 
 export interface ExtensionSlotInstance {
@@ -39,6 +51,10 @@ export interface ExtensionSlotInstance {
    * The number of active registrations on the instance.
    */
   registered: number;
+  /**
+   * The dom element at which the slot is mounted
+   */
+  domElement: HTMLElement | null;
 }
 
 export interface ExtensionSlotInfo {

--- a/packages/esm-implementer-tools-app/__mocks__/openmrs-esm-api.mock.tsx
+++ b/packages/esm-implementer-tools-app/__mocks__/openmrs-esm-api.mock.tsx
@@ -1,59 +1,28 @@
-import createStore, { Store } from "unistore";
-
 export function openmrsFetch() {
   return new Promise(() => {});
 }
 
-interface StoreEntity {
-  value: Store<any>;
-  active: boolean;
+let state;
+
+function makeStore(state) {
+  return {
+    getState: () => state,
+    setState: (val) => {
+      state = { ...state, ...val };
+    },
+    subscribe: (updateFcn) => {
+      updateFcn(state);
+      return () => {};
+    },
+    unsubscribe: () => {},
+  };
 }
 
-const availableStores: Record<string, StoreEntity> = {};
+export const createGlobalStore = jest.fn().mockImplementation((n, value) => {
+  state = value;
+  return makeStore(state);
+});
 
-export function createGlobalStore<TState>(
-  name: string,
-  initialState: TState
-): Store<TState> {
-  const available = availableStores[name];
-
-  if (available) {
-    if (available.active) {
-      console.error(
-        "Cannot override an existing store. Make sure that stores are only created once."
-      );
-    } else {
-      available.value.setState(initialState, true);
-    }
-
-    available.active = true;
-    return available.value;
-  } else {
-    const store = createStore(initialState);
-
-    availableStores[name] = {
-      value: store,
-      active: true,
-    };
-
-    return store;
-  }
-}
-
-export function getGlobalStore<TState = any>(
-  name: string,
-  fallbackState?: TState
-): Store<TState> {
-  const available = availableStores[name];
-
-  if (!available) {
-    const store = createStore(fallbackState);
-    availableStores[name] = {
-      value: store,
-      active: false,
-    };
-    return store;
-  }
-
-  return available.value;
-}
+export const getGlobalStore = jest
+  .fn()
+  .mockImplementation(() => makeStore(state));

--- a/packages/esm-implementer-tools-app/__mocks__/openmrs-esm-extensions.mock.tsx
+++ b/packages/esm-implementer-tools-app/__mocks__/openmrs-esm-extensions.mock.tsx
@@ -1,5 +1,3 @@
-export const getIsUIEditorEnabled = (): boolean => true;
-
 export const setIsUIEditorEnabled = (boolean): void => {};
 
 let state = { slots: {}, extensions: {} };

--- a/packages/esm-implementer-tools-app/__mocks__/openmrs-esm-react-utils.mock.tsx
+++ b/packages/esm-implementer-tools-app/__mocks__/openmrs-esm-react-utils.mock.tsx
@@ -1,3 +1,5 @@
+import { merge } from "lodash-es";
+import { Store } from "unistore";
 import React from "react";
 
 export const ExtensionContext = React.createContext({
@@ -15,3 +17,12 @@ export const openmrsRootDecorator = jest
 export const UserHasAccess = jest.fn().mockImplementation((props: any) => {
   return props.children;
 });
+
+export const createUseStore = (store: Store<any>) => (reducer, actions) => {
+  const state = store.getState();
+  return merge(
+    actions,
+    typeof reducer === "string" ? { [reducer]: state[reducer] } : {},
+    ...(Array.isArray(reducer) ? reducer.map((r) => ({ [r]: state[r] })) : [{}])
+  );
+};

--- a/packages/esm-implementer-tools-app/__mocks__/openmrs-esm-react-utils.mock.tsx
+++ b/packages/esm-implementer-tools-app/__mocks__/openmrs-esm-react-utils.mock.tsx
@@ -1,6 +1,6 @@
-import { merge } from "lodash-es";
 import { Store } from "unistore";
 import React from "react";
+import { extensionStore } from "@openmrs/esm-extensions";
 
 export const ExtensionContext = React.createContext({
   extensionSlotName: "",
@@ -18,11 +18,12 @@ export const UserHasAccess = jest.fn().mockImplementation((props: any) => {
   return props.children;
 });
 
-export const createUseStore = (store: Store<any>) => (reducer, actions) => {
+export const createUseStore = (store: Store<any>) => (actions) => {
   const state = store.getState();
-  return merge(
-    actions,
-    typeof reducer === "string" ? { [reducer]: state[reducer] } : {},
-    ...(Array.isArray(reducer) ? reducer.map((r) => ({ [r]: state[r] })) : [{}])
-  );
+  return { ...state, ...actions };
+};
+
+export const useExtensionStore = (actions) => {
+  const state = extensionStore.getState();
+  return { ...state, ...actions };
 };

--- a/packages/esm-implementer-tools-app/jest.config.js
+++ b/packages/esm-implementer-tools-app/jest.config.js
@@ -10,11 +10,11 @@ module.exports = {
     "\\.(css)$": "identity-obj-proxy",
     "@openmrs/esm-api": "<rootDir>/__mocks__/openmrs-esm-api.mock.tsx",
     "@openmrs/esm-config": "<rootDir>/__mocks__/openmrs-esm-config.mock.tsx",
-    "@openmrs/esm-react-utils":
-      "<rootDir>/__mocks__/openmrs-esm-react-utils.mock.tsx",
     "@openmrs/esm-extensions":
       "<rootDir>/__mocks__/openmrs-esm-extensions.mock.tsx",
     "@openmrs/esm-styleguide":
       "<rootDir>/__mocks__/openmrs-esm-styleguide.mock.tsx",
+    "@openmrs/esm-react-utils":
+      "<rootDir>/__mocks__/openmrs-esm-react-utils.mock.tsx",
   },
 };

--- a/packages/esm-implementer-tools-app/package.json
+++ b/packages/esm-implementer-tools-app/package.json
@@ -13,7 +13,8 @@
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
     "typescript": "tsc",
-    "lint": "eslint src --ext ts,tsx"
+    "lint": "eslint src --ext ts,tsx",
+    "format": "prettier --write src/**"
   },
   "keywords": [
     "openmrs",

--- a/packages/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
+++ b/packages/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
@@ -1,6 +1,6 @@
 import { openmrsFetch } from "@openmrs/esm-api";
 import * as semver from "semver";
-import { difference } from "lodash-es";
+import difference from "lodash-es/difference";
 
 const installedBackendModules: Array<Record<string, string>> = [];
 const modulesWithMissingBackendModules: MissingBackendModules[] = [];

--- a/packages/esm-implementer-tools-app/src/configuration/configuration.component.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/configuration.component.tsx
@@ -24,10 +24,7 @@ const actions = {
 };
 
 export function Configuration({ setHasAlert }: ConfigurationProps) {
-  const { isUIEditorEnabled, toggleIsUIEditorEnabled } = useStore(
-    ["isUIEditorEnabled"],
-    actions
-  );
+  const { isUIEditorEnabled, toggleIsUIEditorEnabled } = useStore(actions);
   const [config, setConfig] = useState({});
   const [isDevConfigActive, setIsDevConfigActive] = useState(
     getAreDevDefaultsOn()
@@ -50,7 +47,6 @@ export function Configuration({ setHasAlert }: ConfigurationProps) {
   useEffect(updateConfig, []);
 
   return (
-<<<<<<< HEAD
     <>
       <div className={styles.tools}>
         <Grid style={{ margin: "0.25rem", padding: 0 }}>
@@ -70,11 +66,8 @@ export function Configuration({ setHasAlert }: ConfigurationProps) {
               <Toggle
                 id={"uiEditorSwitch"}
                 labelText="UI Editor"
-                toggled={isUIEditorActive}
-                onToggle={() => {
-                  setIsUIEditorActive(!isUIEditorActive);
-                  setIsUIEditorEnabled(!isUIEditorActive);
-                }}
+                toggled={isUIEditorEnabled}
+                onToggle={toggleIsUIEditorEnabled}
               />
             </Column>
             <Column sm={1} md={2} className={styles.actionButton}>
@@ -117,53 +110,5 @@ export function Configuration({ setHasAlert }: ConfigurationProps) {
         </div>
       </div>
     </>
-=======
-<>
-<div className={styles.tools}>
-            <Toggle
-              id="devConfigSwitch"
-              labelText="Dev Config"
-              onToggle={() => {
-                setAreDevDefaultsOn(!isDevConfigActive);
-                setIsDevConfigActive(!isDevConfigActive);
-              }}
-              toggled={isDevConfigActive}
-            />
-            <Toggle
-              id={"uiEditorSwitch"}
-              labelText="UI Editor"
-              toggled={isUIEditorEnabled}
-              onToggle={toggleIsUIEditorEnabled}
-            />
-            <Button
-              small
-              kind="secondary"
-              onClick={() => {
-                clearTemporaryConfig();
-                updateConfig();
-              }}
-            >
-              Clear Temporary Config
-            </Button>
-            <Button small kind="secondary" renderIcon={Download16}>
-              <a
-                className={styles.downloadLink}
-                download="temporary_config.json"
-                href={window.URL.createObjectURL(tempConfigObjUrl)}
-              >
-                Download Temporary Config
-              </a>
-            </Button>
-            </div>
-      <div className={styles.mainContent}>
-        <div className={styles.configTreePane}>
-          <ConfigTree config={config} />
-        </div>
-        <div className={styles.descriptionPane}>
-          <Description />
-        </div>
-      </div>
-    </>
->>>>>>> c4338a5... Make the UI Editor work via portals
   );
 }

--- a/packages/esm-implementer-tools-app/src/configuration/configuration.component.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/configuration.component.tsx
@@ -10,20 +10,29 @@ import { Button, Column, Grid, Row, Toggle } from "carbon-components-react";
 import { Download16, TrashCan16 } from "@carbon/icons-react";
 import styles from "./configuration.styles.css";
 import { ConfigTree } from "./config-tree.component";
-import {
-  getIsUIEditorEnabled,
-  setIsUIEditorEnabled,
-} from "@openmrs/esm-extensions";
+import { getStore, ImplementerToolsStore, useStore } from "../store";
 import { Description } from "./description.component";
 
-export default function Configuration(props: ConfigurationProps) {
+export type ConfigurationProps = {
+  setHasAlert(value: boolean): void;
+};
+
+const actions = {
+  toggleIsUIEditorEnabled({ isUIEditorEnabled }: ImplementerToolsStore) {
+    return { isUIEditorEnabled: !isUIEditorEnabled };
+  },
+};
+
+export function Configuration({ setHasAlert }: ConfigurationProps) {
+  const { isUIEditorEnabled, toggleIsUIEditorEnabled } = useStore(
+    ["isUIEditorEnabled"],
+    actions
+  );
   const [config, setConfig] = useState({});
   const [isDevConfigActive, setIsDevConfigActive] = useState(
     getAreDevDefaultsOn()
   );
-  const [isUIEditorActive, setIsUIEditorActive] = useState(
-    getIsUIEditorEnabled()
-  );
+  const store = getStore();
   const tempConfig = getTemporaryConfig();
   const tempConfigObjUrl = new Blob(
     [JSON.stringify(tempConfig, undefined, 2)],
@@ -41,6 +50,7 @@ export default function Configuration(props: ConfigurationProps) {
   useEffect(updateConfig, []);
 
   return (
+<<<<<<< HEAD
     <>
       <div className={styles.tools}>
         <Grid style={{ margin: "0.25rem", padding: 0 }}>
@@ -107,9 +117,53 @@ export default function Configuration(props: ConfigurationProps) {
         </div>
       </div>
     </>
+=======
+<>
+<div className={styles.tools}>
+            <Toggle
+              id="devConfigSwitch"
+              labelText="Dev Config"
+              onToggle={() => {
+                setAreDevDefaultsOn(!isDevConfigActive);
+                setIsDevConfigActive(!isDevConfigActive);
+              }}
+              toggled={isDevConfigActive}
+            />
+            <Toggle
+              id={"uiEditorSwitch"}
+              labelText="UI Editor"
+              toggled={isUIEditorEnabled}
+              onToggle={toggleIsUIEditorEnabled}
+            />
+            <Button
+              small
+              kind="secondary"
+              onClick={() => {
+                clearTemporaryConfig();
+                updateConfig();
+              }}
+            >
+              Clear Temporary Config
+            </Button>
+            <Button small kind="secondary" renderIcon={Download16}>
+              <a
+                className={styles.downloadLink}
+                download="temporary_config.json"
+                href={window.URL.createObjectURL(tempConfigObjUrl)}
+              >
+                Download Temporary Config
+              </a>
+            </Button>
+            </div>
+      <div className={styles.mainContent}>
+        <div className={styles.configTreePane}>
+          <ConfigTree config={config} />
+        </div>
+        <div className={styles.descriptionPane}>
+          <Description />
+        </div>
+      </div>
+    </>
+>>>>>>> c4338a5... Make the UI Editor work via portals
   );
 }
-
-type ConfigurationProps = {
-  setHasAlert(value: boolean): void;
-};

--- a/packages/esm-implementer-tools-app/src/configuration/configuration.test.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/configuration.test.tsx
@@ -13,8 +13,7 @@ import {
   setTemporaryConfigValue,
   Type,
 } from "@openmrs/esm-config";
-import { Provider } from "unistore/react";
-import Configuration from "./configuration.component";
+import { Configuration } from "./configuration.component";
 import { getStore } from "../store";
 import {
   performConceptSearch,
@@ -109,11 +108,7 @@ describe(`<Configuration />`, () => {
   });
 
   function renderConfiguration() {
-    render(
-      <Provider store={getStore()}>
-        <Configuration setHasAlert={() => {}} />
-      </Provider>
-    );
+    render(<Configuration setHasAlert={() => {}} />);
   }
 
   it(`renders without dying`, async () => {

--- a/packages/esm-implementer-tools-app/src/configuration/description.component.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/description.component.tsx
@@ -1,37 +1,36 @@
 import React from "react";
-import { connect } from "unistore/react";
+import { useStore } from "../store";
 import styles from "./description.styles.css";
 
-export const Description = connect("activeItemDescription")(
-  ({ activeItemDescription }) => {
-    return (
-      <div>
-        {activeItemDescription ? (
-          <>
-            <p className={styles.path}>
-              {activeItemDescription.path.slice(1).join(" → ")}
-            </p>
-            <p className={styles.description}>
-              {activeItemDescription.description}
-            </p>
-            <p className={styles.source}>
-              {activeItemDescription.source === "default" ? (
-                <>The current value is the default.</>
-              ) : activeItemDescription.source ? (
-                <>
-                  The current value comes from {activeItemDescription.source}.
-                </>
-              ) : null}
-            </p>
-            {activeItemDescription.value ? <p>Value:</p> : null}
-            <p className={styles.value}>
-              {Array.isArray(activeItemDescription.value)
-                ? activeItemDescription.value.map((v) => <p key={v}>{v}</p>)
-                : activeItemDescription.value}
-            </p>
-          </>
-        ) : null}
-      </div>
-    );
-  }
-);
+export function Description() {
+  const { activeItemDescription } = useStore("activeItemDescription");
+  return (
+    <div>
+    {activeItemDescription ? (
+      <>
+        <p className={styles.path}>
+          {activeItemDescription.path.slice(1).join(" → ")}
+        </p>
+        <p className={styles.description}>
+          {activeItemDescription.description}
+        </p>
+        <p className={styles.source}>
+          {activeItemDescription.source === "default" ? (
+            <>The current value is the default.</>
+          ) : activeItemDescription.source ? (
+            <>
+              The current value comes from {activeItemDescription.source}.
+            </>
+          ) : null}
+        </p>
+        {activeItemDescription.value ? <p>Value:</p> : null}
+        <p className={styles.value}>
+          {Array.isArray(activeItemDescription.value)
+            ? activeItemDescription.value.map((v) => <p key={v}>{v}</p>)
+            : activeItemDescription.value}
+        </p>
+      </>
+    ) : null}
+  </div>
+  );
+}

--- a/packages/esm-implementer-tools-app/src/configuration/description.component.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/description.component.tsx
@@ -3,34 +3,32 @@ import { useStore } from "../store";
 import styles from "./description.styles.css";
 
 export function Description() {
-  const { activeItemDescription } = useStore("activeItemDescription");
+  const { activeItemDescription } = useStore();
   return (
     <div>
-    {activeItemDescription ? (
-      <>
-        <p className={styles.path}>
-          {activeItemDescription.path.slice(1).join(" → ")}
-        </p>
-        <p className={styles.description}>
-          {activeItemDescription.description}
-        </p>
-        <p className={styles.source}>
-          {activeItemDescription.source === "default" ? (
-            <>The current value is the default.</>
-          ) : activeItemDescription.source ? (
-            <>
-              The current value comes from {activeItemDescription.source}.
-            </>
-          ) : null}
-        </p>
-        {activeItemDescription.value ? <p>Value:</p> : null}
-        <p className={styles.value}>
-          {Array.isArray(activeItemDescription.value)
-            ? activeItemDescription.value.map((v) => <p key={v}>{v}</p>)
-            : activeItemDescription.value}
-        </p>
-      </>
-    ) : null}
-  </div>
+      {activeItemDescription ? (
+        <>
+          <p className={styles.path}>
+            {activeItemDescription.path.slice(1).join(" → ")}
+          </p>
+          <p className={styles.description}>
+            {activeItemDescription.description}
+          </p>
+          <p className={styles.source}>
+            {activeItemDescription.source === "default" ? (
+              <>The current value is the default.</>
+            ) : activeItemDescription.source ? (
+              <>The current value comes from {activeItemDescription.source}.</>
+            ) : null}
+          </p>
+          {activeItemDescription.value ? <p>Value:</p> : null}
+          <p className={styles.value}>
+            {Array.isArray(activeItemDescription.value)
+              ? activeItemDescription.value.map((v) => <p key={v}>{v}</p>)
+              : activeItemDescription.value}
+          </p>
+        </>
+      ) : null}
+    </div>
   );
 }

--- a/packages/esm-implementer-tools-app/src/configuration/extension-slots-config-tree.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/extension-slots-config-tree.tsx
@@ -5,29 +5,23 @@ import {
   extensionStore,
   ExtensionStore,
 } from "@openmrs/esm-extensions";
+import { useExtensionStore } from "@openmrs/esm-react-utils";
 import { Provider, connect } from "unistore/react";
 import EditableValue from "./editable-value.component";
-import { getGlobalStore } from "@openmrs/esm-api";
 import { getStore } from "../store";
 import { isEqual } from "lodash-es";
 import { ExtensionConfigureTree } from "./extension-configure-tree";
 import { Subtree } from "./layout/subtree.component";
 
-interface ExtensionsSlotsConfigTreeProps {
+interface ExtensionSlotsConfigTreeProps {
   config: { [key: string]: any };
   moduleName: string;
-}
-
-interface ExtensionSlotsConfigTreeImplProps
-  extends ExtensionsSlotsConfigTreeProps {
   slots: Record<string, ExtensionSlotInfo>;
 }
 
-const ExtensionSlotsConfigTreeImpl = connect(
-  (state: ExtensionStore, _: ExtensionsSlotsConfigTreeProps) => ({
-    slots: state.slots,
-  })
-)(({ config, moduleName, slots }: ExtensionSlotsConfigTreeImplProps) => {
+export function ExtensionSlotsConfigTree({ config, moduleName }: ExtensionSlotsConfigTreeProps) { 
+  const slots = useExtensionStore("slots");
+
   const extensionSlotNames = useMemo(
     () =>
       Object.keys(slots).filter((name) => moduleName in slots[name].instances),
@@ -44,15 +38,7 @@ const ExtensionSlotsConfigTreeImpl = connect(
       ))}
     </Subtree>
   ) : null;
-});
-
-export function ExtensionSlotsConfigTree(props) {
-  return (
-    <Provider store={extensionStore}>
-      <ExtensionSlotsConfigTreeImpl {...props} />
-    </Provider>
-  );
-}
+};
 
 interface ExtensionSlotConfigProps {
   config: ExtensionSlotConfig;

--- a/packages/esm-implementer-tools-app/src/configuration/extension-slots-config-tree.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/extension-slots-config-tree.tsx
@@ -1,26 +1,23 @@
 import React, { useEffect, useMemo, useState } from "react";
 import { ExtensionSlotConfig } from "@openmrs/esm-config";
-import {
-  ExtensionSlotInfo,
-  extensionStore,
-  ExtensionStore,
-} from "@openmrs/esm-extensions";
+import { extensionStore } from "@openmrs/esm-extensions";
 import { useExtensionStore } from "@openmrs/esm-react-utils";
-import { Provider, connect } from "unistore/react";
 import EditableValue from "./editable-value.component";
 import { getStore } from "../store";
-import { isEqual } from "lodash-es";
+import isEqual from "lodash-es/isEqual";
 import { ExtensionConfigureTree } from "./extension-configure-tree";
 import { Subtree } from "./layout/subtree.component";
 
 interface ExtensionSlotsConfigTreeProps {
   config: { [key: string]: any };
   moduleName: string;
-  slots: Record<string, ExtensionSlotInfo>;
 }
 
-export function ExtensionSlotsConfigTree({ config, moduleName }: ExtensionSlotsConfigTreeProps) { 
-  const slots = useExtensionStore("slots");
+export function ExtensionSlotsConfigTree({
+  config,
+  moduleName,
+}: ExtensionSlotsConfigTreeProps) {
+  const { slots } = useExtensionStore();
 
   const extensionSlotNames = useMemo(
     () =>
@@ -38,7 +35,7 @@ export function ExtensionSlotsConfigTree({ config, moduleName }: ExtensionSlotsC
       ))}
     </Subtree>
   ) : null;
-};
+}
 
 interface ExtensionSlotConfigProps {
   config: ExtensionSlotConfig;

--- a/packages/esm-implementer-tools-app/src/configuration/value-editors/object-editor.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/value-editors/object-editor.tsx
@@ -1,17 +1,15 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import {
-  Button,
   StructuredListBody,
   StructuredListCell,
   StructuredListRow,
   StructuredListWrapper,
   Tile,
 } from "carbon-components-react";
-import { Add16, TrashCan16 } from "@carbon/icons-react";
 import { ValueEditorField } from "./value-editor-field";
 import { ConfigValueDescriptor } from "../editable-value.component";
 import { Type } from "@openmrs/esm-config";
-import { cloneDeep } from "lodash-es";
+import cloneDeep from "lodash-es/cloneDeep";
 import styles from "./object-editor.styles.css";
 
 interface ObjectEditorProps {

--- a/packages/esm-implementer-tools-app/src/implementer-tools.component.tsx
+++ b/packages/esm-implementer-tools-app/src/implementer-tools.component.tsx
@@ -1,15 +1,16 @@
-import React, { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect } from "react";
+import { Provider } from "unistore/react";
 import { UserHasAccess } from "@openmrs/esm-react-utils";
-import { connect, Provider } from "unistore/react";
 import Popup from "./popup/popup.component";
 import styles from "./implementer-tools.styles.css";
-import { getStore } from "./store";
 import { showToast } from "@openmrs/esm-styleguide";
 import {
   checkModules,
   MissingBackendModules,
 } from "./backend-dependencies/openmrs-backend-dependencies";
 import { NotificationActionButton } from "carbon-components-react/lib/components/Notification";
+import { getStore, useStore } from "./store";
+import { UiEditor } from "./ui-editor/ui-editor";
 
 export default function ImplementerTools() {
   const store = getStore();
@@ -23,7 +24,7 @@ export default function ImplementerTools() {
   );
 }
 
-const PopupHandler = connect("isOpen")(({ isOpen }) => {
+function PopupHandler() {
   const [hasAlert, setHasAlert] = useState(false);
   const [visibleTabIndex, setVisibleTabIndex] = useState(0);
   const [
@@ -34,6 +35,10 @@ const PopupHandler = connect("isOpen")(({ isOpen }) => {
     modulesWithWrongBackendModulesVersion,
     setModulesWithWrongBackendModulesVersion,
   ] = useState<Array<MissingBackendModules>>([]);
+  const { isOpen, isUIEditorEnabled } = useStore([
+    "isOpen",
+    "isUIEditorEnabled",
+  ]);
 
   function togglePopup() {
     getStore().setState({ isOpen: !isOpen });
@@ -102,6 +107,7 @@ const PopupHandler = connect("isOpen")(({ isOpen }) => {
           visibleTabIndex={visibleTabIndex}
         />
       ) : null}
+      {isUIEditorEnabled ? <UiEditor /> : null}
     </>
   );
-});
+}

--- a/packages/esm-implementer-tools-app/src/implementer-tools.component.tsx
+++ b/packages/esm-implementer-tools-app/src/implementer-tools.component.tsx
@@ -35,10 +35,7 @@ function PopupHandler() {
     modulesWithWrongBackendModulesVersion,
     setModulesWithWrongBackendModulesVersion,
   ] = useState<Array<MissingBackendModules>>([]);
-  const { isOpen, isUIEditorEnabled } = useStore([
-    "isOpen",
-    "isUIEditorEnabled",
-  ]);
+  const { isOpen, isUIEditorEnabled } = useStore();
 
   function togglePopup() {
     getStore().setState({ isOpen: !isOpen });

--- a/packages/esm-implementer-tools-app/src/popup/popup.component.tsx
+++ b/packages/esm-implementer-tools-app/src/popup/popup.component.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from "react";
 import { Button, ContentSwitcher, Switch } from "carbon-components-react";
 import { Close16 } from "@carbon/icons-react";
 import styles from "./popup.styles.css";
-import Configuration from "../configuration/configuration.component";
+import { Configuration } from "../configuration/configuration.component";
 import { ModuleDiagnostics } from "../backend-dependencies/backend-dependecies.component";
 import { MissingBackendModules } from "../backend-dependencies/openmrs-backend-dependencies";
 

--- a/packages/esm-implementer-tools-app/src/store.ts
+++ b/packages/esm-implementer-tools-app/src/store.ts
@@ -1,9 +1,12 @@
 import { createGlobalStore, getGlobalStore } from "@openmrs/esm-api";
+import { createUseStore } from "@openmrs/esm-react-utils";
+import { Store } from "unistore";
 
 export interface ImplementerToolsStore {
   activeItemDescription?: ActiveItemDescription;
   configPathBeingEdited: null | string[];
   isOpen: boolean;
+  isUIEditorEnabled: boolean;
 }
 
 export interface ActiveItemDescription {
@@ -13,29 +16,56 @@ export interface ActiveItemDescription {
   source?: string;
 }
 
-createGlobalStore("implementer-tools", {
-  activeItemDescription: null,
-  configPathBeingEdited: null,
-  isOpen: getIsImplementerToolsOpen(),
-});
+const store: Store<ImplementerToolsStore> = createGlobalStore(
+  "implementer-tools",
+  {
+    activeItemDescription: undefined,
+    configPathBeingEdited: null,
+    isOpen: getIsImplementerToolsOpen(),
+    isUIEditorEnabled: getIsUIEditorEnabled(),
+  }
+);
 
 export const getStore = () =>
   getGlobalStore<ImplementerToolsStore>("implementer-tools");
 
+export const useStore = createUseStore<ImplementerToolsStore>(store);
+
 let lastValueOfIsOpen = getIsImplementerToolsOpen();
+let lastValueOfIsUiEditorEnabled = getIsUIEditorEnabled();
 getStore().subscribe((state) => {
   if (state.isOpen != lastValueOfIsOpen) {
     setIsImplementerToolsOpen(state.isOpen);
     lastValueOfIsOpen = state.isOpen;
   }
+  if (state.isUIEditorEnabled != lastValueOfIsUiEditorEnabled) {
+    setIsUIEditorEnabled(state.isUIEditorEnabled);
+    lastValueOfIsUiEditorEnabled = state.isUIEditorEnabled;
+  }
 });
 
-function setIsImplementerToolsOpen(value: boolean): void {
-  localStorage.setItem("openmrsImplementerToolsAreOpen", JSON.stringify(value));
+function getIsImplementerToolsOpen(): boolean {
+  return (
+    JSON.parse(
+      localStorage.getItem("openmrs:openmrsImplementerToolsAreOpen") || "false"
+    ) ?? false
+  );
 }
 
-function getIsImplementerToolsOpen(): boolean {
-  return JSON.parse(
-    localStorage.getItem("openmrsImplementerToolsAreOpen") || "false"
+function setIsImplementerToolsOpen(value: boolean): void {
+  localStorage.setItem(
+    "openmrs:openmrsImplementerToolsAreOpen",
+    JSON.stringify(value)
   );
+}
+
+function getIsUIEditorEnabled(): boolean {
+  return (
+    JSON.parse(localStorage.getItem("openmrs:isUIEditorEnabled") || "false") ??
+    false
+  );
+}
+
+function setIsUIEditorEnabled(enabled: boolean) {
+  localStorage.setItem("openmrs:isUIEditorEnabled", JSON.stringify(enabled));
 }

--- a/packages/esm-implementer-tools-app/src/ui-editor/extension-overlay.component.tsx
+++ b/packages/esm-implementer-tools-app/src/ui-editor/extension-overlay.component.tsx
@@ -1,0 +1,44 @@
+import React, { useEffect, useState } from "react";
+import { Portal } from "./portal";
+import styles from "./styles.css";
+
+export interface ExtensionOverlayProps {
+  extensionName: string;
+  slotModuleName: string;
+  slotName: string;
+  domElement: HTMLElement;
+}
+
+export function ExtensionOverlay({
+  extensionName,
+  slotModuleName,
+  slotName,
+  domElement,
+}: ExtensionOverlayProps) {
+  const [overlayDomElement, setOverlayDomElement] = useState<HTMLElement>();
+
+  useEffect(() => {
+    if (domElement) {
+      const newOverlayDomElement = document.createElement("div");
+      domElement.parentElement?.appendChild(newOverlayDomElement);
+      setOverlayDomElement(newOverlayDomElement);
+    }
+  }, [domElement]);
+
+  return overlayDomElement ? (
+    <Portal
+      key={`extension-overlay-${slotModuleName}-${slotName}-${extensionName}`}
+      el={overlayDomElement}
+    >
+      <Content extensionId={extensionName} />
+    </Portal>
+  ) : null;
+}
+
+function Content({ extensionId }) {
+  return (
+    <button className={styles.extensionOverlay}>
+      <span className={styles.extensionTooltip}>{extensionId}</span>
+    </button>
+  );
+}

--- a/packages/esm-implementer-tools-app/src/ui-editor/portal.tsx
+++ b/packages/esm-implementer-tools-app/src/ui-editor/portal.tsx
@@ -1,0 +1,5 @@
+import { createPortal } from "react-dom";
+
+export function Portal({ el, children }) {
+  return el ? createPortal(children, el) : null;
+}

--- a/packages/esm-implementer-tools-app/src/ui-editor/styles.css
+++ b/packages/esm-implementer-tools-app/src/ui-editor/styles.css
@@ -1,0 +1,55 @@
+.slotOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: rgba(43, 43, 185, 0.1);
+  border: 1px solid rgba(43, 43, 185, 0.4);
+  pointer-events: none;
+}
+
+.slotName {
+  background-color: rgb(255, 255, 255, 0.85);
+  border: 1px solid rgba(43, 43, 185, 0.4);
+  color: #393939;
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  padding: 0.5em 0.5em 0.5em 0.5em;
+  pointer-events: none;
+}
+
+.extensionOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: none;
+  border: none;
+}
+
+.extensionOverlay:hover {
+  background-color: rgba(43, 43, 185, 0.1);
+}
+
+/* Show the tooltip text when you mouse over the tooltip container */
+.extensionOverlay:focus .extensionTooltip,
+.extensionOverlay:hover .extensionTooltip {
+  visibility: visible;
+  opacity: 1;
+}
+
+.extensionTooltip {
+  visibility: hidden;
+  width: auto;
+  background-color: rgb(255, 255, 255, 0.85);
+  text-align: center;
+  padding: 0.5em 0.5em 0.5em 0.5em;
+  border: 1px solid rgba(43, 43, 185, 0.4);
+
+  position: absolute;
+  top: 0;
+  left: 0;
+}

--- a/packages/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
+++ b/packages/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
@@ -1,0 +1,56 @@
+import React from "react";
+import styles from "./styles.css";
+import { Portal } from "./portal";
+import { ExtensionOverlay } from "./extension-overlay.component";
+import { useExtensionStore } from "@openmrs/esm-react-utils";
+
+export function UiEditor() {
+  const { slots, extensions } = useExtensionStore(["slots", "extensions"]);
+
+  return (
+    <>
+      {slots
+        ? Object.entries(slots).map(([slotName, slotInfo]) =>
+            Object.entries(slotInfo.instances).map(
+              ([slotModuleName, slotInstance]) => (
+                <Portal
+                  key={`slot-overlay-${slotModuleName}-${slotName}`}
+                  el={slotInstance.domElement}
+                >
+                  <SlotOverlay slotName={slotName} />
+                </Portal>
+              )
+            )
+          )
+        : null}
+      {extensions
+        ? Object.entries(extensions).map(([extensionName, extensionInfo]) =>
+            Object.entries(extensionInfo.instances).map(
+              ([slotModuleName, bySlotName]) =>
+                Object.entries(bySlotName).map(
+                  ([slotName, extensionInstance]) => {
+                    return (
+                      <ExtensionOverlay
+                        extensionName={extensionName}
+                        slotModuleName={slotModuleName}
+                        slotName={slotName}
+                        domElement={extensionInstance.domElement}
+                      />
+                    );
+                  }
+                )
+            )
+          )
+        : null}
+    </>
+  );
+}
+
+export function SlotOverlay({ slotName }) {
+  return (
+    <>
+      <div className={styles.slotOverlay}></div>
+      <div className={styles.slotName}>{slotName}</div>
+    </>
+  );
+}

--- a/packages/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
+++ b/packages/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
@@ -5,7 +5,7 @@ import { ExtensionOverlay } from "./extension-overlay.component";
 import { useExtensionStore } from "@openmrs/esm-react-utils";
 
 export function UiEditor() {
-  const { slots, extensions } = useExtensionStore(["slots", "extensions"]);
+  const { slots, extensions } = useExtensionStore();
 
   return (
     <>

--- a/packages/esm-react-utils/src/Extension.tsx
+++ b/packages/esm-react-utils/src/Extension.tsx
@@ -1,6 +1,5 @@
 import React, { useContext } from "react";
-import { TooltipIcon } from "carbon-components-react";
-import { renderExtension, getIsUIEditorEnabled } from "@openmrs/esm-extensions";
+import { renderExtension } from "@openmrs/esm-extensions";
 import { ExtensionContext } from "./ExtensionContext";
 
 export interface ExtensionProps {
@@ -42,15 +41,15 @@ export const Extension: React.FC<ExtensionProps> = ({ state }) => {
     attachedExtensionSlotName,
     extensionSlotModuleName,
     extensionId,
+    ref.current,
   ]);
 
-  return getIsUIEditorEnabled() ? (
-    <TooltipIcon tooltipText={extensionId} align="center" direction="top">
-      <div>
-        <slot ref={ref} />
-      </div>
-    </TooltipIcon>
-  ) : (
-    <slot ref={ref} />
+  return (
+    // The extension is rendered into the `<slot>`. It is surrounded by a
+    // `<div>` with relative positioning in order to allow the UI Editor
+    // to absolutely position elements within it.
+    <div style={{ position: "relative" }}>
+      <slot ref={ref} />
+    </div>
   );
 };

--- a/packages/esm-react-utils/src/ExtensionSlot.tsx
+++ b/packages/esm-react-utils/src/ExtensionSlot.tsx
@@ -1,8 +1,5 @@
-import React, { ReactNode } from "react";
-import {
-  getIsUIEditorEnabled,
-  getExtensionRegistration,
-} from "@openmrs/esm-extensions";
+import React, { CSSProperties, ReactNode, useRef } from "react";
+import { getExtensionRegistration } from "@openmrs/esm-extensions";
 import { ExtensionContext } from "./ExtensionContext";
 import { Extension } from "./Extension";
 import { useExtensionSlot } from "./useExtensionSlot";
@@ -11,25 +8,8 @@ export interface ExtensionSlotBaseProps {
   extensionSlotName: string;
   children?: ReactNode;
   state?: Record<string, any>;
-  className?: string;
+  style?: CSSProperties;
 }
-
-const slotStyle = {
-  backgroundColor: "rgba(43, 43, 185, 0.1)",
-  position: "relative",
-  border: "1px solid rgba(43, 43, 185, 0.4)",
-  margin: "-1px", // accomodates the border
-};
-
-const slotNameStyle = {
-  backgroundColor: "rgb(255 255 255 / 71%)",
-  border: "1px solid rgba(43, 43, 185, 0.4)",
-  color: "#393939",
-  position: "absolute",
-  bottom: "-1px",
-  right: "-1px",
-  padding: "0.5em 0.5em 0.5em 0.5em",
-};
 
 // remainder of props are for the top-level <div>
 export type ExtensionSlotProps<T = {}> = ExtensionSlotBaseProps & T;
@@ -38,21 +18,18 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
   extensionSlotName: actualExtensionSlotName,
   children,
   state,
-  className,
+  style,
   ...divProps
 }: ExtensionSlotProps) => {
+  const slotRef = useRef(null);
   const {
     attachedExtensionSlotName,
     extensionIdsToRender,
     extensionSlotModuleName,
-  } = useExtensionSlot(actualExtensionSlotName);
+  } = useExtensionSlot(actualExtensionSlotName, slotRef);
 
   return (
-    <div
-      className={className}
-      style={getIsUIEditorEnabled() ? (slotStyle as React.CSSProperties) : {}}
-      {...divProps}
-    >
+    <div ref={slotRef} style={{ ...style, position: "relative" }} {...divProps}>
       {extensionIdsToRender.map((extensionId) => {
         const extensionRegistration = getExtensionRegistration(extensionId);
 
@@ -74,11 +51,6 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
           )
         );
       })}
-      {getIsUIEditorEnabled() && (
-        <div style={slotNameStyle as React.CSSProperties}>
-          slot "{attachedExtensionSlotName}"
-        </div>
-      )}
     </div>
   );
 };

--- a/packages/esm-react-utils/src/createUseStore.ts
+++ b/packages/esm-react-utils/src/createUseStore.ts
@@ -1,0 +1,56 @@
+import { useEffect, useMemo, useState } from "react";
+import { Store, BoundAction } from "unistore";
+
+export type Reducer = Function | Array<string> | Object;
+export type Actions = Function | { [key: string]: Function };
+
+function runReducer<T>(state: T, reducer: Reducer) {
+  if (typeof reducer === "function") {
+    return reducer(state);
+  }
+  const out = {};
+  if (typeof reducer === "string") {
+    out[reducer] = state[reducer];
+  } else if (Array.isArray(reducer)) {
+    for (let i of reducer) {
+      out[i] = state[i];
+    }
+  } else if (reducer) {
+    for (let i in reducer) {
+      out[i] = state[reducer[i]];
+    }
+  }
+  return out;
+}
+
+function bindActions<T>(store: Store<T>, actions: Actions) {
+  if (typeof actions == "function") {
+    actions = actions(store);
+  }
+  const bound = {};
+  for (let i in actions) {
+    bound[i] = store.action(actions[i]);
+  }
+  return bound;
+}
+
+export function createUseStore<T>(store: Store<T>) {
+  return function useStore(
+    reducer: Reducer,
+    actions?: Actions
+  ): T & { [key: string]: BoundAction } {
+    const [state, set] = useState(runReducer(store.getState(), reducer));
+    useEffect(
+      () => store.subscribe((state) => set(runReducer(state, reducer))),
+      []
+    );
+    let boundActions = {};
+    if (actions) {
+      boundActions = useMemo(() => bindActions(store, actions), [
+        store,
+        actions,
+      ]);
+    }
+    return { ...state, ...boundActions };
+  };
+}

--- a/packages/esm-react-utils/src/index.ts
+++ b/packages/esm-react-utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./ConfigurableLink";
+export * from "./createUseStore";
 export * from "./Extension";
 export * from "./ExtensionSlot";
 export * from "./getLifecycle";
@@ -7,6 +8,7 @@ export * from "./openmrsRootDecorator";
 export * from "./openmrsExtensionDecorator";
 export * from "./useConfig";
 export * from "./useCurrentPatient";
+export * from "./useExtensionStore";
 export * from "./useForceUpdate";
 export * from "./useNavigationContext";
 export * from "./UserHasAccess";

--- a/packages/esm-react-utils/src/useExtensionSlot.ts
+++ b/packages/esm-react-utils/src/useExtensionSlot.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useState } from "react";
+import { MutableRefObject, useContext, useEffect, useState } from "react";
 import {
   registerExtensionSlot,
   unregisterExtensionSlot,
@@ -7,7 +7,10 @@ import {
 } from "@openmrs/esm-extensions";
 import { ModuleNameContext } from "./ModuleNameContext";
 
-export function useExtensionSlot(actualExtensionSlotName: string) {
+export function useExtensionSlot(
+  actualExtensionSlotName: string,
+  ref: MutableRefObject<HTMLElement | null>
+) {
   const extensionSlotModuleName = useContext(ModuleNameContext);
 
   if (!extensionSlotModuleName) {
@@ -22,10 +25,19 @@ export function useExtensionSlot(actualExtensionSlotName: string) {
   ] = useState<[string | undefined, Array<string>]>([undefined, []]);
 
   useEffect(() => {
-    registerExtensionSlot(extensionSlotModuleName, actualExtensionSlotName);
-    return () =>
-      unregisterExtensionSlot(extensionSlotModuleName, actualExtensionSlotName);
-  }, []);
+    if (ref.current) {
+      registerExtensionSlot(
+        extensionSlotModuleName,
+        actualExtensionSlotName,
+        ref.current
+      );
+      return () =>
+        unregisterExtensionSlot(
+          extensionSlotModuleName,
+          actualExtensionSlotName
+        );
+    }
+  }, [ref.current]);
 
   useEffect(() => {
     const update = (state: ExtensionStore) => {

--- a/packages/esm-react-utils/src/useExtensionStore.ts
+++ b/packages/esm-react-utils/src/useExtensionStore.ts
@@ -1,0 +1,4 @@
+import { ExtensionStore, extensionStore } from "@openmrs/esm-extensions";
+import { createUseStore } from "./createUseStore";
+
+export const useExtensionStore = createUseStore<ExtensionStore>(extensionStore);

--- a/packages/esm-react-utils/tsconfig.json
+++ b/packages/esm-react-utils/tsconfig.json
@@ -16,8 +16,7 @@
       "es2015",
       "es2015.promise",
       "es2016.array.include",
-      "es2018",
-      "esnext"
+      "es2018"
     ]
   },
   "include": ["src/**/*"]


### PR DESCRIPTION
The core feature here is to get all the UI Editor code into implementer-tools. Changing the UI Editor shouldn't require changing the `Extension` or `ExtensionSlot` elements themselves. This change achieves that by using [Portals](https://reactjs.org/docs/portals.html) to get the UI Editor content to appear over the slots and extensions.

In order to accomplish this, the main thing that had to change in Core is that 1. slots need to pass a ref to register with and 2. DOM nodes for slots and extensions should be kept in the store.

Tangentially, I created a function `createUseStore` based on this [comment from the unistore creator](https://github.com/developit/unistore/issues/136#issuecomment-470643278) to make it easier to use state and actions in React components (no more `connect`).

There's pretty much no UI change here. Just an architecture thing. We can now make the UI Editor as elaborate as we want without worrying about the core libraries getting bloated or slowing down.

![Screenshot from 2020-12-24 14-10-33](https://user-images.githubusercontent.com/1031876/103107466-6479b780-45f3-11eb-90a5-b3aef1d71258.png)
