### PR TITLE
Change everything to refer to 'frontend modules' instead of 'microfrontends'

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ All libraries are aggregated in the `@openmrs/esm-framework` package:
 
 - [@openmrs/esm-framework](packages/framework/esm-framework)
 
-### Microfrontends
+### Frontend modules
 
-A set of microfrontends provide the core technical functionality of the application.
+A set of frontend modules provide the core technical functionality of the application.
 
 - [@openmrs/esm-devtools-app](packages/apps/esm-devtools-app)
 - [@openmrs/esm-implementer-tools-app](packages/apps/esm-implementer-tools-app)
@@ -84,7 +84,7 @@ yarn verify
 yarn run:shell
 ```
 
-#### The microfrontends in `apps`
+#### The frontend modules in `apps`
 
 ```sh
 cd packages/apps/esm-[xyz]-app

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,11 +7,11 @@
   Please give it a read and write accordingly.
 
   Canonical names:
-    - "microfrontend": any "-app" package
-    - "microfrontends": the packages or the generic architecture concept
-    - "OpenMRS Frontend 3.0": the OpenMRS framework for microfrontends
+    - "frontend module": any "-app" package
+    - "microfrontends": the generic architecture concept
+    - "OpenMRS Frontend 3.0": the OpenMRS framework for frontend modules
     - "the openmrs-spa.org CI server": openmrs-spa.org
-    - "community-managed microfrontend": what it sounds like. Doesn't necessarily include
+    - "community-managed frontend modules": what it sounds like. Doesn't necessarily include
         everything published to the `openmrs` NPM org.
 
   Other notes:
@@ -48,7 +48,7 @@ Note that this documentation tends to assume that the developer is using React,
 but this is not a requirement of OpenMRS Frontend 3.0. Indeed, the entire purpose
 of choosing a microfrontends-based architecture was to allow collaboration between
 different teams using different technologies. If you are developing
-microfrontends in a technology other than React, please tell us so in the
+frontend modules in a technology other than React, please tell us so in the
 [#microfrontends](https://openmrs.slack.com/archives/CHP5QAE5R) channel on Slack.
 We'd love to work with you to make the development experience as smooth as possible,
 and take the opportunity to expand OpenMRS Frontend 3.0 support for different
@@ -76,9 +76,9 @@ These are videos below 5 minutes showing small dedicated things.
 
 ### Tutorials
 
-These are more extensive videos with focus on showing how to develop new microfrontends.
+These are more extensive videos with focus on showing how to develop new frontend modules.
 
-- [Part 1: OpenMRS SPA Extensions Tutorial: About our Microfrontend Architecture & How to Use Extensions](https://iu.mediaspace.kaltura.com/media/t/1_e7kvnx9t?st=702) 
+- [Part 1: OpenMRS SPA Extensions Tutorial: About our Frontend Module Architecture & How to Use Extensions](https://iu.mediaspace.kaltura.com/media/t/1_e7kvnx9t?st=702) 
 - [Part 2: OpenMRS SPA Extensions Workshop: Practical Session on our MFE Architecture & How to Use Extensions](https://iu.mediaspace.kaltura.com/media/t/1_iaq63mfd?st=282)
    - [OMRS SPA Workshop practice tasks](https://github.com/openmrs/openmrs-esm-testresults/tree/feature/workshop)
    - [OMRS SPA Workshop practice solutions](https://github.com/openmrs/openmrs-esm-testresults/tree/feature/workshop-solutions)

--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -3,10 +3,10 @@
   - [Setup](getting_started/setup.md)
   - [Contributing](getting_started/contributing.md)
   - [Release and Deployment](getting_started/release_and_deployment.md)
-  - [Tour of a Microfrontend](getting_started/tour.md)
+  - [Tour of a Frontend Module](getting_started/tour.md)
 - Main concepts
   - [Map of the project](main/map.md)
-  - [Creating a Microfrontend](main/creating_a_microfrontend.md)
+  - [Creating a Frontend Module](main/creating_a_microfrontend.md)
   - [Design Conventions & Styleguide](main/carbon.md)
   - [Retrieving and Posting Data](main/data.md)
   - [Translations](main/translations.md)

--- a/docs/advanced/architecture.md
+++ b/docs/advanced/architecture.md
@@ -12,16 +12,16 @@ When the application loads it goes through the following steps.
 2. Evaluates the stylesheets and scripts
 3. Configures the SPA application
 4. Installs the service worker for offline capabilities
-5. Loads and evaluates the different microfrontends from the importmap
+5. Loads and evaluates the different frontend modules from the importmap
 6. Loads and validates the provided configurations
 7. Sets up the offline capabilities and synchronization features
 8. Renders the UI
 
-Once the UI is rendered the content is exclusively coming from the different microfrontends. The app shell is solely an orchestration layer.
+Once the UI is rendered the content is exclusively coming from the different frontend modules. The app shell is solely an orchestration layer.
 
-## Microfrontend anatomy
+## Frontend module anatomy
 
-Microfrontends use [dynamic imports](https://webpack.js.org/guides/code-splitting/)
+Frontend modules use [dynamic imports](https://webpack.js.org/guides/code-splitting/)
 to split into a "front bundle" and content bundles.
 The front bundle begins at the entry point, which the
 [webpack config](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/tooling/openmrs/default-webpack-config.js)
@@ -29,4 +29,4 @@ takes from the
 [main entry of package.json](https://github.com/openmrs/openmrs-esm-template-app/blob/69b0f7a3ef3e79e9851fc0621e8b6c8311e7e6d7/package.json#L7)
 and which is usually `src/index.ts`. This bundle should be small and not contain much
 code. The functions `getAsyncLifecycle` and `getLifecycle` use dynamic imports
-to import the microfrontend content only when it is needed.
+to import the frontend module content only when it is needed.

--- a/docs/advanced/distribution.md
+++ b/docs/advanced/distribution.md
@@ -2,7 +2,7 @@
 
 One of the reasons for choosing this kind of modularization in the frontend space is to allow maximum flexibility for creating your own distribution. That way, you can use what you find useful and drop what you don't like to see in your distribution.
 
-This concept is transported to almost all areas including, but not limited to, the available microfrontends, the delivered app shell, and the method of serving the application.
+This concept is transported to almost all areas including, but not limited to, the available frontend modules, the delivered app shell, and the method of serving the application.
 
 In this section we look at some considerations when creating a distribution. Specifically, we investigate what options we provide and how you can leverage these for your use case.
 
@@ -12,10 +12,10 @@ You may be tempted to clone the `openmrs-esm-core` repository for building your 
 
 To build your own distribution a simple Node.js tool called `openmrs` was created. This allows:
 
-- creating an import map with all resources for the contained microfrontends (`openmrs assemble`)
-- build a new app shell to host microfrontends (`openmrs build`)
-- start a debugging session of the shell and a microfrontend (`openmrs debug`)
-- start a debugging session of a microfrontend in the shell (`openmrs develop`)
+- creating an import map with all resources for the contained frontend modules (`openmrs assemble`)
+- build a new app shell to host frontend modules (`openmrs build`)
+- start a debugging session of the shell and a frontend module (`openmrs debug`)
+- start a debugging session of a frontend module in the shell (`openmrs develop`)
 - starts the default app shell locally (`openmrs start`)
 
 For creating a distribution we recommend doing two things:
@@ -23,24 +23,24 @@ For creating a distribution we recommend doing two things:
 1. Build the app shell (`openmrs build`) with the configuration you want to see.
 2. Use `openmrs assemble` to get a custom configuration for your import map.
 
-The import map is used to define what microfrontends are included and where these microfrontends are located.
+The import map is used to define what frontend modules are included and where these frontend modules are located.
 
 ## Customizing the Import Map
 
 By building the app shell you'll already get a rudimenatary version of an import map, which can be used for development purposes. Generally, however, you should provide your own.
 
-An import map can also be specified as an URL. For instance, for the development instance as `openmrs-spa.org` we have [https://spa-modules.nyc3.digitaloceanspaces.com/import-map.json](https://spa-modules.nyc3.digitaloceanspaces.com/import-map.json). The contents of this import map are updated once an update to any (official) microfrontend has been pushed. Thus, while this import map may be great for development purposes, it should be considered unstable. Avoid this for your distribution or any application that should not break unexpectedly.
+An import map can also be specified as an URL. For instance, for the development instance as `openmrs-spa.org` we have [https://spa-modules.nyc3.digitaloceanspaces.com/import-map.json](https://spa-modules.nyc3.digitaloceanspaces.com/import-map.json). The contents of this import map are updated once an update to any (official) frontend module has been pushed. Thus, while this import map may be great for development purposes, it should be considered unstable. Avoid this for your distribution or any application that should not break unexpectedly.
 
-A custom import map can be created using the `openmrs assemble` command. If run directly the command will open a command line survey, guiding you through the different options. It will list all OpenMRS microfrontends that can be found on the NPM registry.
+A custom import map can be created using the `openmrs assemble` command. If run directly the command will open a command line survey, guiding you through the different options. It will list all OpenMRS frontend modules that can be found on the NPM registry.
 
-For CI/CD purposes we encourage you to use a configuration file `spa-build-config.json` instead. This file then defines the wanted microfrontends and configures the whole process.
+For CI/CD purposes we encourage you to use a configuration file `spa-build-config.json` instead. This file then defines the wanted frontend modules and configures the whole process.
 
 The file may looks as follows:
 
 ```json
 {
   "publicUrl": ".",
-  "microfrontends": {
+  "frontendModules": {
     "@openmrs/esm-patient-chart-app": "latest",
     "@openmrs/esm-patient-registration-app": "3.0.0"
   }
@@ -54,7 +54,7 @@ Example:
 ```json
 {
   "publicUrl": "https://openmrs-cdn-example.com/mf",
-  "microfrontends": {
+  "frontendModules": {
     "@openmrs/esm-patient-chart-app": "latest",
     "@openmrs/esm-patient-registration-app": "3.0.0"
   }
@@ -84,4 +84,4 @@ Regarding the versioning you'll have three options:
 
 In general we recommend to stay on non-preview (e.g., `3.2.1`) versions. Preview versions (e.g., `3.2.1-pre.0`) are for development purposes and may not be stable.
 
-For creating a working distribution ideally you'll stick to explicit versioning of non-preview versions. If you use `latest` then individual microfrontends may work as expected, but incompatibilities (e.g., if a certain microfrontend was updated but is now incompatible to another microfrontend that you also use) may then exist - making additional testing required. With an explicit version you can be sure that a working system remains as such in rebuild scenarios.
+For creating a working distribution ideally you'll stick to explicit versioning of non-preview versions. If you use `latest` then individual frontend modules may work as expected, but incompatibilities (e.g., if a certain frontend module was updated but is now incompatible to another frontend module that you also use) may then exist - making additional testing required. With an explicit version you can be sure that a working system remains as such in rebuild scenarios.

--- a/docs/advanced/extensions.md
+++ b/docs/advanced/extensions.md
@@ -37,7 +37,7 @@ As a shorthand for (4) you could already specify a target slot via the `slot` pr
 attach('foo-slot', 'foo');
 ```
 
-Generally, though this is either done at initialization time as a default, or explicitly via a user-provided configuration. The only exception can be found with "dynamic" (or "special") slots. One example in this area is the workspace of the patient chart microfrontend.
+Generally, though this is either done at initialization time as a default, or explicitly via a user-provided configuration. The only exception can be found with "dynamic" (or "special") slots. One example in this area is the workspace of the patient chart frontend module.
 
 ## Rendering
 

--- a/docs/advanced/offline.md
+++ b/docs/advanced/offline.md
@@ -5,8 +5,8 @@ The OpenMRS 3.0 SPA solution uses [Workbox](https://developers.google.com/web/to
 There are three facets that are unique to this approach:
 
 1. Each component (page / extension) can be marked as offline (or online) capable. By default every component is online capable, but not offline capable.
-2. Each microfrontend can declare certain (HTTP) calls to be cacheable.
-3. Each microfrontend can queue items to be processed when the application is back online.
+2. Each frontend module can declare certain (HTTP) calls to be cacheable.
+3. Each frontend module can queue items to be processed when the application is back online.
 
 ## Registration
 

--- a/docs/advanced/squad_devops.md
+++ b/docs/advanced/squad_devops.md
@@ -2,10 +2,10 @@
 
 The CI server at openmrs-spa.org is a community resource maintained by
 AMPATH. It is hosted in DigitalOcean. Every time a commit is made to
-`master` in a community-managed microfrontend repository, GitHub Actions
+`master` in a community-managed frontend module repository, GitHub Actions
 deploys the built package to the CI server.
 
-Every time a GitHub release is created in a community-managed microfrontend repository, GitHub Actions releases a new NPM package for each microfrontend (tag: "latest"). The difference to an ordinary commit to `master` is that these only create preview packages (tag: "next").
+Every time a GitHub release is created in a community-managed frontend module repository, GitHub Actions releases a new NPM package for each frontend module (tag: "latest"). The difference to an ordinary commit to `master` is that these only create preview packages (tag: "next").
 
 [OpenMRS Bamboo](https://ci.openmrs.org/allPlans.action) is used only for
 [openmrs-module-spa](https://github.com/openmrs/openmrs-module-spa/). Its jobs

--- a/docs/advanced/translations.md
+++ b/docs/advanced/translations.md
@@ -7,11 +7,11 @@ There are three places in frontend code that relate to translation/i18n. They ar
 - The [OpenMRS Component Decorator](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/docs/API.md#openmrscomponentdecorator).
   This decorator is generally wrapped around root components by
   [getLifecycle](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/docs/API.md#getasynclifecycle)/[getAsyncLifecycle](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/docs/API.md#getasynclifecycle)—
-  it is generally not used directly by microfrontends.
+  it is generally not used directly by frontend modules.
   This component provides the connection between the i18next "backend"
-  (still on the client side, despite the name) and the microfrontend it wraps.
-- The microfrontend, which uses the `t` function or `<Trans>` component from react-i18next
-  to produce rendered content. Upon each commit, [i18next-parser](https://github.com/i18next/i18next-parser) parses the microfrontend code and automatically extracts translation keys and strings into locale-specific translation files found in the `translations` directory of a microfrontend.
+  (still on the client side, despite the name) and the frontend module it wraps.
+- The frontend module, which uses the `t` function or `<Trans>` component from react-i18next
+  to produce rendered content. Upon each commit, [i18next-parser](https://github.com/i18next/i18next-parser) parses the frontend module code and automatically extracts translation keys and strings into locale-specific translation files found in the `translations` directory of a frontend module.
 
 ## Language Detection
 

--- a/docs/getting_started/contributing.md
+++ b/docs/getting_started/contributing.md
@@ -1,11 +1,11 @@
 # Contributing
 
-You can write your own microfrontends and build the UI features that you
+You can write your own frontend modules and build the UI features that you
 need for your implementation. However, it can be more fun and fruitful to
-collaborate, producing microfrontends that can be useful to various
+collaborate, producing frontend modules that can be useful to various
 implementations and organizations.
 
-As such, there are lots of microfrontends and architectural elements which are
+As such, there are lots of frontend modules and architectural elements which are
 managed by the OpenMRS community. If you're interested in contributing, you'll
 need to take the following steps.
 
@@ -14,7 +14,7 @@ need to take the following steps.
     [Help Desk](https://wiki.openmrs.org/display/~helpdesk).
     Wait at least 24 hours for the request to get approved; you will receive an
     email upon approval. Once approved, take a look at all the
-    [microfrontend-related issues](https://issues.openmrs.org/projects/MF/issues).
+    [frontend module-related issues](https://issues.openmrs.org/projects/MF/issues).
     Good first issues are filed under the
     [intro](https://issues.openmrs.org/browse/MF-508?jql=project%20%3D%20MF%20AND%20resolution%20%3D%20Unresolved%20AND%20labels%20%3D%22intro%22%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC)
     label.

--- a/docs/getting_started/prerequisites.md
+++ b/docs/getting_started/prerequisites.md
@@ -33,7 +33,7 @@ and the video-based [React JS Crash Course 2021](https://www.youtube.com/watch?v
 are good ones.
 
 Take your time. This is a lot of material. The better you understand it, the more
-easily you will be able to develop high-quality microfrontends (and other React applications).
+easily you will be able to develop high-quality frontend modules (and other React applications).
 
 ## TypeScript
 

--- a/docs/getting_started/release_and_deployment.md
+++ b/docs/getting_started/release_and_deployment.md
@@ -2,19 +2,19 @@
 
 <!-- needs improvement -->
 
-Distributions use microfrontends which are published as packages in NPM.
-Those distributions can refer to microfrontend versions by number (e.g. `3.1.0`)
+Distributions use frontend modules which are published as packages in NPM.
+Those distributions can refer to frontend module versions by number (e.g. `3.1.0`)
 or by tag (e.g. `latest`).
 
-GitHub Actions is used to publish microfrontends from the `master` branch
+GitHub Actions is used to publish frontend modules from the `master` branch
 to the `next` tag.
-You can see the published versions of each microfrontend on npmjs.com. See for example
+You can see the published versions of each frontend module on npmjs.com. See for example
 [@openmrs/esm-login-app](https://www.npmjs.com/package/@openmrs/esm-login-app?activeTab=versions).
 The [openmrs-spa.org CI server](https://openmrs-spa.org/openmrs/spa/login)
-always shows the `next` version of all microfrontends (i.e., the latest from the
+always shows the `next` version of all frontend modules (i.e., the latest from the
 `master` branch).
 
-You can version a microfrontend by creating a release in GitHub. This will trigger
+You can version a frontend module by creating a release in GitHub. This will trigger
 GitHub Actions to publish a new version of the package with the `latest` tag.
 Write release notes that explain what's happened since the last release. See
 [an example](https://github.com/openmrs/openmrs-esm-core/releases/tag/v3.1.2).

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -9,7 +9,7 @@ to ensure you're using the latest node.
 Note that as a frontend project, we use node for compiling and bundling frontend code,
 not for running the backend or server.
 
-## Working on a microfrontend
+## Working on a frontend module
 
 Clone the repository of interest. For this example we'll use
 [openmrs-esm-template-app](https://github.com/openmrs/openmrs-esm-template-app).
@@ -40,13 +40,13 @@ npx openmrs develop  # the 'npx' is 'npm exec', which is implicit within `script
 > **For the curious**: This command runs two dev servers. One serves the
 *app shell*, which
 is installed as a dependency of the `openmrs` package.
-The other serves the microfrontend.
+The other serves the frontend module.
 They come together via the import map.
 
 You can usually run commands with `--help` to learn more about them.
 Try `npm run start -- --help` (or `npx openmrs develop --help`), for example.
 
-## Developing microfrontends in a Lerna monorepo
+## Developing frontend modules in a Lerna monorepo
 
 In a [Lerna monorepo](https://github.com/lerna/lerna#readme), the commands are
 a bit different. As an example monorepo you can use
@@ -77,7 +77,7 @@ pattern for the `--sources` parameter. For example,
 npx openmrs develop --sources packages/esm-*-app/
 ```
 
-will run a local server with all the microfrontends matching the pattern.
+will run a local server with all the frontend modules matching the pattern.
 
 Alternatively, you can also specify the `--sources` argument multiple times, e.g.,
 
@@ -114,8 +114,8 @@ used for debugging.
 
 ## Import map overrides
 
-If you'd like to work on multiple microfrontends that aren't in a monorepo together,
-or if you'd like to run a microfrontend you are developing locally on a
+If you'd like to work on multiple frontend modules that aren't in a monorepo together,
+or if you'd like to run a frontend module you are developing locally on a
 deployed server somewhere, you can use import map overrides,
 which is made available through the OpenMRS DevTools.
 
@@ -132,7 +132,7 @@ localStorage.setItem('openmrs:devtools', true)
 After refreshing the page, a little box should appear in the lower-right hand corner of the page.
 Clicking this box opens the OpenMRS DevTools.
 
-In the microfrontend you want to develop, run
+In the frontend module you want to develop, run
 
 ```bash
 # if the OpenMRS frontend you're looking at uses HTTP (e.g. a local server)
@@ -144,12 +144,12 @@ npm run serve --https
 > Substitute `yarn serve` if the project uses Yarn, or `narn serve` if you use
   [narn](https://github.com/joeldenning/narn).
 
-The protocol of the application must match the protocol of the locally-served microfrontend.
+The protocol of the application must match the protocol of the locally-served frontend module.
 
-This command will serve the microfrontend and tell you the port where it is serving,
+This command will serve the frontend module and tell you the port where it is serving,
 as well as showing you the filenames that are being served. You can then use
 the import map overrides panel to override the existing import map
-entry, or add your microfrontend as a new entry.
+entry, or add your frontend module as a new entry.
 
 For example, if you run `yarn serve` in
 [esm-login-app](https://github.com/openmrs/openmrs-esm-core/tree/master/packages/apps/esm-login-app),

--- a/docs/getting_started/tour.md
+++ b/docs/getting_started/tour.md
@@ -1,4 +1,4 @@
-# Tour of a microfrontend
+# Tour of a frontend module
 
 Let's explore the contents of
 [openmrs-esm-template-app](https://github.com/openmrs/openmrs-esm-template-app).
@@ -34,12 +34,12 @@ can generally be treated as boilerplate. The important ones are
 ## The package 📂
 
 `package.json`, as you should be [aware](./prerequisites.md), defines dependencies and
-metadata for the microfrontend (which is a
+metadata for the frontend module (which is a
 [package](https://docs.npmjs.com/about-packages-and-modules)).
 
 Looking inside, we find a bunch of metadata. Most of it can be understood with reference
 to the [`package.json` docs](https://docs.npmjs.com/cli/v7/configuring-npm/package-json).
-- The `name` of our microfrontend ends in `-app` so that it will be recognized as a microfrontend
+- The `name` of our frontend module ends in `-app` so that it will be recognized as a frontend module
   by the app shell and the build tooling.
 - The `browser` entry is the entrypoint of the bundle.
 - The `main` entry is the entrypoint of the source code.

--- a/docs/main/config.md
+++ b/docs/main/config.md
@@ -5,11 +5,11 @@ configuring easier for implementers.
 
 [API Docs](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/docs/API.md)
 
-For introduction to Frontend 3.0 config files and how to configure microfrontends,
+For introduction to Frontend 3.0 config files and how to configure frontend modules,
 please see the the
 [Implementer Documentation](https://wiki.openmrs.org/display/projects/Frontend+3.0+Documentation+for+Implementers#Frontend3.0DocumentationforImplementers-Configuringtheapplication).
 
-## How to make a microfrontend configurable
+## How to make a frontend module configurable
 
 You should use this part of the OpenMRS Frontend Framework to modules configurable.
 

--- a/docs/main/creating_a_microfrontend.md
+++ b/docs/main/creating_a_microfrontend.md
@@ -1,13 +1,13 @@
-# Creating a microfrontend
+# Creating a frontend module
 
-New microfrontends can be created from the
+New frontend modules can be created from the
 [openmrs-esm-template-app](https://github.com/openmrs/openmrs-esm-template-app).
 You can fork that repository, or clone-and-copy it. Follow the instructions
-in the README to turn it into your own microfrontend.
+in the README to turn it into your own frontend module.
 
 ## The `index.ts` file
 
-All microfrontends have an `index.ts` as an
+All frontend modules have an `index.ts` as an
 [entry point](https://webpack.js.org/concepts/entry-points/).
 See the [example](https://github.com/openmrs/openmrs-esm-template-app/blob/master/src/index.ts)
 in openmrs-esm-template-app.
@@ -26,7 +26,7 @@ should only do the following four things:
 - define the [configuration schema](config.md)
 - register [breadcrumbs](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-breadcrumbs/docs/API.md#registerbreadcrumbs)
 - set up [offline support](../advanced/offline.md)
-- return an object specifying the microfrontend's pages and extensions
+- return an object specifying the frontend module's pages and extensions
 
 #### The `setupOpenMRS` return object
 
@@ -43,11 +43,11 @@ Here is an example which uses all of the possible keys.
     pages: [
       {
         // load (required): tells the app shell how to load the
-        //   microfrontend content
+        //   frontend module content
         load: getAsyncLifecycle(() => import('./hello'), options),
         // route (required): a string, RegEx, function, or array of any of the
         //   above, which will be used to determine when to load the
-        //   microfrontend content. It will be matched against the URL path.
+        //   frontend module content. It will be matched against the URL path.
         route: 'hello',
         // `online`, `offline`, and `resources` are described in the offline
         //   support documentation. All are optional.
@@ -95,7 +95,7 @@ for reference. You could then add this as a page to the application:
 ### The `backendDependencies` object
 
 This is an object that tells the frontend application what OpenMRS server modules
-the microfrontend depends on, and what versions. If these dependencies are not
+the frontend module depends on, and what versions. If these dependencies are not
 met, administrators will be alerted.
 
 ### The `importTranslation` function
@@ -109,10 +109,10 @@ That directory must exist at that location relative to the `index.ts` file.
 
 ## Integrating into your application
 
-Once you've created a microfrontend, you'll want to integrate it into your
+Once you've created a frontend module, you'll want to integrate it into your
 application. There are two steps for doing so.
 
-First, publish your microfrontend package to NPM. See
+First, publish your frontend module package to NPM. See
 [Release and Deployment](../getting_started/release_and_deployment.md)
 for more information. At the end, your package should be visible on npm.js,
 like [`@openmrs/esm-login-app`](https://www.npmjs.com/package/@openmrs/esm-login-app).

--- a/docs/main/data.md
+++ b/docs/main/data.md
@@ -1,6 +1,6 @@
 # Retrieving and posting data
 
-Microfrontends interact with the OpenMRS server via the APIs exposed
+Frontend modules interact with the OpenMRS server via the APIs exposed
 by its modules. In general, most of the endpoints we use are provided
 by the [FHIR Module](https://wiki.openmrs.org/display/projects/OpenMRS+HL7+FHIR+Solutions).
 Most of the rest are provided by the

--- a/docs/main/deps.md
+++ b/docs/main/deps.md
@@ -1,6 +1,6 @@
 # Build-time and runtime dependencies
 
-In a microfrontends architecture, different JavaScript applications
+In a frontend modules architecture, different JavaScript applications
 come together on the client in a coordinated way. Each application
 reaches the client as one or more *bundles*. A bundle is the built
 code, transpiled and compiled into a format the browser can read.
@@ -13,7 +13,7 @@ and **runtime dependencies**, respectively.
 > **For the curious:** The client has to know how to resolve runtime
   dependencies. This is the role of SystemJS and the import map.
   SystemJS tells the browser how to use the import map to resolve
-  runtime dependencies. Microfrontends are then compiled into a
+  runtime dependencies. Frontend modules are then compiled into a
   format that tell the browser to use SystemJS for runtime
   dependency resolution.
 

--- a/docs/main/extensions.md
+++ b/docs/main/extensions.md
@@ -1,6 +1,6 @@
 # Extension System
 
-The extension system makes it possible for microfrontends to
+The extension system makes it possible for frontend modules to
 insert UI elements into each other, and for these interactions
 to be configurable by system administrators.
 
@@ -17,7 +17,7 @@ A live workshop was hosted on Zoom, providing a comprehensive introduction
 to the extension system, as well as practical problems.
 Recordings and materials are available below.
 
-- [Part 1: About our Microfrontend Architecture & How to Use Extensions](https://iu.mediaspace.kaltura.com/media/t/1_e7kvnx9t?st=702)
+- [Part 1: About our Frontend Module Architecture & How to Use Extensions](https://iu.mediaspace.kaltura.com/media/t/1_e7kvnx9t?st=702)
 - [Part 2: Practical Session on our MFE Architecture & How to Use Extensions](https://iu.mediaspace.kaltura.com/media/t/1_iaq63mfd?st=282)
   - [Practice tasks](https://github.com/openmrs/openmrs-esm-testresults/tree/feature/workshop)
   - [Practice solutions](https://github.com/openmrs/openmrs-esm-testresults/tree/feature/workshop-solutions)

--- a/docs/main/map.md
+++ b/docs/main/map.md
@@ -2,41 +2,41 @@
 
 ## Orientation
 
-OpenMRS Frontend 3.0 uses microfrontends. A microfrontend is a self-contained piece of application. It has some UI, and some ideas about where in the application it should be rendered. Each microfrontend can be configured, and some aspects of how microfrontends interact can be configured, too.
+OpenMRS Frontend 3.0 uses a microfrontends architecture. We call our microfrontends "frontend modules." A frontend module is a self-contained piece of application. It has some UI, and some ideas about where in the application it should be rendered. Each frontend module can be configured, and some aspects of how frontend modules interact can be configured, too.
 
-There are four important pieces of the OpenMRS Microfrontends system:
+There are four important pieces of the OpenMRS Frontend modules system:
 
 - The **app shell**, which is the "base" of the application and coordinates everything
-- The **framework**, which is a library that all microfrontends use
-- The **import map**, which is a file that tells the app shell what microfrontends to use and where they are
-- The **microfrontends**, from which the interface is composed
+- The **framework**, which is a library that all frontend modules use
+- The **import map**, which is a file that tells the app shell what frontend modules to use and where they are
+- The **frontend modules**, from which the interface is composed
 
-The microfrontends communicate with the **backend**, which is the OpenMRS server, using its APIs.
+The frontend modules communicate with the **backend**, which is the OpenMRS server, using its APIs.
 
 ### The framework
 
 The **framework** is an NPM package called `@openmrs/esm-framework`, which is composed of multiple smaller libraries. These are documented in the
 [OpenMRS Frontend Core README](https://github.com/openmrs/openmrs-esm-core#openmrs-frontend-core).
 
-### The microfrontends
+### The frontend modules
 
-The **microfrontends** are shipped in the ES Module format and usually thus just called `esm`s (same prefix as the libraries). In any case these microfrontends are indeed also libraries, but very special ones that
+The **frontend modules** are shipped in the ES Module format and usually thus just called `esm`s (same prefix as the libraries). In any case these frontend modules are indeed also libraries, but very special ones that
 
 - are not directly integrated into the main application,
 - are loaded indirectly via a special JSON called an "import map", and they
 - export a predefined set of functionality including a function called `setupOpenMRS`.
 
-These microfrontends bring in domain-specific UI capabilities such as menu entries, page content, or notifications. In many cases they also come with dedicted [offline](../advanced/offline.md) capabilities, which allow, e.g., registration or modifications of certain patients while not being connected.
+These frontend modules bring in domain-specific UI capabilities such as menu entries, page content, or notifications. In many cases they also come with dedicted [offline](../advanced/offline.md) capabilities, which allow, e.g., registration or modifications of certain patients while not being connected.
 
 ### The backend
 
 The backend is an OpenMRS server and its APIs. The frontend application and backend server do not have to be colocated. Since the frontend really just a set of static files, it can be served from anywhere. The specific setup is up to you.
 
 ## Repositories you should know
-The 3.x EMR Reference Application is made up of all the microfrontends found in the following repositories:
+The 3.x EMR Reference Application is made up of all the frontend modules found in the following repositories:
 
-- [openmrs-esm-core](https://github.com/openmrs/openmrs-esm-core/tree/master/packages/apps): Microfrontends which are administrative or else integral to the application
-- [openmrs-esm-patient-management](https://github.com/openmrs/openmrs-esm-patient-management/tree/main/packages): Microfrontends which deal with creating, searching, and listing patients
-- [openmrs-esm-patient-chart](https://github.com/openmrs/openmrs-esm-patient-chart/tree/master/packages): The patient chart microfrontend and all its widgets
-- [openmrs-esm-home](https://github.com/openmrs/openmrs-esm-home/tree/master/packages): Microfrontends tied to the home page
-- [openmrs-rfc-frontend](https://github.com/openmrs/openmrs-rfc-frontend): A git repository that facilitates a democratic process where folks can propose changes to the frontend implementation via RFCs (Request For Comments). See, for example, the [Contributing Guidelines for Microfrontends](https://github.com/openmrs/openmrs-rfc-frontend/blob/master/text/0020-contributing-guidelines.md), which were established with RFC #20.
+- [openmrs-esm-core](https://github.com/openmrs/openmrs-esm-core/tree/master/packages/apps): Frontend modules which are administrative or else integral to the application
+- [openmrs-esm-patient-management](https://github.com/openmrs/openmrs-esm-patient-management/tree/main/packages): Frontend modules which deal with creating, searching, and listing patients
+- [openmrs-esm-patient-chart](https://github.com/openmrs/openmrs-esm-patient-chart/tree/master/packages): The patient chart frontend module and all its widgets
+- [openmrs-esm-home](https://github.com/openmrs/openmrs-esm-home/tree/master/packages): Frontend modules tied to the home page
+- [openmrs-rfc-frontend](https://github.com/openmrs/openmrs-rfc-frontend): A git repository that facilitates a democratic process where folks can propose changes to the frontend implementation via RFCs (Request For Comments). See, for example, the [Contributing Guidelines for Frontend Modules](https://github.com/openmrs/openmrs-rfc-frontend/blob/master/text/0020-contributing-guidelines.md), which were established with RFC #20.

--- a/docs/main/state.md
+++ b/docs/main/state.md
@@ -5,11 +5,11 @@ In general, state in React apps should be
 Use the [State Hook](https://reactjs.org/docs/hooks-state.html) (or
 [Reducer Hook](https://reactjs.org/docs/hooks-reference.html#usereducer))
 and [Context](https://reactjs.org/docs/context.html) to pass state around within your
-microfrontend.
+frontend module.
 
 In some cases, you may need to manage state outside React, such as when you
 have separate React applications that need to share state.
-This can come up, for example, if you your microfrontend has multiple extensions
+This can come up, for example, if you your frontend module has multiple extensions
 that need to share state with each other.
 
 In these cases you can use the

--- a/docs/main/translations.md
+++ b/docs/main/translations.md
@@ -1,12 +1,12 @@
 # Translations
 
-We use i18next and react-i18next to internationalize microfrontend content.
+We use i18next and react-i18next to internationalize frontend module content.
 
 Watch a quick tutorial video:
 
 [![https://www.youtube.com/watch?v=1pLUi47BIBo](https://img.youtube.com/vi/1pLUi47BIBo/0.jpg)](https://www.youtube.com/watch?v=1pLUi47BIBo).
 
-In order to internationalize your microfrontend, it needs to have a line in
+In order to internationalize your frontend module, it needs to have a line in
 its `index.ts` file which tells the app shell where to find translations.
 This will generally be exactly:
 
@@ -17,7 +17,7 @@ const importTranslation = require.context("../translations", false, /.json$/, "l
 The `translations` directory should exist at that path relative to the `index.ts` file
 (generally, at the top level of the package). It should contain a file `en.json`, which
 is the translation *source file*, and may contain other JSON files corresponding
-to languages into which the microfrontend is translated.
+to languages into which the frontend module is translated.
 
 You should then be able to use [react-i18next](https://react.i18next.com/) in your
 React components.

--- a/packages/framework/esm-config/README.md
+++ b/packages/framework/esm-config/README.md
@@ -6,7 +6,7 @@
 
 ## What is this?
 
-This is the configuration library for [OpenMRS Microfrontends](https://wiki.openmrs.org/display/projects/OpenMRS+3.0%3A+A+Frontend+Framework+that+enables+collaboration+and+better+User+Experience).
+This is the configuration library for [OpenMRS Frontend 3.0](https://wiki.openmrs.org/display/projects/OpenMRS+3.0%3A+A+Frontend+Framework+that+enables+collaboration+and+better+User+Experience).
 
 Please see the [Developer Documentation](https://openmrs.github.io/openmrs-esm-core/#/main/config)
 for information about how to use it.
@@ -14,7 +14,7 @@ for information about how to use it.
 ## Contributing & Development
 
 PRs welcome! See
-[OpenMRS Microfrontends RFC-20](https://github.com/openmrs/openmrs-rfc-frontend/blob/master/text/0020-contributing-guidelines.md#contributing-guidelines)
+[OpenMRS Frontend RFC-20](https://github.com/openmrs/openmrs-rfc-frontend/blob/master/text/0020-contributing-guidelines.md#contributing-guidelines)
 for guidelines about contributing.
 
 Maintainer: Brandon Istenes (bistenes@pih.org)

--- a/packages/framework/esm-extensions/docs/API.md
+++ b/packages/framework/esm-extensions/docs/API.md
@@ -417,7 +417,7 @@ ___
 ▸ **renderExtension**(`domElement`, `extensionSlotName`, `extensionSlotModuleName`, `extensionId`, `renderFunction?`, `additionalProps?`): [`CancelLoading`](interfaces/CancelLoading.md)
 
 Mounts into a DOM node (representing an extension slot)
-a lazy-loaded component from *any* microfrontend
+a lazy-loaded component from *any* frontend module
 that registered an extension component for this slot.
 
 #### Parameters

--- a/packages/framework/esm-extensions/src/render.ts
+++ b/packages/framework/esm-extensions/src/render.ts
@@ -17,7 +17,7 @@ export interface CancelLoading {
 
 /**
  * Mounts into a DOM node (representing an extension slot)
- * a lazy-loaded component from *any* microfrontend
+ * a lazy-loaded component from *any* frontend module
  * that registered an extension component for this slot.
  */
 export function renderExtension(

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -2758,7 +2758,7 @@ ___
 ▸ **renderExtension**(`domElement`, `extensionSlotName`, `extensionSlotModuleName`, `extensionId`, `renderFunction?`, `additionalProps?`): [`CancelLoading`](interfaces/CancelLoading.md)
 
 Mounts into a DOM node (representing an extension slot)
-a lazy-loaded component from *any* microfrontend
+a lazy-loaded component from *any* frontend module
 that registered an extension component for this slot.
 
 #### Parameters

--- a/packages/shell/esm-app-shell/src/index.ts
+++ b/packages/shell/esm-app-shell/src/index.ts
@@ -25,7 +25,7 @@ function runSpa(config: SpaConfig) {
 }
 
 /**
- * Initializes the OpenMRS Microfrontend App Shell.
+ * Initializes the OpenMRS Frontend App Shell.
  * @param config The global configuration to apply.
  */
 function initializeSpa(config: SpaConfig) {

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -33,7 +33,7 @@ import { Workbox } from "workbox-window";
 const allowedSuffixes = ["-app", "-widgets"];
 
 /**
- * Gets the microfrontend modules (apps). These are entries
+ * Gets the frontend modules (apps). These are entries
  * in the import maps that end with "-app".
  * @param maps The value of the "imports" property of the
  * import maps.
@@ -45,10 +45,10 @@ function getApps(maps: Record<string, string>) {
 }
 
 /**
- * Loads the microfrontends (apps and widgets). Should be done *after*
+ * Loads the frontend modules (apps and widgets). Should be done *after*
  * the import maps initialized, i.e., after modules loaded.
  *
- * By convention we call microfrontends registering activation functions
+ * By convention we call frontend modules registering activation functions
  * apps, and all others widgets. This is not enforced technically.
  */
 function loadApps() {
@@ -76,7 +76,7 @@ function callRegister(registerFn: () => void) {
 }
 
 /**
- * Sets up the microfrontends (apps). Uses the defined export
+ * Sets up the frontend modules (apps). Uses the defined export
  * from the root modules of the apps, which should export a
  * special function called "setupOpenMRS".
  * That function returns an object that is used to feed Single

--- a/packages/tooling/openmrs/README.md
+++ b/packages/tooling/openmrs/README.md
@@ -1,6 +1,6 @@
 # openmrs
 
-The one stop CLI for using the OpenMRS 3.0 Microfrontend app.
+The one stop CLI for using the OpenMRS 3.0 Frontend app.
 
 ## Prerequisites
 
@@ -61,7 +61,7 @@ npx openmrs build
 
 > For implementers.
 
-Assembles an import map incl. assets to provide the microfrontend assets for a distribution.
+Assembles an import map incl. assets to provide the frontend module assets for a distribution.
 
 Example:
 

--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -114,7 +114,7 @@ yargs.command(
 
 yargs.command(
   "develop",
-  "Starts a new microfrontend development session with the OpenMRS app shell.",
+  "Starts a new frontend module development session with the OpenMRS app shell.",
   (argv) =>
     argv
       .number("port")
@@ -273,7 +273,7 @@ yargs.command(
       .default("mode", "survey")
       .describe(
         "mode",
-        "The source of the microfrontends to assemble. `config` uses a configuration file specified via `--config`. `survey` starts an interactive command-line survey."
+        "The source of the frontend modules to assemble. `config` uses a configuration file specified via `--config`. `survey` starts an interactive command-line survey."
       ),
   (args) =>
     runCommand("runAssemble", {
@@ -309,9 +309,9 @@ yargs
     "The SPA build config JSON is a JSON file, typically `frontend.json`, which defines parameters for the `build` and `assemble` " +
       "commands. The keys used by `build` are `apiUrl`, `spaPath`, `configUrls`, and `importmap`, each of " +
       "which is equivalent to the corresponding command line argument. The keys used by `assemble` are:\n" +
-      "  microfrontends  \tAn object which specifies which microfrontends to include. It should have package names " +
+      "  frontendModules  \tAn object which specifies which frontend modules to include. It should have package names " +
       "for keys and versions for values.\n" +
-      "  publicUrl  \tThe URL at which the microfrontends will be made available. Can be relative to the importmap. " +
+      "  publicUrl  \tThe URL at which the frontend modules will be made available. Can be relative to the importmap. " +
       "Defaults to `.` (which means they will be colocated with the import map).\n\n" +
       "For more information visit https://github.com/openmrs/openmrs-esm-core."
   )

--- a/packages/tooling/openmrs/src/commands/assemble.ts
+++ b/packages/tooling/openmrs/src/commands/assemble.ts
@@ -98,7 +98,7 @@ async function readConfig(
       return {
         baseDir: process.cwd(),
         publicUrl: ".",
-        microfrontends: Object.keys(answers)
+        frontendModules: Object.keys(answers)
           .filter((m) => answers[m])
           .reduce((prev, curr) => {
             prev[curr] = answers[curr];
@@ -109,7 +109,7 @@ async function readConfig(
 
   return {
     baseDir: process.cwd(),
-    microfrontends: {},
+    frontendModules: {},
     publicUrl: ".",
   };
 }
@@ -179,7 +179,7 @@ export async function runAssemble(args: AssembleArgs) {
 
   logInfo(`Assembling the importmap ...`);
 
-  const { microfrontends = {}, publicUrl = "." } = config;
+  const { frontendModules = {}, publicUrl = "." } = config;
   const cacheDir = resolve(process.cwd(), ".cache");
 
   if (args.fresh && existsSync(args.target)) {
@@ -189,8 +189,8 @@ export async function runAssemble(args: AssembleArgs) {
   mkdirSync(args.target, { recursive: true });
 
   await Promise.all(
-    Object.keys(microfrontends).map(async (esmName) => {
-      const esmVersion = microfrontends[esmName];
+    Object.keys(frontendModules).map(async (esmName) => {
+      const esmVersion = frontendModules[esmName];
       const tgzFileName = await downloadPackage(
         cacheDir,
         esmName,

--- a/packages/tooling/openmrs/src/commands/assemble.ts
+++ b/packages/tooling/openmrs/src/commands/assemble.ts
@@ -34,7 +34,7 @@ interface NpmSearchResult {
 interface AssembleConfig {
   baseDir: string;
   publicUrl: string;
-  microfrontends: Record<string, string>;
+  frontendModules: Record<string, string>;
 }
 
 async function readConfig(
@@ -55,7 +55,7 @@ async function readConfig(
         ...JSON.parse(readFileSync(config, "utf8")),
       };
     case "survey":
-      logInfo(`Loading available microfrontends ...`);
+      logInfo(`Loading available frontend modules ...`);
 
       const packages = await axios
         .get<NpmSearchResult>(
@@ -76,7 +76,7 @@ async function readConfig(
         questions.push(
           {
             name: pckg.name,
-            message: `Include microfrontend "${pckg.name}"?`,
+            message: `Include frontend module "${pckg.name}"?`,
             default: false,
             type: "confirm",
           },


### PR DESCRIPTION
@gracepotma and @jonathandick have made the decision to change our naming from "microfrontends" to "frontend modules." This is a pretty big shift.

The only meaningful code change here is that the `microfrontends` parameter of the frontend build config is now called `frontendModules`. Heads up @rbuisson , the 3.x distro code will have to change.

We'll also need to update https://wiki.openmrs.org/display/projects/Frontend+3.0+Documentation+for+Implementers