### PR TITLE
Fix routes for 'openmrs develop'. The index.html route was failing.

### DIFF
--- a/packages/tooling/openmrs/src/commands/develop.ts
+++ b/packages/tooling/openmrs/src/commands/develop.ts
@@ -75,7 +75,7 @@ export function runDevelop(args: DevelopArgs) {
   // For all other requests beginning with `apiUrl`, proxy to the backend.
   app.use(
     apiUrl,
-    createProxyMiddleware(`${apiUrl}/*`, {
+    createProxyMiddleware(`${apiUrl}/**`, {
       target: backend,
       changeOrigin: true,
     })


### PR DESCRIPTION
## Summary

In https://github.com/openmrs/openmrs-esm-core/pull/193 I introduced the following bug. When `openmrs develop` is first run, it generates and serves a custom `index.html` file. However, for reasons that remain mysterious to me, after the first serve, the backend proxy middleware decides to take over all SPA routes and serve `index.html` from the backend. I expect it has to do with the attempted double-negation in the route ([Regex Route Tester](https://forbeslindesay.github.io/express-route-tester/) suggests that `!` actually winds up as a `!` in the RegExp, which matches a literal `!`). This causes the module being developed to not be overridden in the import map. I assume this only went so long unnoticed because no one has updated their `openmrs` package in three weeks.

I tested this with a no-args `develop` on an existing patient chart app and on a new patient chart app (not in the existing import map), as well as with a PIH-specific app using `develop --backend https://humci.pih-emr.org --api-url /mirebalais/ --spa-path /mirebalais/spa/ --importmap 'https://humci.pih-emr.org/mirebalais/spa/importmap.json'`.