### PR TITLE
Adjust sidenav width

### DIFF
--- a/packages/framework/esm-styleguide/src/components/_main-content.scss
+++ b/packages/framework/esm-styleguide/src/components/_main-content.scss
@@ -1,5 +1,5 @@
 :root {
-  --omrs-sidenav-width: 16.25rem;
+  --omrs-sidenav-width: 16rem;
   --omrs-topnav-height: 3rem;
 }
 


### PR DESCRIPTION
This makes it so that on desktop, the side nav is flush with the chart container in the patient chart summary view.

- Before (note how the left margin of the side nav encroaches into the patient chart container):

<img width="726" alt="Screenshot 2021-07-22 at 12 12 14" src="https://user-images.githubusercontent.com/8509731/126623996-9d1434f9-159a-410f-a0f8-3d756791c845.png">

- After:

<img width="726" alt="Screenshot 2021-07-22 at 12 09 29" src="https://user-images.githubusercontent.com/8509731/126624072-06a094db-5809-4b95-8848-2073f4b2e3c1.png">


