### PR TITLE
Remove offline setup success notification

### DIFF
--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -213,13 +213,6 @@ async function setupServiceWorker() {
   if (navigator.onLine) {
     try {
       await Promise.all([precacheImportMap(), precacheSharedApiEndpoints()]);
-
-      showNotification({
-        title: "You can now go offline",
-        description:
-          "The application is done preparing the offline mode. You can now use the website without an internet connection.",
-        kind: "info",
-      });
     } catch (e) {
       showNotification({
         critical: true,


### PR DESCRIPTION
The success notification being shown upon successful setup of the offline mode has been superseded by the new offline mode designs.

<img width="914" alt="Screenshot 2021-06-24 at 17 40 32" src="https://user-images.githubusercontent.com/8509731/123283205-d6d04380-d513-11eb-9c47-d8e5a94d44ac.png">


We can now remove this notification per @manuelroemer and Ciaran.

