### PR TITLE
Add ability to pass props to extensions on using `attach`

### DIFF
--- a/packages/framework/esm-extensions/docs/API.md
+++ b/packages/framework/esm-extensions/docs/API.md
@@ -63,7 +63,7 @@
 
 #### Defined in
 
-[store.ts:82](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L82)
+[store.ts:84](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L84)
 
 ___
 
@@ -83,13 +83,13 @@ ___
 
 #### Defined in
 
-[store.ts:77](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L77)
+[store.ts:79](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L79)
 
 ## Functions
 
 ### attach
 
-▸ **attach**(`extensionSlotName`, `extensionId`): `void`
+▸ **attach**(`extensionSlotName`, `extensionId`, `props?`): `void`
 
 #### Parameters
 
@@ -97,6 +97,7 @@ ___
 | :------ | :------ |
 | `extensionSlotName` | `string` |
 | `extensionId` | `string` |
+| `props?` | `object` |
 
 #### Returns
 
@@ -168,7 +169,7 @@ ___
 
 #### Defined in
 
-[extensions.ts:101](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L101)
+[extensions.ts:107](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L107)
 
 ___
 
@@ -188,7 +189,7 @@ ___
 
 #### Defined in
 
-[extensions.ts:124](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L124)
+[extensions.ts:130](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L130)
 
 ___
 
@@ -209,7 +210,7 @@ ___
 
 #### Defined in
 
-[extensions.ts:157](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L157)
+[extensions.ts:163](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L163)
 
 ___
 
@@ -311,7 +312,7 @@ ___
 
 #### Defined in
 
-[extensions.ts:269](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L269)
+[extensions.ts:275](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L275)
 
 ___
 
@@ -338,7 +339,7 @@ with which it has been attached.
 
 #### Defined in
 
-[extensions.ts:296](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L296)
+[extensions.ts:302](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L302)
 
 ___
 
@@ -408,7 +409,7 @@ ___
 
 #### Defined in
 
-[extensions.ts:222](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L222)
+[extensions.ts:228](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L228)
 
 ___
 
@@ -488,7 +489,7 @@ ___
 
 #### Defined in
 
-[extensions.ts:245](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L245)
+[extensions.ts:251](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L251)
 
 ___
 
@@ -514,4 +515,4 @@ ___
 
 #### Defined in
 
-[store.ts:86](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L86)
+[store.ts:88](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L88)

--- a/packages/framework/esm-extensions/docs/interfaces/ExtensionSlotInfo.md
+++ b/packages/framework/esm-extensions/docs/interfaces/ExtensionSlotInfo.md
@@ -9,6 +9,7 @@
 - [attachedIds](ExtensionSlotInfo.md#attachedids)
 - [instances](ExtensionSlotInfo.md#instances)
 - [name](ExtensionSlotInfo.md#name)
+- [props](ExtensionSlotInfo.md#props)
 
 ## Properties
 
@@ -48,3 +49,13 @@ The name under which the extension slot has been registered.
 #### Defined in
 
 [store.ts:63](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L63)
+
+___
+
+### props
+
+• `Optional` **props**: `string` \| `object`
+
+#### Defined in
+
+[store.ts:76](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L76)

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -68,7 +68,11 @@ export const registerExtension: (
   }
 );
 
-export function attach(extensionSlotName: string, extensionId: string) {
+export function attach(
+  extensionSlotName: string,
+  extensionId: string,
+  props?: Record<string, any>
+) {
   updateExtensionStore((state) => {
     const existingSlot = state.slots[extensionSlotName];
 
@@ -80,6 +84,7 @@ export function attach(extensionSlotName: string, extensionId: string) {
           [extensionSlotName]: {
             ...createNewExtensionSlotInfo(extensionSlotName),
             attachedIds: [extensionId],
+            props,
           },
         },
       };
@@ -91,6 +96,7 @@ export function attach(extensionSlotName: string, extensionId: string) {
           [extensionSlotName]: {
             ...existingSlot,
             attachedIds: [...existingSlot.attachedIds, extensionId],
+            props,
           },
         },
       };

--- a/packages/framework/esm-extensions/src/store.ts
+++ b/packages/framework/esm-extensions/src/store.ts
@@ -72,6 +72,8 @@ export interface ExtensionSlotInfo {
    * `assignedIds` is the set defining those.
    */
   attachedIds: Array<string>;
+  /* The props to attached extensions */
+  props?: Record<string, any>;
 }
 
 export const extensionStore = createGlobalStore<ExtensionStore>("extensions", {

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotInfo.md
@@ -9,6 +9,7 @@
 - [attachedIds](ExtensionSlotInfo.md#attachedids)
 - [instances](ExtensionSlotInfo.md#instances)
 - [name](ExtensionSlotInfo.md#name)
+- [props](ExtensionSlotInfo.md#props)
 
 ## Properties
 
@@ -48,3 +49,13 @@ The name under which the extension slot has been registered.
 #### Defined in
 
 [packages/framework/esm-extensions/src/store.ts:63](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L63)
+
+___
+
+### props
+
+• `Optional` **props**: `string` \| `object`
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/store.ts:76](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L76)


### PR DESCRIPTION
### What does this PR do?

1. Add ability to pass props to attached extensions using the `attach` function

#### Intended usage

- Adding a prop

```sh

  attach(extensionSlotName, extensionID, props)

```

- Retrieving the props

```sh

const { slots } = useExtensionStore();
const { props } = slots[extensionSloName]

```

This is to enable this [PR](https://github.com/openmrs/openmrs-esm-patient-chart/pull/322#discussion_r691305749) to move ahead 
