### PR TITLE
Fix: Offline syncing API did not sync at the correct time and did not properly invoke the sync callbacks

### DIFF
--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -284,7 +284,7 @@ function setupOfflineDataSynchronization() {
       kind: "info",
     });
 
-    await Promise.allSettled(syncCallbacks);
+    await Promise.allSettled(syncCallbacks.map(cb => cb()));
 
     showToast({
       title: "Offline Synchronization Finished",
@@ -307,12 +307,12 @@ export function run(configUrls: Array<string>) {
   setupApiModule();
   registerCoreExtensions();
   setupServiceWorker();
-  setupOfflineDataSynchronization();
 
   return loadApps()
     .then(setupApps)
     .then(provideConfigs)
     .then(runShell)
     .catch(handleInitFailure)
-    .then(closeLoading);
+    .then(closeLoading)
+    .then(setupOfflineDataSynchronization);
 }

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -284,7 +284,7 @@ function setupOfflineDataSynchronization() {
       kind: "info",
     });
 
-    await Promise.allSettled(syncCallbacks.map(cb => cb()));
+    await Promise.allSettled(syncCallbacks.map((cb) => cb()));
 
     showToast({
       title: "Offline Synchronization Finished",


### PR DESCRIPTION
Basically fixes the order in which the sync callbacks are invoked. We must give the app the change to setup the cbs before actually invoking them.