### PR TITLE
Improve pre-commit and pre-push hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+set -e  # die on error
+
+npx pretty-quick --staged
+npx lerna run document --since master

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -3,8 +3,6 @@
 
 set -e  # die on error
 
-yarn prettier
-npx lerna run lint
-npx lerna run test
-npx lerna run typescript
-npx lerna run document
+npx lerna run lint --since master
+npx lerna run test --since master
+npx lerna run typescript --since master


### PR DESCRIPTION
This adds a pre-commit hook which formats and documents. It formats only staged files, and documents only packages which have been changed.

It also makes the pre-push checks only run for packages that have had changes since `master`.

Fixes https://issues.openmrs.org/browse/MF-742