### PR TITLE
Removed appui dependency from offline tools.

### DIFF
--- a/packages/apps/esm-offline-tools-app/src/index.ts
+++ b/packages/apps/esm-offline-tools-app/src/index.ts
@@ -12,7 +12,6 @@ const importTranslation = require.context(
 
 const backendDependencies = {
   "webservices.rest": "^2.24.0",
-  appui: "^1.9.0",
 };
 
 const frontendDependencies = {


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Removes the appui dependency from the offline tools module. See [this](https://openmrs.slack.com/archives/CHP5QAE5R/p1634053386165200) conversation for context.


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Optional.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
