### PR TITLE
MF-607: Fix Inconsistent z-order in forms component

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/root.scss
+++ b/packages/apps/esm-primary-navigation-app/src/root.scss
@@ -23,11 +23,9 @@ $labeldropdown: #c6c6c6;
 }
 
 .headerPanel {
-  min-height: fit-content;
+  height: max-content;
 }
 
-.primaryNavContainer {
-  position: fixed;
-  top: 0;
-  z-index: 3;
+.primaryNavContainer header {
+  z-index: 3 !important
 }


### PR DESCRIPTION
### Description

 Fixed the inconsistent content z-index of the forms, this happened because the entire primary-navigation app was `position fixed` and in the document flow resulting in the errant display.

### Screenshoot

![MF-607](https://user-images.githubusercontent.com/28008754/122251366-1cb55800-ced3-11eb-89b5-86ebfc8f3574.gif)
