### PR TITLE
Provide notifications panel extension slots

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/notifications-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/notifications-menu-panel.component.tsx
@@ -1,9 +1,12 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
+import { ExtensionSlot } from "@openmrs/esm-framework";
 import { HeaderPanel, HeaderPanelProps } from "carbon-components-react";
 import styles from "./notifications-menu.component.panel.scss";
-import { useTranslation } from "react-i18next";
 
-interface NotificationsMenuPanelProps extends HeaderPanelProps {}
+interface NotificationsMenuPanelProps extends HeaderPanelProps {
+  expanded: boolean;
+}
 
 const NotificationsMenuPanel: React.FC<NotificationsMenuPanelProps> = ({
   expanded,
@@ -17,11 +20,10 @@ const NotificationsMenuPanel: React.FC<NotificationsMenuPanelProps> = ({
       expanded={expanded}
     >
       <h1 className={styles.heading}>{t("notifications", "Notifications")}</h1>
-      <div>
-        <p className={styles.emptyNotifications}>
-          {t("noNotifications", "You currently have no notifications")}
-        </p>
-      </div>
+      <ExtensionSlot
+        extensionSlotName="notifications-nav-menu-slot"
+        state={{ expanded: expanded }}
+      />
     </HeaderPanel>
   );
 };

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/notifications-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/notifications-menu-panel.component.tsx
@@ -12,6 +12,7 @@ const NotificationsMenuPanel: React.FC<NotificationsMenuPanelProps> = ({
   expanded,
 }) => {
   const { t } = useTranslation();
+  const state = React.useMemo(() => ({ expanded }), [expanded]);
 
   return (
     <HeaderPanel
@@ -22,7 +23,7 @@ const NotificationsMenuPanel: React.FC<NotificationsMenuPanelProps> = ({
       <h1 className={styles.heading}>{t("notifications", "Notifications")}</h1>
       <ExtensionSlot
         extensionSlotName="notifications-nav-menu-slot"
-        state={{ expanded: expanded }}
+        state={state}
       />
     </HeaderPanel>
   );

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/notifications-menu-panel.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/notifications-menu-panel.test.tsx
@@ -1,0 +1,11 @@
+import React from "react";
+import { screen, render } from "@testing-library/react";
+import NotificationsMenuPanel from "./notifications-menu-panel.component";
+
+test("renders the notifications menu panel scaffold", () => {
+  render(<NotificationsMenuPanel expanded />);
+
+  expect(
+    screen.getByRole("heading", { name: /notifications/i })
+  ).toBeInTheDocument();
+});

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -15,7 +15,6 @@ import {
   HeaderGlobalAction,
 } from "carbon-components-react/es/components/UIShell";
 import Close20 from "@carbon/icons-react/lib/close/20";
-import Notification20 from "@carbon/icons-react/es/notification/20";
 import Switcher20 from "@carbon/icons-react/lib/switcher/20";
 import UserAvatarFilledAlt20 from "@carbon/icons-react/es/user--avatar--filled--alt/20";
 import AppMenuPanel from "../navbar-header-panels/app-menu-panel.component";
@@ -96,18 +95,13 @@ const Navbar: React.FC<NavbarProps> = ({
             className={styles.topNavActionSlot}
             state={{ isActive: isActivePanel("") }}
           />
-          <HeaderGlobalAction
-            aria-label="Notifications"
-            name="Notifications"
-            isActive={isActivePanel("notificationsMenu")}
-            onClick={() => togglePanel("notificationsMenu")}
-          >
-            {isActivePanel("notificationsMenu") ? (
-              <Close20 />
-            ) : (
-              <Notification20 />
-            )}
-          </HeaderGlobalAction>
+          <ExtensionSlot
+            extensionSlotName="notifications-menu-button-slot"
+            state={{
+              isActivePanel: isActivePanel,
+              togglePanel: togglePanel,
+            }}
+          />
           <HeaderGlobalAction
             aria-label="Users"
             aria-labelledby="Users Avatar Icon"


### PR DESCRIPTION
- Expose an extension slot for the notifications menu button in the navbar. The SVG button icon rendered in that slot would vary based on the following conditions:

  - `Notification20` as the default.
  - `NewNotification20` when there are new unread notifications.
  - `Close20` when the notifications panel is open.

- Expose an extension slot for the notifications menu panel. The patient alerts logic would ostensibly live in a patient management-type microfrontend which would handle how to fetch and render (and potentially store) those reminders. This extension slot would provide information about whether the panel is open or not (via the `expanded`) boolean prop.