### PR TITLE
Breadcrumbs style mods

### DIFF
--- a/packages/esm-app-shell/src/declarations.d.tsx
+++ b/packages/esm-app-shell/src/declarations.d.tsx
@@ -1,0 +1,2 @@
+declare module "*.css";
+declare module "*.scss";

--- a/packages/esm-app-shell/src/ui/breadcrumbs.scss
+++ b/packages/esm-app-shell/src/ui/breadcrumbs.scss
@@ -1,0 +1,6 @@
+@import "~@openmrs/esm-styleguide/src/vars";
+
+.breadcrumbs {
+  padding: 1rem;
+  background-color: $openmrs-background-grey;
+}

--- a/packages/esm-app-shell/src/ui/breadcrumbs.tsx
+++ b/packages/esm-app-shell/src/ui/breadcrumbs.tsx
@@ -4,6 +4,7 @@ import {
   BreadcrumbItem,
 } from "carbon-components-react/es/components/Breadcrumb";
 import { getBreadcrumbsFor, ConfigurableLink } from "@openmrs/esm-framework";
+import styles from "./breadcrumbs.scss";
 
 function getPath(path: string, params: Array<string>) {
   const parts = [...params];
@@ -29,8 +30,6 @@ function getParams(path: string, matcher: RegExp) {
   return [];
 }
 
-const breadcrumbsStyle: React.CSSProperties = { padding: "1rem" };
-
 export const Breadcrumbs: React.FC = () => {
   const [path, setPath] = React.useState(location.pathname);
   const breadcrumbs = getBreadcrumbsFor(path);
@@ -54,7 +53,7 @@ export const Breadcrumbs: React.FC = () => {
   }
 
   return (
-    <Breadcrumb style={breadcrumbsStyle}>
+    <Breadcrumb className={styles.breadcrumbs}>
       {breadcrumbs.map((bc) => (
         <BreadcrumbItem key={bc.settings.path}>
           <ConfigurableLink to={getPath(bc.settings.path, params)}>

--- a/packages/esm-app-shell/webpack.config.js
+++ b/packages/esm-app-shell/webpack.config.js
@@ -39,7 +39,7 @@ const cssLoader = {
   options: {
     modules: {
       localIdentName:
-        "esm-patient-allergies__[name]__[local]___[hash:base64:5]",
+        "esm-patient-app-shell__[name]__[local]___[hash:base64:5]",
     },
   },
 };
@@ -97,7 +97,11 @@ module.exports = (env, argv = {}) => {
         },
         {
           test: /\.s[ac]ss$/i,
-          use: ["style-loader", cssLoader, "sass-loader"],
+          use: [
+            mode === "production"
+              ? { loader: require.resolve(MiniCssExtractPlugin.loader) }
+              : { loader: require.resolve("sass-loader") },
+          ],
         },
         {
           test: /\.(woff|woff2|png)?$/,

--- a/packages/esm-app-shell/webpack.config.js
+++ b/packages/esm-app-shell/webpack.config.js
@@ -34,6 +34,16 @@ const openmrsConfigUrls = (process.env.OMRS_CONFIG_URLS || "")
   .map((url) => JSON.stringify(url))
   .join(", ");
 
+const cssLoader = {
+  loader: "css-loader",
+  options: {
+    modules: {
+      localIdentName:
+        "esm-patient-allergies__[name]__[local]___[hash:base64:5]",
+    },
+  },
+};
+
 module.exports = (env, argv = {}) => {
   const mode = argv.mode || process.env.NODE_ENV || production;
   const outDir = mode === production ? "dist" : "lib";
@@ -84,6 +94,10 @@ module.exports = (env, argv = {}) => {
               : { loader: require.resolve("style-loader") },
             { loader: require.resolve("css-loader") },
           ],
+        },
+        {
+          test: /\.s[ac]ss$/i,
+          use: ["style-loader", cssLoader, "sass-loader"],
         },
         {
           test: /\.(woff|woff2|png)?$/,

--- a/packages/esm-app-shell/webpack.config.js
+++ b/packages/esm-app-shell/webpack.config.js
@@ -34,19 +34,14 @@ const openmrsConfigUrls = (process.env.OMRS_CONFIG_URLS || "")
   .map((url) => JSON.stringify(url))
   .join(", ");
 
-const cssLoader = {
-  loader: "css-loader",
-  options: {
-    modules: {
-      localIdentName:
-        "esm-patient-app-shell__[name]__[local]___[hash:base64:5]",
-    },
-  },
-};
-
 module.exports = (env, argv = {}) => {
   const mode = argv.mode || process.env.NODE_ENV || production;
   const outDir = mode === production ? "dist" : "lib";
+  const styleLoader =
+    mode === "production"
+      ? { loader: require.resolve(MiniCssExtractPlugin.loader) }
+      : { loader: require.resolve("style-loader") };
+  const cssLoader = { loader: require.resolve("css-loader") };
 
   return {
     entry: resolve(__dirname, "src/index.ts"),
@@ -86,21 +81,18 @@ module.exports = (env, argv = {}) => {
             system: false,
           },
         },
+
         {
           test: /\.css$/,
-          use: [
-            mode === "production"
-              ? { loader: require.resolve(MiniCssExtractPlugin.loader) }
-              : { loader: require.resolve("style-loader") },
-            { loader: require.resolve("css-loader") },
-          ],
+          use: [styleLoader, cssLoader],
         },
+
         {
           test: /\.s[ac]ss$/i,
           use: [
-            mode === "production"
-              ? { loader: require.resolve(MiniCssExtractPlugin.loader) }
-              : { loader: require.resolve("sass-loader") },
+            styleLoader,
+            cssLoader,
+            { loader: require.resolve("sass-loader") },
           ],
         },
         {


### PR DESCRIPTION
- Set background color to `$openmrs-background-grey` so it matches the [designs](https://app.zeplin.io/project/605a0def8c1a5c07401482c1/screen/605a1ca5c27e8c0704aba8e3).
I've moved the styles to an `.scss` file to be able to take advantage of sass variables.