### PR TITLE
Implementer tools should cache all the slots it knows about in case any of them disappear

### DIFF
--- a/packages/esm-implementer-tools-app/src/configuration/config-tree.component.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/config-tree.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React from "react";
 import styles from "./configuration.styles.css";
 import Accordion, {
   AccordionItem,

--- a/packages/esm-implementer-tools-app/src/configuration/config-tree.component.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/config-tree.component.tsx
@@ -1,15 +1,19 @@
-import React from "react";
+import React, { useMemo } from "react";
 import styles from "./configuration.styles.css";
 import Accordion, {
   AccordionItem,
 } from "carbon-components-react/es/components/Accordion";
 import { ConfigTreeForModule } from "./config-tree-for-module.component";
+import { useStore } from "@openmrs/esm-framework";
+import { implementerToolsStore } from "../store";
 
 export interface ConfigTreeProps {
   config: Record<string, any>;
 }
 
 export function ConfigTree({ config }: ConfigTreeProps) {
+  const { slotsByModule } = useStore(implementerToolsStore);
+
   return (
     <div>
       <Accordion align="start">
@@ -18,7 +22,8 @@ export function ConfigTree({ config }: ConfigTreeProps) {
             .sort()
             .map((moduleName) => {
               const moduleConfig = config[moduleName];
-              return Object.keys(moduleConfig).length ? (
+              return Object.keys(moduleConfig).length ||
+                slotsByModule[moduleName] ? (
                 <AccordionItem
                   open
                   title={<h4 className={styles.moduleName}>{moduleName}</h4>}

--- a/packages/esm-implementer-tools-app/src/configuration/extension-slots-config-tree.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/extension-slots-config-tree.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useState } from "react";
 import EditableValue from "./editable-value.component";
 import isEqual from "lodash-es/isEqual";
 import {
@@ -37,6 +37,7 @@ export function ExtensionSlotsConfigTree({
   moduleName,
 }: ExtensionSlotsConfigTreeProps) {
   const { slotsByModule } = useStore(implementerToolsStore);
+
   const extensionSlotNames = slotsByModule[moduleName] ?? [];
 
   return extensionSlotNames.length ? (

--- a/packages/esm-implementer-tools-app/src/configuration/extension-slots-config-tree.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/extension-slots-config-tree.tsx
@@ -3,8 +3,8 @@ import EditableValue from "./editable-value.component";
 import isEqual from "lodash-es/isEqual";
 import {
   extensionStore,
-  useExtensionStore,
   ExtensionSlotConfigureValueObject,
+  useStore,
 } from "@openmrs/esm-framework";
 import { ExtensionConfigureTree } from "./extension-configure-tree";
 import { Subtree } from "./layout/subtree.component";
@@ -36,13 +36,8 @@ export function ExtensionSlotsConfigTree({
   config,
   moduleName,
 }: ExtensionSlotsConfigTreeProps) {
-  const { slots } = useExtensionStore();
-
-  const extensionSlotNames = useMemo(
-    () =>
-      Object.keys(slots).filter((name) => moduleName in slots[name].instances),
-    [slots]
-  );
+  const { slotsByModule } = useStore(implementerToolsStore);
+  const extensionSlotNames = slotsByModule[moduleName] ?? [];
 
   return extensionSlotNames.length ? (
     <Subtree label={"extension slots"} leaf={false}>

--- a/packages/esm-react-utils/src/createUseStore.ts
+++ b/packages/esm-react-utils/src/createUseStore.ts
@@ -8,7 +8,7 @@ function bindActions<T>(store: Store<T>, actions: Actions) {
   if (typeof actions == "function") {
     actions = actions(store);
   }
-  
+
   const bound = {};
 
   for (let i in actions) {
@@ -19,7 +19,7 @@ function bindActions<T>(store: Store<T>, actions: Actions) {
 }
 
 export function createUseStore<T>(store: Store<T>) {
-  return function useStore(actions?: Actions): T & BoundActions {
+  function useStore(actions?: Actions): T & BoundActions {
     const [state, set] = useState(store.getState());
     useEffect(() => store.subscribe((state) => set(state)), []);
     let boundActions: BoundActions = {};
@@ -32,5 +32,7 @@ export function createUseStore<T>(store: Store<T>) {
     }
 
     return { ...state, ...boundActions };
-  };
+  }
+
+  return useStore;
 }

--- a/packages/esm-react-utils/src/createUseStore.ts
+++ b/packages/esm-react-utils/src/createUseStore.ts
@@ -19,7 +19,10 @@ function bindActions<T>(store: Store<T>, actions: Actions) {
 }
 
 export function createUseStore<T>(store: Store<T>) {
-  function useStore(actions?: Actions): T & BoundActions {
+  function useStore(): T;
+  function useStore(actions: Actions): T & BoundActions;
+  function useStore(actions?: Actions): T & BoundActions;
+  function useStore(actions?: Actions) {
     const [state, set] = useState(store.getState());
     useEffect(() => store.subscribe((state) => set(state)), []);
     let boundActions: BoundActions = {};

--- a/packages/esm-react-utils/src/useStore.ts
+++ b/packages/esm-react-utils/src/useStore.ts
@@ -1,6 +1,11 @@
 import { Store } from "unistore";
-import { Actions, createUseStore } from "./createUseStore";
+import { Actions, BoundActions, createUseStore } from "./createUseStore";
 
+export function useStore<T>(store: Store<T>): T;
+export function useStore<T>(
+  store: Store<T>,
+  actions: Actions
+): T & BoundActions;
 export function useStore<T>(store: Store<T>, actions?: Actions) {
   return createUseStore<T>(store)(actions);
 }


### PR DESCRIPTION
The reason @jonathandick and Grace couldn't find the `patient-chart-nav-menu` slot is because the implementer tools were only showing it when it was mounted. This gives the implementer tools a cache of the slots.