### PR TITLE
App shell: Webpack shouldn't call InjectManifest in dev mode

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -206,7 +206,6 @@ module.exports = (env, argv = {}) => {
         analyzerMode: env && env.analyze ? "static" : "disabled",
       }),
       openmrsOffline &&
-        isProd &&
         new InjectManifest({
           swSrc: resolve(__dirname, "./src/service-worker/index.ts"),
           swDest: "service-worker.js",
@@ -217,5 +216,6 @@ module.exports = (env, argv = {}) => {
           ],
         }),
     ].filter(Boolean),
+    ignoreWarnings: [/.*InjectManifest has been called multiple times.*/],
   };
 };


### PR DESCRIPTION
## Summary

Changes the esm-app-shell webpack config to only call InjectManifest in prod mode. @manuelroemer should confirm that this is the right thing to do.

## Screenshots

When running `yarn run:shell`:

Before:
![Screenshot from 2021-10-06 13-22-42](https://user-images.githubusercontent.com/1031876/136293051-72a2a778-f391-4b45-b737-1169842a672f.png)

After, there is no such error.