### PR TITLE
Fixed login location picker showing wrong no of locations

### DIFF
--- a/packages/apps/esm-login-app/src/location-picker/location-picker.component.scss
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.component.scss
@@ -47,6 +47,11 @@
 .locationResultsContainer {
   display: flex;
   overflow-y: auto;
+  margin-top: 0.5rem;
+}
+
+:global(.omrs-breakpoint-gt-tablet) .locationResultsContainer {
+  height: 23rem;
 }
 
 .locationRadioButton {

--- a/packages/apps/esm-login-app/src/location-picker/location-picker.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.component.tsx
@@ -163,7 +163,9 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
   };
 
   React.useEffect(() => {
-    locationData.locationResult.length < pageSize
+    locationData.locationResult.length < pageSize &&
+      setPageSize(locationData.locationResult.length);
+    chooseLocation.numberToShow > locationData.locationResult.length
       ? setPageSize(locationData.locationResult.length)
       : setPageSize(chooseLocation.numberToShow);
   }, [locationData.locationResult.length]);


### PR DESCRIPTION
### Description

1. Fixed location picker showing the wrong number of locations when a user searches for a location and clears the search, it displays the wrong number of locations as shown in the gif below.
2. Add height for location results

before
<img width="404" alt="Screenshot 2021-06-21 at 09 59 24" src="https://user-images.githubusercontent.com/28008754/122720440-272b7500-d278-11eb-9d85-443fde4ef225.png">

after
<img width="455" alt="Screenshot 2021-06-21 at 09 59 39" src="https://user-images.githubusercontent.com/28008754/122720531-44f8da00-d278-11eb-845c-0c15f9252191.png">



### Screenshoot
![wrongNoOfLocations](https://user-images.githubusercontent.com/28008754/122720292-f3e8e600-d277-11eb-9147-810ca5c0a143.gif)

