### PR TITLE
MF-629: Fix design QA issues on the login page

### DIFF
--- a/packages/apps/esm-login-app/src/login/login.component.tsx
+++ b/packages/apps/esm-login-app/src/login/login.component.tsx
@@ -119,6 +119,7 @@ const Login: React.FC<LoginProps> = ({ history, location, isLoginEnabled }) => {
       <use xlinkHref="#omrs-logo-full-color"></use>
     </svg>
   );
+
   return (
     <div className={`canvas ${styles["container"]}`}>
       <div className={`omrs-card ${styles["login-card"]}`}>
@@ -212,7 +213,7 @@ const Login: React.FC<LoginProps> = ({ history, location, isLoginEnabled }) => {
           </Button>
         </p>
       </div>
-      <div className="omrs-margin-top-32">
+      <div className={styles["footer"]}>
         <p className={styles["powered-by-txt"]}>
           {t("poweredBy", "Powered by")}
         </p>

--- a/packages/apps/esm-login-app/src/root.scss
+++ b/packages/apps/esm-login-app/src/root.scss
@@ -64,6 +64,10 @@ $inverse-link: #78a9ff;
   @include carbon--type-style("label-01");
 }
 
+.caption01 {
+  @include carbon--type-style("caption-01");
+}
+
 .helperText01 {
   @include carbon--type-style("helper-text-01");
 }

--- a/packages/apps/esm-login-app/src/styles.scss
+++ b/packages/apps/esm-login-app/src/styles.scss
@@ -7,19 +7,6 @@
   align-items: center;
 }
 
-.login-container {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  width: 23rem;
-  height: 27.5rem;
-  margin: 0 0 0.5rem;
-  padding: 2.5rem;
-  border-radius: 2px;
-  border: solid 1px var(--grey-2);
-  background-color: var(--color-white);
-}
-
 .center {
   text-align: center;
 }
@@ -29,7 +16,9 @@
 }
 
 .logo {
-  margin-bottom: 1rem;
+  margin-bottom: 2.5rem;
+  height: 5rem;
+  width: 13rem;
 }
 
 .logo-img {
@@ -47,18 +36,20 @@
 }
 
 .powered-by-txt {
+  @extend .caption01;
   text-align: center;
   color: var(--omrs-color-ink-low-contrast);
+  color: $text-02;
 }
 
 .need-help {
   display: flex;
-  justify-content: center;
   width: 23rem;
 }
 
 .need-help-txt {
   @extend .bodyShort01;
+  text-align: left;
   color: $text-02;
   display: flex;
   flex-direction: row;
@@ -71,16 +62,18 @@
 }
 
 .powered-by-logo {
-  height: 2.5625rem;
-  width: 8.5rem;
+  height: 2.5rem;
+  width: 6.5rem;
+}
+
+.login-card {
+  border-radius: 0;
+  height: 21.5rem;
+  width: 23rem;
+  padding: 2.5rem;
 }
 
 @media only screen and (min-width: 481px) {
-  .login-card {
-    padding: 2.5rem;
-    width: 23rem;
-  }
-
   .container {
     height: 100vh;
   }
@@ -89,8 +82,6 @@
 @media only screen and (max-width: 480px) {
   .login-card {
     margin-top: 2.5%;
-    width: 23rem;
-    padding: 2.5rem;
     border: none;
   }
 
@@ -127,4 +118,8 @@
   @extend .label01;
   width: 18rem;
   height: 3rem;
+}
+
+.footer {
+  margin-top: 6.75rem;
 }

--- a/packages/framework/esm-framework/docs/interfaces/configurablelinkprops.md
+++ b/packages/framework/esm-framework/docs/interfaces/configurablelinkprops.md
@@ -2,6 +2,8 @@
 
 # Interface: ConfigurableLinkProps
 
+**`noinheritdoc`**
+
 ## Hierarchy
 
 - *AnchorHTMLAttributes*<HTMLAnchorElement\>
@@ -12,12 +14,3071 @@
 
 ### Properties
 
+- [about](configurablelinkprops.md#about)
+- [accessKey](configurablelinkprops.md#accesskey)
+- [aria-activedescendant](configurablelinkprops.md#aria-activedescendant)
+- [aria-atomic](configurablelinkprops.md#aria-atomic)
+- [aria-autocomplete](configurablelinkprops.md#aria-autocomplete)
+- [aria-busy](configurablelinkprops.md#aria-busy)
+- [aria-checked](configurablelinkprops.md#aria-checked)
+- [aria-colcount](configurablelinkprops.md#aria-colcount)
+- [aria-colindex](configurablelinkprops.md#aria-colindex)
+- [aria-colspan](configurablelinkprops.md#aria-colspan)
+- [aria-controls](configurablelinkprops.md#aria-controls)
+- [aria-current](configurablelinkprops.md#aria-current)
+- [aria-describedby](configurablelinkprops.md#aria-describedby)
+- [aria-details](configurablelinkprops.md#aria-details)
+- [aria-disabled](configurablelinkprops.md#aria-disabled)
+- [aria-dropeffect](configurablelinkprops.md#aria-dropeffect)
+- [aria-errormessage](configurablelinkprops.md#aria-errormessage)
+- [aria-expanded](configurablelinkprops.md#aria-expanded)
+- [aria-flowto](configurablelinkprops.md#aria-flowto)
+- [aria-grabbed](configurablelinkprops.md#aria-grabbed)
+- [aria-haspopup](configurablelinkprops.md#aria-haspopup)
+- [aria-hidden](configurablelinkprops.md#aria-hidden)
+- [aria-invalid](configurablelinkprops.md#aria-invalid)
+- [aria-keyshortcuts](configurablelinkprops.md#aria-keyshortcuts)
+- [aria-label](configurablelinkprops.md#aria-label)
+- [aria-labelledby](configurablelinkprops.md#aria-labelledby)
+- [aria-level](configurablelinkprops.md#aria-level)
+- [aria-live](configurablelinkprops.md#aria-live)
+- [aria-modal](configurablelinkprops.md#aria-modal)
+- [aria-multiline](configurablelinkprops.md#aria-multiline)
+- [aria-multiselectable](configurablelinkprops.md#aria-multiselectable)
+- [aria-orientation](configurablelinkprops.md#aria-orientation)
+- [aria-owns](configurablelinkprops.md#aria-owns)
+- [aria-placeholder](configurablelinkprops.md#aria-placeholder)
+- [aria-posinset](configurablelinkprops.md#aria-posinset)
+- [aria-pressed](configurablelinkprops.md#aria-pressed)
+- [aria-readonly](configurablelinkprops.md#aria-readonly)
+- [aria-relevant](configurablelinkprops.md#aria-relevant)
+- [aria-required](configurablelinkprops.md#aria-required)
+- [aria-roledescription](configurablelinkprops.md#aria-roledescription)
+- [aria-rowcount](configurablelinkprops.md#aria-rowcount)
+- [aria-rowindex](configurablelinkprops.md#aria-rowindex)
+- [aria-rowspan](configurablelinkprops.md#aria-rowspan)
+- [aria-selected](configurablelinkprops.md#aria-selected)
+- [aria-setsize](configurablelinkprops.md#aria-setsize)
+- [aria-sort](configurablelinkprops.md#aria-sort)
+- [aria-valuemax](configurablelinkprops.md#aria-valuemax)
+- [aria-valuemin](configurablelinkprops.md#aria-valuemin)
+- [aria-valuenow](configurablelinkprops.md#aria-valuenow)
+- [aria-valuetext](configurablelinkprops.md#aria-valuetext)
+- [autoCapitalize](configurablelinkprops.md#autocapitalize)
+- [autoCorrect](configurablelinkprops.md#autocorrect)
+- [autoSave](configurablelinkprops.md#autosave)
+- [children](configurablelinkprops.md#children)
+- [className](configurablelinkprops.md#classname)
+- [color](configurablelinkprops.md#color)
+- [contentEditable](configurablelinkprops.md#contenteditable)
+- [contextMenu](configurablelinkprops.md#contextmenu)
+- [dangerouslySetInnerHTML](configurablelinkprops.md#dangerouslysetinnerhtml)
+- [datatype](configurablelinkprops.md#datatype)
+- [defaultChecked](configurablelinkprops.md#defaultchecked)
+- [defaultValue](configurablelinkprops.md#defaultvalue)
+- [dir](configurablelinkprops.md#dir)
+- [download](configurablelinkprops.md#download)
+- [draggable](configurablelinkprops.md#draggable)
+- [hidden](configurablelinkprops.md#hidden)
+- [href](configurablelinkprops.md#href)
+- [hrefLang](configurablelinkprops.md#hreflang)
+- [id](configurablelinkprops.md#id)
+- [inlist](configurablelinkprops.md#inlist)
+- [inputMode](configurablelinkprops.md#inputmode)
+- [is](configurablelinkprops.md#is)
+- [itemID](configurablelinkprops.md#itemid)
+- [itemProp](configurablelinkprops.md#itemprop)
+- [itemRef](configurablelinkprops.md#itemref)
+- [itemScope](configurablelinkprops.md#itemscope)
+- [itemType](configurablelinkprops.md#itemtype)
+- [lang](configurablelinkprops.md#lang)
+- [media](configurablelinkprops.md#media)
+- [onAbort](configurablelinkprops.md#onabort)
+- [onAbortCapture](configurablelinkprops.md#onabortcapture)
+- [onAnimationEnd](configurablelinkprops.md#onanimationend)
+- [onAnimationEndCapture](configurablelinkprops.md#onanimationendcapture)
+- [onAnimationIteration](configurablelinkprops.md#onanimationiteration)
+- [onAnimationIterationCapture](configurablelinkprops.md#onanimationiterationcapture)
+- [onAnimationStart](configurablelinkprops.md#onanimationstart)
+- [onAnimationStartCapture](configurablelinkprops.md#onanimationstartcapture)
+- [onAuxClick](configurablelinkprops.md#onauxclick)
+- [onAuxClickCapture](configurablelinkprops.md#onauxclickcapture)
+- [onBeforeInput](configurablelinkprops.md#onbeforeinput)
+- [onBeforeInputCapture](configurablelinkprops.md#onbeforeinputcapture)
+- [onBlur](configurablelinkprops.md#onblur)
+- [onBlurCapture](configurablelinkprops.md#onblurcapture)
+- [onCanPlay](configurablelinkprops.md#oncanplay)
+- [onCanPlayCapture](configurablelinkprops.md#oncanplaycapture)
+- [onCanPlayThrough](configurablelinkprops.md#oncanplaythrough)
+- [onCanPlayThroughCapture](configurablelinkprops.md#oncanplaythroughcapture)
+- [onChange](configurablelinkprops.md#onchange)
+- [onChangeCapture](configurablelinkprops.md#onchangecapture)
+- [onClick](configurablelinkprops.md#onclick)
+- [onClickCapture](configurablelinkprops.md#onclickcapture)
+- [onCompositionEnd](configurablelinkprops.md#oncompositionend)
+- [onCompositionEndCapture](configurablelinkprops.md#oncompositionendcapture)
+- [onCompositionStart](configurablelinkprops.md#oncompositionstart)
+- [onCompositionStartCapture](configurablelinkprops.md#oncompositionstartcapture)
+- [onCompositionUpdate](configurablelinkprops.md#oncompositionupdate)
+- [onCompositionUpdateCapture](configurablelinkprops.md#oncompositionupdatecapture)
+- [onContextMenu](configurablelinkprops.md#oncontextmenu)
+- [onContextMenuCapture](configurablelinkprops.md#oncontextmenucapture)
+- [onCopy](configurablelinkprops.md#oncopy)
+- [onCopyCapture](configurablelinkprops.md#oncopycapture)
+- [onCut](configurablelinkprops.md#oncut)
+- [onCutCapture](configurablelinkprops.md#oncutcapture)
+- [onDoubleClick](configurablelinkprops.md#ondoubleclick)
+- [onDoubleClickCapture](configurablelinkprops.md#ondoubleclickcapture)
+- [onDrag](configurablelinkprops.md#ondrag)
+- [onDragCapture](configurablelinkprops.md#ondragcapture)
+- [onDragEnd](configurablelinkprops.md#ondragend)
+- [onDragEndCapture](configurablelinkprops.md#ondragendcapture)
+- [onDragEnter](configurablelinkprops.md#ondragenter)
+- [onDragEnterCapture](configurablelinkprops.md#ondragentercapture)
+- [onDragExit](configurablelinkprops.md#ondragexit)
+- [onDragExitCapture](configurablelinkprops.md#ondragexitcapture)
+- [onDragLeave](configurablelinkprops.md#ondragleave)
+- [onDragLeaveCapture](configurablelinkprops.md#ondragleavecapture)
+- [onDragOver](configurablelinkprops.md#ondragover)
+- [onDragOverCapture](configurablelinkprops.md#ondragovercapture)
+- [onDragStart](configurablelinkprops.md#ondragstart)
+- [onDragStartCapture](configurablelinkprops.md#ondragstartcapture)
+- [onDrop](configurablelinkprops.md#ondrop)
+- [onDropCapture](configurablelinkprops.md#ondropcapture)
+- [onDurationChange](configurablelinkprops.md#ondurationchange)
+- [onDurationChangeCapture](configurablelinkprops.md#ondurationchangecapture)
+- [onEmptied](configurablelinkprops.md#onemptied)
+- [onEmptiedCapture](configurablelinkprops.md#onemptiedcapture)
+- [onEncrypted](configurablelinkprops.md#onencrypted)
+- [onEncryptedCapture](configurablelinkprops.md#onencryptedcapture)
+- [onEnded](configurablelinkprops.md#onended)
+- [onEndedCapture](configurablelinkprops.md#onendedcapture)
+- [onError](configurablelinkprops.md#onerror)
+- [onErrorCapture](configurablelinkprops.md#onerrorcapture)
+- [onFocus](configurablelinkprops.md#onfocus)
+- [onFocusCapture](configurablelinkprops.md#onfocuscapture)
+- [onGotPointerCapture](configurablelinkprops.md#ongotpointercapture)
+- [onGotPointerCaptureCapture](configurablelinkprops.md#ongotpointercapturecapture)
+- [onInput](configurablelinkprops.md#oninput)
+- [onInputCapture](configurablelinkprops.md#oninputcapture)
+- [onInvalid](configurablelinkprops.md#oninvalid)
+- [onInvalidCapture](configurablelinkprops.md#oninvalidcapture)
+- [onKeyDown](configurablelinkprops.md#onkeydown)
+- [onKeyDownCapture](configurablelinkprops.md#onkeydowncapture)
+- [onKeyPress](configurablelinkprops.md#onkeypress)
+- [onKeyPressCapture](configurablelinkprops.md#onkeypresscapture)
+- [onKeyUp](configurablelinkprops.md#onkeyup)
+- [onKeyUpCapture](configurablelinkprops.md#onkeyupcapture)
+- [onLoad](configurablelinkprops.md#onload)
+- [onLoadCapture](configurablelinkprops.md#onloadcapture)
+- [onLoadStart](configurablelinkprops.md#onloadstart)
+- [onLoadStartCapture](configurablelinkprops.md#onloadstartcapture)
+- [onLoadedData](configurablelinkprops.md#onloadeddata)
+- [onLoadedDataCapture](configurablelinkprops.md#onloadeddatacapture)
+- [onLoadedMetadata](configurablelinkprops.md#onloadedmetadata)
+- [onLoadedMetadataCapture](configurablelinkprops.md#onloadedmetadatacapture)
+- [onLostPointerCapture](configurablelinkprops.md#onlostpointercapture)
+- [onLostPointerCaptureCapture](configurablelinkprops.md#onlostpointercapturecapture)
+- [onMouseDown](configurablelinkprops.md#onmousedown)
+- [onMouseDownCapture](configurablelinkprops.md#onmousedowncapture)
+- [onMouseEnter](configurablelinkprops.md#onmouseenter)
+- [onMouseLeave](configurablelinkprops.md#onmouseleave)
+- [onMouseMove](configurablelinkprops.md#onmousemove)
+- [onMouseMoveCapture](configurablelinkprops.md#onmousemovecapture)
+- [onMouseOut](configurablelinkprops.md#onmouseout)
+- [onMouseOutCapture](configurablelinkprops.md#onmouseoutcapture)
+- [onMouseOver](configurablelinkprops.md#onmouseover)
+- [onMouseOverCapture](configurablelinkprops.md#onmouseovercapture)
+- [onMouseUp](configurablelinkprops.md#onmouseup)
+- [onMouseUpCapture](configurablelinkprops.md#onmouseupcapture)
+- [onPaste](configurablelinkprops.md#onpaste)
+- [onPasteCapture](configurablelinkprops.md#onpastecapture)
+- [onPause](configurablelinkprops.md#onpause)
+- [onPauseCapture](configurablelinkprops.md#onpausecapture)
+- [onPlay](configurablelinkprops.md#onplay)
+- [onPlayCapture](configurablelinkprops.md#onplaycapture)
+- [onPlaying](configurablelinkprops.md#onplaying)
+- [onPlayingCapture](configurablelinkprops.md#onplayingcapture)
+- [onPointerCancel](configurablelinkprops.md#onpointercancel)
+- [onPointerCancelCapture](configurablelinkprops.md#onpointercancelcapture)
+- [onPointerDown](configurablelinkprops.md#onpointerdown)
+- [onPointerDownCapture](configurablelinkprops.md#onpointerdowncapture)
+- [onPointerEnter](configurablelinkprops.md#onpointerenter)
+- [onPointerEnterCapture](configurablelinkprops.md#onpointerentercapture)
+- [onPointerLeave](configurablelinkprops.md#onpointerleave)
+- [onPointerLeaveCapture](configurablelinkprops.md#onpointerleavecapture)
+- [onPointerMove](configurablelinkprops.md#onpointermove)
+- [onPointerMoveCapture](configurablelinkprops.md#onpointermovecapture)
+- [onPointerOut](configurablelinkprops.md#onpointerout)
+- [onPointerOutCapture](configurablelinkprops.md#onpointeroutcapture)
+- [onPointerOver](configurablelinkprops.md#onpointerover)
+- [onPointerOverCapture](configurablelinkprops.md#onpointerovercapture)
+- [onPointerUp](configurablelinkprops.md#onpointerup)
+- [onPointerUpCapture](configurablelinkprops.md#onpointerupcapture)
+- [onProgress](configurablelinkprops.md#onprogress)
+- [onProgressCapture](configurablelinkprops.md#onprogresscapture)
+- [onRateChange](configurablelinkprops.md#onratechange)
+- [onRateChangeCapture](configurablelinkprops.md#onratechangecapture)
+- [onReset](configurablelinkprops.md#onreset)
+- [onResetCapture](configurablelinkprops.md#onresetcapture)
+- [onScroll](configurablelinkprops.md#onscroll)
+- [onScrollCapture](configurablelinkprops.md#onscrollcapture)
+- [onSeeked](configurablelinkprops.md#onseeked)
+- [onSeekedCapture](configurablelinkprops.md#onseekedcapture)
+- [onSeeking](configurablelinkprops.md#onseeking)
+- [onSeekingCapture](configurablelinkprops.md#onseekingcapture)
+- [onSelect](configurablelinkprops.md#onselect)
+- [onSelectCapture](configurablelinkprops.md#onselectcapture)
+- [onStalled](configurablelinkprops.md#onstalled)
+- [onStalledCapture](configurablelinkprops.md#onstalledcapture)
+- [onSubmit](configurablelinkprops.md#onsubmit)
+- [onSubmitCapture](configurablelinkprops.md#onsubmitcapture)
+- [onSuspend](configurablelinkprops.md#onsuspend)
+- [onSuspendCapture](configurablelinkprops.md#onsuspendcapture)
+- [onTimeUpdate](configurablelinkprops.md#ontimeupdate)
+- [onTimeUpdateCapture](configurablelinkprops.md#ontimeupdatecapture)
+- [onTouchCancel](configurablelinkprops.md#ontouchcancel)
+- [onTouchCancelCapture](configurablelinkprops.md#ontouchcancelcapture)
+- [onTouchEnd](configurablelinkprops.md#ontouchend)
+- [onTouchEndCapture](configurablelinkprops.md#ontouchendcapture)
+- [onTouchMove](configurablelinkprops.md#ontouchmove)
+- [onTouchMoveCapture](configurablelinkprops.md#ontouchmovecapture)
+- [onTouchStart](configurablelinkprops.md#ontouchstart)
+- [onTouchStartCapture](configurablelinkprops.md#ontouchstartcapture)
+- [onTransitionEnd](configurablelinkprops.md#ontransitionend)
+- [onTransitionEndCapture](configurablelinkprops.md#ontransitionendcapture)
+- [onVolumeChange](configurablelinkprops.md#onvolumechange)
+- [onVolumeChangeCapture](configurablelinkprops.md#onvolumechangecapture)
+- [onWaiting](configurablelinkprops.md#onwaiting)
+- [onWaitingCapture](configurablelinkprops.md#onwaitingcapture)
+- [onWheel](configurablelinkprops.md#onwheel)
+- [onWheelCapture](configurablelinkprops.md#onwheelcapture)
+- [ping](configurablelinkprops.md#ping)
+- [placeholder](configurablelinkprops.md#placeholder)
+- [prefix](configurablelinkprops.md#prefix)
+- [property](configurablelinkprops.md#property)
+- [radioGroup](configurablelinkprops.md#radiogroup)
+- [referrerPolicy](configurablelinkprops.md#referrerpolicy)
+- [rel](configurablelinkprops.md#rel)
+- [resource](configurablelinkprops.md#resource)
+- [results](configurablelinkprops.md#results)
+- [role](configurablelinkprops.md#role)
+- [security](configurablelinkprops.md#security)
+- [slot](configurablelinkprops.md#slot)
+- [spellCheck](configurablelinkprops.md#spellcheck)
+- [style](configurablelinkprops.md#style)
+- [suppressContentEditableWarning](configurablelinkprops.md#suppresscontenteditablewarning)
+- [suppressHydrationWarning](configurablelinkprops.md#suppresshydrationwarning)
+- [tabIndex](configurablelinkprops.md#tabindex)
+- [target](configurablelinkprops.md#target)
+- [title](configurablelinkprops.md#title)
 - [to](configurablelinkprops.md#to)
+- [translate](configurablelinkprops.md#translate)
+- [type](configurablelinkprops.md#type)
+- [typeof](configurablelinkprops.md#typeof)
+- [unselectable](configurablelinkprops.md#unselectable)
+- [vocab](configurablelinkprops.md#vocab)
 
 ## Properties
+
+### about
+
+• `Optional` **about**: *string*
+
+Inherited from: AnchorHTMLAttributes.about
+
+Defined in: node_modules/@types/react/index.d.ts:1772
+
+___
+
+### accessKey
+
+• `Optional` **accessKey**: *string*
+
+Inherited from: AnchorHTMLAttributes.accessKey
+
+Defined in: node_modules/@types/react/index.d.ts:1748
+
+___
+
+### aria-activedescendant
+
+• `Optional` **aria-activedescendant**: *string*
+
+Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.
+
+Inherited from: AnchorHTMLAttributes.aria-activedescendant
+
+Defined in: node_modules/@types/react/index.d.ts:1553
+
+___
+
+### aria-atomic
+
+• `Optional` **aria-atomic**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.
+
+Inherited from: AnchorHTMLAttributes.aria-atomic
+
+Defined in: node_modules/@types/react/index.d.ts:1555
+
+___
+
+### aria-autocomplete
+
+• `Optional` **aria-autocomplete**: ``"none"`` \| ``"inline"`` \| ``"list"`` \| ``"both"``
+
+Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
+presented if they are made.
+
+Inherited from: AnchorHTMLAttributes.aria-autocomplete
+
+Defined in: node_modules/@types/react/index.d.ts:1557
+
+___
+
+### aria-busy
+
+• `Optional` **aria-busy**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.
+
+Inherited from: AnchorHTMLAttributes.aria-busy
+
+Defined in: node_modules/@types/react/index.d.ts:1562
+
+___
+
+### aria-checked
+
+• `Optional` **aria-checked**: *boolean* \| ``"true"`` \| ``"false"`` \| ``"mixed"``
+
+Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
+
+**`see`** aria-pressed @see aria-selected.
+
+Inherited from: AnchorHTMLAttributes.aria-checked
+
+Defined in: node_modules/@types/react/index.d.ts:1564
+
+___
+
+### aria-colcount
+
+• `Optional` **aria-colcount**: *number*
+
+Defines the total number of columns in a table, grid, or treegrid.
+
+**`see`** aria-colindex.
+
+Inherited from: AnchorHTMLAttributes.aria-colcount
+
+Defined in: node_modules/@types/react/index.d.ts:1569
+
+___
+
+### aria-colindex
+
+• `Optional` **aria-colindex**: *number*
+
+Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+
+**`see`** aria-colcount @see aria-colspan.
+
+Inherited from: AnchorHTMLAttributes.aria-colindex
+
+Defined in: node_modules/@types/react/index.d.ts:1574
+
+___
+
+### aria-colspan
+
+• `Optional` **aria-colspan**: *number*
+
+Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+
+**`see`** aria-colindex @see aria-rowspan.
+
+Inherited from: AnchorHTMLAttributes.aria-colspan
+
+Defined in: node_modules/@types/react/index.d.ts:1579
+
+___
+
+### aria-controls
+
+• `Optional` **aria-controls**: *string*
+
+Identifies the element (or elements) whose contents or presence are controlled by the current element.
+
+**`see`** aria-owns.
+
+Inherited from: AnchorHTMLAttributes.aria-controls
+
+Defined in: node_modules/@types/react/index.d.ts:1584
+
+___
+
+### aria-current
+
+• `Optional` **aria-current**: *boolean* \| ``"true"`` \| ``"false"`` \| ``"page"`` \| ``"step"`` \| ``"location"`` \| ``"date"`` \| ``"time"``
+
+Indicates the element that represents the current item within a container or set of related elements.
+
+Inherited from: AnchorHTMLAttributes.aria-current
+
+Defined in: node_modules/@types/react/index.d.ts:1589
+
+___
+
+### aria-describedby
+
+• `Optional` **aria-describedby**: *string*
+
+Identifies the element (or elements) that describes the object.
+
+**`see`** aria-labelledby
+
+Inherited from: AnchorHTMLAttributes.aria-describedby
+
+Defined in: node_modules/@types/react/index.d.ts:1591
+
+___
+
+### aria-details
+
+• `Optional` **aria-details**: *string*
+
+Identifies the element that provides a detailed, extended description for the object.
+
+**`see`** aria-describedby.
+
+Inherited from: AnchorHTMLAttributes.aria-details
+
+Defined in: node_modules/@types/react/index.d.ts:1596
+
+___
+
+### aria-disabled
+
+• `Optional` **aria-disabled**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+
+**`see`** aria-hidden @see aria-readonly.
+
+Inherited from: AnchorHTMLAttributes.aria-disabled
+
+Defined in: node_modules/@types/react/index.d.ts:1601
+
+___
+
+### aria-dropeffect
+
+• `Optional` **aria-dropeffect**: ``"link"`` \| ``"none"`` \| ``"copy"`` \| ``"execute"`` \| ``"move"`` \| ``"popup"``
+
+Indicates what functions can be performed when a dragged object is released on the drop target.
+
+**`deprecated`** in ARIA 1.1
+
+Inherited from: AnchorHTMLAttributes.aria-dropeffect
+
+Defined in: node_modules/@types/react/index.d.ts:1606
+
+___
+
+### aria-errormessage
+
+• `Optional` **aria-errormessage**: *string*
+
+Identifies the element that provides an error message for the object.
+
+**`see`** aria-invalid @see aria-describedby.
+
+Inherited from: AnchorHTMLAttributes.aria-errormessage
+
+Defined in: node_modules/@types/react/index.d.ts:1611
+
+___
+
+### aria-expanded
+
+• `Optional` **aria-expanded**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.
+
+Inherited from: AnchorHTMLAttributes.aria-expanded
+
+Defined in: node_modules/@types/react/index.d.ts:1616
+
+___
+
+### aria-flowto
+
+• `Optional` **aria-flowto**: *string*
+
+Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
+allows assistive technology to override the general default of reading in document source order.
+
+Inherited from: AnchorHTMLAttributes.aria-flowto
+
+Defined in: node_modules/@types/react/index.d.ts:1618
+
+___
+
+### aria-grabbed
+
+• `Optional` **aria-grabbed**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates an element's "grabbed" state in a drag-and-drop operation.
+
+**`deprecated`** in ARIA 1.1
+
+Inherited from: AnchorHTMLAttributes.aria-grabbed
+
+Defined in: node_modules/@types/react/index.d.ts:1623
+
+___
+
+### aria-haspopup
+
+• `Optional` **aria-haspopup**: *boolean* \| ``"dialog"`` \| ``"true"`` \| ``"false"`` \| ``"menu"`` \| ``"listbox"`` \| ``"tree"`` \| ``"grid"``
+
+Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
+
+Inherited from: AnchorHTMLAttributes.aria-haspopup
+
+Defined in: node_modules/@types/react/index.d.ts:1628
+
+___
+
+### aria-hidden
+
+• `Optional` **aria-hidden**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates whether the element is exposed to an accessibility API.
+
+**`see`** aria-disabled.
+
+Inherited from: AnchorHTMLAttributes.aria-hidden
+
+Defined in: node_modules/@types/react/index.d.ts:1630
+
+___
+
+### aria-invalid
+
+• `Optional` **aria-invalid**: *boolean* \| ``"true"`` \| ``"false"`` \| ``"grammar"`` \| ``"spelling"``
+
+Indicates the entered value does not conform to the format expected by the application.
+
+**`see`** aria-errormessage.
+
+Inherited from: AnchorHTMLAttributes.aria-invalid
+
+Defined in: node_modules/@types/react/index.d.ts:1635
+
+___
+
+### aria-keyshortcuts
+
+• `Optional` **aria-keyshortcuts**: *string*
+
+Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
+
+Inherited from: AnchorHTMLAttributes.aria-keyshortcuts
+
+Defined in: node_modules/@types/react/index.d.ts:1640
+
+___
+
+### aria-label
+
+• `Optional` **aria-label**: *string*
+
+Defines a string value that labels the current element.
+
+**`see`** aria-labelledby.
+
+Inherited from: AnchorHTMLAttributes.aria-label
+
+Defined in: node_modules/@types/react/index.d.ts:1642
+
+___
+
+### aria-labelledby
+
+• `Optional` **aria-labelledby**: *string*
+
+Identifies the element (or elements) that labels the current element.
+
+**`see`** aria-describedby.
+
+Inherited from: AnchorHTMLAttributes.aria-labelledby
+
+Defined in: node_modules/@types/react/index.d.ts:1647
+
+___
+
+### aria-level
+
+• `Optional` **aria-level**: *number*
+
+Defines the hierarchical level of an element within a structure.
+
+Inherited from: AnchorHTMLAttributes.aria-level
+
+Defined in: node_modules/@types/react/index.d.ts:1652
+
+___
+
+### aria-live
+
+• `Optional` **aria-live**: ``"off"`` \| ``"assertive"`` \| ``"polite"``
+
+Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
+
+Inherited from: AnchorHTMLAttributes.aria-live
+
+Defined in: node_modules/@types/react/index.d.ts:1654
+
+___
+
+### aria-modal
+
+• `Optional` **aria-modal**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates whether an element is modal when displayed.
+
+Inherited from: AnchorHTMLAttributes.aria-modal
+
+Defined in: node_modules/@types/react/index.d.ts:1656
+
+___
+
+### aria-multiline
+
+• `Optional` **aria-multiline**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates whether a text box accepts multiple lines of input or only a single line.
+
+Inherited from: AnchorHTMLAttributes.aria-multiline
+
+Defined in: node_modules/@types/react/index.d.ts:1658
+
+___
+
+### aria-multiselectable
+
+• `Optional` **aria-multiselectable**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates that the user may select more than one item from the current selectable descendants.
+
+Inherited from: AnchorHTMLAttributes.aria-multiselectable
+
+Defined in: node_modules/@types/react/index.d.ts:1660
+
+___
+
+### aria-orientation
+
+• `Optional` **aria-orientation**: ``"horizontal"`` \| ``"vertical"``
+
+Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
+
+Inherited from: AnchorHTMLAttributes.aria-orientation
+
+Defined in: node_modules/@types/react/index.d.ts:1662
+
+___
+
+### aria-owns
+
+• `Optional` **aria-owns**: *string*
+
+Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
+between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
+
+**`see`** aria-controls.
+
+Inherited from: AnchorHTMLAttributes.aria-owns
+
+Defined in: node_modules/@types/react/index.d.ts:1664
+
+___
+
+### aria-placeholder
+
+• `Optional` **aria-placeholder**: *string*
+
+Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
+A hint could be a sample value or a brief description of the expected format.
+
+Inherited from: AnchorHTMLAttributes.aria-placeholder
+
+Defined in: node_modules/@types/react/index.d.ts:1670
+
+___
+
+### aria-posinset
+
+• `Optional` **aria-posinset**: *number*
+
+Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+
+**`see`** aria-setsize.
+
+Inherited from: AnchorHTMLAttributes.aria-posinset
+
+Defined in: node_modules/@types/react/index.d.ts:1675
+
+___
+
+### aria-pressed
+
+• `Optional` **aria-pressed**: *boolean* \| ``"true"`` \| ``"false"`` \| ``"mixed"``
+
+Indicates the current "pressed" state of toggle buttons.
+
+**`see`** aria-checked @see aria-selected.
+
+Inherited from: AnchorHTMLAttributes.aria-pressed
+
+Defined in: node_modules/@types/react/index.d.ts:1680
+
+___
+
+### aria-readonly
+
+• `Optional` **aria-readonly**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates that the element is not editable, but is otherwise operable.
+
+**`see`** aria-disabled.
+
+Inherited from: AnchorHTMLAttributes.aria-readonly
+
+Defined in: node_modules/@types/react/index.d.ts:1685
+
+___
+
+### aria-relevant
+
+• `Optional` **aria-relevant**: ``"text"`` \| ``"additions"`` \| ``"additions removals"`` \| ``"additions text"`` \| ``"all"`` \| ``"removals"`` \| ``"removals additions"`` \| ``"removals text"`` \| ``"text additions"`` \| ``"text removals"``
+
+Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
+
+**`see`** aria-atomic.
+
+Inherited from: AnchorHTMLAttributes.aria-relevant
+
+Defined in: node_modules/@types/react/index.d.ts:1690
+
+___
+
+### aria-required
+
+• `Optional` **aria-required**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates that user input is required on the element before a form may be submitted.
+
+Inherited from: AnchorHTMLAttributes.aria-required
+
+Defined in: node_modules/@types/react/index.d.ts:1695
+
+___
+
+### aria-roledescription
+
+• `Optional` **aria-roledescription**: *string*
+
+Defines a human-readable, author-localized description for the role of an element.
+
+Inherited from: AnchorHTMLAttributes.aria-roledescription
+
+Defined in: node_modules/@types/react/index.d.ts:1697
+
+___
+
+### aria-rowcount
+
+• `Optional` **aria-rowcount**: *number*
+
+Defines the total number of rows in a table, grid, or treegrid.
+
+**`see`** aria-rowindex.
+
+Inherited from: AnchorHTMLAttributes.aria-rowcount
+
+Defined in: node_modules/@types/react/index.d.ts:1699
+
+___
+
+### aria-rowindex
+
+• `Optional` **aria-rowindex**: *number*
+
+Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+
+**`see`** aria-rowcount @see aria-rowspan.
+
+Inherited from: AnchorHTMLAttributes.aria-rowindex
+
+Defined in: node_modules/@types/react/index.d.ts:1704
+
+___
+
+### aria-rowspan
+
+• `Optional` **aria-rowspan**: *number*
+
+Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+
+**`see`** aria-rowindex @see aria-colspan.
+
+Inherited from: AnchorHTMLAttributes.aria-rowspan
+
+Defined in: node_modules/@types/react/index.d.ts:1709
+
+___
+
+### aria-selected
+
+• `Optional` **aria-selected**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates the current "selected" state of various widgets.
+
+**`see`** aria-checked @see aria-pressed.
+
+Inherited from: AnchorHTMLAttributes.aria-selected
+
+Defined in: node_modules/@types/react/index.d.ts:1714
+
+___
+
+### aria-setsize
+
+• `Optional` **aria-setsize**: *number*
+
+Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+
+**`see`** aria-posinset.
+
+Inherited from: AnchorHTMLAttributes.aria-setsize
+
+Defined in: node_modules/@types/react/index.d.ts:1719
+
+___
+
+### aria-sort
+
+• `Optional` **aria-sort**: ``"none"`` \| ``"ascending"`` \| ``"descending"`` \| ``"other"``
+
+Indicates if items in a table or grid are sorted in ascending or descending order.
+
+Inherited from: AnchorHTMLAttributes.aria-sort
+
+Defined in: node_modules/@types/react/index.d.ts:1724
+
+___
+
+### aria-valuemax
+
+• `Optional` **aria-valuemax**: *number*
+
+Defines the maximum allowed value for a range widget.
+
+Inherited from: AnchorHTMLAttributes.aria-valuemax
+
+Defined in: node_modules/@types/react/index.d.ts:1726
+
+___
+
+### aria-valuemin
+
+• `Optional` **aria-valuemin**: *number*
+
+Defines the minimum allowed value for a range widget.
+
+Inherited from: AnchorHTMLAttributes.aria-valuemin
+
+Defined in: node_modules/@types/react/index.d.ts:1728
+
+___
+
+### aria-valuenow
+
+• `Optional` **aria-valuenow**: *number*
+
+Defines the current value for a range widget.
+
+**`see`** aria-valuetext.
+
+Inherited from: AnchorHTMLAttributes.aria-valuenow
+
+Defined in: node_modules/@types/react/index.d.ts:1730
+
+___
+
+### aria-valuetext
+
+• `Optional` **aria-valuetext**: *string*
+
+Defines the human readable text alternative of aria-valuenow for a range widget.
+
+Inherited from: AnchorHTMLAttributes.aria-valuetext
+
+Defined in: node_modules/@types/react/index.d.ts:1735
+
+___
+
+### autoCapitalize
+
+• `Optional` **autoCapitalize**: *string*
+
+Inherited from: AnchorHTMLAttributes.autoCapitalize
+
+Defined in: node_modules/@types/react/index.d.ts:1782
+
+___
+
+### autoCorrect
+
+• `Optional` **autoCorrect**: *string*
+
+Inherited from: AnchorHTMLAttributes.autoCorrect
+
+Defined in: node_modules/@types/react/index.d.ts:1783
+
+___
+
+### autoSave
+
+• `Optional` **autoSave**: *string*
+
+Inherited from: AnchorHTMLAttributes.autoSave
+
+Defined in: node_modules/@types/react/index.d.ts:1784
+
+___
+
+### children
+
+• `Optional` **children**: ReactNode
+
+Inherited from: AnchorHTMLAttributes.children
+
+Defined in: node_modules/@types/react/index.d.ts:1345
+
+___
+
+### className
+
+• `Optional` **className**: *string*
+
+Inherited from: AnchorHTMLAttributes.className
+
+Defined in: node_modules/@types/react/index.d.ts:1749
+
+___
+
+### color
+
+• `Optional` **color**: *string*
+
+Inherited from: AnchorHTMLAttributes.color
+
+Defined in: node_modules/@types/react/index.d.ts:1785
+
+___
+
+### contentEditable
+
+• `Optional` **contentEditable**: Booleanish \| ``"inherit"``
+
+Inherited from: AnchorHTMLAttributes.contentEditable
+
+Defined in: node_modules/@types/react/index.d.ts:1750
+
+___
+
+### contextMenu
+
+• `Optional` **contextMenu**: *string*
+
+Inherited from: AnchorHTMLAttributes.contextMenu
+
+Defined in: node_modules/@types/react/index.d.ts:1751
+
+___
+
+### dangerouslySetInnerHTML
+
+• `Optional` **dangerouslySetInnerHTML**: *object*
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `__html` | *string* |
+
+Inherited from: AnchorHTMLAttributes.dangerouslySetInnerHTML
+
+Defined in: node_modules/@types/react/index.d.ts:1346
+
+___
+
+### datatype
+
+• `Optional` **datatype**: *string*
+
+Inherited from: AnchorHTMLAttributes.datatype
+
+Defined in: node_modules/@types/react/index.d.ts:1773
+
+___
+
+### defaultChecked
+
+• `Optional` **defaultChecked**: *boolean*
+
+Inherited from: AnchorHTMLAttributes.defaultChecked
+
+Defined in: node_modules/@types/react/index.d.ts:1742
+
+___
+
+### defaultValue
+
+• `Optional` **defaultValue**: *string* \| *number* \| readonly *string*[]
+
+Inherited from: AnchorHTMLAttributes.defaultValue
+
+Defined in: node_modules/@types/react/index.d.ts:1743
+
+___
+
+### dir
+
+• `Optional` **dir**: *string*
+
+Inherited from: AnchorHTMLAttributes.dir
+
+Defined in: node_modules/@types/react/index.d.ts:1752
+
+___
+
+### download
+
+• `Optional` **download**: *any*
+
+Inherited from: AnchorHTMLAttributes.download
+
+Defined in: node_modules/@types/react/index.d.ts:1930
+
+___
+
+### draggable
+
+• `Optional` **draggable**: Booleanish
+
+Inherited from: AnchorHTMLAttributes.draggable
+
+Defined in: node_modules/@types/react/index.d.ts:1753
+
+___
+
+### hidden
+
+• `Optional` **hidden**: *boolean*
+
+Inherited from: AnchorHTMLAttributes.hidden
+
+Defined in: node_modules/@types/react/index.d.ts:1754
+
+___
+
+### href
+
+• `Optional` **href**: *string*
+
+Inherited from: AnchorHTMLAttributes.href
+
+Defined in: node_modules/@types/react/index.d.ts:1931
+
+___
+
+### hrefLang
+
+• `Optional` **hrefLang**: *string*
+
+Inherited from: AnchorHTMLAttributes.hrefLang
+
+Defined in: node_modules/@types/react/index.d.ts:1932
+
+___
+
+### id
+
+• `Optional` **id**: *string*
+
+Inherited from: AnchorHTMLAttributes.id
+
+Defined in: node_modules/@types/react/index.d.ts:1755
+
+___
+
+### inlist
+
+• `Optional` **inlist**: *any*
+
+Inherited from: AnchorHTMLAttributes.inlist
+
+Defined in: node_modules/@types/react/index.d.ts:1774
+
+___
+
+### inputMode
+
+• `Optional` **inputMode**: ``"none"`` \| ``"text"`` \| ``"tel"`` \| ``"url"`` \| ``"email"`` \| ``"numeric"`` \| ``"decimal"`` \| ``"search"``
+
+Hints at the type of data that might be entered by the user while editing the element or its contents
+
+**`see`** https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute
+
+Inherited from: AnchorHTMLAttributes.inputMode
+
+Defined in: node_modules/@types/react/index.d.ts:1800
+
+___
+
+### is
+
+• `Optional` **is**: *string*
+
+Specify that a standard HTML element should behave like a defined custom built-in element
+
+**`see`** https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is
+
+Inherited from: AnchorHTMLAttributes.is
+
+Defined in: node_modules/@types/react/index.d.ts:1805
+
+___
+
+### itemID
+
+• `Optional` **itemID**: *string*
+
+Inherited from: AnchorHTMLAttributes.itemID
+
+Defined in: node_modules/@types/react/index.d.ts:1789
+
+___
+
+### itemProp
+
+• `Optional` **itemProp**: *string*
+
+Inherited from: AnchorHTMLAttributes.itemProp
+
+Defined in: node_modules/@types/react/index.d.ts:1786
+
+___
+
+### itemRef
+
+• `Optional` **itemRef**: *string*
+
+Inherited from: AnchorHTMLAttributes.itemRef
+
+Defined in: node_modules/@types/react/index.d.ts:1790
+
+___
+
+### itemScope
+
+• `Optional` **itemScope**: *boolean*
+
+Inherited from: AnchorHTMLAttributes.itemScope
+
+Defined in: node_modules/@types/react/index.d.ts:1787
+
+___
+
+### itemType
+
+• `Optional` **itemType**: *string*
+
+Inherited from: AnchorHTMLAttributes.itemType
+
+Defined in: node_modules/@types/react/index.d.ts:1788
+
+___
+
+### lang
+
+• `Optional` **lang**: *string*
+
+Inherited from: AnchorHTMLAttributes.lang
+
+Defined in: node_modules/@types/react/index.d.ts:1756
+
+___
+
+### media
+
+• `Optional` **media**: *string*
+
+Inherited from: AnchorHTMLAttributes.media
+
+Defined in: node_modules/@types/react/index.d.ts:1933
+
+___
+
+### onAbort
+
+• `Optional` **onAbort**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAbort
+
+Defined in: node_modules/@types/react/index.d.ts:1401
+
+___
+
+### onAbortCapture
+
+• `Optional` **onAbortCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAbortCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1402
+
+___
+
+### onAnimationEnd
+
+• `Optional` **onAnimationEnd**: *AnimationEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAnimationEnd
+
+Defined in: node_modules/@types/react/index.d.ts:1531
+
+___
+
+### onAnimationEndCapture
+
+• `Optional` **onAnimationEndCapture**: *AnimationEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAnimationEndCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1532
+
+___
+
+### onAnimationIteration
+
+• `Optional` **onAnimationIteration**: *AnimationEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAnimationIteration
+
+Defined in: node_modules/@types/react/index.d.ts:1533
+
+___
+
+### onAnimationIterationCapture
+
+• `Optional` **onAnimationIterationCapture**: *AnimationEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAnimationIterationCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1534
+
+___
+
+### onAnimationStart
+
+• `Optional` **onAnimationStart**: *AnimationEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAnimationStart
+
+Defined in: node_modules/@types/react/index.d.ts:1529
+
+___
+
+### onAnimationStartCapture
+
+• `Optional` **onAnimationStartCapture**: *AnimationEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAnimationStartCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1530
+
+___
+
+### onAuxClick
+
+• `Optional` **onAuxClick**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAuxClick
+
+Defined in: node_modules/@types/react/index.d.ts:1447
+
+___
+
+### onAuxClickCapture
+
+• `Optional` **onAuxClickCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAuxClickCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1448
+
+___
+
+### onBeforeInput
+
+• `Optional` **onBeforeInput**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onBeforeInput
+
+Defined in: node_modules/@types/react/index.d.ts:1375
+
+___
+
+### onBeforeInputCapture
+
+• `Optional` **onBeforeInputCapture**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onBeforeInputCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1376
+
+___
+
+### onBlur
+
+• `Optional` **onBlur**: *FocusEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onBlur
+
+Defined in: node_modules/@types/react/index.d.ts:1369
+
+___
+
+### onBlurCapture
+
+• `Optional` **onBlurCapture**: *FocusEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onBlurCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1370
+
+___
+
+### onCanPlay
+
+• `Optional` **onCanPlay**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCanPlay
+
+Defined in: node_modules/@types/react/index.d.ts:1403
+
+___
+
+### onCanPlayCapture
+
+• `Optional` **onCanPlayCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCanPlayCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1404
+
+___
+
+### onCanPlayThrough
+
+• `Optional` **onCanPlayThrough**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCanPlayThrough
+
+Defined in: node_modules/@types/react/index.d.ts:1405
+
+___
+
+### onCanPlayThroughCapture
+
+• `Optional` **onCanPlayThroughCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCanPlayThroughCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1406
+
+___
+
+### onChange
+
+• `Optional` **onChange**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onChange
+
+Defined in: node_modules/@types/react/index.d.ts:1373
+
+___
+
+### onChangeCapture
+
+• `Optional` **onChangeCapture**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onChangeCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1374
+
+___
+
+### onClick
+
+• `Optional` **onClick**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onClick
+
+Defined in: node_modules/@types/react/index.d.ts:1449
+
+___
+
+### onClickCapture
+
+• `Optional` **onClickCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onClickCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1450
+
+___
+
+### onCompositionEnd
+
+• `Optional` **onCompositionEnd**: *CompositionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCompositionEnd
+
+Defined in: node_modules/@types/react/index.d.ts:1359
+
+___
+
+### onCompositionEndCapture
+
+• `Optional` **onCompositionEndCapture**: *CompositionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCompositionEndCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1360
+
+___
+
+### onCompositionStart
+
+• `Optional` **onCompositionStart**: *CompositionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCompositionStart
+
+Defined in: node_modules/@types/react/index.d.ts:1361
+
+___
+
+### onCompositionStartCapture
+
+• `Optional` **onCompositionStartCapture**: *CompositionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCompositionStartCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1362
+
+___
+
+### onCompositionUpdate
+
+• `Optional` **onCompositionUpdate**: *CompositionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCompositionUpdate
+
+Defined in: node_modules/@types/react/index.d.ts:1363
+
+___
+
+### onCompositionUpdateCapture
+
+• `Optional` **onCompositionUpdateCapture**: *CompositionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCompositionUpdateCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1364
+
+___
+
+### onContextMenu
+
+• `Optional` **onContextMenu**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onContextMenu
+
+Defined in: node_modules/@types/react/index.d.ts:1451
+
+___
+
+### onContextMenuCapture
+
+• `Optional` **onContextMenuCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onContextMenuCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1452
+
+___
+
+### onCopy
+
+• `Optional` **onCopy**: *ClipboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCopy
+
+Defined in: node_modules/@types/react/index.d.ts:1351
+
+___
+
+### onCopyCapture
+
+• `Optional` **onCopyCapture**: *ClipboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCopyCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1352
+
+___
+
+### onCut
+
+• `Optional` **onCut**: *ClipboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCut
+
+Defined in: node_modules/@types/react/index.d.ts:1353
+
+___
+
+### onCutCapture
+
+• `Optional` **onCutCapture**: *ClipboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCutCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1354
+
+___
+
+### onDoubleClick
+
+• `Optional` **onDoubleClick**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDoubleClick
+
+Defined in: node_modules/@types/react/index.d.ts:1453
+
+___
+
+### onDoubleClickCapture
+
+• `Optional` **onDoubleClickCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDoubleClickCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1454
+
+___
+
+### onDrag
+
+• `Optional` **onDrag**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDrag
+
+Defined in: node_modules/@types/react/index.d.ts:1455
+
+___
+
+### onDragCapture
+
+• `Optional` **onDragCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1456
+
+___
+
+### onDragEnd
+
+• `Optional` **onDragEnd**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragEnd
+
+Defined in: node_modules/@types/react/index.d.ts:1457
+
+___
+
+### onDragEndCapture
+
+• `Optional` **onDragEndCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragEndCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1458
+
+___
+
+### onDragEnter
+
+• `Optional` **onDragEnter**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragEnter
+
+Defined in: node_modules/@types/react/index.d.ts:1459
+
+___
+
+### onDragEnterCapture
+
+• `Optional` **onDragEnterCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragEnterCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1460
+
+___
+
+### onDragExit
+
+• `Optional` **onDragExit**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragExit
+
+Defined in: node_modules/@types/react/index.d.ts:1461
+
+___
+
+### onDragExitCapture
+
+• `Optional` **onDragExitCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragExitCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1462
+
+___
+
+### onDragLeave
+
+• `Optional` **onDragLeave**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragLeave
+
+Defined in: node_modules/@types/react/index.d.ts:1463
+
+___
+
+### onDragLeaveCapture
+
+• `Optional` **onDragLeaveCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragLeaveCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1464
+
+___
+
+### onDragOver
+
+• `Optional` **onDragOver**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragOver
+
+Defined in: node_modules/@types/react/index.d.ts:1465
+
+___
+
+### onDragOverCapture
+
+• `Optional` **onDragOverCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragOverCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1466
+
+___
+
+### onDragStart
+
+• `Optional` **onDragStart**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragStart
+
+Defined in: node_modules/@types/react/index.d.ts:1467
+
+___
+
+### onDragStartCapture
+
+• `Optional` **onDragStartCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragStartCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1468
+
+___
+
+### onDrop
+
+• `Optional` **onDrop**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDrop
+
+Defined in: node_modules/@types/react/index.d.ts:1469
+
+___
+
+### onDropCapture
+
+• `Optional` **onDropCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDropCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1470
+
+___
+
+### onDurationChange
+
+• `Optional` **onDurationChange**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDurationChange
+
+Defined in: node_modules/@types/react/index.d.ts:1407
+
+___
+
+### onDurationChangeCapture
+
+• `Optional` **onDurationChangeCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDurationChangeCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1408
+
+___
+
+### onEmptied
+
+• `Optional` **onEmptied**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onEmptied
+
+Defined in: node_modules/@types/react/index.d.ts:1409
+
+___
+
+### onEmptiedCapture
+
+• `Optional` **onEmptiedCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onEmptiedCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1410
+
+___
+
+### onEncrypted
+
+• `Optional` **onEncrypted**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onEncrypted
+
+Defined in: node_modules/@types/react/index.d.ts:1411
+
+___
+
+### onEncryptedCapture
+
+• `Optional` **onEncryptedCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onEncryptedCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1412
+
+___
+
+### onEnded
+
+• `Optional` **onEnded**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onEnded
+
+Defined in: node_modules/@types/react/index.d.ts:1413
+
+___
+
+### onEndedCapture
+
+• `Optional` **onEndedCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onEndedCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1414
+
+___
+
+### onError
+
+• `Optional` **onError**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onError
+
+Defined in: node_modules/@types/react/index.d.ts:1389
+
+___
+
+### onErrorCapture
+
+• `Optional` **onErrorCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onErrorCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1390
+
+___
+
+### onFocus
+
+• `Optional` **onFocus**: *FocusEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onFocus
+
+Defined in: node_modules/@types/react/index.d.ts:1367
+
+___
+
+### onFocusCapture
+
+• `Optional` **onFocusCapture**: *FocusEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onFocusCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1368
+
+___
+
+### onGotPointerCapture
+
+• `Optional` **onGotPointerCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onGotPointerCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1515
+
+___
+
+### onGotPointerCaptureCapture
+
+• `Optional` **onGotPointerCaptureCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onGotPointerCaptureCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1516
+
+___
+
+### onInput
+
+• `Optional` **onInput**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onInput
+
+Defined in: node_modules/@types/react/index.d.ts:1377
+
+___
+
+### onInputCapture
+
+• `Optional` **onInputCapture**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onInputCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1378
+
+___
+
+### onInvalid
+
+• `Optional` **onInvalid**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onInvalid
+
+Defined in: node_modules/@types/react/index.d.ts:1383
+
+___
+
+### onInvalidCapture
+
+• `Optional` **onInvalidCapture**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onInvalidCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1384
+
+___
+
+### onKeyDown
+
+• `Optional` **onKeyDown**: *KeyboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onKeyDown
+
+Defined in: node_modules/@types/react/index.d.ts:1393
+
+___
+
+### onKeyDownCapture
+
+• `Optional` **onKeyDownCapture**: *KeyboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onKeyDownCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1394
+
+___
+
+### onKeyPress
+
+• `Optional` **onKeyPress**: *KeyboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onKeyPress
+
+Defined in: node_modules/@types/react/index.d.ts:1395
+
+___
+
+### onKeyPressCapture
+
+• `Optional` **onKeyPressCapture**: *KeyboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onKeyPressCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1396
+
+___
+
+### onKeyUp
+
+• `Optional` **onKeyUp**: *KeyboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onKeyUp
+
+Defined in: node_modules/@types/react/index.d.ts:1397
+
+___
+
+### onKeyUpCapture
+
+• `Optional` **onKeyUpCapture**: *KeyboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onKeyUpCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1398
+
+___
+
+### onLoad
+
+• `Optional` **onLoad**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoad
+
+Defined in: node_modules/@types/react/index.d.ts:1387
+
+___
+
+### onLoadCapture
+
+• `Optional` **onLoadCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1388
+
+___
+
+### onLoadStart
+
+• `Optional` **onLoadStart**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadStart
+
+Defined in: node_modules/@types/react/index.d.ts:1419
+
+___
+
+### onLoadStartCapture
+
+• `Optional` **onLoadStartCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadStartCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1420
+
+___
+
+### onLoadedData
+
+• `Optional` **onLoadedData**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadedData
+
+Defined in: node_modules/@types/react/index.d.ts:1415
+
+___
+
+### onLoadedDataCapture
+
+• `Optional` **onLoadedDataCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadedDataCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1416
+
+___
+
+### onLoadedMetadata
+
+• `Optional` **onLoadedMetadata**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadedMetadata
+
+Defined in: node_modules/@types/react/index.d.ts:1417
+
+___
+
+### onLoadedMetadataCapture
+
+• `Optional` **onLoadedMetadataCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadedMetadataCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1418
+
+___
+
+### onLostPointerCapture
+
+• `Optional` **onLostPointerCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLostPointerCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1517
+
+___
+
+### onLostPointerCaptureCapture
+
+• `Optional` **onLostPointerCaptureCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLostPointerCaptureCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1518
+
+___
+
+### onMouseDown
+
+• `Optional` **onMouseDown**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseDown
+
+Defined in: node_modules/@types/react/index.d.ts:1471
+
+___
+
+### onMouseDownCapture
+
+• `Optional` **onMouseDownCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseDownCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1472
+
+___
+
+### onMouseEnter
+
+• `Optional` **onMouseEnter**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseEnter
+
+Defined in: node_modules/@types/react/index.d.ts:1473
+
+___
+
+### onMouseLeave
+
+• `Optional` **onMouseLeave**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseLeave
+
+Defined in: node_modules/@types/react/index.d.ts:1474
+
+___
+
+### onMouseMove
+
+• `Optional` **onMouseMove**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseMove
+
+Defined in: node_modules/@types/react/index.d.ts:1475
+
+___
+
+### onMouseMoveCapture
+
+• `Optional` **onMouseMoveCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseMoveCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1476
+
+___
+
+### onMouseOut
+
+• `Optional` **onMouseOut**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseOut
+
+Defined in: node_modules/@types/react/index.d.ts:1477
+
+___
+
+### onMouseOutCapture
+
+• `Optional` **onMouseOutCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseOutCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1478
+
+___
+
+### onMouseOver
+
+• `Optional` **onMouseOver**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseOver
+
+Defined in: node_modules/@types/react/index.d.ts:1479
+
+___
+
+### onMouseOverCapture
+
+• `Optional` **onMouseOverCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseOverCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1480
+
+___
+
+### onMouseUp
+
+• `Optional` **onMouseUp**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseUp
+
+Defined in: node_modules/@types/react/index.d.ts:1481
+
+___
+
+### onMouseUpCapture
+
+• `Optional` **onMouseUpCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseUpCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1482
+
+___
+
+### onPaste
+
+• `Optional` **onPaste**: *ClipboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPaste
+
+Defined in: node_modules/@types/react/index.d.ts:1355
+
+___
+
+### onPasteCapture
+
+• `Optional` **onPasteCapture**: *ClipboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPasteCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1356
+
+___
+
+### onPause
+
+• `Optional` **onPause**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPause
+
+Defined in: node_modules/@types/react/index.d.ts:1421
+
+___
+
+### onPauseCapture
+
+• `Optional` **onPauseCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPauseCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1422
+
+___
+
+### onPlay
+
+• `Optional` **onPlay**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPlay
+
+Defined in: node_modules/@types/react/index.d.ts:1423
+
+___
+
+### onPlayCapture
+
+• `Optional` **onPlayCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPlayCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1424
+
+___
+
+### onPlaying
+
+• `Optional` **onPlaying**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPlaying
+
+Defined in: node_modules/@types/react/index.d.ts:1425
+
+___
+
+### onPlayingCapture
+
+• `Optional` **onPlayingCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPlayingCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1426
+
+___
+
+### onPointerCancel
+
+• `Optional` **onPointerCancel**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerCancel
+
+Defined in: node_modules/@types/react/index.d.ts:1505
+
+___
+
+### onPointerCancelCapture
+
+• `Optional` **onPointerCancelCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerCancelCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1506
+
+___
+
+### onPointerDown
+
+• `Optional` **onPointerDown**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerDown
+
+Defined in: node_modules/@types/react/index.d.ts:1499
+
+___
+
+### onPointerDownCapture
+
+• `Optional` **onPointerDownCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerDownCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1500
+
+___
+
+### onPointerEnter
+
+• `Optional` **onPointerEnter**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerEnter
+
+Defined in: node_modules/@types/react/index.d.ts:1507
+
+___
+
+### onPointerEnterCapture
+
+• `Optional` **onPointerEnterCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerEnterCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1508
+
+___
+
+### onPointerLeave
+
+• `Optional` **onPointerLeave**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerLeave
+
+Defined in: node_modules/@types/react/index.d.ts:1509
+
+___
+
+### onPointerLeaveCapture
+
+• `Optional` **onPointerLeaveCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerLeaveCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1510
+
+___
+
+### onPointerMove
+
+• `Optional` **onPointerMove**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerMove
+
+Defined in: node_modules/@types/react/index.d.ts:1501
+
+___
+
+### onPointerMoveCapture
+
+• `Optional` **onPointerMoveCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerMoveCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1502
+
+___
+
+### onPointerOut
+
+• `Optional` **onPointerOut**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerOut
+
+Defined in: node_modules/@types/react/index.d.ts:1513
+
+___
+
+### onPointerOutCapture
+
+• `Optional` **onPointerOutCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerOutCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1514
+
+___
+
+### onPointerOver
+
+• `Optional` **onPointerOver**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerOver
+
+Defined in: node_modules/@types/react/index.d.ts:1511
+
+___
+
+### onPointerOverCapture
+
+• `Optional` **onPointerOverCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerOverCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1512
+
+___
+
+### onPointerUp
+
+• `Optional` **onPointerUp**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerUp
+
+Defined in: node_modules/@types/react/index.d.ts:1503
+
+___
+
+### onPointerUpCapture
+
+• `Optional` **onPointerUpCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerUpCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1504
+
+___
+
+### onProgress
+
+• `Optional` **onProgress**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onProgress
+
+Defined in: node_modules/@types/react/index.d.ts:1427
+
+___
+
+### onProgressCapture
+
+• `Optional` **onProgressCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onProgressCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1428
+
+___
+
+### onRateChange
+
+• `Optional` **onRateChange**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onRateChange
+
+Defined in: node_modules/@types/react/index.d.ts:1429
+
+___
+
+### onRateChangeCapture
+
+• `Optional` **onRateChangeCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onRateChangeCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1430
+
+___
+
+### onReset
+
+• `Optional` **onReset**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onReset
+
+Defined in: node_modules/@types/react/index.d.ts:1379
+
+___
+
+### onResetCapture
+
+• `Optional` **onResetCapture**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onResetCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1380
+
+___
+
+### onScroll
+
+• `Optional` **onScroll**: *UIEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onScroll
+
+Defined in: node_modules/@types/react/index.d.ts:1521
+
+___
+
+### onScrollCapture
+
+• `Optional` **onScrollCapture**: *UIEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onScrollCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1522
+
+___
+
+### onSeeked
+
+• `Optional` **onSeeked**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSeeked
+
+Defined in: node_modules/@types/react/index.d.ts:1431
+
+___
+
+### onSeekedCapture
+
+• `Optional` **onSeekedCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSeekedCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1432
+
+___
+
+### onSeeking
+
+• `Optional` **onSeeking**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSeeking
+
+Defined in: node_modules/@types/react/index.d.ts:1433
+
+___
+
+### onSeekingCapture
+
+• `Optional` **onSeekingCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSeekingCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1434
+
+___
+
+### onSelect
+
+• `Optional` **onSelect**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSelect
+
+Defined in: node_modules/@types/react/index.d.ts:1485
+
+___
+
+### onSelectCapture
+
+• `Optional` **onSelectCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSelectCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1486
+
+___
+
+### onStalled
+
+• `Optional` **onStalled**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onStalled
+
+Defined in: node_modules/@types/react/index.d.ts:1435
+
+___
+
+### onStalledCapture
+
+• `Optional` **onStalledCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onStalledCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1436
+
+___
+
+### onSubmit
+
+• `Optional` **onSubmit**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSubmit
+
+Defined in: node_modules/@types/react/index.d.ts:1381
+
+___
+
+### onSubmitCapture
+
+• `Optional` **onSubmitCapture**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSubmitCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1382
+
+___
+
+### onSuspend
+
+• `Optional` **onSuspend**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSuspend
+
+Defined in: node_modules/@types/react/index.d.ts:1437
+
+___
+
+### onSuspendCapture
+
+• `Optional` **onSuspendCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSuspendCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1438
+
+___
+
+### onTimeUpdate
+
+• `Optional` **onTimeUpdate**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTimeUpdate
+
+Defined in: node_modules/@types/react/index.d.ts:1439
+
+___
+
+### onTimeUpdateCapture
+
+• `Optional` **onTimeUpdateCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTimeUpdateCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1440
+
+___
+
+### onTouchCancel
+
+• `Optional` **onTouchCancel**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchCancel
+
+Defined in: node_modules/@types/react/index.d.ts:1489
+
+___
+
+### onTouchCancelCapture
+
+• `Optional` **onTouchCancelCapture**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchCancelCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1490
+
+___
+
+### onTouchEnd
+
+• `Optional` **onTouchEnd**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchEnd
+
+Defined in: node_modules/@types/react/index.d.ts:1491
+
+___
+
+### onTouchEndCapture
+
+• `Optional` **onTouchEndCapture**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchEndCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1492
+
+___
+
+### onTouchMove
+
+• `Optional` **onTouchMove**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchMove
+
+Defined in: node_modules/@types/react/index.d.ts:1493
+
+___
+
+### onTouchMoveCapture
+
+• `Optional` **onTouchMoveCapture**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchMoveCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1494
+
+___
+
+### onTouchStart
+
+• `Optional` **onTouchStart**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchStart
+
+Defined in: node_modules/@types/react/index.d.ts:1495
+
+___
+
+### onTouchStartCapture
+
+• `Optional` **onTouchStartCapture**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchStartCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1496
+
+___
+
+### onTransitionEnd
+
+• `Optional` **onTransitionEnd**: *TransitionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTransitionEnd
+
+Defined in: node_modules/@types/react/index.d.ts:1537
+
+___
+
+### onTransitionEndCapture
+
+• `Optional` **onTransitionEndCapture**: *TransitionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTransitionEndCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1538
+
+___
+
+### onVolumeChange
+
+• `Optional` **onVolumeChange**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onVolumeChange
+
+Defined in: node_modules/@types/react/index.d.ts:1441
+
+___
+
+### onVolumeChangeCapture
+
+• `Optional` **onVolumeChangeCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onVolumeChangeCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1442
+
+___
+
+### onWaiting
+
+• `Optional` **onWaiting**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onWaiting
+
+Defined in: node_modules/@types/react/index.d.ts:1443
+
+___
+
+### onWaitingCapture
+
+• `Optional` **onWaitingCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onWaitingCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1444
+
+___
+
+### onWheel
+
+• `Optional` **onWheel**: *WheelEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onWheel
+
+Defined in: node_modules/@types/react/index.d.ts:1525
+
+___
+
+### onWheelCapture
+
+• `Optional` **onWheelCapture**: *WheelEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onWheelCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1526
+
+___
+
+### ping
+
+• `Optional` **ping**: *string*
+
+Inherited from: AnchorHTMLAttributes.ping
+
+Defined in: node_modules/@types/react/index.d.ts:1934
+
+___
+
+### placeholder
+
+• `Optional` **placeholder**: *string*
+
+Inherited from: AnchorHTMLAttributes.placeholder
+
+Defined in: node_modules/@types/react/index.d.ts:1757
+
+___
+
+### prefix
+
+• `Optional` **prefix**: *string*
+
+Inherited from: AnchorHTMLAttributes.prefix
+
+Defined in: node_modules/@types/react/index.d.ts:1775
+
+___
+
+### property
+
+• `Optional` **property**: *string*
+
+Inherited from: AnchorHTMLAttributes.property
+
+Defined in: node_modules/@types/react/index.d.ts:1776
+
+___
+
+### radioGroup
+
+• `Optional` **radioGroup**: *string*
+
+Inherited from: AnchorHTMLAttributes.radioGroup
+
+Defined in: node_modules/@types/react/index.d.ts:1766
+
+___
+
+### referrerPolicy
+
+• `Optional` **referrerPolicy**: HTMLAttributeReferrerPolicy
+
+Inherited from: AnchorHTMLAttributes.referrerPolicy
+
+Defined in: node_modules/@types/react/index.d.ts:1938
+
+___
+
+### rel
+
+• `Optional` **rel**: *string*
+
+Inherited from: AnchorHTMLAttributes.rel
+
+Defined in: node_modules/@types/react/index.d.ts:1935
+
+___
+
+### resource
+
+• `Optional` **resource**: *string*
+
+Inherited from: AnchorHTMLAttributes.resource
+
+Defined in: node_modules/@types/react/index.d.ts:1777
+
+___
+
+### results
+
+• `Optional` **results**: *number*
+
+Inherited from: AnchorHTMLAttributes.results
+
+Defined in: node_modules/@types/react/index.d.ts:1791
+
+___
+
+### role
+
+• `Optional` **role**: *string*
+
+Inherited from: AnchorHTMLAttributes.role
+
+Defined in: node_modules/@types/react/index.d.ts:1769
+
+___
+
+### security
+
+• `Optional` **security**: *string*
+
+Inherited from: AnchorHTMLAttributes.security
+
+Defined in: node_modules/@types/react/index.d.ts:1792
+
+___
+
+### slot
+
+• `Optional` **slot**: *string*
+
+Inherited from: AnchorHTMLAttributes.slot
+
+Defined in: node_modules/@types/react/index.d.ts:1758
+
+___
+
+### spellCheck
+
+• `Optional` **spellCheck**: Booleanish
+
+Inherited from: AnchorHTMLAttributes.spellCheck
+
+Defined in: node_modules/@types/react/index.d.ts:1759
+
+___
+
+### style
+
+• `Optional` **style**: *CSSProperties*
+
+Inherited from: AnchorHTMLAttributes.style
+
+Defined in: node_modules/@types/react/index.d.ts:1760
+
+___
+
+### suppressContentEditableWarning
+
+• `Optional` **suppressContentEditableWarning**: *boolean*
+
+Inherited from: AnchorHTMLAttributes.suppressContentEditableWarning
+
+Defined in: node_modules/@types/react/index.d.ts:1744
+
+___
+
+### suppressHydrationWarning
+
+• `Optional` **suppressHydrationWarning**: *boolean*
+
+Inherited from: AnchorHTMLAttributes.suppressHydrationWarning
+
+Defined in: node_modules/@types/react/index.d.ts:1745
+
+___
+
+### tabIndex
+
+• `Optional` **tabIndex**: *number*
+
+Inherited from: AnchorHTMLAttributes.tabIndex
+
+Defined in: node_modules/@types/react/index.d.ts:1761
+
+___
+
+### target
+
+• `Optional` **target**: *string*
+
+Inherited from: AnchorHTMLAttributes.target
+
+Defined in: node_modules/@types/react/index.d.ts:1936
+
+___
+
+### title
+
+• `Optional` **title**: *string*
+
+Inherited from: AnchorHTMLAttributes.title
+
+Defined in: node_modules/@types/react/index.d.ts:1762
+
+___
 
 ### to
 
 • **to**: *string*
 
 Defined in: [packages/framework/esm-react-utils/src/ConfigurableLink.tsx:21](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L21)
+
+___
+
+### translate
+
+• `Optional` **translate**: ``"yes"`` \| ``"no"``
+
+Inherited from: AnchorHTMLAttributes.translate
+
+Defined in: node_modules/@types/react/index.d.ts:1763
+
+___
+
+### type
+
+• `Optional` **type**: *string*
+
+Inherited from: AnchorHTMLAttributes.type
+
+Defined in: node_modules/@types/react/index.d.ts:1937
+
+___
+
+### typeof
+
+• `Optional` **typeof**: *string*
+
+Inherited from: AnchorHTMLAttributes.typeof
+
+Defined in: node_modules/@types/react/index.d.ts:1778
+
+___
+
+### unselectable
+
+• `Optional` **unselectable**: ``"on"`` \| ``"off"``
+
+Inherited from: AnchorHTMLAttributes.unselectable
+
+Defined in: node_modules/@types/react/index.d.ts:1793
+
+___
+
+### vocab
+
+• `Optional` **vocab**: *string*
+
+Inherited from: AnchorHTMLAttributes.vocab
+
+Defined in: node_modules/@types/react/index.d.ts:1779

--- a/packages/framework/esm-react-utils/docs/interfaces/configurablelinkprops.md
+++ b/packages/framework/esm-react-utils/docs/interfaces/configurablelinkprops.md
@@ -2,6 +2,8 @@
 
 # Interface: ConfigurableLinkProps
 
+**`noinheritdoc`**
+
 ## Hierarchy
 
 - *AnchorHTMLAttributes*<HTMLAnchorElement\>
@@ -12,12 +14,3071 @@
 
 ### Properties
 
+- [about](configurablelinkprops.md#about)
+- [accessKey](configurablelinkprops.md#accesskey)
+- [aria-activedescendant](configurablelinkprops.md#aria-activedescendant)
+- [aria-atomic](configurablelinkprops.md#aria-atomic)
+- [aria-autocomplete](configurablelinkprops.md#aria-autocomplete)
+- [aria-busy](configurablelinkprops.md#aria-busy)
+- [aria-checked](configurablelinkprops.md#aria-checked)
+- [aria-colcount](configurablelinkprops.md#aria-colcount)
+- [aria-colindex](configurablelinkprops.md#aria-colindex)
+- [aria-colspan](configurablelinkprops.md#aria-colspan)
+- [aria-controls](configurablelinkprops.md#aria-controls)
+- [aria-current](configurablelinkprops.md#aria-current)
+- [aria-describedby](configurablelinkprops.md#aria-describedby)
+- [aria-details](configurablelinkprops.md#aria-details)
+- [aria-disabled](configurablelinkprops.md#aria-disabled)
+- [aria-dropeffect](configurablelinkprops.md#aria-dropeffect)
+- [aria-errormessage](configurablelinkprops.md#aria-errormessage)
+- [aria-expanded](configurablelinkprops.md#aria-expanded)
+- [aria-flowto](configurablelinkprops.md#aria-flowto)
+- [aria-grabbed](configurablelinkprops.md#aria-grabbed)
+- [aria-haspopup](configurablelinkprops.md#aria-haspopup)
+- [aria-hidden](configurablelinkprops.md#aria-hidden)
+- [aria-invalid](configurablelinkprops.md#aria-invalid)
+- [aria-keyshortcuts](configurablelinkprops.md#aria-keyshortcuts)
+- [aria-label](configurablelinkprops.md#aria-label)
+- [aria-labelledby](configurablelinkprops.md#aria-labelledby)
+- [aria-level](configurablelinkprops.md#aria-level)
+- [aria-live](configurablelinkprops.md#aria-live)
+- [aria-modal](configurablelinkprops.md#aria-modal)
+- [aria-multiline](configurablelinkprops.md#aria-multiline)
+- [aria-multiselectable](configurablelinkprops.md#aria-multiselectable)
+- [aria-orientation](configurablelinkprops.md#aria-orientation)
+- [aria-owns](configurablelinkprops.md#aria-owns)
+- [aria-placeholder](configurablelinkprops.md#aria-placeholder)
+- [aria-posinset](configurablelinkprops.md#aria-posinset)
+- [aria-pressed](configurablelinkprops.md#aria-pressed)
+- [aria-readonly](configurablelinkprops.md#aria-readonly)
+- [aria-relevant](configurablelinkprops.md#aria-relevant)
+- [aria-required](configurablelinkprops.md#aria-required)
+- [aria-roledescription](configurablelinkprops.md#aria-roledescription)
+- [aria-rowcount](configurablelinkprops.md#aria-rowcount)
+- [aria-rowindex](configurablelinkprops.md#aria-rowindex)
+- [aria-rowspan](configurablelinkprops.md#aria-rowspan)
+- [aria-selected](configurablelinkprops.md#aria-selected)
+- [aria-setsize](configurablelinkprops.md#aria-setsize)
+- [aria-sort](configurablelinkprops.md#aria-sort)
+- [aria-valuemax](configurablelinkprops.md#aria-valuemax)
+- [aria-valuemin](configurablelinkprops.md#aria-valuemin)
+- [aria-valuenow](configurablelinkprops.md#aria-valuenow)
+- [aria-valuetext](configurablelinkprops.md#aria-valuetext)
+- [autoCapitalize](configurablelinkprops.md#autocapitalize)
+- [autoCorrect](configurablelinkprops.md#autocorrect)
+- [autoSave](configurablelinkprops.md#autosave)
+- [children](configurablelinkprops.md#children)
+- [className](configurablelinkprops.md#classname)
+- [color](configurablelinkprops.md#color)
+- [contentEditable](configurablelinkprops.md#contenteditable)
+- [contextMenu](configurablelinkprops.md#contextmenu)
+- [dangerouslySetInnerHTML](configurablelinkprops.md#dangerouslysetinnerhtml)
+- [datatype](configurablelinkprops.md#datatype)
+- [defaultChecked](configurablelinkprops.md#defaultchecked)
+- [defaultValue](configurablelinkprops.md#defaultvalue)
+- [dir](configurablelinkprops.md#dir)
+- [download](configurablelinkprops.md#download)
+- [draggable](configurablelinkprops.md#draggable)
+- [hidden](configurablelinkprops.md#hidden)
+- [href](configurablelinkprops.md#href)
+- [hrefLang](configurablelinkprops.md#hreflang)
+- [id](configurablelinkprops.md#id)
+- [inlist](configurablelinkprops.md#inlist)
+- [inputMode](configurablelinkprops.md#inputmode)
+- [is](configurablelinkprops.md#is)
+- [itemID](configurablelinkprops.md#itemid)
+- [itemProp](configurablelinkprops.md#itemprop)
+- [itemRef](configurablelinkprops.md#itemref)
+- [itemScope](configurablelinkprops.md#itemscope)
+- [itemType](configurablelinkprops.md#itemtype)
+- [lang](configurablelinkprops.md#lang)
+- [media](configurablelinkprops.md#media)
+- [onAbort](configurablelinkprops.md#onabort)
+- [onAbortCapture](configurablelinkprops.md#onabortcapture)
+- [onAnimationEnd](configurablelinkprops.md#onanimationend)
+- [onAnimationEndCapture](configurablelinkprops.md#onanimationendcapture)
+- [onAnimationIteration](configurablelinkprops.md#onanimationiteration)
+- [onAnimationIterationCapture](configurablelinkprops.md#onanimationiterationcapture)
+- [onAnimationStart](configurablelinkprops.md#onanimationstart)
+- [onAnimationStartCapture](configurablelinkprops.md#onanimationstartcapture)
+- [onAuxClick](configurablelinkprops.md#onauxclick)
+- [onAuxClickCapture](configurablelinkprops.md#onauxclickcapture)
+- [onBeforeInput](configurablelinkprops.md#onbeforeinput)
+- [onBeforeInputCapture](configurablelinkprops.md#onbeforeinputcapture)
+- [onBlur](configurablelinkprops.md#onblur)
+- [onBlurCapture](configurablelinkprops.md#onblurcapture)
+- [onCanPlay](configurablelinkprops.md#oncanplay)
+- [onCanPlayCapture](configurablelinkprops.md#oncanplaycapture)
+- [onCanPlayThrough](configurablelinkprops.md#oncanplaythrough)
+- [onCanPlayThroughCapture](configurablelinkprops.md#oncanplaythroughcapture)
+- [onChange](configurablelinkprops.md#onchange)
+- [onChangeCapture](configurablelinkprops.md#onchangecapture)
+- [onClick](configurablelinkprops.md#onclick)
+- [onClickCapture](configurablelinkprops.md#onclickcapture)
+- [onCompositionEnd](configurablelinkprops.md#oncompositionend)
+- [onCompositionEndCapture](configurablelinkprops.md#oncompositionendcapture)
+- [onCompositionStart](configurablelinkprops.md#oncompositionstart)
+- [onCompositionStartCapture](configurablelinkprops.md#oncompositionstartcapture)
+- [onCompositionUpdate](configurablelinkprops.md#oncompositionupdate)
+- [onCompositionUpdateCapture](configurablelinkprops.md#oncompositionupdatecapture)
+- [onContextMenu](configurablelinkprops.md#oncontextmenu)
+- [onContextMenuCapture](configurablelinkprops.md#oncontextmenucapture)
+- [onCopy](configurablelinkprops.md#oncopy)
+- [onCopyCapture](configurablelinkprops.md#oncopycapture)
+- [onCut](configurablelinkprops.md#oncut)
+- [onCutCapture](configurablelinkprops.md#oncutcapture)
+- [onDoubleClick](configurablelinkprops.md#ondoubleclick)
+- [onDoubleClickCapture](configurablelinkprops.md#ondoubleclickcapture)
+- [onDrag](configurablelinkprops.md#ondrag)
+- [onDragCapture](configurablelinkprops.md#ondragcapture)
+- [onDragEnd](configurablelinkprops.md#ondragend)
+- [onDragEndCapture](configurablelinkprops.md#ondragendcapture)
+- [onDragEnter](configurablelinkprops.md#ondragenter)
+- [onDragEnterCapture](configurablelinkprops.md#ondragentercapture)
+- [onDragExit](configurablelinkprops.md#ondragexit)
+- [onDragExitCapture](configurablelinkprops.md#ondragexitcapture)
+- [onDragLeave](configurablelinkprops.md#ondragleave)
+- [onDragLeaveCapture](configurablelinkprops.md#ondragleavecapture)
+- [onDragOver](configurablelinkprops.md#ondragover)
+- [onDragOverCapture](configurablelinkprops.md#ondragovercapture)
+- [onDragStart](configurablelinkprops.md#ondragstart)
+- [onDragStartCapture](configurablelinkprops.md#ondragstartcapture)
+- [onDrop](configurablelinkprops.md#ondrop)
+- [onDropCapture](configurablelinkprops.md#ondropcapture)
+- [onDurationChange](configurablelinkprops.md#ondurationchange)
+- [onDurationChangeCapture](configurablelinkprops.md#ondurationchangecapture)
+- [onEmptied](configurablelinkprops.md#onemptied)
+- [onEmptiedCapture](configurablelinkprops.md#onemptiedcapture)
+- [onEncrypted](configurablelinkprops.md#onencrypted)
+- [onEncryptedCapture](configurablelinkprops.md#onencryptedcapture)
+- [onEnded](configurablelinkprops.md#onended)
+- [onEndedCapture](configurablelinkprops.md#onendedcapture)
+- [onError](configurablelinkprops.md#onerror)
+- [onErrorCapture](configurablelinkprops.md#onerrorcapture)
+- [onFocus](configurablelinkprops.md#onfocus)
+- [onFocusCapture](configurablelinkprops.md#onfocuscapture)
+- [onGotPointerCapture](configurablelinkprops.md#ongotpointercapture)
+- [onGotPointerCaptureCapture](configurablelinkprops.md#ongotpointercapturecapture)
+- [onInput](configurablelinkprops.md#oninput)
+- [onInputCapture](configurablelinkprops.md#oninputcapture)
+- [onInvalid](configurablelinkprops.md#oninvalid)
+- [onInvalidCapture](configurablelinkprops.md#oninvalidcapture)
+- [onKeyDown](configurablelinkprops.md#onkeydown)
+- [onKeyDownCapture](configurablelinkprops.md#onkeydowncapture)
+- [onKeyPress](configurablelinkprops.md#onkeypress)
+- [onKeyPressCapture](configurablelinkprops.md#onkeypresscapture)
+- [onKeyUp](configurablelinkprops.md#onkeyup)
+- [onKeyUpCapture](configurablelinkprops.md#onkeyupcapture)
+- [onLoad](configurablelinkprops.md#onload)
+- [onLoadCapture](configurablelinkprops.md#onloadcapture)
+- [onLoadStart](configurablelinkprops.md#onloadstart)
+- [onLoadStartCapture](configurablelinkprops.md#onloadstartcapture)
+- [onLoadedData](configurablelinkprops.md#onloadeddata)
+- [onLoadedDataCapture](configurablelinkprops.md#onloadeddatacapture)
+- [onLoadedMetadata](configurablelinkprops.md#onloadedmetadata)
+- [onLoadedMetadataCapture](configurablelinkprops.md#onloadedmetadatacapture)
+- [onLostPointerCapture](configurablelinkprops.md#onlostpointercapture)
+- [onLostPointerCaptureCapture](configurablelinkprops.md#onlostpointercapturecapture)
+- [onMouseDown](configurablelinkprops.md#onmousedown)
+- [onMouseDownCapture](configurablelinkprops.md#onmousedowncapture)
+- [onMouseEnter](configurablelinkprops.md#onmouseenter)
+- [onMouseLeave](configurablelinkprops.md#onmouseleave)
+- [onMouseMove](configurablelinkprops.md#onmousemove)
+- [onMouseMoveCapture](configurablelinkprops.md#onmousemovecapture)
+- [onMouseOut](configurablelinkprops.md#onmouseout)
+- [onMouseOutCapture](configurablelinkprops.md#onmouseoutcapture)
+- [onMouseOver](configurablelinkprops.md#onmouseover)
+- [onMouseOverCapture](configurablelinkprops.md#onmouseovercapture)
+- [onMouseUp](configurablelinkprops.md#onmouseup)
+- [onMouseUpCapture](configurablelinkprops.md#onmouseupcapture)
+- [onPaste](configurablelinkprops.md#onpaste)
+- [onPasteCapture](configurablelinkprops.md#onpastecapture)
+- [onPause](configurablelinkprops.md#onpause)
+- [onPauseCapture](configurablelinkprops.md#onpausecapture)
+- [onPlay](configurablelinkprops.md#onplay)
+- [onPlayCapture](configurablelinkprops.md#onplaycapture)
+- [onPlaying](configurablelinkprops.md#onplaying)
+- [onPlayingCapture](configurablelinkprops.md#onplayingcapture)
+- [onPointerCancel](configurablelinkprops.md#onpointercancel)
+- [onPointerCancelCapture](configurablelinkprops.md#onpointercancelcapture)
+- [onPointerDown](configurablelinkprops.md#onpointerdown)
+- [onPointerDownCapture](configurablelinkprops.md#onpointerdowncapture)
+- [onPointerEnter](configurablelinkprops.md#onpointerenter)
+- [onPointerEnterCapture](configurablelinkprops.md#onpointerentercapture)
+- [onPointerLeave](configurablelinkprops.md#onpointerleave)
+- [onPointerLeaveCapture](configurablelinkprops.md#onpointerleavecapture)
+- [onPointerMove](configurablelinkprops.md#onpointermove)
+- [onPointerMoveCapture](configurablelinkprops.md#onpointermovecapture)
+- [onPointerOut](configurablelinkprops.md#onpointerout)
+- [onPointerOutCapture](configurablelinkprops.md#onpointeroutcapture)
+- [onPointerOver](configurablelinkprops.md#onpointerover)
+- [onPointerOverCapture](configurablelinkprops.md#onpointerovercapture)
+- [onPointerUp](configurablelinkprops.md#onpointerup)
+- [onPointerUpCapture](configurablelinkprops.md#onpointerupcapture)
+- [onProgress](configurablelinkprops.md#onprogress)
+- [onProgressCapture](configurablelinkprops.md#onprogresscapture)
+- [onRateChange](configurablelinkprops.md#onratechange)
+- [onRateChangeCapture](configurablelinkprops.md#onratechangecapture)
+- [onReset](configurablelinkprops.md#onreset)
+- [onResetCapture](configurablelinkprops.md#onresetcapture)
+- [onScroll](configurablelinkprops.md#onscroll)
+- [onScrollCapture](configurablelinkprops.md#onscrollcapture)
+- [onSeeked](configurablelinkprops.md#onseeked)
+- [onSeekedCapture](configurablelinkprops.md#onseekedcapture)
+- [onSeeking](configurablelinkprops.md#onseeking)
+- [onSeekingCapture](configurablelinkprops.md#onseekingcapture)
+- [onSelect](configurablelinkprops.md#onselect)
+- [onSelectCapture](configurablelinkprops.md#onselectcapture)
+- [onStalled](configurablelinkprops.md#onstalled)
+- [onStalledCapture](configurablelinkprops.md#onstalledcapture)
+- [onSubmit](configurablelinkprops.md#onsubmit)
+- [onSubmitCapture](configurablelinkprops.md#onsubmitcapture)
+- [onSuspend](configurablelinkprops.md#onsuspend)
+- [onSuspendCapture](configurablelinkprops.md#onsuspendcapture)
+- [onTimeUpdate](configurablelinkprops.md#ontimeupdate)
+- [onTimeUpdateCapture](configurablelinkprops.md#ontimeupdatecapture)
+- [onTouchCancel](configurablelinkprops.md#ontouchcancel)
+- [onTouchCancelCapture](configurablelinkprops.md#ontouchcancelcapture)
+- [onTouchEnd](configurablelinkprops.md#ontouchend)
+- [onTouchEndCapture](configurablelinkprops.md#ontouchendcapture)
+- [onTouchMove](configurablelinkprops.md#ontouchmove)
+- [onTouchMoveCapture](configurablelinkprops.md#ontouchmovecapture)
+- [onTouchStart](configurablelinkprops.md#ontouchstart)
+- [onTouchStartCapture](configurablelinkprops.md#ontouchstartcapture)
+- [onTransitionEnd](configurablelinkprops.md#ontransitionend)
+- [onTransitionEndCapture](configurablelinkprops.md#ontransitionendcapture)
+- [onVolumeChange](configurablelinkprops.md#onvolumechange)
+- [onVolumeChangeCapture](configurablelinkprops.md#onvolumechangecapture)
+- [onWaiting](configurablelinkprops.md#onwaiting)
+- [onWaitingCapture](configurablelinkprops.md#onwaitingcapture)
+- [onWheel](configurablelinkprops.md#onwheel)
+- [onWheelCapture](configurablelinkprops.md#onwheelcapture)
+- [ping](configurablelinkprops.md#ping)
+- [placeholder](configurablelinkprops.md#placeholder)
+- [prefix](configurablelinkprops.md#prefix)
+- [property](configurablelinkprops.md#property)
+- [radioGroup](configurablelinkprops.md#radiogroup)
+- [referrerPolicy](configurablelinkprops.md#referrerpolicy)
+- [rel](configurablelinkprops.md#rel)
+- [resource](configurablelinkprops.md#resource)
+- [results](configurablelinkprops.md#results)
+- [role](configurablelinkprops.md#role)
+- [security](configurablelinkprops.md#security)
+- [slot](configurablelinkprops.md#slot)
+- [spellCheck](configurablelinkprops.md#spellcheck)
+- [style](configurablelinkprops.md#style)
+- [suppressContentEditableWarning](configurablelinkprops.md#suppresscontenteditablewarning)
+- [suppressHydrationWarning](configurablelinkprops.md#suppresshydrationwarning)
+- [tabIndex](configurablelinkprops.md#tabindex)
+- [target](configurablelinkprops.md#target)
+- [title](configurablelinkprops.md#title)
 - [to](configurablelinkprops.md#to)
+- [translate](configurablelinkprops.md#translate)
+- [type](configurablelinkprops.md#type)
+- [typeof](configurablelinkprops.md#typeof)
+- [unselectable](configurablelinkprops.md#unselectable)
+- [vocab](configurablelinkprops.md#vocab)
 
 ## Properties
+
+### about
+
+• `Optional` **about**: *string*
+
+Inherited from: AnchorHTMLAttributes.about
+
+Defined in: node_modules/@types/react/index.d.ts:1772
+
+___
+
+### accessKey
+
+• `Optional` **accessKey**: *string*
+
+Inherited from: AnchorHTMLAttributes.accessKey
+
+Defined in: node_modules/@types/react/index.d.ts:1748
+
+___
+
+### aria-activedescendant
+
+• `Optional` **aria-activedescendant**: *string*
+
+Identifies the currently active element when DOM focus is on a composite widget, textbox, group, or application.
+
+Inherited from: AnchorHTMLAttributes.aria-activedescendant
+
+Defined in: node_modules/@types/react/index.d.ts:1553
+
+___
+
+### aria-atomic
+
+• `Optional` **aria-atomic**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates whether assistive technologies will present all, or only parts of, the changed region based on the change notifications defined by the aria-relevant attribute.
+
+Inherited from: AnchorHTMLAttributes.aria-atomic
+
+Defined in: node_modules/@types/react/index.d.ts:1555
+
+___
+
+### aria-autocomplete
+
+• `Optional` **aria-autocomplete**: ``"none"`` \| ``"inline"`` \| ``"list"`` \| ``"both"``
+
+Indicates whether inputting text could trigger display of one or more predictions of the user's intended value for an input and specifies how predictions would be
+presented if they are made.
+
+Inherited from: AnchorHTMLAttributes.aria-autocomplete
+
+Defined in: node_modules/@types/react/index.d.ts:1557
+
+___
+
+### aria-busy
+
+• `Optional` **aria-busy**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates an element is being modified and that assistive technologies MAY want to wait until the modifications are complete before exposing them to the user.
+
+Inherited from: AnchorHTMLAttributes.aria-busy
+
+Defined in: node_modules/@types/react/index.d.ts:1562
+
+___
+
+### aria-checked
+
+• `Optional` **aria-checked**: *boolean* \| ``"true"`` \| ``"false"`` \| ``"mixed"``
+
+Indicates the current "checked" state of checkboxes, radio buttons, and other widgets.
+
+**`see`** aria-pressed @see aria-selected.
+
+Inherited from: AnchorHTMLAttributes.aria-checked
+
+Defined in: node_modules/@types/react/index.d.ts:1564
+
+___
+
+### aria-colcount
+
+• `Optional` **aria-colcount**: *number*
+
+Defines the total number of columns in a table, grid, or treegrid.
+
+**`see`** aria-colindex.
+
+Inherited from: AnchorHTMLAttributes.aria-colcount
+
+Defined in: node_modules/@types/react/index.d.ts:1569
+
+___
+
+### aria-colindex
+
+• `Optional` **aria-colindex**: *number*
+
+Defines an element's column index or position with respect to the total number of columns within a table, grid, or treegrid.
+
+**`see`** aria-colcount @see aria-colspan.
+
+Inherited from: AnchorHTMLAttributes.aria-colindex
+
+Defined in: node_modules/@types/react/index.d.ts:1574
+
+___
+
+### aria-colspan
+
+• `Optional` **aria-colspan**: *number*
+
+Defines the number of columns spanned by a cell or gridcell within a table, grid, or treegrid.
+
+**`see`** aria-colindex @see aria-rowspan.
+
+Inherited from: AnchorHTMLAttributes.aria-colspan
+
+Defined in: node_modules/@types/react/index.d.ts:1579
+
+___
+
+### aria-controls
+
+• `Optional` **aria-controls**: *string*
+
+Identifies the element (or elements) whose contents or presence are controlled by the current element.
+
+**`see`** aria-owns.
+
+Inherited from: AnchorHTMLAttributes.aria-controls
+
+Defined in: node_modules/@types/react/index.d.ts:1584
+
+___
+
+### aria-current
+
+• `Optional` **aria-current**: *boolean* \| ``"true"`` \| ``"false"`` \| ``"page"`` \| ``"step"`` \| ``"location"`` \| ``"date"`` \| ``"time"``
+
+Indicates the element that represents the current item within a container or set of related elements.
+
+Inherited from: AnchorHTMLAttributes.aria-current
+
+Defined in: node_modules/@types/react/index.d.ts:1589
+
+___
+
+### aria-describedby
+
+• `Optional` **aria-describedby**: *string*
+
+Identifies the element (or elements) that describes the object.
+
+**`see`** aria-labelledby
+
+Inherited from: AnchorHTMLAttributes.aria-describedby
+
+Defined in: node_modules/@types/react/index.d.ts:1591
+
+___
+
+### aria-details
+
+• `Optional` **aria-details**: *string*
+
+Identifies the element that provides a detailed, extended description for the object.
+
+**`see`** aria-describedby.
+
+Inherited from: AnchorHTMLAttributes.aria-details
+
+Defined in: node_modules/@types/react/index.d.ts:1596
+
+___
+
+### aria-disabled
+
+• `Optional` **aria-disabled**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates that the element is perceivable but disabled, so it is not editable or otherwise operable.
+
+**`see`** aria-hidden @see aria-readonly.
+
+Inherited from: AnchorHTMLAttributes.aria-disabled
+
+Defined in: node_modules/@types/react/index.d.ts:1601
+
+___
+
+### aria-dropeffect
+
+• `Optional` **aria-dropeffect**: ``"none"`` \| ``"copy"`` \| ``"execute"`` \| ``"link"`` \| ``"move"`` \| ``"popup"``
+
+Indicates what functions can be performed when a dragged object is released on the drop target.
+
+**`deprecated`** in ARIA 1.1
+
+Inherited from: AnchorHTMLAttributes.aria-dropeffect
+
+Defined in: node_modules/@types/react/index.d.ts:1606
+
+___
+
+### aria-errormessage
+
+• `Optional` **aria-errormessage**: *string*
+
+Identifies the element that provides an error message for the object.
+
+**`see`** aria-invalid @see aria-describedby.
+
+Inherited from: AnchorHTMLAttributes.aria-errormessage
+
+Defined in: node_modules/@types/react/index.d.ts:1611
+
+___
+
+### aria-expanded
+
+• `Optional` **aria-expanded**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates whether the element, or another grouping element it controls, is currently expanded or collapsed.
+
+Inherited from: AnchorHTMLAttributes.aria-expanded
+
+Defined in: node_modules/@types/react/index.d.ts:1616
+
+___
+
+### aria-flowto
+
+• `Optional` **aria-flowto**: *string*
+
+Identifies the next element (or elements) in an alternate reading order of content which, at the user's discretion,
+allows assistive technology to override the general default of reading in document source order.
+
+Inherited from: AnchorHTMLAttributes.aria-flowto
+
+Defined in: node_modules/@types/react/index.d.ts:1618
+
+___
+
+### aria-grabbed
+
+• `Optional` **aria-grabbed**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates an element's "grabbed" state in a drag-and-drop operation.
+
+**`deprecated`** in ARIA 1.1
+
+Inherited from: AnchorHTMLAttributes.aria-grabbed
+
+Defined in: node_modules/@types/react/index.d.ts:1623
+
+___
+
+### aria-haspopup
+
+• `Optional` **aria-haspopup**: *boolean* \| ``"true"`` \| ``"false"`` \| ``"menu"`` \| ``"listbox"`` \| ``"tree"`` \| ``"grid"`` \| ``"dialog"``
+
+Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by an element.
+
+Inherited from: AnchorHTMLAttributes.aria-haspopup
+
+Defined in: node_modules/@types/react/index.d.ts:1628
+
+___
+
+### aria-hidden
+
+• `Optional` **aria-hidden**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates whether the element is exposed to an accessibility API.
+
+**`see`** aria-disabled.
+
+Inherited from: AnchorHTMLAttributes.aria-hidden
+
+Defined in: node_modules/@types/react/index.d.ts:1630
+
+___
+
+### aria-invalid
+
+• `Optional` **aria-invalid**: *boolean* \| ``"true"`` \| ``"false"`` \| ``"grammar"`` \| ``"spelling"``
+
+Indicates the entered value does not conform to the format expected by the application.
+
+**`see`** aria-errormessage.
+
+Inherited from: AnchorHTMLAttributes.aria-invalid
+
+Defined in: node_modules/@types/react/index.d.ts:1635
+
+___
+
+### aria-keyshortcuts
+
+• `Optional` **aria-keyshortcuts**: *string*
+
+Indicates keyboard shortcuts that an author has implemented to activate or give focus to an element.
+
+Inherited from: AnchorHTMLAttributes.aria-keyshortcuts
+
+Defined in: node_modules/@types/react/index.d.ts:1640
+
+___
+
+### aria-label
+
+• `Optional` **aria-label**: *string*
+
+Defines a string value that labels the current element.
+
+**`see`** aria-labelledby.
+
+Inherited from: AnchorHTMLAttributes.aria-label
+
+Defined in: node_modules/@types/react/index.d.ts:1642
+
+___
+
+### aria-labelledby
+
+• `Optional` **aria-labelledby**: *string*
+
+Identifies the element (or elements) that labels the current element.
+
+**`see`** aria-describedby.
+
+Inherited from: AnchorHTMLAttributes.aria-labelledby
+
+Defined in: node_modules/@types/react/index.d.ts:1647
+
+___
+
+### aria-level
+
+• `Optional` **aria-level**: *number*
+
+Defines the hierarchical level of an element within a structure.
+
+Inherited from: AnchorHTMLAttributes.aria-level
+
+Defined in: node_modules/@types/react/index.d.ts:1652
+
+___
+
+### aria-live
+
+• `Optional` **aria-live**: ``"off"`` \| ``"assertive"`` \| ``"polite"``
+
+Indicates that an element will be updated, and describes the types of updates the user agents, assistive technologies, and user can expect from the live region.
+
+Inherited from: AnchorHTMLAttributes.aria-live
+
+Defined in: node_modules/@types/react/index.d.ts:1654
+
+___
+
+### aria-modal
+
+• `Optional` **aria-modal**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates whether an element is modal when displayed.
+
+Inherited from: AnchorHTMLAttributes.aria-modal
+
+Defined in: node_modules/@types/react/index.d.ts:1656
+
+___
+
+### aria-multiline
+
+• `Optional` **aria-multiline**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates whether a text box accepts multiple lines of input or only a single line.
+
+Inherited from: AnchorHTMLAttributes.aria-multiline
+
+Defined in: node_modules/@types/react/index.d.ts:1658
+
+___
+
+### aria-multiselectable
+
+• `Optional` **aria-multiselectable**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates that the user may select more than one item from the current selectable descendants.
+
+Inherited from: AnchorHTMLAttributes.aria-multiselectable
+
+Defined in: node_modules/@types/react/index.d.ts:1660
+
+___
+
+### aria-orientation
+
+• `Optional` **aria-orientation**: ``"horizontal"`` \| ``"vertical"``
+
+Indicates whether the element's orientation is horizontal, vertical, or unknown/ambiguous.
+
+Inherited from: AnchorHTMLAttributes.aria-orientation
+
+Defined in: node_modules/@types/react/index.d.ts:1662
+
+___
+
+### aria-owns
+
+• `Optional` **aria-owns**: *string*
+
+Identifies an element (or elements) in order to define a visual, functional, or contextual parent/child relationship
+between DOM elements where the DOM hierarchy cannot be used to represent the relationship.
+
+**`see`** aria-controls.
+
+Inherited from: AnchorHTMLAttributes.aria-owns
+
+Defined in: node_modules/@types/react/index.d.ts:1664
+
+___
+
+### aria-placeholder
+
+• `Optional` **aria-placeholder**: *string*
+
+Defines a short hint (a word or short phrase) intended to aid the user with data entry when the control has no value.
+A hint could be a sample value or a brief description of the expected format.
+
+Inherited from: AnchorHTMLAttributes.aria-placeholder
+
+Defined in: node_modules/@types/react/index.d.ts:1670
+
+___
+
+### aria-posinset
+
+• `Optional` **aria-posinset**: *number*
+
+Defines an element's number or position in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+
+**`see`** aria-setsize.
+
+Inherited from: AnchorHTMLAttributes.aria-posinset
+
+Defined in: node_modules/@types/react/index.d.ts:1675
+
+___
+
+### aria-pressed
+
+• `Optional` **aria-pressed**: *boolean* \| ``"true"`` \| ``"false"`` \| ``"mixed"``
+
+Indicates the current "pressed" state of toggle buttons.
+
+**`see`** aria-checked @see aria-selected.
+
+Inherited from: AnchorHTMLAttributes.aria-pressed
+
+Defined in: node_modules/@types/react/index.d.ts:1680
+
+___
+
+### aria-readonly
+
+• `Optional` **aria-readonly**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates that the element is not editable, but is otherwise operable.
+
+**`see`** aria-disabled.
+
+Inherited from: AnchorHTMLAttributes.aria-readonly
+
+Defined in: node_modules/@types/react/index.d.ts:1685
+
+___
+
+### aria-relevant
+
+• `Optional` **aria-relevant**: ``"text"`` \| ``"additions"`` \| ``"additions removals"`` \| ``"additions text"`` \| ``"all"`` \| ``"removals"`` \| ``"removals additions"`` \| ``"removals text"`` \| ``"text additions"`` \| ``"text removals"``
+
+Indicates what notifications the user agent will trigger when the accessibility tree within a live region is modified.
+
+**`see`** aria-atomic.
+
+Inherited from: AnchorHTMLAttributes.aria-relevant
+
+Defined in: node_modules/@types/react/index.d.ts:1690
+
+___
+
+### aria-required
+
+• `Optional` **aria-required**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates that user input is required on the element before a form may be submitted.
+
+Inherited from: AnchorHTMLAttributes.aria-required
+
+Defined in: node_modules/@types/react/index.d.ts:1695
+
+___
+
+### aria-roledescription
+
+• `Optional` **aria-roledescription**: *string*
+
+Defines a human-readable, author-localized description for the role of an element.
+
+Inherited from: AnchorHTMLAttributes.aria-roledescription
+
+Defined in: node_modules/@types/react/index.d.ts:1697
+
+___
+
+### aria-rowcount
+
+• `Optional` **aria-rowcount**: *number*
+
+Defines the total number of rows in a table, grid, or treegrid.
+
+**`see`** aria-rowindex.
+
+Inherited from: AnchorHTMLAttributes.aria-rowcount
+
+Defined in: node_modules/@types/react/index.d.ts:1699
+
+___
+
+### aria-rowindex
+
+• `Optional` **aria-rowindex**: *number*
+
+Defines an element's row index or position with respect to the total number of rows within a table, grid, or treegrid.
+
+**`see`** aria-rowcount @see aria-rowspan.
+
+Inherited from: AnchorHTMLAttributes.aria-rowindex
+
+Defined in: node_modules/@types/react/index.d.ts:1704
+
+___
+
+### aria-rowspan
+
+• `Optional` **aria-rowspan**: *number*
+
+Defines the number of rows spanned by a cell or gridcell within a table, grid, or treegrid.
+
+**`see`** aria-rowindex @see aria-colspan.
+
+Inherited from: AnchorHTMLAttributes.aria-rowspan
+
+Defined in: node_modules/@types/react/index.d.ts:1709
+
+___
+
+### aria-selected
+
+• `Optional` **aria-selected**: *boolean* \| ``"true"`` \| ``"false"``
+
+Indicates the current "selected" state of various widgets.
+
+**`see`** aria-checked @see aria-pressed.
+
+Inherited from: AnchorHTMLAttributes.aria-selected
+
+Defined in: node_modules/@types/react/index.d.ts:1714
+
+___
+
+### aria-setsize
+
+• `Optional` **aria-setsize**: *number*
+
+Defines the number of items in the current set of listitems or treeitems. Not required if all elements in the set are present in the DOM.
+
+**`see`** aria-posinset.
+
+Inherited from: AnchorHTMLAttributes.aria-setsize
+
+Defined in: node_modules/@types/react/index.d.ts:1719
+
+___
+
+### aria-sort
+
+• `Optional` **aria-sort**: ``"none"`` \| ``"ascending"`` \| ``"descending"`` \| ``"other"``
+
+Indicates if items in a table or grid are sorted in ascending or descending order.
+
+Inherited from: AnchorHTMLAttributes.aria-sort
+
+Defined in: node_modules/@types/react/index.d.ts:1724
+
+___
+
+### aria-valuemax
+
+• `Optional` **aria-valuemax**: *number*
+
+Defines the maximum allowed value for a range widget.
+
+Inherited from: AnchorHTMLAttributes.aria-valuemax
+
+Defined in: node_modules/@types/react/index.d.ts:1726
+
+___
+
+### aria-valuemin
+
+• `Optional` **aria-valuemin**: *number*
+
+Defines the minimum allowed value for a range widget.
+
+Inherited from: AnchorHTMLAttributes.aria-valuemin
+
+Defined in: node_modules/@types/react/index.d.ts:1728
+
+___
+
+### aria-valuenow
+
+• `Optional` **aria-valuenow**: *number*
+
+Defines the current value for a range widget.
+
+**`see`** aria-valuetext.
+
+Inherited from: AnchorHTMLAttributes.aria-valuenow
+
+Defined in: node_modules/@types/react/index.d.ts:1730
+
+___
+
+### aria-valuetext
+
+• `Optional` **aria-valuetext**: *string*
+
+Defines the human readable text alternative of aria-valuenow for a range widget.
+
+Inherited from: AnchorHTMLAttributes.aria-valuetext
+
+Defined in: node_modules/@types/react/index.d.ts:1735
+
+___
+
+### autoCapitalize
+
+• `Optional` **autoCapitalize**: *string*
+
+Inherited from: AnchorHTMLAttributes.autoCapitalize
+
+Defined in: node_modules/@types/react/index.d.ts:1782
+
+___
+
+### autoCorrect
+
+• `Optional` **autoCorrect**: *string*
+
+Inherited from: AnchorHTMLAttributes.autoCorrect
+
+Defined in: node_modules/@types/react/index.d.ts:1783
+
+___
+
+### autoSave
+
+• `Optional` **autoSave**: *string*
+
+Inherited from: AnchorHTMLAttributes.autoSave
+
+Defined in: node_modules/@types/react/index.d.ts:1784
+
+___
+
+### children
+
+• `Optional` **children**: ReactNode
+
+Inherited from: AnchorHTMLAttributes.children
+
+Defined in: node_modules/@types/react/index.d.ts:1345
+
+___
+
+### className
+
+• `Optional` **className**: *string*
+
+Inherited from: AnchorHTMLAttributes.className
+
+Defined in: node_modules/@types/react/index.d.ts:1749
+
+___
+
+### color
+
+• `Optional` **color**: *string*
+
+Inherited from: AnchorHTMLAttributes.color
+
+Defined in: node_modules/@types/react/index.d.ts:1785
+
+___
+
+### contentEditable
+
+• `Optional` **contentEditable**: Booleanish \| ``"inherit"``
+
+Inherited from: AnchorHTMLAttributes.contentEditable
+
+Defined in: node_modules/@types/react/index.d.ts:1750
+
+___
+
+### contextMenu
+
+• `Optional` **contextMenu**: *string*
+
+Inherited from: AnchorHTMLAttributes.contextMenu
+
+Defined in: node_modules/@types/react/index.d.ts:1751
+
+___
+
+### dangerouslySetInnerHTML
+
+• `Optional` **dangerouslySetInnerHTML**: *object*
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `__html` | *string* |
+
+Inherited from: AnchorHTMLAttributes.dangerouslySetInnerHTML
+
+Defined in: node_modules/@types/react/index.d.ts:1346
+
+___
+
+### datatype
+
+• `Optional` **datatype**: *string*
+
+Inherited from: AnchorHTMLAttributes.datatype
+
+Defined in: node_modules/@types/react/index.d.ts:1773
+
+___
+
+### defaultChecked
+
+• `Optional` **defaultChecked**: *boolean*
+
+Inherited from: AnchorHTMLAttributes.defaultChecked
+
+Defined in: node_modules/@types/react/index.d.ts:1742
+
+___
+
+### defaultValue
+
+• `Optional` **defaultValue**: *string* \| *number* \| readonly *string*[]
+
+Inherited from: AnchorHTMLAttributes.defaultValue
+
+Defined in: node_modules/@types/react/index.d.ts:1743
+
+___
+
+### dir
+
+• `Optional` **dir**: *string*
+
+Inherited from: AnchorHTMLAttributes.dir
+
+Defined in: node_modules/@types/react/index.d.ts:1752
+
+___
+
+### download
+
+• `Optional` **download**: *any*
+
+Inherited from: AnchorHTMLAttributes.download
+
+Defined in: node_modules/@types/react/index.d.ts:1930
+
+___
+
+### draggable
+
+• `Optional` **draggable**: Booleanish
+
+Inherited from: AnchorHTMLAttributes.draggable
+
+Defined in: node_modules/@types/react/index.d.ts:1753
+
+___
+
+### hidden
+
+• `Optional` **hidden**: *boolean*
+
+Inherited from: AnchorHTMLAttributes.hidden
+
+Defined in: node_modules/@types/react/index.d.ts:1754
+
+___
+
+### href
+
+• `Optional` **href**: *string*
+
+Inherited from: AnchorHTMLAttributes.href
+
+Defined in: node_modules/@types/react/index.d.ts:1931
+
+___
+
+### hrefLang
+
+• `Optional` **hrefLang**: *string*
+
+Inherited from: AnchorHTMLAttributes.hrefLang
+
+Defined in: node_modules/@types/react/index.d.ts:1932
+
+___
+
+### id
+
+• `Optional` **id**: *string*
+
+Inherited from: AnchorHTMLAttributes.id
+
+Defined in: node_modules/@types/react/index.d.ts:1755
+
+___
+
+### inlist
+
+• `Optional` **inlist**: *any*
+
+Inherited from: AnchorHTMLAttributes.inlist
+
+Defined in: node_modules/@types/react/index.d.ts:1774
+
+___
+
+### inputMode
+
+• `Optional` **inputMode**: ``"none"`` \| ``"text"`` \| ``"tel"`` \| ``"url"`` \| ``"email"`` \| ``"numeric"`` \| ``"decimal"`` \| ``"search"``
+
+Hints at the type of data that might be entered by the user while editing the element or its contents
+
+**`see`** https://html.spec.whatwg.org/multipage/interaction.html#input-modalities:-the-inputmode-attribute
+
+Inherited from: AnchorHTMLAttributes.inputMode
+
+Defined in: node_modules/@types/react/index.d.ts:1800
+
+___
+
+### is
+
+• `Optional` **is**: *string*
+
+Specify that a standard HTML element should behave like a defined custom built-in element
+
+**`see`** https://html.spec.whatwg.org/multipage/custom-elements.html#attr-is
+
+Inherited from: AnchorHTMLAttributes.is
+
+Defined in: node_modules/@types/react/index.d.ts:1805
+
+___
+
+### itemID
+
+• `Optional` **itemID**: *string*
+
+Inherited from: AnchorHTMLAttributes.itemID
+
+Defined in: node_modules/@types/react/index.d.ts:1789
+
+___
+
+### itemProp
+
+• `Optional` **itemProp**: *string*
+
+Inherited from: AnchorHTMLAttributes.itemProp
+
+Defined in: node_modules/@types/react/index.d.ts:1786
+
+___
+
+### itemRef
+
+• `Optional` **itemRef**: *string*
+
+Inherited from: AnchorHTMLAttributes.itemRef
+
+Defined in: node_modules/@types/react/index.d.ts:1790
+
+___
+
+### itemScope
+
+• `Optional` **itemScope**: *boolean*
+
+Inherited from: AnchorHTMLAttributes.itemScope
+
+Defined in: node_modules/@types/react/index.d.ts:1787
+
+___
+
+### itemType
+
+• `Optional` **itemType**: *string*
+
+Inherited from: AnchorHTMLAttributes.itemType
+
+Defined in: node_modules/@types/react/index.d.ts:1788
+
+___
+
+### lang
+
+• `Optional` **lang**: *string*
+
+Inherited from: AnchorHTMLAttributes.lang
+
+Defined in: node_modules/@types/react/index.d.ts:1756
+
+___
+
+### media
+
+• `Optional` **media**: *string*
+
+Inherited from: AnchorHTMLAttributes.media
+
+Defined in: node_modules/@types/react/index.d.ts:1933
+
+___
+
+### onAbort
+
+• `Optional` **onAbort**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAbort
+
+Defined in: node_modules/@types/react/index.d.ts:1401
+
+___
+
+### onAbortCapture
+
+• `Optional` **onAbortCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAbortCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1402
+
+___
+
+### onAnimationEnd
+
+• `Optional` **onAnimationEnd**: *AnimationEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAnimationEnd
+
+Defined in: node_modules/@types/react/index.d.ts:1531
+
+___
+
+### onAnimationEndCapture
+
+• `Optional` **onAnimationEndCapture**: *AnimationEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAnimationEndCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1532
+
+___
+
+### onAnimationIteration
+
+• `Optional` **onAnimationIteration**: *AnimationEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAnimationIteration
+
+Defined in: node_modules/@types/react/index.d.ts:1533
+
+___
+
+### onAnimationIterationCapture
+
+• `Optional` **onAnimationIterationCapture**: *AnimationEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAnimationIterationCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1534
+
+___
+
+### onAnimationStart
+
+• `Optional` **onAnimationStart**: *AnimationEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAnimationStart
+
+Defined in: node_modules/@types/react/index.d.ts:1529
+
+___
+
+### onAnimationStartCapture
+
+• `Optional` **onAnimationStartCapture**: *AnimationEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAnimationStartCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1530
+
+___
+
+### onAuxClick
+
+• `Optional` **onAuxClick**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAuxClick
+
+Defined in: node_modules/@types/react/index.d.ts:1447
+
+___
+
+### onAuxClickCapture
+
+• `Optional` **onAuxClickCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onAuxClickCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1448
+
+___
+
+### onBeforeInput
+
+• `Optional` **onBeforeInput**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onBeforeInput
+
+Defined in: node_modules/@types/react/index.d.ts:1375
+
+___
+
+### onBeforeInputCapture
+
+• `Optional` **onBeforeInputCapture**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onBeforeInputCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1376
+
+___
+
+### onBlur
+
+• `Optional` **onBlur**: *FocusEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onBlur
+
+Defined in: node_modules/@types/react/index.d.ts:1369
+
+___
+
+### onBlurCapture
+
+• `Optional` **onBlurCapture**: *FocusEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onBlurCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1370
+
+___
+
+### onCanPlay
+
+• `Optional` **onCanPlay**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCanPlay
+
+Defined in: node_modules/@types/react/index.d.ts:1403
+
+___
+
+### onCanPlayCapture
+
+• `Optional` **onCanPlayCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCanPlayCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1404
+
+___
+
+### onCanPlayThrough
+
+• `Optional` **onCanPlayThrough**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCanPlayThrough
+
+Defined in: node_modules/@types/react/index.d.ts:1405
+
+___
+
+### onCanPlayThroughCapture
+
+• `Optional` **onCanPlayThroughCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCanPlayThroughCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1406
+
+___
+
+### onChange
+
+• `Optional` **onChange**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onChange
+
+Defined in: node_modules/@types/react/index.d.ts:1373
+
+___
+
+### onChangeCapture
+
+• `Optional` **onChangeCapture**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onChangeCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1374
+
+___
+
+### onClick
+
+• `Optional` **onClick**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onClick
+
+Defined in: node_modules/@types/react/index.d.ts:1449
+
+___
+
+### onClickCapture
+
+• `Optional` **onClickCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onClickCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1450
+
+___
+
+### onCompositionEnd
+
+• `Optional` **onCompositionEnd**: *CompositionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCompositionEnd
+
+Defined in: node_modules/@types/react/index.d.ts:1359
+
+___
+
+### onCompositionEndCapture
+
+• `Optional` **onCompositionEndCapture**: *CompositionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCompositionEndCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1360
+
+___
+
+### onCompositionStart
+
+• `Optional` **onCompositionStart**: *CompositionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCompositionStart
+
+Defined in: node_modules/@types/react/index.d.ts:1361
+
+___
+
+### onCompositionStartCapture
+
+• `Optional` **onCompositionStartCapture**: *CompositionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCompositionStartCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1362
+
+___
+
+### onCompositionUpdate
+
+• `Optional` **onCompositionUpdate**: *CompositionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCompositionUpdate
+
+Defined in: node_modules/@types/react/index.d.ts:1363
+
+___
+
+### onCompositionUpdateCapture
+
+• `Optional` **onCompositionUpdateCapture**: *CompositionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCompositionUpdateCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1364
+
+___
+
+### onContextMenu
+
+• `Optional` **onContextMenu**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onContextMenu
+
+Defined in: node_modules/@types/react/index.d.ts:1451
+
+___
+
+### onContextMenuCapture
+
+• `Optional` **onContextMenuCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onContextMenuCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1452
+
+___
+
+### onCopy
+
+• `Optional` **onCopy**: *ClipboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCopy
+
+Defined in: node_modules/@types/react/index.d.ts:1351
+
+___
+
+### onCopyCapture
+
+• `Optional` **onCopyCapture**: *ClipboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCopyCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1352
+
+___
+
+### onCut
+
+• `Optional` **onCut**: *ClipboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCut
+
+Defined in: node_modules/@types/react/index.d.ts:1353
+
+___
+
+### onCutCapture
+
+• `Optional` **onCutCapture**: *ClipboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onCutCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1354
+
+___
+
+### onDoubleClick
+
+• `Optional` **onDoubleClick**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDoubleClick
+
+Defined in: node_modules/@types/react/index.d.ts:1453
+
+___
+
+### onDoubleClickCapture
+
+• `Optional` **onDoubleClickCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDoubleClickCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1454
+
+___
+
+### onDrag
+
+• `Optional` **onDrag**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDrag
+
+Defined in: node_modules/@types/react/index.d.ts:1455
+
+___
+
+### onDragCapture
+
+• `Optional` **onDragCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1456
+
+___
+
+### onDragEnd
+
+• `Optional` **onDragEnd**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragEnd
+
+Defined in: node_modules/@types/react/index.d.ts:1457
+
+___
+
+### onDragEndCapture
+
+• `Optional` **onDragEndCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragEndCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1458
+
+___
+
+### onDragEnter
+
+• `Optional` **onDragEnter**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragEnter
+
+Defined in: node_modules/@types/react/index.d.ts:1459
+
+___
+
+### onDragEnterCapture
+
+• `Optional` **onDragEnterCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragEnterCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1460
+
+___
+
+### onDragExit
+
+• `Optional` **onDragExit**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragExit
+
+Defined in: node_modules/@types/react/index.d.ts:1461
+
+___
+
+### onDragExitCapture
+
+• `Optional` **onDragExitCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragExitCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1462
+
+___
+
+### onDragLeave
+
+• `Optional` **onDragLeave**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragLeave
+
+Defined in: node_modules/@types/react/index.d.ts:1463
+
+___
+
+### onDragLeaveCapture
+
+• `Optional` **onDragLeaveCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragLeaveCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1464
+
+___
+
+### onDragOver
+
+• `Optional` **onDragOver**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragOver
+
+Defined in: node_modules/@types/react/index.d.ts:1465
+
+___
+
+### onDragOverCapture
+
+• `Optional` **onDragOverCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragOverCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1466
+
+___
+
+### onDragStart
+
+• `Optional` **onDragStart**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragStart
+
+Defined in: node_modules/@types/react/index.d.ts:1467
+
+___
+
+### onDragStartCapture
+
+• `Optional` **onDragStartCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDragStartCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1468
+
+___
+
+### onDrop
+
+• `Optional` **onDrop**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDrop
+
+Defined in: node_modules/@types/react/index.d.ts:1469
+
+___
+
+### onDropCapture
+
+• `Optional` **onDropCapture**: *DragEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDropCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1470
+
+___
+
+### onDurationChange
+
+• `Optional` **onDurationChange**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDurationChange
+
+Defined in: node_modules/@types/react/index.d.ts:1407
+
+___
+
+### onDurationChangeCapture
+
+• `Optional` **onDurationChangeCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onDurationChangeCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1408
+
+___
+
+### onEmptied
+
+• `Optional` **onEmptied**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onEmptied
+
+Defined in: node_modules/@types/react/index.d.ts:1409
+
+___
+
+### onEmptiedCapture
+
+• `Optional` **onEmptiedCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onEmptiedCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1410
+
+___
+
+### onEncrypted
+
+• `Optional` **onEncrypted**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onEncrypted
+
+Defined in: node_modules/@types/react/index.d.ts:1411
+
+___
+
+### onEncryptedCapture
+
+• `Optional` **onEncryptedCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onEncryptedCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1412
+
+___
+
+### onEnded
+
+• `Optional` **onEnded**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onEnded
+
+Defined in: node_modules/@types/react/index.d.ts:1413
+
+___
+
+### onEndedCapture
+
+• `Optional` **onEndedCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onEndedCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1414
+
+___
+
+### onError
+
+• `Optional` **onError**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onError
+
+Defined in: node_modules/@types/react/index.d.ts:1389
+
+___
+
+### onErrorCapture
+
+• `Optional` **onErrorCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onErrorCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1390
+
+___
+
+### onFocus
+
+• `Optional` **onFocus**: *FocusEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onFocus
+
+Defined in: node_modules/@types/react/index.d.ts:1367
+
+___
+
+### onFocusCapture
+
+• `Optional` **onFocusCapture**: *FocusEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onFocusCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1368
+
+___
+
+### onGotPointerCapture
+
+• `Optional` **onGotPointerCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onGotPointerCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1515
+
+___
+
+### onGotPointerCaptureCapture
+
+• `Optional` **onGotPointerCaptureCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onGotPointerCaptureCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1516
+
+___
+
+### onInput
+
+• `Optional` **onInput**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onInput
+
+Defined in: node_modules/@types/react/index.d.ts:1377
+
+___
+
+### onInputCapture
+
+• `Optional` **onInputCapture**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onInputCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1378
+
+___
+
+### onInvalid
+
+• `Optional` **onInvalid**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onInvalid
+
+Defined in: node_modules/@types/react/index.d.ts:1383
+
+___
+
+### onInvalidCapture
+
+• `Optional` **onInvalidCapture**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onInvalidCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1384
+
+___
+
+### onKeyDown
+
+• `Optional` **onKeyDown**: *KeyboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onKeyDown
+
+Defined in: node_modules/@types/react/index.d.ts:1393
+
+___
+
+### onKeyDownCapture
+
+• `Optional` **onKeyDownCapture**: *KeyboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onKeyDownCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1394
+
+___
+
+### onKeyPress
+
+• `Optional` **onKeyPress**: *KeyboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onKeyPress
+
+Defined in: node_modules/@types/react/index.d.ts:1395
+
+___
+
+### onKeyPressCapture
+
+• `Optional` **onKeyPressCapture**: *KeyboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onKeyPressCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1396
+
+___
+
+### onKeyUp
+
+• `Optional` **onKeyUp**: *KeyboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onKeyUp
+
+Defined in: node_modules/@types/react/index.d.ts:1397
+
+___
+
+### onKeyUpCapture
+
+• `Optional` **onKeyUpCapture**: *KeyboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onKeyUpCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1398
+
+___
+
+### onLoad
+
+• `Optional` **onLoad**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoad
+
+Defined in: node_modules/@types/react/index.d.ts:1387
+
+___
+
+### onLoadCapture
+
+• `Optional` **onLoadCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1388
+
+___
+
+### onLoadStart
+
+• `Optional` **onLoadStart**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadStart
+
+Defined in: node_modules/@types/react/index.d.ts:1419
+
+___
+
+### onLoadStartCapture
+
+• `Optional` **onLoadStartCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadStartCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1420
+
+___
+
+### onLoadedData
+
+• `Optional` **onLoadedData**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadedData
+
+Defined in: node_modules/@types/react/index.d.ts:1415
+
+___
+
+### onLoadedDataCapture
+
+• `Optional` **onLoadedDataCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadedDataCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1416
+
+___
+
+### onLoadedMetadata
+
+• `Optional` **onLoadedMetadata**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadedMetadata
+
+Defined in: node_modules/@types/react/index.d.ts:1417
+
+___
+
+### onLoadedMetadataCapture
+
+• `Optional` **onLoadedMetadataCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLoadedMetadataCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1418
+
+___
+
+### onLostPointerCapture
+
+• `Optional` **onLostPointerCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLostPointerCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1517
+
+___
+
+### onLostPointerCaptureCapture
+
+• `Optional` **onLostPointerCaptureCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onLostPointerCaptureCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1518
+
+___
+
+### onMouseDown
+
+• `Optional` **onMouseDown**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseDown
+
+Defined in: node_modules/@types/react/index.d.ts:1471
+
+___
+
+### onMouseDownCapture
+
+• `Optional` **onMouseDownCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseDownCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1472
+
+___
+
+### onMouseEnter
+
+• `Optional` **onMouseEnter**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseEnter
+
+Defined in: node_modules/@types/react/index.d.ts:1473
+
+___
+
+### onMouseLeave
+
+• `Optional` **onMouseLeave**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseLeave
+
+Defined in: node_modules/@types/react/index.d.ts:1474
+
+___
+
+### onMouseMove
+
+• `Optional` **onMouseMove**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseMove
+
+Defined in: node_modules/@types/react/index.d.ts:1475
+
+___
+
+### onMouseMoveCapture
+
+• `Optional` **onMouseMoveCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseMoveCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1476
+
+___
+
+### onMouseOut
+
+• `Optional` **onMouseOut**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseOut
+
+Defined in: node_modules/@types/react/index.d.ts:1477
+
+___
+
+### onMouseOutCapture
+
+• `Optional` **onMouseOutCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseOutCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1478
+
+___
+
+### onMouseOver
+
+• `Optional` **onMouseOver**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseOver
+
+Defined in: node_modules/@types/react/index.d.ts:1479
+
+___
+
+### onMouseOverCapture
+
+• `Optional` **onMouseOverCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseOverCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1480
+
+___
+
+### onMouseUp
+
+• `Optional` **onMouseUp**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseUp
+
+Defined in: node_modules/@types/react/index.d.ts:1481
+
+___
+
+### onMouseUpCapture
+
+• `Optional` **onMouseUpCapture**: *MouseEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onMouseUpCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1482
+
+___
+
+### onPaste
+
+• `Optional` **onPaste**: *ClipboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPaste
+
+Defined in: node_modules/@types/react/index.d.ts:1355
+
+___
+
+### onPasteCapture
+
+• `Optional` **onPasteCapture**: *ClipboardEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPasteCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1356
+
+___
+
+### onPause
+
+• `Optional` **onPause**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPause
+
+Defined in: node_modules/@types/react/index.d.ts:1421
+
+___
+
+### onPauseCapture
+
+• `Optional` **onPauseCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPauseCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1422
+
+___
+
+### onPlay
+
+• `Optional` **onPlay**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPlay
+
+Defined in: node_modules/@types/react/index.d.ts:1423
+
+___
+
+### onPlayCapture
+
+• `Optional` **onPlayCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPlayCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1424
+
+___
+
+### onPlaying
+
+• `Optional` **onPlaying**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPlaying
+
+Defined in: node_modules/@types/react/index.d.ts:1425
+
+___
+
+### onPlayingCapture
+
+• `Optional` **onPlayingCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPlayingCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1426
+
+___
+
+### onPointerCancel
+
+• `Optional` **onPointerCancel**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerCancel
+
+Defined in: node_modules/@types/react/index.d.ts:1505
+
+___
+
+### onPointerCancelCapture
+
+• `Optional` **onPointerCancelCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerCancelCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1506
+
+___
+
+### onPointerDown
+
+• `Optional` **onPointerDown**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerDown
+
+Defined in: node_modules/@types/react/index.d.ts:1499
+
+___
+
+### onPointerDownCapture
+
+• `Optional` **onPointerDownCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerDownCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1500
+
+___
+
+### onPointerEnter
+
+• `Optional` **onPointerEnter**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerEnter
+
+Defined in: node_modules/@types/react/index.d.ts:1507
+
+___
+
+### onPointerEnterCapture
+
+• `Optional` **onPointerEnterCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerEnterCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1508
+
+___
+
+### onPointerLeave
+
+• `Optional` **onPointerLeave**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerLeave
+
+Defined in: node_modules/@types/react/index.d.ts:1509
+
+___
+
+### onPointerLeaveCapture
+
+• `Optional` **onPointerLeaveCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerLeaveCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1510
+
+___
+
+### onPointerMove
+
+• `Optional` **onPointerMove**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerMove
+
+Defined in: node_modules/@types/react/index.d.ts:1501
+
+___
+
+### onPointerMoveCapture
+
+• `Optional` **onPointerMoveCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerMoveCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1502
+
+___
+
+### onPointerOut
+
+• `Optional` **onPointerOut**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerOut
+
+Defined in: node_modules/@types/react/index.d.ts:1513
+
+___
+
+### onPointerOutCapture
+
+• `Optional` **onPointerOutCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerOutCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1514
+
+___
+
+### onPointerOver
+
+• `Optional` **onPointerOver**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerOver
+
+Defined in: node_modules/@types/react/index.d.ts:1511
+
+___
+
+### onPointerOverCapture
+
+• `Optional` **onPointerOverCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerOverCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1512
+
+___
+
+### onPointerUp
+
+• `Optional` **onPointerUp**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerUp
+
+Defined in: node_modules/@types/react/index.d.ts:1503
+
+___
+
+### onPointerUpCapture
+
+• `Optional` **onPointerUpCapture**: *PointerEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onPointerUpCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1504
+
+___
+
+### onProgress
+
+• `Optional` **onProgress**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onProgress
+
+Defined in: node_modules/@types/react/index.d.ts:1427
+
+___
+
+### onProgressCapture
+
+• `Optional` **onProgressCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onProgressCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1428
+
+___
+
+### onRateChange
+
+• `Optional` **onRateChange**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onRateChange
+
+Defined in: node_modules/@types/react/index.d.ts:1429
+
+___
+
+### onRateChangeCapture
+
+• `Optional` **onRateChangeCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onRateChangeCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1430
+
+___
+
+### onReset
+
+• `Optional` **onReset**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onReset
+
+Defined in: node_modules/@types/react/index.d.ts:1379
+
+___
+
+### onResetCapture
+
+• `Optional` **onResetCapture**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onResetCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1380
+
+___
+
+### onScroll
+
+• `Optional` **onScroll**: *UIEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onScroll
+
+Defined in: node_modules/@types/react/index.d.ts:1521
+
+___
+
+### onScrollCapture
+
+• `Optional` **onScrollCapture**: *UIEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onScrollCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1522
+
+___
+
+### onSeeked
+
+• `Optional` **onSeeked**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSeeked
+
+Defined in: node_modules/@types/react/index.d.ts:1431
+
+___
+
+### onSeekedCapture
+
+• `Optional` **onSeekedCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSeekedCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1432
+
+___
+
+### onSeeking
+
+• `Optional` **onSeeking**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSeeking
+
+Defined in: node_modules/@types/react/index.d.ts:1433
+
+___
+
+### onSeekingCapture
+
+• `Optional` **onSeekingCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSeekingCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1434
+
+___
+
+### onSelect
+
+• `Optional` **onSelect**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSelect
+
+Defined in: node_modules/@types/react/index.d.ts:1485
+
+___
+
+### onSelectCapture
+
+• `Optional` **onSelectCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSelectCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1486
+
+___
+
+### onStalled
+
+• `Optional` **onStalled**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onStalled
+
+Defined in: node_modules/@types/react/index.d.ts:1435
+
+___
+
+### onStalledCapture
+
+• `Optional` **onStalledCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onStalledCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1436
+
+___
+
+### onSubmit
+
+• `Optional` **onSubmit**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSubmit
+
+Defined in: node_modules/@types/react/index.d.ts:1381
+
+___
+
+### onSubmitCapture
+
+• `Optional` **onSubmitCapture**: *FormEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSubmitCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1382
+
+___
+
+### onSuspend
+
+• `Optional` **onSuspend**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSuspend
+
+Defined in: node_modules/@types/react/index.d.ts:1437
+
+___
+
+### onSuspendCapture
+
+• `Optional` **onSuspendCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onSuspendCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1438
+
+___
+
+### onTimeUpdate
+
+• `Optional` **onTimeUpdate**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTimeUpdate
+
+Defined in: node_modules/@types/react/index.d.ts:1439
+
+___
+
+### onTimeUpdateCapture
+
+• `Optional` **onTimeUpdateCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTimeUpdateCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1440
+
+___
+
+### onTouchCancel
+
+• `Optional` **onTouchCancel**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchCancel
+
+Defined in: node_modules/@types/react/index.d.ts:1489
+
+___
+
+### onTouchCancelCapture
+
+• `Optional` **onTouchCancelCapture**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchCancelCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1490
+
+___
+
+### onTouchEnd
+
+• `Optional` **onTouchEnd**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchEnd
+
+Defined in: node_modules/@types/react/index.d.ts:1491
+
+___
+
+### onTouchEndCapture
+
+• `Optional` **onTouchEndCapture**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchEndCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1492
+
+___
+
+### onTouchMove
+
+• `Optional` **onTouchMove**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchMove
+
+Defined in: node_modules/@types/react/index.d.ts:1493
+
+___
+
+### onTouchMoveCapture
+
+• `Optional` **onTouchMoveCapture**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchMoveCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1494
+
+___
+
+### onTouchStart
+
+• `Optional` **onTouchStart**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchStart
+
+Defined in: node_modules/@types/react/index.d.ts:1495
+
+___
+
+### onTouchStartCapture
+
+• `Optional` **onTouchStartCapture**: *TouchEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTouchStartCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1496
+
+___
+
+### onTransitionEnd
+
+• `Optional` **onTransitionEnd**: *TransitionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTransitionEnd
+
+Defined in: node_modules/@types/react/index.d.ts:1537
+
+___
+
+### onTransitionEndCapture
+
+• `Optional` **onTransitionEndCapture**: *TransitionEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onTransitionEndCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1538
+
+___
+
+### onVolumeChange
+
+• `Optional` **onVolumeChange**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onVolumeChange
+
+Defined in: node_modules/@types/react/index.d.ts:1441
+
+___
+
+### onVolumeChangeCapture
+
+• `Optional` **onVolumeChangeCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onVolumeChangeCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1442
+
+___
+
+### onWaiting
+
+• `Optional` **onWaiting**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onWaiting
+
+Defined in: node_modules/@types/react/index.d.ts:1443
+
+___
+
+### onWaitingCapture
+
+• `Optional` **onWaitingCapture**: *ReactEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onWaitingCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1444
+
+___
+
+### onWheel
+
+• `Optional` **onWheel**: *WheelEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onWheel
+
+Defined in: node_modules/@types/react/index.d.ts:1525
+
+___
+
+### onWheelCapture
+
+• `Optional` **onWheelCapture**: *WheelEventHandler*<HTMLAnchorElement\>
+
+Inherited from: AnchorHTMLAttributes.onWheelCapture
+
+Defined in: node_modules/@types/react/index.d.ts:1526
+
+___
+
+### ping
+
+• `Optional` **ping**: *string*
+
+Inherited from: AnchorHTMLAttributes.ping
+
+Defined in: node_modules/@types/react/index.d.ts:1934
+
+___
+
+### placeholder
+
+• `Optional` **placeholder**: *string*
+
+Inherited from: AnchorHTMLAttributes.placeholder
+
+Defined in: node_modules/@types/react/index.d.ts:1757
+
+___
+
+### prefix
+
+• `Optional` **prefix**: *string*
+
+Inherited from: AnchorHTMLAttributes.prefix
+
+Defined in: node_modules/@types/react/index.d.ts:1775
+
+___
+
+### property
+
+• `Optional` **property**: *string*
+
+Inherited from: AnchorHTMLAttributes.property
+
+Defined in: node_modules/@types/react/index.d.ts:1776
+
+___
+
+### radioGroup
+
+• `Optional` **radioGroup**: *string*
+
+Inherited from: AnchorHTMLAttributes.radioGroup
+
+Defined in: node_modules/@types/react/index.d.ts:1766
+
+___
+
+### referrerPolicy
+
+• `Optional` **referrerPolicy**: HTMLAttributeReferrerPolicy
+
+Inherited from: AnchorHTMLAttributes.referrerPolicy
+
+Defined in: node_modules/@types/react/index.d.ts:1938
+
+___
+
+### rel
+
+• `Optional` **rel**: *string*
+
+Inherited from: AnchorHTMLAttributes.rel
+
+Defined in: node_modules/@types/react/index.d.ts:1935
+
+___
+
+### resource
+
+• `Optional` **resource**: *string*
+
+Inherited from: AnchorHTMLAttributes.resource
+
+Defined in: node_modules/@types/react/index.d.ts:1777
+
+___
+
+### results
+
+• `Optional` **results**: *number*
+
+Inherited from: AnchorHTMLAttributes.results
+
+Defined in: node_modules/@types/react/index.d.ts:1791
+
+___
+
+### role
+
+• `Optional` **role**: *string*
+
+Inherited from: AnchorHTMLAttributes.role
+
+Defined in: node_modules/@types/react/index.d.ts:1769
+
+___
+
+### security
+
+• `Optional` **security**: *string*
+
+Inherited from: AnchorHTMLAttributes.security
+
+Defined in: node_modules/@types/react/index.d.ts:1792
+
+___
+
+### slot
+
+• `Optional` **slot**: *string*
+
+Inherited from: AnchorHTMLAttributes.slot
+
+Defined in: node_modules/@types/react/index.d.ts:1758
+
+___
+
+### spellCheck
+
+• `Optional` **spellCheck**: Booleanish
+
+Inherited from: AnchorHTMLAttributes.spellCheck
+
+Defined in: node_modules/@types/react/index.d.ts:1759
+
+___
+
+### style
+
+• `Optional` **style**: *CSSProperties*
+
+Inherited from: AnchorHTMLAttributes.style
+
+Defined in: node_modules/@types/react/index.d.ts:1760
+
+___
+
+### suppressContentEditableWarning
+
+• `Optional` **suppressContentEditableWarning**: *boolean*
+
+Inherited from: AnchorHTMLAttributes.suppressContentEditableWarning
+
+Defined in: node_modules/@types/react/index.d.ts:1744
+
+___
+
+### suppressHydrationWarning
+
+• `Optional` **suppressHydrationWarning**: *boolean*
+
+Inherited from: AnchorHTMLAttributes.suppressHydrationWarning
+
+Defined in: node_modules/@types/react/index.d.ts:1745
+
+___
+
+### tabIndex
+
+• `Optional` **tabIndex**: *number*
+
+Inherited from: AnchorHTMLAttributes.tabIndex
+
+Defined in: node_modules/@types/react/index.d.ts:1761
+
+___
+
+### target
+
+• `Optional` **target**: *string*
+
+Inherited from: AnchorHTMLAttributes.target
+
+Defined in: node_modules/@types/react/index.d.ts:1936
+
+___
+
+### title
+
+• `Optional` **title**: *string*
+
+Inherited from: AnchorHTMLAttributes.title
+
+Defined in: node_modules/@types/react/index.d.ts:1762
+
+___
 
 ### to
 
 • **to**: *string*
 
 Defined in: [packages/framework/esm-react-utils/src/ConfigurableLink.tsx:21](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L21)
+
+___
+
+### translate
+
+• `Optional` **translate**: ``"yes"`` \| ``"no"``
+
+Inherited from: AnchorHTMLAttributes.translate
+
+Defined in: node_modules/@types/react/index.d.ts:1763
+
+___
+
+### type
+
+• `Optional` **type**: *string*
+
+Inherited from: AnchorHTMLAttributes.type
+
+Defined in: node_modules/@types/react/index.d.ts:1937
+
+___
+
+### typeof
+
+• `Optional` **typeof**: *string*
+
+Inherited from: AnchorHTMLAttributes.typeof
+
+Defined in: node_modules/@types/react/index.d.ts:1778
+
+___
+
+### unselectable
+
+• `Optional` **unselectable**: ``"on"`` \| ``"off"``
+
+Inherited from: AnchorHTMLAttributes.unselectable
+
+Defined in: node_modules/@types/react/index.d.ts:1793
+
+___
+
+### vocab
+
+• `Optional` **vocab**: *string*
+
+Inherited from: AnchorHTMLAttributes.vocab
+
+Defined in: node_modules/@types/react/index.d.ts:1779

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -37,12 +37,15 @@
 }
 
 .bx--btn--primary,
-.bx--btn--primary:hover,
 .bx--btn--primary:active,
 .bx--btn--tertiary:hover,
 .bx--btn--tertiary:active,
 .bx--btn--tertiary:focus {
   background-color: #007d79;
+}
+
+.bx--btn--primary:hover {
+  background-color: #005d5d;
 }
 
 .bx--btn--tertiary {


### PR DESCRIPTION
> [Ticket](https://issues.openmrs.org/browse/MF-629).
> Ciaran's [design QA doc](https://www.notion.so/Login-1a92cd2c5f5245188e2b5e9088b293e6).

These fixes include:

- Left-indent helper text.
- Change the hover colour of `primary` buttons to `IBM Teal-70`.
- Remove border-radius from the login container (no more rounded corners).
- Set fixed height and width properties for the login container.
- Change the colour of `Powered by` text to `text-02` and font style to `caption-01`.
- Constrain logo to the dimensions specified in the designs.

<img width="953" alt="Screenshot 2021-06-18 at 15 45 15" src="https://user-images.githubusercontent.com/8509731/122603760-85403880-d07d-11eb-94f4-2c63f4b3d5fc.png">
