### PR TITLE
O3-767: display right global navigation in tablet mode

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -83,10 +83,7 @@ const Navbar: React.FC<NavbarProps> = ({
               isActive={isActivePanel("sideMenu")}
             />
           )}
-          <ConfigurableLink
-            className="bx--header__name"
-            to="${openmrsSpaBase}/home"
-          >
+          <ConfigurableLink to="${openmrsSpaBase}/home">
             <Logo />
           </ConfigurableLink>
           <ExtensionSlot


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary
Display global nav in tablet mode.
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

![ezgif com-gif-maker (5)](https://user-images.githubusercontent.com/48877319/140269562-d04102e2-3af5-4f94-bd9e-3377a10f1616.gif)

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Optional.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
