### PR TITLE
MF-632: Fix design issues on the location picker page

### DIFF
--- a/packages/apps/esm-login-app/src/location-picker/location-picker.component.scss
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.component.scss
@@ -15,15 +15,17 @@
   width: 23rem;
   background-color: $ui-background;
   margin: 0;
+  padding: 1.5rem;
+  border: 1px solid $ui-03;
 }
 
-.welcomeContainer {
-  margin: 1.5rem 1.5rem 1rem 1.5rem;
-  width: 20rem;
-}
 .welcomeTitle {
   @extend .productiveHeading03;
   text-transform: capitalize;
+}
+
+.searchBox {
+  margin-top: 1rem;
 }
 
 .welcomeMessage {
@@ -33,20 +35,18 @@
 }
 
 .searchResults {
-  background-color: $ui-01;
-  height: 2.5rem;
   @extend .bodyShort02;
+  margin: 1rem 0rem;
+}
+
+.resultsCount {
+  @extend .bodyShort01;
   color: $color-gray-70;
-  padding: 1rem 1.5rem 0rem 1.5rem;
 }
 
 .locationResultsContainer {
   display: flex;
-  background-color: $ui-01;
-  padding: 0rem 1.5rem 1.5rem 1.5rem;
-  height: 23.5rem;
-  width: 23rem;
-  overflow-y: scroll;
+  overflow-y: auto;
 }
 
 .locationRadioButton {
@@ -54,7 +54,6 @@
   justify-content: flex-start;
   align-items: flex-start;
   @extend .bodyShort01;
-  color: $color-gray-70;
   padding: 0.5rem 0rem;
   text-align: left;
   width: 18rem;
@@ -64,11 +63,6 @@
   @extend .bodyShort01;
   padding: 1rem 0rem;
   color: $color-gray-70;
-}
-
-.confirmButton {
-  width: 23rem;
-  padding: 1.5rem 1.5rem;
 }
 
 .confirmButton button {

--- a/packages/apps/esm-login-app/src/location-picker/location-picker.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.component.tsx
@@ -172,7 +172,7 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
     <div className={styles["locationPickerContainer"]}>
       <form onSubmit={handleSubmit}>
         <div className={`${styles["location-card"]}`}>
-          <div className={styles["welcomeContainer"]}>
+          <div>
             <p className={styles["welcomeTitle"]}>
               {t("welcome", "Welcome")} {currentUser}
             </p>
@@ -183,18 +183,17 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
               )}
             </p>
           </div>
-          <div>
-            <Search
-              labelText="Search for location"
-              id="search-1"
-              placeholder={t("searchForLocation", "Search for a location")}
-              onChange={(ev) => search(ev.target.value)}
-              autoFocus={true}
-              name="searchForLocation"
-            />
-          </div>
+          <Search
+            className={styles["searchBox"]}
+            labelText="Search for location"
+            id="search-1"
+            placeholder={t("searchForLocation", "Search for a location")}
+            onChange={(ev) => search(ev.target.value)}
+            autoFocus={true}
+            name="searchForLocation"
+          />
           <div className={styles["searchResults"]}>
-            <p>
+            <p className={styles["resultsCount"]}>
               {searchTerm
                 ? `${locationData.locationResult.length} ${
                     locationData.locationResult.length === 1
@@ -205,37 +204,39 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
                     locationData.locationResult.length
                   } ${t("locations", "locations")}`}
             </p>
-          </div>
-          <div className={styles["locationResultsContainer"]}>
-            {!isEmpty(locationData.locationResult) && (
-              <RadioButtonGroup
-                valueSelected={locationData.activeLocation}
-                orientation="vertical"
-                name={locationData.activeLocation}
-                onChange={(ev) => {
-                  changeLocationData({ activeLocation: ev.toString() });
-                }}
-              >
-                {locationData.locationResult.slice(0, pageSize).map((entry) => (
-                  <RadioButton
-                    className={styles["locationRadioButton"]}
-                    key={entry.resource.id}
-                    id={entry.resource.name}
-                    labelText={entry.resource.name}
-                    value={entry.resource.id}
-                  />
-                ))}
-              </RadioButtonGroup>
-            )}
-            {locationData.locationResult.length === 0 && (
-              <p className={styles["locationNotFound"]}>
-                <Trans i18nKey="locationNotFound">
-                  Sorry, no matching location was found
-                </Trans>
-              </p>
-            )}
-            <div className={styles["center"]}>
-              <p className={styles["error-msg"]} />
+            <div className={styles["locationResultsContainer"]}>
+              {!isEmpty(locationData.locationResult) && (
+                <RadioButtonGroup
+                  valueSelected={locationData.activeLocation}
+                  orientation="vertical"
+                  name={locationData.activeLocation}
+                  onChange={(ev) => {
+                    changeLocationData({ activeLocation: ev.toString() });
+                  }}
+                >
+                  {locationData.locationResult
+                    .slice(0, pageSize)
+                    .map((entry) => (
+                      <RadioButton
+                        className={styles["locationRadioButton"]}
+                        key={entry.resource.id}
+                        id={entry.resource.name}
+                        labelText={entry.resource.name}
+                        value={entry.resource.id}
+                      />
+                    ))}
+                </RadioButtonGroup>
+              )}
+              {locationData.locationResult.length === 0 && (
+                <p className={styles["locationNotFound"]}>
+                  <Trans i18nKey="locationNotFound">
+                    Sorry, no matching location was found
+                  </Trans>
+                </p>
+              )}
+              <div className={styles["center"]}>
+                <p className={styles["error-msg"]} />
+              </div>
             </div>
           </div>
           <div className={styles["confirmButton"]}>

--- a/packages/apps/esm-login-app/src/location-picker/location-picker.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.component.tsx
@@ -184,12 +184,12 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
             </p>
           </div>
           <Search
+            autoFocus
             className={styles["searchBox"]}
-            labelText="Search for location"
+            labelText={t("searchForLocation", "Search for a location")}
             id="search-1"
             placeholder={t("searchForLocation", "Search for a location")}
             onChange={(ev) => search(ev.target.value)}
-            autoFocus={true}
             name="searchForLocation"
           />
           <div className={styles["searchResults"]}>


### PR DESCRIPTION
> [Ticket](https://issues.openmrs.org/browse/MF-629).
> Ciaran's [design QA doc](https://www.notion.so/Login-1a92cd2c5f5245188e2b5e9088b293e6).

These fixes include:

- Add a gray border to the location picker container.
- Adjust the location card padding so it matches the designs.
- Remove the gray background colour from the location search results panel.
- Change the vertical overflow behaviour of the location search results panel to `auto` from `scroll`.
- Change the font style of search results count text to `carbon--type-style("body-short-01")` (This is not shown in the screenshot below).
- Remove the `gray` colour of the location search results panel radio buttons label text.
- A bunch of spacing-related fixes.

<img width="583" alt="Screenshot 2021-06-18 at 16 29 12" src="https://user-images.githubusercontent.com/8509731/122610733-cbe76000-d088-11eb-9b62-6488f5218b01.png">
