### PR TITLE
Found modules with unresolved backend dependencies.

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
+++ b/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
@@ -102,7 +102,9 @@ function getMisMatchedBackendModules(
   for (let uuid in installedAndRequiredBackendModules) {
     const requiredVersion = installedAndRequiredBackendModules[uuid].version;
     const moduleName = installedAndRequiredBackendModules[uuid].uuid;
-    const installedVersion = installedBackendModules.find((mod) => mod.uuid == moduleName)?.version ?? "";
+    const installedVersion =
+      installedBackendModules.find((mod) => mod.uuid == moduleName)?.version ??
+      "";
 
     if (!isVersionSatisfied(requiredVersion, installedVersion)) {
       misMatchedBackendModules.push({

--- a/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
+++ b/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
@@ -102,7 +102,7 @@ function getMisMatchedBackendModules(
   for (let uuid in installedAndRequiredBackendModules) {
     const requiredVersion = installedAndRequiredBackendModules[uuid].version;
     const moduleName = installedAndRequiredBackendModules[uuid].uuid;
-    const installedVersion = installedBackendModules.find(mod => mod.uuid == moduleName)?.version ?? "";
+    const installedVersion = installedBackendModules.find((mod) => mod.uuid == moduleName)?.version ?? "";
 
     if (!isVersionSatisfied(requiredVersion, installedVersion)) {
       misMatchedBackendModules.push({

--- a/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
+++ b/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
@@ -102,7 +102,7 @@ function getMisMatchedBackendModules(
   for (let uuid in installedAndRequiredBackendModules) {
     const requiredVersion = installedAndRequiredBackendModules[uuid].version;
     const moduleName = installedAndRequiredBackendModules[uuid].uuid;
-    const installedVersion = getInstalledVersion(moduleName);
+    const installedVersion = installedBackendModules.find(mod => mod.uuid == moduleName)?.version ?? "";
 
     if (!isVersionSatisfied(requiredVersion, installedVersion)) {
       misMatchedBackendModules.push({
@@ -113,17 +113,6 @@ function getMisMatchedBackendModules(
     }
   }
   return misMatchedBackendModules;
-}
-
-function getInstalledVersion(moduleName: string) {
-  let installedVersion: string = "";
-  for (let idx in installedBackendModules) {
-    if (installedBackendModules[idx].uuid == moduleName) {
-      installedVersion = installedBackendModules[idx].version;
-      break;
-    }
-  }
-  return installedVersion;
 }
 
 export interface UnresolvedBackendDependencies {

--- a/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
+++ b/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
@@ -100,9 +100,9 @@ function getMisMatchedBackendModules(
 ) {
   let misMatchedBackendModules: BackendModule[] = [];
   for (let uuid in installedAndRequiredBackendModules) {
-    const installedVersion = installedBackendModules[uuid].version;
     const requiredVersion = installedAndRequiredBackendModules[uuid].version;
     const moduleName = installedAndRequiredBackendModules[uuid].uuid;
+    const installedVersion = getInstalledVersion(moduleName);
 
     if (!isVersionSatisfied(requiredVersion, installedVersion)) {
       misMatchedBackendModules.push({
@@ -113,6 +113,17 @@ function getMisMatchedBackendModules(
     }
   }
   return misMatchedBackendModules;
+}
+
+function getInstalledVersion(moduleName: string) {
+  let installedVersion: string = "";
+  for (let idx in installedBackendModules) {
+    if (installedBackendModules[idx].uuid == moduleName) {
+      installedVersion = installedBackendModules[idx].version;
+      break;
+    }
+  }
+  return installedVersion;
 }
 
 export interface UnresolvedBackendDependencies {


### PR DESCRIPTION
 - The current implementation comparing required backend dependencies with actual installed dependencies compares with an incorrect version. e.g. openmrs-spa -> implementer tools -> backend modules (webservices.rest installed _**2.2**_ whereas actual is _**2.31.0-SNAPSHOT.7e24fb**_
 - semver.satisfies(installedVersion, requiredVersion) ("2.31.0", "^2.2") return false. @samuelmale  @FlorianRappl - Is this the expected outcome?
 - Kindly