### PR TITLE
Fix typescript to 4.5.x to avoid breakages over minor versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "typedoc": "0.21.4",
     "typedoc-plugin-markdown": "^3.6.0",
     "typedoc-plugin-no-inherit": "^1.3.0",
-    "typescript": "^4.5.2",
+    "typescript": "~4.5.2",
     "webpack": "^5.64.0",
     "webpack-bundle-analyzer": "^4.4.1",
     "webpack-cli": "^4.9.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16722,7 +16722,7 @@ typescript@^4.0.2, typescript@^4.2.4:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.2.tgz#6d618640d430e3569a1dfb44f7d7e600ced3ee86"
   integrity sha512-gzP+t5W4hdy4c+68bfcv0t400HVJMMd2+H9B7gae1nQlBzCqvrXX+6GL/b3GAgyTH966pzrZ70/fRjwAtZksSQ==
 
-typescript@^4.5.2:
+typescript@~4.5.2:
   version "4.5.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
   integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==


### PR DESCRIPTION
We'll have to be proactive about keeping up to date, but this will make it so there's not a fire every time Typescript releases a new minor version.