### PR TITLE
Allow building a config file into the distro

### DIFF
--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -244,6 +244,12 @@ yargs.command(
         "config-url",
         "The URL to a frontend configuration. Can be used multiple times. Resolved by the client during initialization."
       )
+      .array("config-path")
+      .default("config-path", [])
+      .describe(
+        "config-path",
+        "The path to a frontend configuration file. Can be used multiple times. The file is copied directly into the build directory."
+      )
       .string("importmap")
       .default("importmap", "importmap.json")
       .describe(
@@ -261,6 +267,7 @@ yargs.command(
       apiUrl: args["api-url"],
       spaPath: args["spa-path"],
       configUrls: args["config-url"],
+      configPaths: args["config-path"].map((p) => resolve(process.cwd(), p)),
       pageTitle: args["page-title"],
       supportOffline: args["support-offline"],
       downloadCoreapps: args["download-coreapps"],


### PR DESCRIPTION
This adds an optional argument to `openmrs` which allows providing a config file which will be built into the distro. This will simplify the build pipeline for a PIH distro, and probably many future distros.