### PR TITLE
Add support for automatically downloading the core apps

### DIFF
--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -191,6 +191,9 @@ yargs.command(
         "target",
         "The target directory where the build artifacts will be stored."
       )
+      .string("registry")
+      .default("registry", "https://registry.npmjs.org/")
+      .describe("registry", "The NPM registry used for getting the packages.")
       .boolean("fresh")
       .describe(
         "fresh",
@@ -230,6 +233,12 @@ yargs.command(
       .describe(
         "importmap",
         "The import map to use. Can be a path to an import map to be taken literally, an URL, or a fixed JSON object."
+      )
+      .boolean("download-coreapps")
+      .default("download-coreapps", false)
+      .describe(
+        "download-coreapps",
+        "Allows automatically downloading the core app shell apps if they are not currently avaialble."
       ),
   async (args) =>
     runCommand("runBuild", {
@@ -238,6 +247,7 @@ yargs.command(
       configUrls: args["config-url"],
       pageTitle: args["page-title"],
       supportOffline: args["support-offline"],
+      downloadCoreapps: args["download-coreapps"],
       ...args,
       importmap: args.importmap,
       buildConfig:

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -1,17 +1,30 @@
-import { existsSync, readFileSync } from "fs";
-import { getImportmap, loadWebpackConfig, logInfo } from "../utils";
+import {
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "fs";
+import { getImportmap, loadWebpackConfig, logInfo, untar } from "../utils";
 import rimraf from "rimraf";
+import { resolve } from "path";
+import { execSync } from "child_process";
 
 /* eslint-disable no-console */
 
 export interface BuildArgs {
   target: string;
+  registry: string;
   importmap: string;
   spaPath: string;
   fresh?: boolean;
   apiUrl: string;
   pageTitle: string;
   supportOffline?: boolean;
+  downloadCoreapps: boolean;
   configUrls: Array<string>;
   buildConfig?: string;
 }
@@ -33,9 +46,100 @@ function loadBuildConfig(buildConfigPath?: string): BuildConfig {
   }
 }
 
+async function extractFiles(sourceFile: string, targetDir: string) {
+  const packageRoot = "package/";
+  const rs = createReadStream(sourceFile);
+  const files = await untar(rs);
+  const packageJson = JSON.parse(
+    files[`${packageRoot}package.json`].toString("utf8")
+  );
+  const entryModule =
+    packageJson.browser ?? packageJson.module ?? packageJson.main;
+
+  Object.keys(files)
+    .filter(
+      (f) =>
+        f === "package/package.json" ||
+        f.substr(packageRoot.length) === entryModule
+    )
+    .forEach((f) => {
+      const content = files[f];
+      const fileName = f.replace(packageRoot, "");
+      const targetFile = resolve(targetDir, fileName);
+      writeFileSync(targetFile, content);
+    });
+
+  unlinkSync(sourceFile);
+}
+
+function loadCoreApps(registry: string) {
+  /*
+   * if the user specified a OMRS_ESM_CORE_APPS_DIR, we assume this has
+   * the necessary coreapps; otherwise, we check if there are any coreapps
+   * available in the places the webpack configuration will check; if there
+   * aren't, we download the apps specified in the app-shell devDependencies
+   */
+  const appsPath =
+    process.env.OMRS_ESM_CORE_APPS_DIR ??
+    resolve(require.resolve("@openmrs/esm-app-shell"), "..", "..", "apps");
+
+  let hasApp = false;
+  if (existsSync(appsPath) && statSync(appsPath).isDirectory()) {
+    hasApp = readdirSync(appsPath).some((entry) => {
+      if (statSync(entry).isDirectory()) {
+        const packageJson = resolve(entry, "package.json");
+        if (existsSync(packageJson) && statSync(packageJson).isFile()) {
+          return require(packageJson).name?.endsWith("-app");
+        }
+      }
+    });
+  }
+
+  if (!hasApp) {
+    logInfo("Fetching core apps...");
+    const devDependencies: Record<string, string> =
+      require("@openmrs/esm-app-shell/package.json").devDependencies;
+
+    const apps = Object.keys(devDependencies)
+      .filter((dep) => dep.endsWith("-app"))
+      .map((dep) => [dep, devDependencies[dep]]);
+
+    if (apps.length > 0) {
+      const cacheDir = resolve(process.cwd(), ".cache");
+      !existsSync(cacheDir) && mkdirSync(cacheDir, { recursive: true });
+      const coreAppsDir =
+        process.env.OMRS_ESM_CORE_APPS_DIR ??
+        resolve(process.cwd(), ".cache", "apps");
+      rimraf.sync(coreAppsDir);
+      mkdirSync(coreAppsDir, { recursive: true });
+
+      apps.forEach(async ([name, version]) => {
+        const packageName = `${name}@${version}`;
+        const command = `npm pack ${packageName} --registry ${registry}`;
+        const result = execSync(command, {
+          cwd: cacheDir,
+        });
+
+        const tgzFile =
+          result.toString("utf8").split("\n").filter(Boolean).pop() ?? "";
+        const appDirName = tgzFile.replace(".tgz", "");
+        await extractFiles(
+          resolve(cacheDir, tgzFile),
+          resolve(coreAppsDir, appDirName)
+        );
+      });
+
+      return coreAppsDir;
+    }
+  }
+}
+
 export async function runBuild(args: BuildArgs) {
   const webpack = require("webpack");
   const buildConfig = loadBuildConfig(args.buildConfig);
+  const coreAppsDir = args.downloadCoreapps
+    ? loadCoreApps(args.registry)
+    : undefined;
   const config = loadWebpackConfig({
     importmap: await getImportmap(buildConfig.importmap || args.importmap),
     env: "production",
@@ -44,6 +148,7 @@ export async function runBuild(args: BuildArgs) {
     pageTitle: buildConfig.pageTitle || args.pageTitle,
     supportOffline: buildConfig.supportOffline ?? args.supportOffline,
     spaPath: buildConfig.spaPath || args.spaPath,
+    coreAppsDir,
   });
 
   logInfo(`Running build process ...`);

--- a/packages/tooling/openmrs/src/utils/config.ts
+++ b/packages/tooling/openmrs/src/utils/config.ts
@@ -10,6 +10,7 @@ export interface WebpackOptions {
   supportOffline?: boolean;
   configUrls?: Array<string>;
   env?: string;
+  coreAppsDir?: string;
 }
 
 export function loadWebpackConfig(options: WebpackOptions = {}) {
@@ -53,6 +54,10 @@ export function loadWebpackConfig(options: WebpackOptions = {}) {
         variables.OMRS_ESM_IMPORTMAP_URL = options.importmap.value;
         break;
     }
+  }
+
+  if (typeof options.coreAppsDir === "string") {
+    variables.OMRS_ESM_CORE_APPS_DIR = options.coreAppsDir;
   }
 
   setEnvVariables(variables);


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->

Much more detail [on Slack](https://openmrs.slack.com/archives/GQJA12F4L/p1633101215112700).

This adds a new flag to the `build` command of the `openmrs` tool to enable automatically downloading and extracting the "core" apps of the appshell (those listed as `devDependencies` of the appshell).

Rationale: to maintain a dev server with the current [importmap overrides](https://spa-modules.nyc3.digitaloceanspaces.com/import-map.json), we need to bundle the core applications into the appshell, since they aren't included in that importmap. When building from the monorepo, this is done automatically, by using a relative path. However, when building an OpenMRS distribution using `npx openmrs build`, we don't have the entire monorepo checked out. Thus we need some way to identify the apps from the monorepo and ensure they are in a location that Webpack can find when performing the build.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Optional.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
