### PR TITLE
Small UI changes to the implementer tools panel

### DIFF
--- a/packages/esm-implementer-tools-app/src/configuration/configuration.component.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/configuration.component.tsx
@@ -6,8 +6,8 @@ import {
   clearTemporaryConfig,
   getTemporaryConfig,
 } from "@openmrs/esm-config";
-import { Toggle, Button } from "carbon-components-react";
-import { Download16 } from "@carbon/icons-react";
+import { Button, Column, Grid, Row, Toggle } from "carbon-components-react";
+import { Download16, TrashCan16 } from "@carbon/icons-react";
 import styles from "./configuration.styles.css";
 import { ConfigTree } from "./config-tree.component";
 import {
@@ -43,43 +43,60 @@ export default function Configuration(props: ConfigurationProps) {
   return (
     <>
       <div className={styles.tools}>
-        <Toggle
-          id="devConfigSwitch"
-          labelText="Dev Config"
-          onToggle={() => {
-            setAreDevDefaultsOn(!isDevConfigActive);
-            setIsDevConfigActive(!isDevConfigActive);
-          }}
-          toggled={isDevConfigActive}
-        />
-        <Toggle
-          id={"uiEditorSwitch"}
-          labelText="UI Editor"
-          toggled={isUIEditorActive}
-          onToggle={() => {
-            setIsUIEditorActive(!isUIEditorActive);
-            setIsUIEditorEnabled(!isUIEditorActive);
-          }}
-        />
-        <Button
-          size="sm"
-          kind="secondary"
-          onClick={() => {
-            clearTemporaryConfig();
-            updateConfig();
-          }}
-        >
-          Clear Temporary Config
-        </Button>
-        <Button size="sm" kind="secondary" renderIcon={Download16}>
-          <a
-            className={styles.downloadLink}
-            download="temporary_config.json"
-            href={window.URL.createObjectURL(tempConfigObjUrl)}
-          >
-            Download Temporary Config
-          </a>
-        </Button>
+        <Grid style={{ margin: "0.25rem", padding: 0 }}>
+          <Row>
+            <Column sm={1} md={1}>
+              <Toggle
+                id="devConfigSwitch"
+                labelText="Dev Config"
+                onToggle={() => {
+                  setAreDevDefaultsOn(!isDevConfigActive);
+                  setIsDevConfigActive(!isDevConfigActive);
+                }}
+                toggled={isDevConfigActive}
+              />
+            </Column>
+            <Column sm={1} md={1} className={styles.actionButton}>
+              <Toggle
+                id={"uiEditorSwitch"}
+                labelText="UI Editor"
+                toggled={isUIEditorActive}
+                onToggle={() => {
+                  setIsUIEditorActive(!isUIEditorActive);
+                  setIsUIEditorEnabled(!isUIEditorActive);
+                }}
+              />
+            </Column>
+            <Column sm={1} md={2} className={styles.actionButton}>
+              <Button
+                kind="danger"
+                iconDescription="Clear temporary config"
+                renderIcon={TrashCan16}
+                onClick={() => {
+                  clearTemporaryConfig();
+                  updateConfig();
+                }}
+              >
+                Clear Temporary Config
+              </Button>
+            </Column>
+            <Column sm={1} md={2} className={styles.actionButton}>
+              <Button
+                kind="secondary"
+                iconDescription="Download temporary config"
+                renderIcon={Download16}
+              >
+                <a
+                  className={styles.downloadLink}
+                  download="temporary_config.json"
+                  href={window.URL.createObjectURL(tempConfigObjUrl)}
+                >
+                  Download Temporary Config
+                </a>
+              </Button>
+            </Column>
+          </Row>
+        </Grid>
       </div>
       <div className={styles.mainContent}>
         <div className={styles.configTreePane}>

--- a/packages/esm-implementer-tools-app/src/configuration/configuration.styles.css
+++ b/packages/esm-implementer-tools-app/src/configuration/configuration.styles.css
@@ -2,16 +2,18 @@
   position: fixed;
   width: 100%;
   background-color: #e0e0e0;
-  display: flex;
-  gap: 4em;
   padding: 0.5em 1.5em;
   border-bottom: 1px solid #a0a0a0;
-  border-top: 1px solid #c0c0c0;
   z-index: 2;
 }
 
 .tools > div {
   flex: 0 1 auto;
+}
+
+.actionButton {
+  display: inline-flex;
+  align-items: center;
 }
 
 .downloadLink {

--- a/packages/esm-implementer-tools-app/src/configuration/configuration.styles.css
+++ b/packages/esm-implementer-tools-app/src/configuration/configuration.styles.css
@@ -4,6 +4,7 @@
   background-color: #e0e0e0;
   padding: 0.5em 1.5em;
   border-bottom: 1px solid #a0a0a0;
+  border-top: 1px solid #c0c0c0;
   z-index: 2;
 }
 

--- a/packages/esm-implementer-tools-app/src/popup/popup.styles.css
+++ b/packages/esm-implementer-tools-app/src/popup/popup.styles.css
@@ -18,7 +18,7 @@
 }
 
 .content {
-  margin-top: 40px;
+  margin-top: 48px;
   width: 100%;
 }
 
@@ -28,12 +28,13 @@
 
 .topBar {
   position: fixed;
-  background-color: #d0d0d0;
+  align-items: center;
+  background-color: #e0e0e0;
+  padding: 0 0.5rem;
   width: 100%;
-  height: 42px;
+  height: 48px;
   display: flex;
   justify-content: space-between;
-  border-bottom: 1px solid #a0a0a0;
   z-index: 2;
 }
 

--- a/packages/esm-implementer-tools-app/src/popup/popup.styles.css
+++ b/packages/esm-implementer-tools-app/src/popup/popup.styles.css
@@ -41,8 +41,8 @@
   padding: 0 1em;
 }
 
-:global(.bx--content-switcher-btn:first-child),
-:global(.bx--content-switcher-btn:last-child) {
+.topBar :global(.bx--content-switcher-btn:first-child),
+.topBar :global(.bx--content-switcher-btn:last-child) {
   border-top-left-radius: 0;
   border-bottom-left-radius: 0;
   border-top-right-radius: 0;

--- a/packages/esm-implementer-tools-app/src/popup/popup.styles.css
+++ b/packages/esm-implementer-tools-app/src/popup/popup.styles.css
@@ -18,7 +18,7 @@
 }
 
 .content {
-  margin-top: 48px;
+  margin-top: 40px;
   width: 100%;
 }
 
@@ -28,17 +28,23 @@
 
 .topBar {
   position: fixed;
-  align-items: center;
-  background-color: #e0e0e0;
-  padding: 0 0.5rem;
   width: 100%;
-  height: 48px;
+  height: 42px;
   display: flex;
   justify-content: space-between;
+  border-bottom: 1px solid #a0a0a0;
   z-index: 2;
 }
 
 .closeButton {
   min-height: 3em;
   padding: 0 1em;
+}
+
+:global(.bx--content-switcher-btn:first-child),
+:global(.bx--content-switcher-btn:last-child) {
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-right-radius: 0;
+  border-bottom-right-radius: 0;
 }


### PR DESCRIPTION
Before:
![Screenshot from 2021-01-03 15-32-39](https://user-images.githubusercontent.com/8509731/103478651-3e190080-4dd9-11eb-87f5-f05cfae2774b.png)

After:
![Screenshot from 2021-01-03 15-29-54](https://user-images.githubusercontent.com/8509731/103478560-a6b3ad80-4dd8-11eb-800f-864f05cff12f.png)

- Adds padding around the `ContentSwitcher` and the Close (X) panel button - there's no longer a space between the rounded edges of the ContentSwitcher buttons and the implementer tools panel edges.
- Restores the grid layout to the `Configuration` component with rows and columns. 
- Adds styling to the `Clear Temporary Config` button that denotes it as a button with destructive effects.

