### PR TITLE
Enhanced the SW route registration table with a strategy column and reworked the routing to be strategy driven.

### DIFF
--- a/packages/framework/esm-offline/src/service-worker-http-headers.ts
+++ b/packages/framework/esm-offline/src/service-worker-http-headers.ts
@@ -5,6 +5,8 @@ export const omrsOfflineResponseStatusHttpHeaderName =
 export const omrsOfflineCachingStrategyHttpHeaderName =
   "x-omrs-offline-caching-strategy";
 
+export type OmrsOfflineCachingStrategy = "default" | "network-first";
+
 /**
  * Defines the keys of the custom headers which can be appended to an HTTP request.
  * HTTP requests with these headers are handled in a special way by the SPA's service worker.
@@ -30,7 +32,7 @@ export type OmrsOfflineHttpHeaders = {
    *   The service worker decides the strategy to be used.
    * * `network-first`: The service worker will make the request and cache its response.
    */
-  [omrsOfflineCachingStrategyHttpHeaderName]?: "default" | "network-first";
+  [omrsOfflineCachingStrategyHttpHeaderName]?: OmrsOfflineCachingStrategy;
 };
 
 export type OmrsOfflineHttpHeaderNames = keyof OmrsOfflineHttpHeaders;

--- a/packages/framework/esm-offline/src/service-worker-http-headers.ts
+++ b/packages/framework/esm-offline/src/service-worker-http-headers.ts
@@ -5,7 +5,17 @@ export const omrsOfflineResponseStatusHttpHeaderName =
 export const omrsOfflineCachingStrategyHttpHeaderName =
   "x-omrs-offline-caching-strategy";
 
-export type OmrsOfflineCachingStrategy = "default" | "network-first";
+/**
+ *
+ *
+ * * `cache-or-network`: The default strategy, equal to the absence of this header.
+ *   The SW attempts to resolve the request via the network, but falls back to the cache if required.
+ *   The service worker decides the strategy to be used.
+ * * `network-first`: See https://developers.google.com/web/tools/workbox/modules/workbox-strategies#network_first_network_falling_back_to_cache.
+ */
+export type OmrsOfflineCachingStrategy =
+  | "network-only-or-cache-only"
+  | "network-first";
 
 /**
  * Defines the keys of the custom headers which can be appended to an HTTP request.
@@ -26,11 +36,6 @@ export type OmrsOfflineHttpHeaders = {
   [omrsOfflineResponseStatusHttpHeaderName]?: `${number}`;
   /**
    * Instructs the service worker to use a specific caching strategy for this request.
-   * The supported values are:
-   *
-   * * `default`: Equal to the absence of this header/an invalid value.
-   *   The service worker decides the strategy to be used.
-   * * `network-first`: The service worker will make the request and cache its response.
    */
   [omrsOfflineCachingStrategyHttpHeaderName]?: OmrsOfflineCachingStrategy;
 };

--- a/packages/framework/esm-offline/src/service-worker-messaging.ts
+++ b/packages/framework/esm-offline/src/service-worker-messaging.ts
@@ -1,4 +1,5 @@
 import type { ImportMap } from "@openmrs/esm-globals";
+import { OmrsOfflineCachingStrategy } from "./service-worker-http-headers";
 import { getOmrsServiceWorker } from "./service-worker";
 
 /**
@@ -38,6 +39,7 @@ export interface RegisterDynamicRouteMessage
   extends OmrsServiceWorkerMessage<"registerDynamicRoute"> {
   pattern?: string;
   url?: string;
+  strategy?: OmrsOfflineCachingStrategy;
 }
 
 export type KnownOmrsServiceWorkerMessages =

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -260,6 +260,7 @@ async function precacheSharedApiEndpoints() {
   await messageOmrsServiceWorker({
     type: "registerDynamicRoute",
     url: sessionPathUrl,
+    strategy: "network-first",
   });
 }
 

--- a/packages/shell/esm-app-shell/src/service-worker/http-header-utils.ts
+++ b/packages/shell/esm-app-shell/src/service-worker/http-header-utils.ts
@@ -24,14 +24,6 @@ export function parseOmrsOfflineResponseStatusHeader(headers: Headers) {
   return isNaN(status) || status < 200 || status > 599 ? 503 : status;
 }
 
-export function hasOmrsNetworkFirstHeader(headers: Headers) {
-  const header = getOmrsHeader(
-    headers,
-    omrsOfflineCachingStrategyHttpHeaderName
-  );
-  return header === "network-first";
-}
-
 export function getOmrsHeader<T extends OmrsOfflineHttpHeaderNames>(
   headers: Headers,
   name: T

--- a/packages/shell/esm-app-shell/src/service-worker/message.ts
+++ b/packages/shell/esm-app-shell/src/service-worker/message.ts
@@ -24,6 +24,7 @@ async function clearDynamicRoutes() {
 async function registerDynamicRoute({
   pattern,
   url,
+  strategy,
 }: RegisterDynamicRouteMessage) {
   let finalPattern = pattern;
   if (!finalPattern && url) {
@@ -31,7 +32,11 @@ async function registerDynamicRoute({
   }
 
   if (finalPattern) {
-    const registration: DynamicRouteRegistration = { pattern: finalPattern };
+    const registration: DynamicRouteRegistration = {
+      pattern: finalPattern,
+      strategy,
+    };
+
     await new ServiceWorkerDb().dynamicRouteRegistrations.put(registration);
   }
 }

--- a/packages/shell/esm-app-shell/src/service-worker/routing.ts
+++ b/packages/shell/esm-app-shell/src/service-worker/routing.ts
@@ -91,7 +91,9 @@ const knownHandlers: Record<
   (options: RouteHandlerCallbackOptions) => Promise<Response>
 > = {
   ["network-first"]: (options) => networkFirst.handle(options),
-  ["default"]: async (options: RouteHandlerCallbackOptions) => {
+  ["network-only-or-cache-only"]: async (
+    options: RouteHandlerCallbackOptions
+  ) => {
     try {
       return await networkOnly.handle(options);
     } catch (e) {
@@ -129,7 +131,7 @@ async function getHandlerKeyFromDynamicRouteRegistrations(url: string) {
     // In that case, prioritize the available strategies. When in doubt, cache the resource again.
     const priorities: Array<OmrsOfflineCachingStrategy> = [
       "network-first",
-      "default",
+      "network-only-or-cache-only",
     ];
 
     return (

--- a/packages/shell/esm-app-shell/src/service-worker/storage.ts
+++ b/packages/shell/esm-app-shell/src/service-worker/storage.ts
@@ -17,9 +17,6 @@ export interface DynamicRouteRegistration {
    * The caching strategy to be used for caching matching URLs.
    * Due to historical reasons, this value might be missing.
    * In such cases, `network-first` should be assumed (the historical default).
-   *
-   * * `default`: No explicit strategy should be applied. Matching requests should remain in the cache though.
-   * * `network-first`: Use the network-first strategy. Matching requests keep being added to the cache.
    */
   strategy?: OmrsOfflineCachingStrategy;
 }

--- a/packages/shell/esm-app-shell/src/service-worker/storage.ts
+++ b/packages/shell/esm-app-shell/src/service-worker/storage.ts
@@ -1,17 +1,27 @@
+import { OmrsOfflineCachingStrategy } from "@openmrs/esm-offline";
 import Dexie, { Table } from "dexie";
 
 /**
  * Contains information about dynamic route registrations.
- * Dynamic route registrations are routes which should be cached using a Network First approach,
+ * Dynamic route registrations are routes which should be kept in the cache,
  * but are not by default known by the Service Worker.
  * They are typically registerd by the the window/app at runtime as soon as they are known.
  */
 export interface DynamicRouteRegistration {
   /**
    * A regular expression which matches against a URL.
-   * If it matches, the URL should be cached.
+   * If it matches, the URL should be cached using the `strategy`.
    */
   pattern: string;
+  /**
+   * The caching strategy to be used for caching matching URLs.
+   * Due to historical reasons, this value might be missing.
+   * In such cases, `network-first` should be assumed (the historical default).
+   *
+   * * `default`: No explicit strategy should be applied. Matching requests should remain in the cache though.
+   * * `network-first`: Use the network-first strategy. Matching requests keep being added to the cache.
+   */
+  strategy?: OmrsOfflineCachingStrategy;
 }
 
 /**


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

As a temporary step towards fixing unwanted cache invalidation, the SW's internal route table was updated with a new `strategy` column. This allows the SW to determine if a matching request should be actively (re)cached or simply be kept during the invalidation.

## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

Addresses/Fixes the underlying issue described by https://issues.openmrs.org/browse/O3-915, but does not implement the proposed API.
<!--
Optional.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

While this should fix the cache invalidation problem for now, I still believe that a better approach would be to generally move the cache handling out of the SW.
