### PR TITLE
Add grey OpenMRS Logo to match design

### DIFF
--- a/packages/esm-styleguide/src/logo/logo.css
+++ b/packages/esm-styleguide/src/logo/logo.css
@@ -17,3 +17,13 @@
   --logo-green: rgba(19, 19, 21, 0.6) !important;
   --logo-black: rgba(19, 19, 21, 0.6) !important;
 }
+
+#omrs-logo-full-grey,
+#omrs-logo-partial-grey,
+#omrs-logo-icon-grey {
+  --logo-red: #eee;
+  --logo-orange: #eee;
+  --logo-purple: #c6c6c6;
+  --logo-green: #c6c6c6;
+  --logo-black: #c6c6c6;
+}

--- a/packages/esm-styleguide/src/logo/logo.js
+++ b/packages/esm-styleguide/src/logo/logo.js
@@ -6,7 +6,10 @@ import { addSvg } from "../svg-utils";
 
 addSvg("omrs-logo-full-color", fullLogo);
 addSvg("omrs-logo-full-mono", fullLogo);
+addSvg("omrs-logo-full-grey", fullLogo);
 addSvg("omrs-logo-partial-color", partialLogo);
 addSvg("omrs-logo-partial-mono", partialLogo);
+addSvg("omrs-logo-partial-grey", partialLogo);
 addSvg("omrs-logo-icon-color", iconLogo);
 addSvg("omrs-logo-icon-mono", iconLogo);
+addSvg("omrs-logo-icon-grey", iconLogo);

--- a/packages/esm-styleguide/src/logo/logo.stories.js
+++ b/packages/esm-styleguide/src/logo/logo.stories.js
@@ -21,6 +21,7 @@ storiesOf("OpenMRS Styleguide", module).add("Logos", () => {
     {
       "With Colors": "color",
       "Mono / Grey": "mono",
+      Grey: "grey",
     },
     "color"
   );


### PR DESCRIPTION
### What does this PR do?

1. Add grey OpenMRS grey to match latest designs

### Screenshoot

<img width="1150" alt="Screenshot 2021-02-03 at 23 12 45" src="https://user-images.githubusercontent.com/28008754/106804302-497c7780-6676-11eb-8b1c-f4e4c7023b29.png">
﻿
