### PR TITLE
Add UI Shell overrides and revert button ghost to match designs

### DIFF
--- a/packages/esm-styleguide/src/carbon-overrides.css
+++ b/packages/esm-styleguide/src/carbon-overrides.css
@@ -49,28 +49,42 @@
 .bx--btn--primary:active,
 .bx--btn--tertiary:hover,
 .bx--btn--tertiary:active,
-.bx--btn--tertiary:focus{
+.bx--btn--tertiary:focus {
   background-color: #007d79;
 }
 
-.bx--btn--tertiary,
-.bx--btn--ghost,
-.bx--btn--ghost:hover,
-.bx--btn--ghost:active
-{
+.bx--btn--tertiary {
   color: #007d79;
 }
 
 .bx--btn--tertiary,
 .bx--btn--primary:focus,
-.bx--btn--tertiary:focus,
-.bx--btn--ghost:focus
-{
+.bx--btn--tertiary:focus {
   border-color: #007d79;
 }
 
 .bx--btn--tertiary:hover,
 .bx--btn--tertiary:active,
-.bx--btn--tertiary:focus{
+.bx--btn--tertiary:focus {
   color: #ffffff;
+}
+
+/* UI Shell header */
+
+.bx--header {
+  background-color: #005d5d;
+  border-bottom: #004144;
+}
+
+.bx--header__action:hover {
+  background-color: #004144;
+}
+
+.bx--header-panel {
+  background-color: #004144;
+}
+
+.bx--header__action--active {
+  background-color: #004144;
+  border-color: #004144;
 }


### PR DESCRIPTION
### What does this PR do?

1. Add UI Shell header styles 
2. Revert over styles for `.bx-ghost` to match designs as shown here [styleguide](https://app.zeplin.io/project/5f7223cfda10f94d67cec6d0/styleguide/components?coid=5fb501d06b819082e64764b6)