### PR TITLE
Fix github action not deploying core-apps directory

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -51,8 +51,8 @@ jobs:
         run: |
           mkdir -p dist/${{ env.ESM_NAME }}/${{ env.TIMESTAMP }}_${{ github.sha }}
           mkdir -p dist/${{ env.ESM_NAME }}/latest
-          cp packages/shell/esm-app-shell/dist/*.* dist/${{ env.ESM_NAME }}/${{ env.TIMESTAMP }}_${{ github.sha }}/
-          cp packages/shell/esm-app-shell/dist/*.* dist/${{ env.ESM_NAME }}/latest/
+          cp -r packages/shell/esm-app-shell/dist/*.* dist/${{ env.ESM_NAME }}/${{ env.TIMESTAMP }}_${{ github.sha }}/
+          cp -r packages/shell/esm-app-shell/dist/*.* dist/${{ env.ESM_NAME }}/latest/
       - name: Publish to Digital Ocean
         uses: jakejarvis/s3-sync-action@master
         with:


### PR DESCRIPTION
### Description

At the moment the copy command for deploying app-shell assets isn't deploying the directories containing

1. esm-login-app
2. esm-primary-navigation-app
3. esm-devtools-app
4. esm-implementer-tools-app

This PR address this issue on our demo environment

<img width="1675" alt="Screenshot 2021-05-22 at 15 08 27" src="https://user-images.githubusercontent.com/28008754/119225990-a742ab80-bb0f-11eb-9071-33919047f544.png">
