### PR TITLE
MF-820: Add some space between left nav menu and home page button

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.scss
@@ -1,4 +1,5 @@
 @import "~@openmrs/esm-styleguide/src/vars";
+@import "~carbon-components/src/globals/scss/vars";
 .topNavActionsSlot {
   display: flex;
 }
@@ -13,4 +14,11 @@
 
 .activePanel {
   background-color: $brand-01;
+}
+
+.headerMenuButton {
+  height: $spacing-09;
+  width: $spacing-09;
+  padding: $spacing-04;
+  margin-right: $spacing-02;
 }

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -75,6 +75,7 @@ const Navbar: React.FC<NavbarProps> = ({
             <HeaderMenuButton
               aria-label="Open menu"
               isCollapsible
+              className={styles.headerMenuButton}
               onClick={(event) => {
                 togglePanel("sideMenu");
                 event.stopPropagation();

--- a/packages/apps/esm-primary-navigation-app/src/index.ts
+++ b/packages/apps/esm-primary-navigation-app/src/index.ts
@@ -23,7 +23,7 @@ const backendDependencies = {
 };
 
 const frontendDependencies = {
-  "@openmrs/esm-framework": process.env.FRAMEWORK_VERSION,
+  "@openmrs/esm-framework": "3.1.10-pre.553",
 };
 
 const options = {

--- a/packages/apps/esm-primary-navigation-app/src/index.ts
+++ b/packages/apps/esm-primary-navigation-app/src/index.ts
@@ -23,7 +23,7 @@ const backendDependencies = {
 };
 
 const frontendDependencies = {
-  "@openmrs/esm-framework": "3.1.10-pre.553",
+  "@openmrs/esm-framework": process.env.FRAMEWORK_VERSION,
 };
 
 const options = {


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Adjust Hamburger button to have more height and weight to be more user-friendly on tablets as indicated on this [ticket](https://issues.openmrs.org/projects/MF/issues/MF-820?filter=myopenissues)


## Screenshots

![MF-820](https://user-images.githubusercontent.com/28008754/135066614-464af0e5-30de-40e7-9b61-639cdb03cc6e.gif)



## Related Issue

*None.*
<!--
Optional.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
