### PR TITLE
Include Extension Slot, required for Name, Programme switcher

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.scss
@@ -1,5 +1,6 @@
 .topNavActionSlot {
   display: flex;
+  z-index: 9999 !important;
 }
 
 .headerGlobalBar button {

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.scss
@@ -1,6 +1,5 @@
 .topNavActionSlot {
-  display: flex;
-  z-index: 9999 !important;
+  display: flex; 
 }
 
 .headerGlobalBar button {

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -93,7 +93,7 @@ const Navbar: React.FC<NavbarProps> = ({
           </HeaderLink>
           <ExtensionSlot
             className={styles.dividerOverride}
-            extensionSlotName="top-navigation-slot"
+            extensionSlotName="top-nav-info-slot"
           />
           <HeaderGlobalBar className={styles.headerGlobalBar}>
             <ExtensionSlot

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -91,6 +91,10 @@ const Navbar: React.FC<NavbarProps> = ({
           >
             <Logo />
           </HeaderLink>
+          <ExtensionSlot
+            className={styles.dividerOverride}
+            extensionSlotName="top-navigation-slot"
+          />
           <HeaderGlobalBar className={styles.headerGlobalBar}>
             <ExtensionSlot
               extensionSlotName="top-nav-actions-slot"

--- a/packages/apps/esm-primary-navigation-app/src/root.scss
+++ b/packages/apps/esm-primary-navigation-app/src/root.scss
@@ -21,6 +21,3 @@
   height: var(--omrs-topnav-height);
 }
 
-.primaryNavContainer header {
-  z-index: 3 !important;
-}


### PR DESCRIPTION





<img width="1438" alt="Screen Shot 2021-07-23 at 03 59 13" src="https://user-images.githubusercontent.com/4475142/126729666-d831ab30-b903-4d46-a322-24c4481ea9c6.png">
<img width="846" alt="Screen Shot 2021-07-23 at 04 04 33" src="https://user-images.githubusercontent.com/4475142/126729668-7f807943-8390-4212-ad63-0f94189741d6.png">
While creating an extension slot to allow customization for a drop-down. The below over-position is found: 

![Extension_Slot_v5](https://user-images.githubusercontent.com/4475142/126728960-e4afcc0d-d71d-4650-a264-9e68ec46aa3b.gif)

Also additional changes to Z-index oft the style guides. 


The hack needed here to override:

![Screen Shot 2021-07-22 at 08 46 44](https://user-images.githubusercontent.com/4475142/126599725-1d402acf-2a34-4ac7-bea2-e1e7ad1e0737.png)

The solution requires the  z-Index on the root.scss to be removed:

![Screen Shot 2021-07-22 at 08 46 53](https://user-images.githubusercontent.com/4475142/126599739-41355bcb-cf2b-44c1-ad59-62e58c40840c.png)
