### PR TITLE
Fix openmrs develop to work with non-default apiUrl, spaPath, or configUrls

### DIFF
--- a/packages/tooling/openmrs/src/commands/develop.ts
+++ b/packages/tooling/openmrs/src/commands/develop.ts
@@ -33,9 +33,10 @@ export function runDevelop(args: DevelopArgs) {
     "lib"
   );
   const index = resolve(source, "index.html");
-  const indexContent = readFileSync(index, "utf8").replace(
-    RegExp("<script>[\\s\\S]+</script>"),
-    `
+  const indexContent = readFileSync(index, "utf8")
+    .replace(
+      RegExp("<script>[\\s\\S]+</script>"),
+      `
     <script>
         initializeSpa({
           apiUrl: ${JSON.stringify(apiUrl)},
@@ -46,7 +47,10 @@ export function runDevelop(args: DevelopArgs) {
         });
     </script>
   `
-  );
+    )
+    .replace(/href="\/openmrs\/spa/g, `href="${spaPath}`)
+    .replace(/src="\/openmrs\/spa/g, `src="${spaPath}`);
+
   const pageUrl = `http://${host}:${port}${spaPath}/`;
 
   app.get(`${spaPath}/importmap.json`, (_, res) => {


### PR DESCRIPTION
`openmrs develop` did not respect the parameters given to it. The `indexContent` replacement was never made (because `.` does not match `\n`). It was never used anyway because the `app.use(spaPath, express.static(...))` route would catch everything, since the `source` directory contains an `index.html` file.