### PR TITLE
Make 'uuid' a dependency, not devDependency, of esm-offline

### DIFF
--- a/packages/framework/esm-offline/package.json
+++ b/packages/framework/esm-offline/package.json
@@ -42,8 +42,7 @@
     "@openmrs/esm-state": "^3.1.10",
     "@openmrs/esm-styleguide": "^3.1.10",
     "@types/uuid": "^8.3.0",
-    "rxjs": "^6.5.3",
-    "uuid": "^8.3.2"
+    "rxjs": "^6.5.3"
   },
   "peerDependencies": {
     "@openmrs/esm-api": "3.x",
@@ -55,6 +54,7 @@
   "dependencies": {
     "dexie": "^3.0.3",
     "lodash-es": "4.17.21",
+    "uuid": "^8.3.2",
     "workbox-window": "^6.1.5"
   }
 }


### PR DESCRIPTION
Compiling a microfrontend with typescript I got

```
> @pih/esm-referrals-queue-app@1.0.5 typescript
> tsc

node_modules/@openmrs/esm-offline/src/uuid.ts:1:20 - error TS2307: Cannot find module 'uuid' or its corresponding type declarations.

1 import { v4 } from "uuid";
                     ~~~~~~
```

I'm hoping this solves it?