### PR TITLE
fix login and primary navigation translation

### DIFF
--- a/packages/apps/esm-login-app/package.json
+++ b/packages/apps/esm-login-app/package.json
@@ -44,6 +44,7 @@
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "react": "16.x",
+    "react-i18next": "11.x",
     "react-dom": "16.x",
     "react-router-dom": "5.x",
     "rxjs": "6.x"

--- a/packages/apps/esm-primary-navigation-app/package.json
+++ b/packages/apps/esm-primary-navigation-app/package.json
@@ -44,6 +44,7 @@
     "carbon-components": "10.x",
     "carbon-icons": "7.x",
     "react": "16.x",
+    "react-i18next": "11.x",
     "react-dom": "16.x",
     "react-router-dom": "5.x",
     "rxjs": "6.x"


### PR DESCRIPTION
### Description

At the moment the `initReactI18next` instance isn't passed to both login and primary navigation as a result of missing peer dependency of `react-i18next`