### PR TITLE
ContentSwitcher component style overrides

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -114,3 +114,35 @@
 .bx--pagination-nav__page:focus {
   outline: 2px solid $brand-teal-01;
 }
+
+/* Content Switcher */
+
+.bx--content-switcher-btn {
+  background-color: $ui-02;
+  border: 1px solid #a6c8ff;
+  color: $text-02;
+
+  &:first-of-type[aria-selected="false"] {
+    border-right: 0;
+  }
+
+  &:last-of-type[aria-selected="false"] {
+    border-left: 0;
+  }
+
+  &:focus,
+  &:hover {
+    background-color: $interactive-01;
+    color: $ui-background;
+  }
+
+  &.bx--content-switcher--selected {
+    background-color: #edf5ff;
+    border: 1px solid $interactive-01;
+    color: $interactive-01;
+  }
+}
+
+.bx--content-switcher-btn:before {
+  display: none;
+}


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

This PR adds style overrides that make the Carbon `ContentSwitcher` component match the UI envisaged in the [designs](zpl.io/aNOxYAe).

## Screenshots

Before:

<img width="925" alt="Screenshot 2021-09-13 at 23 07 24" src="https://user-images.githubusercontent.com/8509731/133149616-650e848a-2da9-4a88-b1ca-0b30ab74e745.png">

After:

<img width="960" alt="Screenshot 2021-09-13 at 22 57 48" src="https://user-images.githubusercontent.com/8509731/133149643-d6d20898-0650-4bb5-b3c1-50f1e3bd680e.png">

<img width="960" alt="Screenshot 2021-09-13 at 22 57 21" src="https://user-images.githubusercontent.com/8509731/133149657-e676210c-2ba5-4af9-8812-88b285cc794b.png">

Hover state:
<img width="957" alt="Screenshot 2021-09-13 at 22 57 33" src="https://user-images.githubusercontent.com/8509731/133149671-03127ca0-a172-4f1e-80d5-ff396cbbe65d.png">
