### PR TITLE
Fix Extension Store infinite loop

### DIFF
--- a/packages/esm-react-utils/src/createUseStore.ts
+++ b/packages/esm-react-utils/src/createUseStore.ts
@@ -24,7 +24,9 @@ export function createUseStore<T>(store: Store<T>) {
   function useStore(actions?: Actions): T & BoundActions;
   function useStore(actions?: Actions) {
     const [state, set] = useState(store.getState());
-    useEffect(() => store.subscribe((state) => set(state)), []);
+    useEffect(() => {
+      store.subscribe((globalState) => set(globalState))
+    }, []);
     let boundActions: BoundActions = {};
 
     if (actions) {


### PR DESCRIPTION
# Description

I'm not sure y'all were getting this error but when using the `useExtensionStore` hook, the hook would infinitely set the state.

So just having the useEffect hook not perform an explicit cleanup fixed it. 