### PR TITLE
Release 3.1.13

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,7 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.1.12",
+  "version": "3.1.13",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/packages/apps/esm-devtools-app/package.json
+++ b/packages/apps/esm-devtools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-devtools-app",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "Dev tools for frontend devs using OpenMRS",
   "browser": "dist/openmrs-esm-devtools-app.js",
@@ -43,7 +43,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.1.12",
+    "@openmrs/esm-framework": "^3.1.13",
     "@types/carbon-components-react": "^7.24.0",
     "carbon-components": "10.31.0",
     "carbon-icons": "7.0.7",

--- a/packages/apps/esm-implementer-tools-app/package.json
+++ b/packages/apps/esm-implementer-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-implementer-tools-app",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "The admin interface for OpenMRS Frontend",
   "browser": "dist/openmrs-esm-implementer-tools-app.js",
@@ -51,7 +51,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.1.12",
+    "@openmrs/esm-framework": "^3.1.13",
     "@types/carbon-components-react": "^7.24.0",
     "jest": "^26.6.3",
     "react": "^16.13.1",

--- a/packages/apps/esm-login-app/package.json
+++ b/packages/apps/esm-login-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-login-app",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "The login microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-login-app.js",
@@ -52,7 +52,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.1.12",
+    "@openmrs/esm-framework": "^3.1.13",
     "@types/carbon-components-react": "^7.24.0",
     "@types/react-router-dom": "^5.1.7",
     "jest": "^26.6.3",

--- a/packages/apps/esm-offline-tools-app/package.json
+++ b/packages/apps/esm-offline-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline-tools-app",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "The offline tools microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-offline-tools-app.js",
@@ -53,7 +53,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.1.12",
+    "@openmrs/esm-framework": "^3.1.13",
     "@types/carbon-components-react": "^7.24.0",
     "@types/lodash-es": "^4.17.5",
     "@types/react-router-dom": "^5.1.7",

--- a/packages/apps/esm-primary-navigation-app/package.json
+++ b/packages/apps/esm-primary-navigation-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-primary-navigation-app",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "Main navbar microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-primary-navigation-app.js",
@@ -51,7 +51,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.1.12",
+    "@openmrs/esm-framework": "^3.1.13",
     "@types/carbon-components-react": "^7.24.0",
     "@types/react-router-dom": "^5.1.7",
     "jest": "^26.6.3",

--- a/packages/framework/esm-api/package.json
+++ b/packages/framework/esm-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-api",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "The javascript module for interacting with the OpenMRS API",
   "browser": "dist/openmrs-esm-api.js",
@@ -45,9 +45,9 @@
     "@openmrs/esm-error-handling": "3.x"
   },
   "devDependencies": {
-    "@openmrs/esm-config": "^3.1.12",
-    "@openmrs/esm-error-handling": "^3.1.12",
-    "@openmrs/esm-state": "^3.1.12",
+    "@openmrs/esm-config": "^3.1.13",
+    "@openmrs/esm-error-handling": "^3.1.13",
+    "@openmrs/esm-state": "^3.1.13",
     "@types/fhir": "0.0.31",
     "rxjs": "^6.5.3"
   }

--- a/packages/framework/esm-breadcrumbs/package.json
+++ b/packages/framework/esm-breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-breadcrumbs",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "The javascript module for breadcrumb registration",
   "browser": "dist/openmrs-esm-breadcrumbs.js",
@@ -43,6 +43,6 @@
     "@openmrs/esm-state": "3.x"
   },
   "devDependencies": {
-    "@openmrs/esm-state": "^3.1.12"
+    "@openmrs/esm-state": "^3.1.13"
   }
 }

--- a/packages/framework/esm-config/package.json
+++ b/packages/framework/esm-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-config",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "A configuration library for the OpenMRS Single-Spa framework.",
   "browser": "dist/openmrs-esm-module-config.js",
@@ -46,8 +46,8 @@
     "systemjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-globals": "^3.1.12",
-    "@openmrs/esm-state": "^3.1.12",
+    "@openmrs/esm-globals": "^3.1.13",
+    "@openmrs/esm-state": "^3.1.13",
     "@types/ramda": "^0.26.44",
     "@types/systemjs": "^6.1.0",
     "babel-plugin-ramda": "^2.0.0",

--- a/packages/framework/esm-error-handling/package.json
+++ b/packages/framework/esm-error-handling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-error-handling",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "An ES module to help with error handling",
   "browser": "dist/openmrs-esm-error-handling.js",
@@ -40,6 +40,6 @@
     "@openmrs/esm-globals": "3.x"
   },
   "devDependencies": {
-    "@openmrs/esm-globals": "^3.1.12"
+    "@openmrs/esm-globals": "^3.1.13"
   }
 }

--- a/packages/framework/esm-extensions/package.json
+++ b/packages/framework/esm-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-extensions",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "Coordinates extensions and extension points in the OpenMRS Frontend",
   "browser": "dist/openmrs-esm-extensions.js",
@@ -43,9 +43,9 @@
     "single-spa": "5.x"
   },
   "devDependencies": {
-    "@openmrs/esm-api": "^3.1.12",
-    "@openmrs/esm-config": "^3.1.12",
-    "@openmrs/esm-state": "^3.1.12",
+    "@openmrs/esm-api": "^3.1.13",
+    "@openmrs/esm-config": "^3.1.13",
+    "@openmrs/esm-state": "^3.1.13",
     "single-spa": "^5.9.2"
   }
 }

--- a/packages/framework/esm-framework/package.json
+++ b/packages/framework/esm-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-framework",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "browser": "dist/openmrs-esm-framework.js",
   "main": "src/index.ts",
@@ -35,16 +35,16 @@
     "access": "public"
   },
   "dependencies": {
-    "@openmrs/esm-api": "^3.1.12",
-    "@openmrs/esm-breadcrumbs": "^3.1.12",
-    "@openmrs/esm-config": "^3.1.12",
-    "@openmrs/esm-error-handling": "^3.1.12",
-    "@openmrs/esm-extensions": "^3.1.12",
-    "@openmrs/esm-globals": "^3.1.12",
-    "@openmrs/esm-offline": "^3.1.12",
-    "@openmrs/esm-react-utils": "^3.1.12",
-    "@openmrs/esm-state": "^3.1.12",
-    "@openmrs/esm-styleguide": "^3.1.12",
-    "@openmrs/esm-utils": "^3.1.12"
+    "@openmrs/esm-api": "^3.1.13",
+    "@openmrs/esm-breadcrumbs": "^3.1.13",
+    "@openmrs/esm-config": "^3.1.13",
+    "@openmrs/esm-error-handling": "^3.1.13",
+    "@openmrs/esm-extensions": "^3.1.13",
+    "@openmrs/esm-globals": "^3.1.13",
+    "@openmrs/esm-offline": "^3.1.13",
+    "@openmrs/esm-react-utils": "^3.1.13",
+    "@openmrs/esm-state": "^3.1.13",
+    "@openmrs/esm-styleguide": "^3.1.13",
+    "@openmrs/esm-utils": "^3.1.13"
   }
 }

--- a/packages/framework/esm-globals/package.json
+++ b/packages/framework/esm-globals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-globals",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "browser": "dist/openmrs-esm-globals.js",
   "main": "src/index.ts",

--- a/packages/framework/esm-offline/package.json
+++ b/packages/framework/esm-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "browser": "dist/openmrs-esm-offline.js",
@@ -37,10 +37,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@openmrs/esm-api": "^3.1.12",
-    "@openmrs/esm-globals": "^3.1.12",
-    "@openmrs/esm-state": "^3.1.12",
-    "@openmrs/esm-styleguide": "^3.1.12",
+    "@openmrs/esm-api": "^3.1.13",
+    "@openmrs/esm-globals": "^3.1.13",
+    "@openmrs/esm-state": "^3.1.13",
+    "@openmrs/esm-styleguide": "^3.1.13",
     "@types/uuid": "^8.3.0",
     "rxjs": "^6.5.3"
   },

--- a/packages/framework/esm-react-utils/package.json
+++ b/packages/framework/esm-react-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-react-utils",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "React utilities for OpenMRS.",
   "browser": "dist/openmrs-esm-react-utils.js",
@@ -54,11 +54,11 @@
     "react-i18next": "11.x"
   },
   "devDependencies": {
-    "@openmrs/esm-api": "^3.1.12",
-    "@openmrs/esm-config": "^3.1.12",
-    "@openmrs/esm-error-handling": "^3.1.12",
-    "@openmrs/esm-extensions": "^3.1.12",
-    "@openmrs/esm-globals": "^3.1.12",
+    "@openmrs/esm-api": "^3.1.13",
+    "@openmrs/esm-config": "^3.1.13",
+    "@openmrs/esm-error-handling": "^3.1.13",
+    "@openmrs/esm-extensions": "^3.1.13",
+    "@openmrs/esm-globals": "^3.1.13",
     "i18next": "^19.6.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/packages/framework/esm-state/package.json
+++ b/packages/framework/esm-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-state",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "Frontend stores & state management for OpenMRS",
   "browser": "dist/openmrs-esm-state.js",

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-styleguide",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "The styleguide for OpenMRS SPA",
   "browser": "dist/openmrs-esm-styleguide.js",
@@ -52,7 +52,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-extensions": "^3.1.12",
+    "@openmrs/esm-extensions": "^3.1.13",
     "@pickra/copy-code-block": "^1.1.7",
     "@storybook/addon-a11y": "^5.2.1",
     "@storybook/addon-knobs": "^5.2.1",

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-utils",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "browser": "dist/openmrs-esm-utils.js",

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-app-shell",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "main": "dist/openmrs.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@openmrs/esm-framework": "^3.1.12",
+    "@openmrs/esm-framework": "^3.1.13",
     "carbon-components": "10.31.0",
     "carbon-icons": "7.0.7",
     "dayjs": "^1.10.4",
@@ -57,11 +57,11 @@
     "workbox-window": "^6.1.5"
   },
   "devDependencies": {
-    "@openmrs/esm-devtools-app": "^3.1.12",
+    "@openmrs/esm-devtools-app": "^3.1.13",
     "@openmrs/esm-implementer-tools-app": "3.1.0",
-    "@openmrs/esm-login-app": "^3.1.12",
-    "@openmrs/esm-offline-tools-app": "^3.1.12",
-    "@openmrs/esm-primary-navigation-app": "^3.1.12",
+    "@openmrs/esm-login-app": "^3.1.13",
+    "@openmrs/esm-offline-tools-app": "^3.1.13",
+    "@openmrs/esm-primary-navigation-app": "^3.1.13",
     "webpack-pwa-manifest": "^4.3.0",
     "workbox-webpack-plugin": "^6.1.2"
   }

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmrs",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "main": "dist/index.js",
   "bin": {
@@ -31,7 +31,7 @@
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
-    "@openmrs/esm-app-shell": "^3.1.12",
+    "@openmrs/esm-app-shell": "^3.1.13",
     "@types/react": "^16.9.46",
     "@types/systemjs": "^6.1.0",
     "autoprefixer": "^9.6.1",


### PR DESCRIPTION
## Breaking changes
- Remove support for loading config files from the import map [\#201](https://github.com/openmrs/openmrs-esm-core/pull/201) ([brandones](https://github.com/brandones))

Config files can no longer be loaded via the import map. The URL to a config file should be built into the index.html file when using `openmrs build`.

## Features
- Enhanced the SW route registration table with a strategy column and reworked the routing to be strategy driven. [\#220](https://github.com/openmrs/openmrs-esm-core/pull/220) ([manuelroemer](https://github.com/manuelroemer))
- O3-909 - Dynamically shared dependencies [\#219](https://github.com/openmrs/openmrs-esm-core/pull/219) ([FlorianRappl](https://github.com/FlorianRappl))
- Allow building a config file into the distro [\#217](https://github.com/openmrs/openmrs-esm-core/pull/217) ([brandones](https://github.com/brandones))
- MF-863: Make the Offline Tools MF dynamically composable via extensions [\#207](https://github.com/openmrs/openmrs-esm-core/pull/207) ([manuelroemer](https://github.com/manuelroemer))
- Added option for promises in breadcrumbs' title [\#202](https://github.com/openmrs/openmrs-esm-core/pull/202) ([vasharma05](https://github.com/vasharma05))

## UI
- O3-767: display right global navigation in tablet mode [\#216](https://github.com/openmrs/openmrs-esm-core/pull/216) ([walteronoh](https://github.com/walteronoh))
- MF-891: Tab colors changed to teal [\#211](https://github.com/openmrs/openmrs-esm-core/pull/211) ([vasharma05](https://github.com/vasharma05))
- MF-716: Improved User Settings UI to match Designs [\#214](https://github.com/openmrs/openmrs-esm-core/pull/214) ([KorirC](https://github.com/KorirC))
- Remove offline setup success notification [\#142](https://github.com/openmrs/openmrs-esm-core/pull/142) ([denniskigen](https://github.com/denniskigen))

## Fixes
- Removed obsolete "default" route handlers | Don't clear dynamic routes when app starts [\#221](https://github.com/openmrs/openmrs-esm-core/pull/221) ([manuelroemer](https://github.com/manuelroemer))
- Fix routes for 'openmrs develop'. The index.html route was failing. [\#212](https://github.com/openmrs/openmrs-esm-core/pull/212) ([brandones](https://github.com/brandones))
- Make 'pre' versions come before the corresponding release version [\#208](https://github.com/openmrs/openmrs-esm-core/pull/208) ([brandones](https://github.com/brandones))
- Fixup for  Make 'pre' versions come before the corresponding release version \#208  [\#209](https://github.com/openmrs/openmrs-esm-core/pull/209) ([brandones](https://github.com/brandones))
- MF-865  Page "order" attribute not working on Chrome [\#205](https://github.com/openmrs/openmrs-esm-core/pull/205) ([brandones](https://github.com/brandones))

## Maintenance
- Fix typescript to 4.5.x to avoid breakages over minor versions [\#224](https://github.com/openmrs/openmrs-esm-core/pull/224) ([brandones](https://github.com/brandones))
- Update to Typescript 4.5 [\#223](https://github.com/openmrs/openmrs-esm-core/pull/223) ([brandones](https://github.com/brandones))
- Docs: Document additional keys used by SPA build config in build step [\#218](https://github.com/openmrs/openmrs-esm-core/pull/218) ([brandones](https://github.com/brandones))
- Add useVisitTypes mock [\#215](https://github.com/openmrs/openmrs-esm-core/pull/215) ([denniskigen](https://github.com/denniskigen))
- Add usePagination mock [\#213](https://github.com/openmrs/openmrs-esm-core/pull/213) ([brandones](https://github.com/brandones))
- MF-894: Changed hex to variables in styleguide. [\#210](https://github.com/openmrs/openmrs-esm-core/pull/210) ([vasharma05](https://github.com/vasharma05))
- Tests for the configurability of the extension system [\#206](https://github.com/openmrs/openmrs-esm-core/pull/206) ([brandones](https://github.com/brandones))
- Removed appui dependency from offline tools. [\#204](https://github.com/openmrs/openmrs-esm-core/pull/204) ([manuelroemer](https://github.com/manuelroemer))
- Removed app-ui dependency from the login app. [\#203](https://github.com/openmrs/openmrs-esm-core/pull/203) ([vasharma05](https://github.com/vasharma05))
- Revert "MF-855: Versioning core should create a release version" [\#200](https://github.com/openmrs/openmrs-esm-core/pull/200) ([brandones](https://github.com/brandones))
