### PR TITLE
fixes background color of Implementers Tool button

### DIFF
--- a/packages/esm-implementer-tools-app/src/implementer-tools.component.tsx
+++ b/packages/esm-implementer-tools-app/src/implementer-tools.component.tsx
@@ -94,6 +94,7 @@ function PopupHandler() {
         aria-label="Implementer Tools"
         aria-labelledby="Implementer Tools"
         name="ImplementerToolsIcon"
+        className={styles.toolStyles}
       >
         <Tools32
           onClick={togglePopup}

--- a/packages/esm-implementer-tools-app/src/implementer-tools.styles.css
+++ b/packages/esm-implementer-tools-app/src/implementer-tools.styles.css
@@ -9,3 +9,7 @@
 .triggerButtonAlert {
   background-color: var(--omrs-color-danger);
 }
+
+.toolStyles {
+  background-color: transparent;
+}


### PR DESCRIPTION
MF-497:

currently:
![image](https://user-images.githubusercontent.com/58779460/113663681-15e6b980-96c8-11eb-918f-fac33aedbff3.png)
after changes:
![image](https://user-images.githubusercontent.com/58779460/113663714-2434d580-96c8-11eb-9ea7-aad569a4310f.png)
