### PR TITLE
MF-855: Versioning core should create a release version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "run:shell": "lerna run watch --scope @openmrs/esm-app-shell --stream",
     "ci:publish": "lerna publish from-package --yes",
     "ci:prepublish": "lerna publish from-package --no-git-reset --yes --dist-tag next",
-    "ci:release": "lerna version --no-git-tag-version",
+    "ci:release": "lerna version --no-git-tag-version --conventional-graduate",
     "ci:prerelease": "lerna version prerelease --no-git-tag-version --yes",
     "setup": "lerna bootstrap && lerna run build && lerna clean --yes && lerna bootstrap",
     "verify": "lerna run lint && lerna run test && lerna run typescript",


### PR DESCRIPTION
We need to be able to create proper release versions (`X.Y.Z`). The current release behavior is to create an `alpha.0` version. This is a problem because all our packages refer to each other with peerDependency version `3.x`, and prerelease versions do not satisfy `3.x`.

Use 'lerna version --conventional-graduate' to release versions with CI.

https://issues.openmrs.org/browse/MF-855