### PR TITLE
MF-497 : implementer-tool shifted to top-nav-bar

### DIFF
--- a/packages/esm-devtools-app/src/devtools/devtools.styles.css
+++ b/packages/esm-devtools-app/src/devtools/devtools.styles.css
@@ -4,7 +4,7 @@
   height: 40px !important;
   width: 40px !important;
   bottom: 10px;
-  right: 54px;
+  right: 8px;
   position: fixed;
   border-radius: 2px;
 }

--- a/packages/esm-implementer-tools-app/src/implementer-tools.component.tsx
+++ b/packages/esm-implementer-tools-app/src/implementer-tools.component.tsx
@@ -10,7 +10,7 @@ import { NotificationActionButton } from "carbon-components-react/es/components/
 import { UiEditor } from "./ui-editor/ui-editor";
 import { implementerToolsStore } from "./store";
 import { HeaderGlobalAction } from "carbon-components-react/es/components/UIShell";
-import { Tools32 } from "@carbon/icons-react";
+import Tools32 from "@carbon/icons-react/es/tools/32";
 
 export default function ImplementerTools() {
   return (

--- a/packages/esm-implementer-tools-app/src/implementer-tools.component.tsx
+++ b/packages/esm-implementer-tools-app/src/implementer-tools.component.tsx
@@ -9,6 +9,7 @@ import {
 import { NotificationActionButton } from "carbon-components-react/es/components/Notification";
 import { UiEditor } from "./ui-editor/ui-editor";
 import { implementerToolsStore } from "./store";
+import { HeaderGlobalAction } from "carbon-components-react/es/components/UIShell";
 import { Tools32 } from "@carbon/icons-react";
 
 export default function ImplementerTools() {
@@ -89,12 +90,18 @@ function PopupHandler() {
 
   return (
     <>
-      <Tools32
-        onClick={togglePopup}
-        className={`${styles.popupTriggerButton} ${
-          hasAlert ? styles.triggerButtonAlert : ""
-        }`}
-      />
+      <HeaderGlobalAction
+        aria-label="Implementer Tools"
+        aria-labelledby="Implementer Tools"
+        name="ImplementerToolsIcon"
+      >
+        <Tools32
+          onClick={togglePopup}
+          className={`${styles.popupTriggerButton} ${
+            hasAlert ? styles.triggerButtonAlert : ""
+          }`}
+        />
+      </HeaderGlobalAction>
       {isOpen ? (
         <Popup
           close={togglePopup}

--- a/packages/esm-implementer-tools-app/src/implementer-tools.component.tsx
+++ b/packages/esm-implementer-tools-app/src/implementer-tools.component.tsx
@@ -9,6 +9,7 @@ import {
 import { NotificationActionButton } from "carbon-components-react/es/components/Notification";
 import { UiEditor } from "./ui-editor/ui-editor";
 import { implementerToolsStore } from "./store";
+import { Tools32 } from "@carbon/icons-react";
 
 export default function ImplementerTools() {
   return (
@@ -88,7 +89,7 @@ function PopupHandler() {
 
   return (
     <>
-      <button
+      <Tools32
         onClick={togglePopup}
         className={`${styles.popupTriggerButton} ${
           hasAlert ? styles.triggerButtonAlert : ""

--- a/packages/esm-implementer-tools-app/src/implementer-tools.styles.css
+++ b/packages/esm-implementer-tools-app/src/implementer-tools.styles.css
@@ -1,11 +1,8 @@
 .popupTriggerButton {
   z-index: 100000;
-  background-color: var(--omrs-color-interaction-minus-two);
-  height: 40px !important;
-  width: 40px !important;
-  bottom: 10px;
-  right: 8px;
-  position: fixed;
+  height: 25px !important;
+  width: 25px !important;
+  position: relative;
   border-radius: 2px;
 }
 

--- a/packages/esm-implementer-tools-app/src/index.ts
+++ b/packages/esm-implementer-tools-app/src/index.ts
@@ -8,11 +8,6 @@ function setupOpenMRS() {
   };
 
   return {
-    lifecycle: getAsyncLifecycle(
-      () => import("./implementer-tools.component"),
-      options
-    ),
-    activate: () => true,
     extensions: [
       {
         id: "implementer-tools-button",

--- a/packages/esm-implementer-tools-app/src/index.ts
+++ b/packages/esm-implementer-tools-app/src/index.ts
@@ -1,15 +1,28 @@
 import { getAsyncLifecycle } from "@openmrs/esm-framework";
 
 function setupOpenMRS() {
+  const moduleName = "@openmrs/esm-implementer-tools-app";
+  const options = {
+    featureName: "Implementer Tools",
+    moduleName,
+  };
+
   return {
     lifecycle: getAsyncLifecycle(
       () => import("./implementer-tools.component"),
-      {
-        featureName: "Implementer Tools",
-        moduleName: "@openmrs/esm-implementer-tools-app",
-      }
+      options
     ),
     activate: () => true,
+    extensions: [
+      {
+        id: "implementer-tools-button",
+        slot: "top-nav-actions-slot",
+        load: getAsyncLifecycle(
+          () => import("./implementer-tools.component"),
+          options
+        ),
+      },
+    ],
   };
 }
 


### PR DESCRIPTION
ticket https://issues.openmrs.org/browse/MF-497

esm-implementer-tools is registering an extension "implementer-tools-button" and attach it to "top-nav-actions-slot."
but the button is not visible I am not able to understand
@brandones @FlorianRappl can u please help

It is` not Complete` yet ,I am stuck at above attaching

![image](https://user-images.githubusercontent.com/58779460/113148680-c16ab680-924f-11eb-97b1-1524326e1d91.png)
