### PR TITLE
Fixed the css of the modal rendered in the styleguide

### DIFF
--- a/packages/framework/esm-styleguide/src/modals/_modals.scss
+++ b/packages/framework/esm-styleguide/src/modals/_modals.scss
@@ -5,13 +5,9 @@
   background-color: rgba(0, 0, 0, 0.5);
   z-index: 9000;
   visibility: hidden;
-
-  > div {
-    width: 100%;
-    height: 100%;
-
-    display: grid;
-    justify-items: center;
-    align-items: center;
-  }
+  top: 0;
+  left: 0;
+  display: flex;
+  justify-content: center;
+  align-items: center;
 }


### PR DESCRIPTION
### What does this PR include?
This PR includes the CSS changes to the modal rendered, which was first taking full width and height and wasn't according to what it should be. The difference is highlighted in the screenshots attached.

Before: 
![image](https://user-images.githubusercontent.com/51502471/126527197-74dbe694-2db6-454c-a238-0c2f44b7b876.png)

After:
![image](https://user-images.githubusercontent.com/51502471/126528625-14408b0f-7928-4def-ada4-a0b30f1f63ff.png)

 