### PR TITLE
MF-716: Improved User Settings UI to match Designs

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.component.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.component.scss
@@ -1,5 +1,39 @@
 @import "../../root.scss";
 
-.labelselect label {
+.switcherContainer {
+  display: flex;
+  flex-direction: column;
+}
+.switcherContainer label {
   color: $labeldropdown;
+}
+.switcherContainer ul button {
+  @extend .productiveHeading01;
+  width: 100%;
+  background-color: $brand-02;
+}
+
+.switcherContainer ul div {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: flex-start;
+  @extend .bodyLong01;
+}
+
+.switcherContainer ul div button {
+  color: $inverse-link;
+  margin-left: 0.5rem;
+  width: 5rem;
+}
+
+.switcherContainer ul div button:hover {
+  background-color: $brand-01;
+  color: $inverse-link;
+}
+
+.switcherContainer hr {
+  background-color: $ui-background;
+  width: 18rem;
+  margin: 0.5rem 0rem;
 }

--- a/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.component.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import styles from "./change-locale.component.scss";
 import { Select, SelectItem } from "carbon-components-react";
-import { LoggedInUser } from "@openmrs/esm-framework";
+import { ExtensionSlot, LoggedInUser } from "@openmrs/esm-framework";
 import { PostUserProperties } from "./change-locale.resource";
 
 export interface ChangeLocaleProps {
@@ -30,7 +30,7 @@ const ChangeLocale: React.FC<ChangeLocaleProps> = ({
   }, [userProps]);
 
   return (
-    <div className={`omrs-margin-12 ${styles.labelselect}`}>
+    <div className={`omrs-margin-12 ${styles.switcherContainer}`}>
       <Select
         name="selectLocale"
         id="selectLocale"
@@ -44,6 +44,7 @@ const ChangeLocale: React.FC<ChangeLocaleProps> = ({
       >
         {options}
       </Select>
+      <ExtensionSlot extensionSlotName="user-panel-actions-slot" />
     </div>
   );
 };

--- a/packages/apps/esm-primary-navigation-app/src/components/user-panel-switcher-item/user-panel-switcher.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/user-panel-switcher-item/user-panel-switcher.component.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import UserAvatarFilledAlt20 from "@carbon/icons-react/es/user--avatar--filled--alt/20";
 import styles from "./user-panel-switcher.component.scss";
 import { Switcher } from "carbon-components-react";
-import { ExtensionSlot, LoggedInUser } from "@openmrs/esm-framework";
+import { LoggedInUser } from "@openmrs/esm-framework";
 
 export interface UserPanelSwitcherItemProps {
   user: LoggedInUser;
@@ -14,7 +14,6 @@ const UserPanelSwitcher: React.FC<UserPanelSwitcherItemProps> = ({ user }) => (
       <UserAvatarFilledAlt20 />
       <p>{user.person.display}</p>
     </Switcher>
-    <ExtensionSlot extensionSlotName="user-panel-actions-slot" />
   </div>
 );
 

--- a/packages/apps/esm-primary-navigation-app/src/index.ts
+++ b/packages/apps/esm-primary-navigation-app/src/index.ts
@@ -44,14 +44,14 @@ function setupOpenMRS() {
           !location.pathname.startsWith(window.getOpenmrsSpaBase() + "login"),
         online: true,
         offline: true,
-        order: 0, // should be first DOM element
+        order: 2,
       },
     ],
     extensions: [
       {
         id: "default-user-panel",
         slot: "user-panel-slot",
-        order: 2,
+        order: 0, // should be first DOM element
         load: getAsyncLifecycle(
           () =>
             import(
@@ -65,7 +65,7 @@ function setupOpenMRS() {
       {
         id: "change-locale",
         slot: "user-panel-slot",
-        order: 0,
+        order: 1,
         load: getAsyncLifecycle(
           () => import("./components/choose-locale/change-locale.component"),
           options


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/60d5c680c59b0f11240a82ca).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Improved user settings UI to match designs


## Screenshots
![MF-716](https://user-images.githubusercontent.com/40205991/139808553-a73bc4b5-f272-48f2-a448-fb4ea05437b5.png)


## Related Issue

Issue [MF-716](https://issues.openmrs.org/browse/MF-716)


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
