### PR TITLE
MF-632: Follow-up fix

### DIFF
--- a/packages/apps/esm-login-app/src/location-picker/location-picker.component.scss
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.component.scss
@@ -37,6 +37,7 @@
 .searchResults {
   @extend .bodyShort02;
   margin: 1rem 0rem;
+  height: 26.125rem;
 }
 
 .resultsCount {


### PR DESCRIPTION
Constrain the height of the search results div to the dimensions specified in the design. The height should not change when the number of results displayed changes.

![Screenshot 2021-06-22 at 12 58 12](https://user-images.githubusercontent.com/8509731/122907636-076d7d00-d35c-11eb-8b79-a247d5828139.png)
