### PR TITLE
Minor fixes and improvements to docs

### DIFF
--- a/docs/advanced/translations.md
+++ b/docs/advanced/translations.md
@@ -1,6 +1,6 @@
 # How translation works
 
-There are three places in frontend code that relate to translation/i18n. They are
+There are three places in frontend code that relate to translation/i18n. They are:
 
 - The app shell, in [locale.ts](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/shell/esm-app-shell/src/locale.ts).
   This sets up i18next and react-i18next.
@@ -11,5 +11,4 @@ There are three places in frontend code that relate to translation/i18n. They ar
   This component provides the connection between the i18next "backend"
   (still on the client side, despite the name) and the microfrontend it wraps.
 - The microfrontend, which uses the `t` function or `<Trans>` component from react-i18next
-  to produce rendered content.
-
+  to produce rendered content. Upon each commit, [i18next-parser](https://github.com/i18next/i18next-parser) parses the microfrontend code and automatically extracts translation keys and strings into locale-specific translation files found in the `translations` directory of a microfrontend.

--- a/docs/getting_started/prerequisites.md
+++ b/docs/getting_started/prerequisites.md
@@ -5,7 +5,7 @@ Before developing OpenMRS Frontend 3.0, you should be familiar with the followin
 ## Javascript
 
 Knowing Javascript is prerequisite to everything else. Consider 
-[Introduction to Javascript](https://www.codecademy.com/learn/introduction-to-javascript).
+[Introduction to Javascript](https://www.codecademy.com/learn/introduction-to-javascript) and [The Modern JavaScript Tutorial](https://javascript.info/).
 
 ## JavaScript Tooling
 
@@ -43,7 +43,7 @@ please read [TypeScript in 5 Minutes](https://www.typescriptlang.org/docs/handbo
 ## Git
 
 It is imperative that you keep your code in a version control system. OpenMRS uses
-[Git](https://git-scm.com/). You should know the basics of using git and GitHub.
+[Git](https://git-scm.com/). You should know the basics of using Git and GitHub.
 The website [Learn Git Branching](https://learngitbranching.js.org/) and the video
-[Git and GitHub for Begineers](https://www.youtube.com/watch?v=RGOj5yH7evk)
+[Git and GitHub for Beginners](https://www.youtube.com/watch?v=RGOj5yH7evk)
 are excellent resources.

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -113,7 +113,7 @@ npm run serve --https
 
 The protocol of the application must match the protocol of the locally-served microfrontend.
 
-This command will serve the microfrontend and tell you the port where it is serving it at,
+This command will serve the microfrontend and tell you the port where it is serving,
 as well as showing you the filenames that are being served. You can then use
 the import map overrides panel to override the existing import map
 entry, or add your microfrontend as a new entry.

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -1,8 +1,8 @@
 # Setup
 
-## Prerequsities
+## Prerequisities
 
-You must have git, node, and npm installed. See [prerequisites](./prerequisites).
+You must have git, node, and npm installed. See [prerequisites](getting_started/prerequisites).
 Consider using [nvm](https://github.com/nvm-sh/nvm#node-version-manager---)
 to ensure you're using the latest node.
 
@@ -87,16 +87,16 @@ deployed server somewhere, you can use Import Map Overrides,
 which is made available through the OpenMRS DevTools.
 
 > If you'd like to understand how Import Map Overrides works, check out
-  [the documentation](https://github.com/joeldenning/import-map-overrides).
+  the [documentation](https://github.com/joeldenning/import-map-overrides).
   If you'd just like to use it, continue reading here.
 
-To use enable the OpenMRS DevTools, open your browser's JavaScript console and execute
+To enable the OpenMRS DevTools, open your browser's JavaScript console and execute
 
 ```javascript
 localStorage.setItem('openmrs:devtools', true)
 ```
 
-After refreshing the page, a little box appear should in the lower-right hand corner of the page.
+After refreshing the page, a little box should appear in the lower-right hand corner of the page.
 Clicking this box opens the OpenMRS DevTools.
 
 In the microfrontend you want to develop, run
@@ -113,7 +113,7 @@ npm run serve --https
 
 The protocol of the application must match the protocol of the locally-served microfrontend.
 
-This command will serve the microfrontend and tell you the port where it is serving,
+This command will serve the microfrontend and tell you the port where it is serving it at,
 as well as showing you the filenames that are being served. You can then use
 the import map overrides panel to override the existing import map
 entry, or add your microfrontend as a new entry.
@@ -138,5 +138,5 @@ You can also simply type `8080` and Import Map Overrides will infer the URL abov
 If you're using import map overrides on a server that uses HTTPS, you must use `serve` with the
 `--https` flag. Your browser will probably complain about the certificate.
 You will need to convince it
-that there is no security risk. In Chrome, the "allow insecure localhost" flag
+that there is no security risk. In Chrome, enabling the "allow insecure localhost" flag
 (chrome://flags/#allow-insecure-localhost) can help.

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -2,7 +2,7 @@
 
 ## Prerequisities
 
-You must have git, node, and npm installed. See [prerequisites](getting_started/prerequisites).
+You must have git, node, and npm installed. See [prerequisites](getting_started/prerequisites.md).
 Consider using [nvm](https://github.com/nvm-sh/nvm#node-version-manager---)
 to ensure you're using the latest node.
 

--- a/docs/main/carbon.md
+++ b/docs/main/carbon.md
@@ -7,27 +7,26 @@ interface guidelines, and a community of contributors.
 
 OpenMRS 3.0 uses Carbon to create a unified UI. Third party Design Systems like Carbon 
 are kept professionally maintained by another community which reduces work for OpenMRS 
-contributors. (More details below in the section *Why use a Style Guide or a Design System?*)
+contributors. (More details in the [Why Use a Style Guide or a Design System](/main/carbon?id=why-use-a-style-guide-or-a-design-system) section below.
 
 ## How to Use Carbon in OpenMRS 3.0
 * See [Getting Started with Carbon](https://www.carbondesignsystem.com/developing/get-started/)
-  for first steps, dev resources, and a react-specific tutorial. 
-* More Carbon resources are availble on [GitHub here](https://github.com/carbon-design-system/carbon).
+  for first steps, dev resources, and a React-specific tutorial. 
+* More Carbon resources are available on [GitHub here](https://github.com/carbon-design-system/carbon).
 
 ## How to Use Zeplin
-**Zeplin** is a webapp tool that helps designs be handed over to developers. OpenMRS uses Zeplin for two purposes:
+**Zeplin** is a design collaboration tool that facilitates prototyping between UI designers and frontend developers. OpenMRS uses Zeplin for two purposes:
 1. *Design Handover*: To share designs as community assets.
 2. *Style Guide*: To clearly communicate the OpenMRS 3.0 frontend components, spacing 
     and layout, color palette, and text styles (since Carbon Design doesn't
     automatically customize all these for us). 
 
 ### To see the designs anytime
-To see the designs without needing Zeplin account access:
-[Desktop](https://zpl.io/agmBNlR) | [Tablet](https://zpl.io/VKev8wP) 
+You can see the designs without creating a Zeplin account by accessing the [Desktop](https://zpl.io/agmBNlR) and [Tablet](https://zpl.io/VKev8wP) screens.
 
 ### To use the designs and the styleguide
 
-First, watch this video for Devs on how to use Zeplin:
+First, watch this video guide for Developers on how to use Zeplin:
 [![How to see UX & component guidance in Zeplin designs](https://img.youtube.com/vi/SjluEGDH4LU/0.jpg)](https://www.youtube.com/watch?v=SjluEGDH4LU&feature=youtu.be&ab_channel=OpenMRS "OpenMRS 3.0: Zeplin Intro for New OpenMRS Devs")
 
 To use the designs as a developer, you'll need to request Zeplin access from an OpenMRS
@@ -57,5 +56,5 @@ are structured. Style Guides like Bootstrap and Material typically don’t provi
 kind of detail. We wanted a Style Guide that would also link to code you'll use in 
 your actual code base. 
 
-You can learn more about 
-[why we specifically chose Carbon Design as our Design System here](https://wiki.openmrs.org/x/uAwGDg). 
+Learn more about [Why we chose Carbon](https://wiki.openmrs.org/x/uAwGDg) as our design system.
+

--- a/docs/main/carbon.md
+++ b/docs/main/carbon.md
@@ -7,7 +7,7 @@ interface guidelines, and a community of contributors.
 
 OpenMRS 3.0 uses Carbon to create a unified UI. Third party Design Systems like Carbon 
 are kept professionally maintained by another community which reduces work for OpenMRS 
-contributors. (More details in the [Why Use a Style Guide or a Design System](/main/carbon?id=why-use-a-style-guide-or-a-design-system) section below.
+contributors. (More details in the [Why Use a Style Guide or a Design System](#why-use-a-style-guide-or-a-design-system) section below.
 
 ## How to Use Carbon in OpenMRS 3.0
 * See [Getting Started with Carbon](https://www.carbondesignsystem.com/developing/get-started/)

--- a/docs/main/config.md
+++ b/docs/main/config.md
@@ -288,7 +288,7 @@ defaults for configuration elements for which no values have been provided.
 
 #### Support in other frameworks (Angular, Vue, Svelte, etc.)
 
-This hasn't been implemented yet, but we would like to implement it! See [Contributing](/getting_started/contributing).
+This hasn't been implemented yet, but we would like to implement it! See [Contributing](../getting_started/contributing).
 
 ## Schema Reference
 

--- a/docs/main/config.md
+++ b/docs/main/config.md
@@ -23,7 +23,7 @@ including defaults and validations.
 ### Designing a schema
 
 You'll probably start with some idea of what you want configs for your module
-to look like. Try and put yourself in the implementer's shoes an imagine what
+to look like. Try and put yourself in the implementer's shoes and imagine what
 features they will expect to be configurable, and what they might expect the
 configuration property to be called. Assume they don't know anything about
 the internal workings of your module.
@@ -111,7 +111,7 @@ You should provide validators for your configuration elements wherever possible.
 This reduces the probability that implementers using your module will have
 hard-to-debug runtime errors. It gives you, the module developer, the opportunity
 to provide implementers with very helpful explanations about why their configuration
-on't work.
+doesn't work.
 
 ```js
 robot: {
@@ -160,7 +160,7 @@ For convenience, some common validators are provided out of the box. See the
 You can accept and validate arrays, and arrays containing objects, in your
 configuration schema. This is configured with the `elements` parameter, used
 with `_type: Type.Array`. For example, a schema which would accept an array
-of strings up to 30 characters long:
+of strings up to 30 characters long would look like this:
 
 ```js
 virtualProvider: {
@@ -288,7 +288,7 @@ defaults for configuration elements for which no values have been provided.
 
 #### Support in other frameworks (Angular, Vue, Svelte, etc.)
 
-This hasn't been implemented yet, but we would like to implement it! See "Contributing"
+This hasn't been implemented yet, but we would like to implement it! See [Contributing](/getting_started/contributing).
 
 ## Schema Reference
 

--- a/docs/main/config.md
+++ b/docs/main/config.md
@@ -288,7 +288,7 @@ defaults for configuration elements for which no values have been provided.
 
 #### Support in other frameworks (Angular, Vue, Svelte, etc.)
 
-This hasn't been implemented yet, but we would like to implement it! See [Contributing](../getting_started/contributing).
+This hasn't been implemented yet, but we would like to implement it! See [Contributing](../getting_started/contributing.md).
 
 ## Schema Reference
 

--- a/docs/main/creating_a_microfrontend.md
+++ b/docs/main/creating_a_microfrontend.md
@@ -11,7 +11,7 @@ Once you've created a microfrontend, you'll want to integrate it into your
 application. There are two steps for doing so.
 
 First, publish your microfrontend package to NPM. See
-[Release and Deployment](../getting_started/release_and_deployment)
+[Release and Deployment](getting_started/release_and_deployment)
 for more information. At the end, your package should be visible on npm.js,
 like [`@openmrs/esm-login-app`](https://www.npmjs.com/package/@openmrs/esm-login-app).
 

--- a/docs/main/creating_a_microfrontend.md
+++ b/docs/main/creating_a_microfrontend.md
@@ -11,7 +11,7 @@ Once you've created a microfrontend, you'll want to integrate it into your
 application. There are two steps for doing so.
 
 First, publish your microfrontend package to NPM. See
-[Release and Deployment](getting_started/release_and_deployment)
+[Release and Deployment](../getting_started/release_and_deployment.md)
 for more information. At the end, your package should be visible on npm.js,
 like [`@openmrs/esm-login-app`](https://www.npmjs.com/package/@openmrs/esm-login-app).
 

--- a/docs/main/data.md
+++ b/docs/main/data.md
@@ -10,7 +10,7 @@ documented [here](https://rest.openmrs.org/).
 Endpoints from the FHIR Module should always be preferred, when they are
 available. FHIR is an interoperability standard which OpenMRS supports.
 
-Some data is available using higher-level functions or React Hooks provided
+Some data is available using higher-level functions or custom React Hooks provided
 by `@openmrs/esm-framework`.  These should be used when available.
 
 All of this functionality (React hooks excepted) is provided by the
@@ -72,7 +72,9 @@ in a [`useEffect` hook](https://reactjs.org/docs/hooks-effect.html):
 ```typescript
 useEffect(() => {
   const abortController = new AbortController();
-  someFetchFunction(abortController).then(setResult);
+  someFetchFunction(abortController)
+    .then(setResult)
+    .catch(setError);
   return () => abortController.abort();
 }, []);
 ```

--- a/docs/main/state.md
+++ b/docs/main/state.md
@@ -80,6 +80,6 @@ import { bookStore } from "./bookStore";
 bookStore.setState({ books: ["A History of Global Health"] });
 ```
 
-See [the Unistore docs](https://github.com/developit/unistore#unistore) for more
+See the [Unistore docs](https://github.com/developit/unistore#unistore) for more
 information about stores.
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -171,7 +171,6 @@
 - [attach](API.md#attach)
 - [checkStatus](API.md#checkstatus)
 - [checkStatusFor](API.md#checkstatusfor)
-- [createAppState](API.md#createappstate)
 - [createErrorHandler](API.md#createerrorhandler)
 - [createGlobalStore](API.md#createglobalstore)
 - [createUseStore](API.md#createusestore)
@@ -1097,22 +1096,6 @@ Defined in: [packages/framework/esm-extensions/src/helpers.ts:9](https://github.
 
 ___
 
-### createAppState
-
-▸ **createAppState**(`initialState`: [*AppState*](interfaces/appstate.md)): *Store*<[*AppState*](interfaces/appstate.md)\>
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `initialState` | [*AppState*](interfaces/appstate.md) |
-
-**Returns:** *Store*<[*AppState*](interfaces/appstate.md)\>
-
-Defined in: [packages/framework/esm-state/src/state.ts:59](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-state/src/state.ts#L59)
-
-___
-
 ### createErrorHandler
 
 ▸ **createErrorHandler**(): *function*
@@ -1127,6 +1110,8 @@ ___
 
 ▸ **createGlobalStore**<TState\>(`name`: *string*, `initialState`: TState): *Store*<TState\>
 
+Creates a Unistore [store](https://github.com/developit/unistore#store).
+
 #### Type parameters
 
 | Name |
@@ -1135,14 +1120,16 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `name` | *string* |
-| `initialState` | TState |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | *string* | A name by which the store can be looked up later.    Must be unique across the entire application. |
+| `initialState` | TState | An object which will be the initial state of the store. |
 
 **Returns:** *Store*<TState\>
 
-Defined in: [packages/framework/esm-state/src/state.ts:10](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-state/src/state.ts#L10)
+The newly created store.
+
+Defined in: [packages/framework/esm-state/src/state.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-state/src/state.ts#L18)
 
 ___
 
@@ -1292,7 +1279,9 @@ ___
 
 **Returns:** *Store*<[*AppState*](interfaces/appstate.md)\>
 
-Defined in: [packages/framework/esm-state/src/state.ts:63](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-state/src/state.ts#L63)
+The [store](https://github.com/developit/unistore#store) named `app`.
+
+Defined in: [packages/framework/esm-state/src/state.ts:85](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-state/src/state.ts#L85)
 
 ___
 
@@ -1524,6 +1513,9 @@ ___
 
 ▸ **getGlobalStore**<TState\>(`name`: *string*, `fallbackState?`: TState): *Store*<TState\>
 
+Returns the existing [store](https://github.com/developit/unistore#store) named `name`,
+or creates a new store named `name` if none exists.
+
 #### Type parameters
 
 | Name | Default |
@@ -1532,14 +1524,16 @@ ___
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `name` | *string* |
-| `fallbackState?` | TState |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | *string* | The name of the store to look up. |
+| `fallbackState?` | TState | The initial value of the new store if no store named `name` exists. |
 
 **Returns:** *Store*<TState\>
 
-Defined in: [packages/framework/esm-state/src/state.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-state/src/state.ts#L39)
+The found or newly created store.
+
+Defined in: [packages/framework/esm-state/src/state.ts:55](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-state/src/state.ts#L55)
 
 ___
 
@@ -2244,7 +2238,7 @@ ___
 
 **Returns:** Unsubscribe
 
-Defined in: [packages/framework/esm-state/src/state.ts:67](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-state/src/state.ts#L67)
+Defined in: [packages/framework/esm-state/src/state.ts:89](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-state/src/state.ts#L89)
 
 ___
 


### PR DESCRIPTION
- Fix a broken link to `Prerequisites` in the `Setup` guide.
- Add [The Modern JavaScript Tutorial](https://javascript.info) as a suggested JavaScript resource.
- Change bolded content to a relative link in the `What is Carbon?` section of the `Using Carbon and the Styleguide` guide.
- Update Zeplin description in the `How to Use Zeplin` section of the `Using Carbon and the Styleguide` guide.
- Add a relative link to the `Contributing` guide in the `Support in other frameworks` section of the `Config` guide.
- Add a `catch` block to the `useEffect hook` example in the `Retrieving and posting data` guide.
- Add a bit about automatic extraction of translations using `i18next-parser` in the `How translation works` guide.
- Small grammatical fixes.