### PR TITLE
MF-865  Page "order" attribute not working on Chrome

### DIFF
--- a/packages/shell/esm-app-shell/src/apps.ts
+++ b/packages/shell/esm-app-shell/src/apps.ts
@@ -153,7 +153,6 @@ export function registerApp(appName: string, appExports: System.Module) {
 
 export function finishRegisteringAllApps() {
   pages.sort((a, b) => a.order - b.order);
-  console.log(JSON.stringify(pages.map((p) => p.appName)));
   // Create a div for each page. This ensures their DOM order.
   // If we don't do this, Single-SPA 5 will create the DOM element only once
   // the page becomes active, which makes it impossible to guarantee order.
@@ -170,7 +169,6 @@ export function finishRegisteringAllApps() {
     const div = document.createElement("div");
     div.id = `single-spa-application:${name}`;
     document.body.appendChild(div);
-    console.log("registering " + name, "order " + page.order);
     tryRegisterPage(name, page);
   }
 }

--- a/packages/shell/esm-app-shell/src/apps.ts
+++ b/packages/shell/esm-app-shell/src/apps.ts
@@ -152,7 +152,8 @@ export function registerApp(appName: string, appExports: System.Module) {
 }
 
 export function finishRegisteringAllApps() {
-  pages.sort((p) => p.order);
+  pages.sort((a, b) => a.order - b.order);
+  console.log(JSON.stringify(pages.map((p) => p.appName)));
   // Create a div for each page. This ensures their DOM order.
   // If we don't do this, Single-SPA 5 will create the DOM element only once
   // the page becomes active, which makes it impossible to guarantee order.
@@ -169,6 +170,7 @@ export function finishRegisteringAllApps() {
     const div = document.createElement("div");
     div.id = `single-spa-application:${name}`;
     document.body.appendChild(div);
+    console.log("registering " + name, "order " + page.order);
     tryRegisterPage(name, page);
   }
 }


### PR DESCRIPTION
## Summary

Fix invalid comparison function used with `sort`. See https://stackoverflow.com/a/1969200/1464495

Fixes error introduced in https://github.com/openmrs/openmrs-esm-core/pull/196

## Screenshots

![Screenshot from 2021-10-14 14-04-06](https://user-images.githubusercontent.com/1031876/137395213-4b9bf86a-df8a-4075-ab6c-b8d9402917e5.png)

## Related Issue

https://issues.openmrs.org/browse/MF-865

