### PR TITLE
Give implementer tools a cache of the extension IDs assigned to each slot

### DIFF
--- a/packages/esm-implementer-tools-app/src/configuration/config-tree.component.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/config-tree.component.tsx
@@ -12,7 +12,7 @@ export interface ConfigTreeProps {
 }
 
 export function ConfigTree({ config }: ConfigTreeProps) {
-  const { slotsByModule } = useStore(implementerToolsStore);
+  const { extensionIdBySlotByModule } = useStore(implementerToolsStore);
 
   return (
     <div>
@@ -23,7 +23,7 @@ export function ConfigTree({ config }: ConfigTreeProps) {
             .map((moduleName) => {
               const moduleConfig = config[moduleName];
               return Object.keys(moduleConfig).length ||
-                slotsByModule[moduleName] ? (
+                extensionIdBySlotByModule[moduleName] ? (
                 <AccordionItem
                   title={<h6 className={styles.moduleName}>{moduleName}</h6>}
                   className={styles.fullWidthAccordion}

--- a/packages/esm-implementer-tools-app/src/configuration/extension-slots-config-tree.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/extension-slots-config-tree.tsx
@@ -36,9 +36,11 @@ export function ExtensionSlotsConfigTree({
   config,
   moduleName,
 }: ExtensionSlotsConfigTreeProps) {
-  const { slotsByModule } = useStore(implementerToolsStore);
+  const { extensionIdBySlotByModule } = useStore(implementerToolsStore);
 
-  const extensionSlotNames = slotsByModule[moduleName] ?? [];
+  const extensionSlotNames = Object.keys(
+    extensionIdBySlotByModule[moduleName] || {}
+  );
 
   return extensionSlotNames.length ? (
     <Subtree label={"extension slots"} leaf={false}>

--- a/packages/esm-implementer-tools-app/src/configuration/value-editors/extension-slot-order.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/value-editors/extension-slot-order.tsx
@@ -1,5 +1,6 @@
-import React, { useState, useEffect } from "react";
-import { ExtensionStore, extensionStore } from "@openmrs/esm-framework";
+import React from "react";
+import { useStore } from "@openmrs/esm-framework";
+import { implementerToolsStore } from "../../store";
 
 export function ExtensionSlotOrder({
   slotName,
@@ -7,19 +8,7 @@ export function ExtensionSlotOrder({
   value,
   setValue,
 }) {
-  const [attachedExtensions, setAttachedExtensions] = useState<Array<string>>(
-    []
-  );
-
-  useEffect(() => {
-    function update(state: ExtensionStore) {
-      setAttachedExtensions(
-        state.slots[slotName].instances[slotModuleName].assignedIds
-      );
-    }
-    update(extensionStore.getState());
-    return extensionStore.subscribe(update);
-  }, []);
+  const { extensionIdBySlotByModule } = useStore(implementerToolsStore);
 
   return <div>Todo: compose array with extension lookup</div>;
 }

--- a/packages/esm-implementer-tools-app/src/configuration/value-editors/extension-slot-remove.tsx
+++ b/packages/esm-implementer-tools-app/src/configuration/value-editors/extension-slot-remove.tsx
@@ -1,6 +1,7 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import MultiSelect from "carbon-components-react/es/components/MultiSelect";
-import { ExtensionStore, extensionStore } from "@openmrs/esm-framework";
+import { useStore } from "@openmrs/esm-framework";
+import { implementerToolsStore } from "../../store";
 
 export function ExtensionSlotRemove({
   slotName,
@@ -8,24 +9,14 @@ export function ExtensionSlotRemove({
   value,
   setValue,
 }) {
-  const [attachedExtensions, setAttachedExtensions] = useState<Array<string>>(
-    []
-  );
-
-  useEffect(() => {
-    function update(state: ExtensionStore) {
-      setAttachedExtensions(
-        state.slots[slotName].instances[slotModuleName].assignedIds
-      );
-    }
-    update(extensionStore.getState());
-    return extensionStore.subscribe(update);
-  }, []);
+  const { extensionIdBySlotByModule } = useStore(implementerToolsStore);
 
   return (
     <MultiSelect.Filterable
       id={`add-select`}
-      items={attachedExtensions.map((name) => ({ id: name, label: name }))}
+      items={extensionIdBySlotByModule[slotModuleName][
+        slotName
+      ].map((name) => ({ id: name, label: name }))}
       placeholder="Select extensions"
       onChange={(value) => setValue(value.selectedItems.map((v) => v.id))}
       initialSelectedItems={value}


### PR DESCRIPTION
Allows the extension slot config interface to work.

![impl-tools-fix](https://user-images.githubusercontent.com/1031876/109744504-45654c00-7b87-11eb-9c48-1712f3291e06.gif)
