### PR TITLE
Smarter config mocks

### DIFF
--- a/docs/getting_started/tour.md
+++ b/docs/getting_started/tour.md
@@ -15,12 +15,16 @@ can generally be treated as boilerplate. The important ones are
 - `babel.config.json`: Babel transpiles code to JavaScript that the browser can understand.
   This allows us to write in TypeScript, JSX, and ES2020, even though browsers
   generally don't understand that.
-- `jest.config.json`: Jest is the test runner. In this file you'll see that Jest is
-  configured to use Babel (via babel-jest) to transform code so that Jest, like the
-  browser, can understand it. The contents of `node_modules` are not transformed,
-  except the `@openmrs` packages, so that tests can make use of the generic mock
-  for `@openmrs/esm-framework`. The `moduleNameMapper` entry transforms `import`
-  statements in the code, whether to mock them or make them understandable to Jest.
+- `jest.config.json`: Jest is the test runner. In this file you'll see:
+  - Jest is configured to use Babel (via babel-jest) to transform code so that Jest, like the
+    browser, can understand it. The contents of `node_modules` are not transformed,
+    except the `@openmrs` packages, so that tests can make use of the generic mock
+    for `@openmrs/esm-framework`.
+  - The `moduleNameMapper` entry transforms `import`
+    statements in the code, whether to mock them or make them understandable to Jest.
+    Default mocks are provided for everything in `@openmrs/esm-framework`. Note that many
+    of these mocked functions have no implementation or return `undefined`, which may
+    not work for your tests—you may have to override their implementations.
 - `prettier.config.js`: Prettier is an auto-formatter. This ensures that you never have
   to worry about correct indentation, optional punctuation, or line breaks. Configuration
   is optional.

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -110,11 +110,33 @@ export const validators = {
   isObject: jest.fn(),
 };
 
-export const getConfig = jest.fn();
+let configSchema = {};
+function getDefaults(schema) {
+  let tmp = {};
+  for (let k of Object.keys(schema)) {
+    if (schema[k].hasOwnProperty("_default")) {
+      tmp[k] = schema[k]._default;
+    } else if (k.startsWith("_")) {
+      continue;
+    } else if (isOrdinaryObject(schema[k])) {
+      tmp[k] = getDefaults(schema[k]);
+    } else {
+      tmp[k] = schema[k];
+    }
+  }
+  return tmp;
+}
+function isOrdinaryObject(x) {
+  return !!x && x.constructor === Object;
+}
 
-export const useConfig = jest.fn();
+export const getConfig = jest.fn().mockReturnValue(getDefaults(configSchema));
 
-export function defineConfigSchema() {}
+export const useConfig = jest.fn().mockReturnValue(getDefaults(configSchema));
+
+export function defineConfigSchema(moduleName, schema) {
+  configSchema = schema;
+}
 
 export const createErrorHandler = () => jest.fn().mockReturnValue(never());
 


### PR DESCRIPTION
## Summary

This makes it so that by default, test authors don't have to override the `useConfig` implementation. It also ensures that the tests stay up to date with changes in the config schema.