### PR TITLE
fixed missing module open when running openmrs develop

### DIFF
--- a/packages/openmrs/src/commands/develop.ts
+++ b/packages/openmrs/src/commands/develop.ts
@@ -70,7 +70,7 @@ export function runDevelop(args: DevelopArgs) {
     logInfo(`SPA available at ${pageUrl}`);
 
     if (open) {
-      const open = require("opn");
+      const open = require("open");
 
       open(pageUrl, { wait: false }).catch(() => {
         logWarn(

--- a/packages/openmrs/src/commands/start.ts
+++ b/packages/openmrs/src/commands/start.ts
@@ -38,7 +38,7 @@ export function runStart(args: StartArgs) {
     logInfo(`SPA available at ${pageUrl}`);
 
     if (args.open) {
-      const open = require("opn");
+      const open = require("open");
 
       open(pageUrl, { wait: false }).catch(() => {
         logWarn(


### PR DESCRIPTION
### Description

On installing the latest version of `openmrs` the following error occurs 

<img width="1680" alt="Screenshot 2021-05-13 at 10 39 58" src="https://user-images.githubusercontent.com/28008754/118096559-2d594680-b3da-11eb-83ea-f877c6af69ea.png">
