### PR TITLE
Correct useCurrentPatient typing

### DIFF
--- a/packages/esm-framework/mock.tsx
+++ b/packages/esm-framework/mock.tsx
@@ -126,7 +126,7 @@ export const openmrsObservableFetch = jest.fn(() =>
 
 export const setIsUIEditorEnabled = (boolean): void => {};
 
-export const useCurrentPatient = jest.fn(() => [false, null, null, null]);
+export const useCurrentPatient = jest.fn(() => [null, null, null, null]);
 
 export const getCurrentPatient = jest.fn(() =>
   jest.fn().mockReturnValue(never())


### PR DESCRIPTION
Typescript infers the return type to `boolean[]`.

This breaks the Typing here:

![Screenshot 2021-03-16 at 11 55 18 (2)](https://user-images.githubusercontent.com/26084581/111282109-b0665680-864e-11eb-8e77-65bd9ac61af8.png)
 