### PR TITLE
MF-650 Back button from Login Password page should lead to Login Username Page

### DIFF
--- a/packages/apps/esm-login-app/src/login/login.component.tsx
+++ b/packages/apps/esm-login-app/src/login/login.component.tsx
@@ -39,10 +39,17 @@ const Login: React.FC<LoginProps> = ({ history, location, isLoginEnabled }) => {
   const [t] = useTranslation();
 
   useEffect(() => {
+
     if (user) {
       history.push("/login/location", location ? location.state : undefined);
     }
+    if (!location.hash) {
+      setShowPassword(false);
+      setUsername("");
+    }
+
   }, [user, history, location]);
+
 
   useEffect(() => {
     const field = showPassword
@@ -58,6 +65,7 @@ const Login: React.FC<LoginProps> = ({ history, location, isLoginEnabled }) => {
     const field = usernameInputRef.current;
 
     if (field.value.length > 0) {
+      history.push("/login/#user");
       setShowPassword(true);
     } else {
       field.focus();
@@ -88,6 +96,7 @@ const Login: React.FC<LoginProps> = ({ history, location, isLoginEnabled }) => {
         continueLogin();
         return false;
       }
+
 
       try {
         const loginRes = await performLogin(username, password);
@@ -196,6 +205,7 @@ const Login: React.FC<LoginProps> = ({ history, location, isLoginEnabled }) => {
               >
                 {t("login", "Log in")}
               </Button>
+
             </div>
           )}
           <div className={styles["center"]}>


### PR DESCRIPTION
### What does this PR do


This fixes browser navigation in the event a user inputs the wrong username and continues to the password page. They can go back and change the username 

![Browser Button](https://user-images.githubusercontent.com/67265839/129158290-b9c6a634-ecdb-4581-accf-e4e5c8c6819d.gif)



### Screenshot
