### PR TITLE
Adjust top nav height

### DIFF
--- a/packages/esm-styleguide/src/components/_main-content.scss
+++ b/packages/esm-styleguide/src/components/_main-content.scss
@@ -1,6 +1,6 @@
 :root {
   --omrs-sidenav-width: 16.25rem;
-  --omrs-topnav-height: 3.5rem;
+  --omrs-topnav-height: 3rem;
 }
 
 .omrs-main-content {


### PR DESCRIPTION
Removes the `0.5rem` overhang from the nav menu into the patient banner (before and after shots below for context):

<img width="1503" alt="Screenshot 2021-03-25 at 15 40 14" src="https://user-images.githubusercontent.com/8509731/112475696-24f17180-8d82-11eb-8ff1-7dbdc40e36f8.png">


<img width="1503" alt="Screenshot 2021-03-25 at 15 38 12" src="https://user-images.githubusercontent.com/8509731/112475512-ef4c8880-8d81-11eb-9a92-d204bb9b54c7.png">
