### PR TITLE
MF-623: show search icon on far left

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.scss
@@ -1,3 +1,4 @@
 .topNavActionSlot {
   display: flex;
+  flex-direction: row-reverse;
 }


### PR DESCRIPTION
# Description

Using row -reverse to show the search icon first. if someone could let me know how to do this better, please tell me.

the major culprit is here: https://github.com/openmrs/openmrs-esm-patient-management/blob/main/packages/esm-patient-search-app/src/index.ts#L22 where we are loading the extension

<img width="257" alt="Screen Shot 2021-06-16 at 8 35 05 PM" src="https://user-images.githubusercontent.com/2448569/122312503-56da2600-cee2-11eb-90b7-1de86bde7ae6.png">
