### PR TITLE
MF-633: Align navbar menu item button interactions

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/implementer-tools.button.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/implementer-tools.button.tsx
@@ -1,24 +1,30 @@
 import React from "react";
-import Tools20 from "@carbon/icons-react/es/tools/20";
-import styles from "./implementer-tools.styles.css";
-import { UserHasAccess } from "@openmrs/esm-framework";
-import { togglePopup } from "./store";
-import { HeaderGlobalAction } from "carbon-components-react/es/components/UIShell";
 import { useTranslation } from "react-i18next";
+import Close20 from "@carbon/icons-react/lib/close/20";
+import Tools20 from "@carbon/icons-react/es/tools/20";
+import { HeaderGlobalAction } from "carbon-components-react/es/components/UIShell";
+import { UserHasAccess, useStore } from "@openmrs/esm-framework";
+import { implementerToolsStore, togglePopup } from "./store";
+import styles from "./implementer-tools.styles.css";
 
 const ImplementerToolsButton: React.FC = () => {
   const { t } = useTranslation();
+  const { isOpen } = useStore(implementerToolsStore);
 
   return (
     <UserHasAccess privilege="coreapps.systemAdministration">
       <HeaderGlobalAction
-        onClick={togglePopup}
         aria-label={t("implementerTools", "Implementer Tools")}
         aria-labelledby="Implementer Tools"
-        name="ImplementerToolsIcon"
         className={styles.toolStyles}
+        name="ImplementerToolsIcon"
+        onClick={togglePopup}
       >
-        <Tools20 className={styles.popupTriggerButton} />
+        {isOpen ? (
+          <Close20 />
+        ) : (
+          <Tools20 className={styles.popupTriggerButton} />
+        )}
       </HeaderGlobalAction>
     </UserHasAccess>
   );

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.scss
@@ -1,4 +1,4 @@
-.topNavActionSlot {
+.topNavActionsSlot {
   display: flex;
 }
 

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -101,8 +101,7 @@ const Navbar: React.FC<NavbarProps> = ({
           <HeaderGlobalBar className={styles.headerGlobalBar}>
             <ExtensionSlot
               extensionSlotName="top-nav-actions-slot"
-              className={styles.topNavActionSlot}
-              state={{ isActive: isActivePanel("") }}
+              className={styles.topNavActionsSlot}
             />
             <ExtensionSlot
               extensionSlotName="notifications-menu-button-slot"


### PR DESCRIPTION
This PR aligns the interaction behaviour for menu items in the navbar as suggested in Ciaran's [QA design review doc](https://www.notion.so/Top-Nav-6d97f575ec0d46e0a1fd199b7df6b079). More specifically, we want that when menu item buttons are first clicked (to open a menu panel or similar), the menu item button icon gets replaced by an 'X'. Later, when the menu item button gets clicked (to close a menu panel or similar), the 'X' gets replaced with the original button icon.

Open state:
<img width="933" alt="Screenshot 2021-08-13 at 11 49 31" src="https://user-images.githubusercontent.com/8509731/129331658-1859d30b-276d-4d75-adaf-2435fba9c744.png">

Closed state:
<img width="933" alt="Screenshot 2021-08-13 at 11 49 20" src="https://user-images.githubusercontent.com/8509731/129332160-1969cb1d-e8db-4270-80ca-08b9c15d55a9.png">

Using `isOpen` from the implementer tools store offers a nice advantage - being able to change the navbar icon state by clicking the close button directly from the implementer tools panel.

<img width="994" alt="Screenshot 2021-08-13 at 11 49 51" src="https://user-images.githubusercontent.com/8509731/129331707-567c8ce8-837e-4139-ae42-0b06c2c5dcbe.png">

