### PR TITLE
Removed obsolete "default" route handlers | Don't clear dynamic routes when app starts

### DIFF
--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -248,8 +248,6 @@ async function precacheImportMap() {
 }
 
 async function precacheSharedApiEndpoints() {
-  await messageOmrsServiceWorker({ type: "clearDynamicRoutes" });
-
   // By default, cache the session endpoint.
   // This ensures that a lot of user/session related functions also work offline.
   const sessionPathUrl = new URL(

--- a/packages/shell/esm-app-shell/src/service-worker/caching.ts
+++ b/packages/shell/esm-app-shell/src/service-worker/caching.ts
@@ -45,7 +45,7 @@ export async function addToOmrsCache(urls: Array<string>) {
         await retry(() => cache.add(url), {
           onError: (e, attempt) =>
             console.debug(
-              `Failure attempt ${attempt} at caching "${url}". Error: `,
+              `[SW] Failure attempt ${attempt} at caching "${url}". Error: `,
               e
             ),
         });
@@ -60,14 +60,14 @@ export async function addToOmrsCache(urls: Array<string>) {
   const failedToCache = results.filter((r) => !r.success);
   if (cached.length > 0) {
     console.debug(
-      `Successfully added ${cached.length} URLs to the OMRS cache. URLs: `,
+      `[SW] Successfully added ${cached.length} URLs to the OMRS cache. URLs: `,
       cached.map((r) => r.url)
     );
   }
 
   if (failedToCache.length > 0) {
     console.error(
-      `Failed to cache ${failedToCache.length} URLs. URLs: `,
+      `[SW] Failed to cache ${failedToCache.length} URLs. URLs: `,
       failedToCache.map((r) => r.url)
     );
   }
@@ -86,13 +86,13 @@ async function invalidateObsoleteCacheEntries(newImportMapUrls: Array<string>) {
   );
 
   console.info(
-    "Removing the following expired URLs from the cache: ",
+    "[SW] Removing the following expired URLs from the cache: ",
     urlsToInvalidate
   );
 
   // eslint-disable-next-line no-console
   console.debug(
-    "The following URLs were known and not invalidated: ",
+    "[SW] The following URLs were known and not invalidated: ",
     absoluteWbManifestUrls,
     newImportMapUrls,
     dynamicRoutes

--- a/packages/shell/esm-app-shell/src/service-worker/message.ts
+++ b/packages/shell/esm-app-shell/src/service-worker/message.ts
@@ -70,7 +70,7 @@ export async function handleMessage(event: ExtendableMessageEvent) {
   }
 
   function fail(error: string) {
-    console.warn("Handling a message resulted in an error.", error);
+    console.warn("[SW] Handling a message resulted in an error.", error);
     resolve({
       success: false,
       error,


### PR DESCRIPTION

## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Removed `default` route handlers still in the code. Shame on me for missing these in the last PR.
Also used that chance to improve logging done by the SW.

Clearing all dynamic route registrations on app start was also removed. This doesn't make any sense anymore when these routes are dynamically registered **_once_** because of certain user actions (e.g. when marking a form as offline). 
<!--
Required.
Please describe what problems your PR addresses.
-->


## Screenshots

*None.*
<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->


## Related Issue

*None.*
<!--
Optional.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->


## Other

*None.*
<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
