### PR TITLE
Refinements to notifications

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -215,6 +215,7 @@
 - [messageOmrsServiceWorker](API.md#messageomrsserviceworker)
 - [openVisitsNoteWorkspace](API.md#openvisitsnoteworkspace)
 - [openmrsComponentDecorator](API.md#openmrscomponentdecorator)
+- [patchXMLHttpRequest](API.md#patchxmlhttprequest)
 - [processConfig](API.md#processconfig)
 - [provide](API.md#provide)
 - [pushNavigationContext](API.md#pushnavigationcontext)
@@ -1854,6 +1855,16 @@ ___
 **Returns:** (`Comp`: *ComponentType*<{}\>) => *ComponentType*<any\>
 
 Defined in: [packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx:71](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx#L71)
+
+___
+
+### patchXMLHttpRequest
+
+▸ **patchXMLHttpRequest**(): *void*
+
+**Returns:** *void*
+
+Defined in: [packages/framework/esm-offline/src/patches.ts:1](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-offline/src/patches.ts#L1)
 
 ___
 

--- a/packages/framework/esm-offline/docs/API.md
+++ b/packages/framework/esm-offline/docs/API.md
@@ -27,6 +27,7 @@
 - [getOmrsServiceWorker](API.md#getomrsserviceworker)
 - [getSynchronizationCallbacks](API.md#getsynchronizationcallbacks)
 - [messageOmrsServiceWorker](API.md#messageomrsserviceworker)
+- [patchXMLHttpRequest](API.md#patchxmlhttprequest)
 - [registerOmrsServiceWorker](API.md#registeromrsserviceworker)
 - [registerSynchronizationCallback](API.md#registersynchronizationcallback)
 - [subscribeNetworkRequestFailed](API.md#subscribenetworkrequestfailed)
@@ -123,6 +124,16 @@ Sends the specified message to the application's service worker.
 A promise which completes when the message has been successfully processed by the Service Worker.
 
 Defined in: [service-worker-messaging.ts:9](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-offline/src/service-worker-messaging.ts#L9)
+
+___
+
+### patchXMLHttpRequest
+
+▸ **patchXMLHttpRequest**(): *void*
+
+**Returns:** *void*
+
+Defined in: [patches.ts:1](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-offline/src/patches.ts#L1)
 
 ___
 

--- a/packages/framework/esm-styleguide/src/notifications/active-notifications.component.tsx
+++ b/packages/framework/esm-styleguide/src/notifications/active-notifications.component.tsx
@@ -13,12 +13,6 @@ const ActiveNotifications: React.FC<ActiveNotificationProps> = ({
     Array<InlineNotificationMeta>
   >([]);
 
-  const closeNotification = React.useCallback((notification) => {
-    setNotifications((notifications) =>
-      notifications.filter((n) => n !== notification)
-    );
-  }, []);
-
   React.useEffect(() => {
     const subscription = subject.subscribe((notification) =>
       setNotifications((notifications) => [
@@ -39,11 +33,7 @@ const ActiveNotifications: React.FC<ActiveNotificationProps> = ({
   return (
     <>
       {notifications.map((notification) => (
-        <Notification
-          key={notification.id}
-          notification={notification}
-          closeNotification={() => closeNotification(notification)}
-        />
+        <Notification key={notification.id} notification={notification} />
       ))}
     </>
   );

--- a/packages/framework/esm-styleguide/src/notifications/notification.component.tsx
+++ b/packages/framework/esm-styleguide/src/notifications/notification.component.tsx
@@ -8,8 +8,8 @@ export interface NotificationProps {
 export interface NotificationDescriptor {
   description: React.ReactNode;
   action?: React.ReactNode;
-  kind?: any;
-  lowContrast?: boolean;
+  kind?: InlineNotificationType;
+  critical?: boolean;
   millis?: number;
   title?: string;
 }
@@ -27,13 +27,13 @@ export type InlineNotificationType =
   | "warning-alt";
 
 export const Notification: React.FC<NotificationProps> = ({ notification }) => {
-  const { description, action, kind, lowContrast, title } = notification;
+  const { description, action, kind, critical, title } = notification;
 
   return (
     <InlineNotification
       actions={action}
       kind={kind || "info"}
-      lowContrast={lowContrast ?? true}
+      lowContrast={critical}
       subtitle={description}
       title={title || ""}
     />

--- a/packages/framework/esm-styleguide/src/notifications/notification.component.tsx
+++ b/packages/framework/esm-styleguide/src/notifications/notification.component.tsx
@@ -1,19 +1,15 @@
 import React from "react";
 import { InlineNotification } from "carbon-components-react/es/components/Notification";
 
-const defaultOptions = {
-  millis: 4000,
-};
-
 export interface NotificationProps {
   notification: InlineNotificationMeta;
-  closeNotification(): void;
 }
 
 export interface NotificationDescriptor {
   description: React.ReactNode;
   action?: React.ReactNode;
   kind?: any;
+  lowContrast?: boolean;
   millis?: number;
   title?: string;
 }
@@ -30,38 +26,16 @@ export type InlineNotificationType =
   | "warning"
   | "warning-alt";
 
-export const Notification: React.FC<NotificationProps> = ({
-  notification,
-  closeNotification,
-}) => {
-  const {
-    description,
-    action,
-    kind,
-    millis = defaultOptions.millis,
-    title,
-  } = notification;
-  const [waitingForTime, setWaitingForTime] = React.useState(true);
-
-  React.useEffect(() => {
-    if (waitingForTime) {
-      const timeoutId = setTimeout(closeNotification, millis);
-      return () => clearTimeout(timeoutId);
-    }
-  }, [waitingForTime]);
+export const Notification: React.FC<NotificationProps> = ({ notification }) => {
+  const { description, action, kind, lowContrast, title } = notification;
 
   return (
-    <div
-      onMouseEnter={() => setWaitingForTime(false)}
-      onMouseLeave={() => setWaitingForTime(true)}
-    >
-      <InlineNotification
-        lowContrast
-        actions={action}
-        kind={kind || "info"}
-        subtitle={description}
-        title={title || ""}
-      />
-    </div>
+    <InlineNotification
+      actions={action}
+      kind={kind || "info"}
+      lowContrast={lowContrast ?? true}
+      subtitle={description}
+      title={title || ""}
+    />
   );
 };

--- a/packages/framework/esm-styleguide/src/toasts/toast.component.tsx
+++ b/packages/framework/esm-styleguide/src/toasts/toast.component.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ToastNotification } from "carbon-components-react/es/components/Notification";
 
 const defaultOptions = {
-  millis: 4000,
+  millis: 5000,
 };
 
 export interface ToastProps {
@@ -13,6 +13,7 @@ export interface ToastProps {
 export interface ToastDescriptor {
   description: React.ReactNode;
   kind?: ToastType;
+  lowContrast?: boolean;
   title?: string;
   millis?: number;
 }
@@ -30,7 +31,13 @@ export type ToastType =
   | "warning-alt";
 
 export const Toast: React.FC<ToastProps> = ({ toast, closeToast }) => {
-  const { description, kind, title, millis = defaultOptions.millis } = toast;
+  const {
+    description,
+    kind,
+    lowContrast,
+    title,
+    millis = defaultOptions.millis,
+  } = toast;
   const [waitingForTime, setWaitingForTime] = React.useState(true);
 
   React.useEffect(() => {
@@ -46,8 +53,8 @@ export const Toast: React.FC<ToastProps> = ({ toast, closeToast }) => {
       onMouseLeave={() => setWaitingForTime(true)}
     >
       <ToastNotification
-        lowContrast
         kind={kind || "info"}
+        lowContrast={lowContrast ?? true}
         subtitle={description}
         title={title || ""}
         timeout={millis}

--- a/packages/framework/esm-styleguide/src/toasts/toast.component.tsx
+++ b/packages/framework/esm-styleguide/src/toasts/toast.component.tsx
@@ -13,7 +13,7 @@ export interface ToastProps {
 export interface ToastDescriptor {
   description: React.ReactNode;
   kind?: ToastType;
-  lowContrast?: boolean;
+  critical?: boolean;
   title?: string;
   millis?: number;
 }
@@ -34,10 +34,11 @@ export const Toast: React.FC<ToastProps> = ({ toast, closeToast }) => {
   const {
     description,
     kind,
-    lowContrast,
+    critical,
     title,
     millis = defaultOptions.millis,
   } = toast;
+
   const [waitingForTime, setWaitingForTime] = React.useState(true);
 
   React.useEffect(() => {
@@ -54,7 +55,7 @@ export const Toast: React.FC<ToastProps> = ({ toast, closeToast }) => {
     >
       <ToastNotification
         kind={kind || "info"}
-        lowContrast={lowContrast ?? true}
+        lowContrast={critical}
         subtitle={description}
         title={title || ""}
         timeout={millis}

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -108,6 +108,7 @@ function connectivityChanged() {
   const online = navigator.onLine;
   dispatchConnectivityChanged(online);
   showToast({
+    critical: true,
     description: `Connection: ${online ? "online" : "offline"}`,
     title: "App",
     kind: online ? "success" : "warning",
@@ -221,6 +222,7 @@ async function setupServiceWorker() {
       });
     } catch (e) {
       showNotification({
+        critical: true,
         title: "Offline Setup Error",
         description: `There was an error while preparing the website's offline mode. You can try reloading the page to potentially fix the error. Details: ${e}.`,
       });


### PR DESCRIPTION
Following a conversation with Ciaran earlier today, I've made a few adjustments to notifications:

- Notifications can have either low or high contrast, with critical  system notifications or patient-related notifications being high contrast.
- Inline notifications should not dismiss automatically.
- Toasts should dismiss automatically after 5 seconds.