### PR TITLE
Fix for O3-941

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,6 @@
 - [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
 - [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).
 
-
 ## Summary
 
 <!--
@@ -11,30 +10,30 @@ Required.
 Please describe what problems your PR addresses.
 -->
 
-
 ## Screenshots
 
-*None.*
+_None._
+
 <!--
 Optional.
 If possible, please insert any screenshots/videos of your changes here.
 Don't forget to remove the *None.* above if you do fill this section.
 -->
 
-
 ## Related Issue
 
-*None.*
+_None._
+
 <!--
 Optional.
 If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
 Don't forget to remove the *None.* above if you do fill this section.
 -->
 
-
 ## Other
 
-*None.*
+_None._
+
 <!--
 Optional.
 Anything else that isn't covered by one of the sections above.

--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,7 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.1.12",
+  "version": "3.1.13",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/packages/apps/esm-devtools-app/package.json
+++ b/packages/apps/esm-devtools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-devtools-app",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "Dev tools for frontend devs using OpenMRS",
   "browser": "dist/openmrs-esm-devtools-app.js",
@@ -43,7 +43,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.1.12",
+    "@openmrs/esm-framework": "^3.1.13",
     "@types/carbon-components-react": "^7.24.0",
     "carbon-components": "10.31.0",
     "carbon-icons": "7.0.7",

--- a/packages/apps/esm-devtools-app/tsconfig.json
+++ b/packages/apps/esm-devtools-app/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "skipLibCheck": true,

--- a/packages/apps/esm-implementer-tools-app/package.json
+++ b/packages/apps/esm-implementer-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-implementer-tools-app",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "The admin interface for OpenMRS Frontend",
   "browser": "dist/openmrs-esm-implementer-tools-app.js",
@@ -51,7 +51,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.1.12",
+    "@openmrs/esm-framework": "^3.1.13",
     "@types/carbon-components-react": "^7.24.0",
     "jest": "^26.6.3",
     "react": "^16.13.1",

--- a/packages/apps/esm-implementer-tools-app/tsconfig.json
+++ b/packages/apps/esm-implementer-tools-app/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "strictNullChecks": true,

--- a/packages/apps/esm-login-app/package.json
+++ b/packages/apps/esm-login-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-login-app",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "The login microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-login-app.js",
@@ -52,7 +52,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.1.12",
+    "@openmrs/esm-framework": "^3.1.13",
     "@types/carbon-components-react": "^7.24.0",
     "@types/react-router-dom": "^5.1.7",
     "jest": "^26.6.3",

--- a/packages/apps/esm-login-app/tsconfig.json
+++ b/packages/apps/esm-login-app/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "moduleResolution": "node",

--- a/packages/apps/esm-offline-tools-app/package.json
+++ b/packages/apps/esm-offline-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline-tools-app",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "The offline tools microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-offline-tools-app.js",
@@ -53,7 +53,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.1.12",
+    "@openmrs/esm-framework": "^3.1.13",
     "@types/carbon-components-react": "^7.24.0",
     "@types/lodash-es": "^4.17.5",
     "@types/react-router-dom": "^5.1.7",

--- a/packages/apps/esm-offline-tools-app/tsconfig.json
+++ b/packages/apps/esm-offline-tools-app/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "moduleResolution": "node",

--- a/packages/apps/esm-primary-navigation-app/package.json
+++ b/packages/apps/esm-primary-navigation-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-primary-navigation-app",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "Main navbar microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-primary-navigation-app.js",
@@ -51,7 +51,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.1.12",
+    "@openmrs/esm-framework": "^3.1.13",
     "@types/carbon-components-react": "^7.24.0",
     "@types/react-router-dom": "^5.1.7",
     "jest": "^26.6.3",

--- a/packages/apps/esm-primary-navigation-app/tsconfig.json
+++ b/packages/apps/esm-primary-navigation-app/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "moduleResolution": "node",

--- a/packages/framework/esm-api/package.json
+++ b/packages/framework/esm-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-api",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "The javascript module for interacting with the OpenMRS API",
   "browser": "dist/openmrs-esm-api.js",
@@ -45,9 +45,9 @@
     "@openmrs/esm-error-handling": "3.x"
   },
   "devDependencies": {
-    "@openmrs/esm-config": "^3.1.12",
-    "@openmrs/esm-error-handling": "^3.1.12",
-    "@openmrs/esm-state": "^3.1.12",
+    "@openmrs/esm-config": "^3.1.13",
+    "@openmrs/esm-error-handling": "^3.1.13",
+    "@openmrs/esm-state": "^3.1.13",
     "@types/fhir": "0.0.31",
     "rxjs": "^6.5.3"
   }

--- a/packages/framework/esm-api/tsconfig.json
+++ b/packages/framework/esm-api/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "strictNullChecks": true,

--- a/packages/framework/esm-breadcrumbs/docs/interfaces/BreadcrumbRegistration.md
+++ b/packages/framework/esm-breadcrumbs/docs/interfaces/BreadcrumbRegistration.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[types.ts:31](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-breadcrumbs/src/types.ts#L31)
+[types.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-breadcrumbs/src/types.ts#L34)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[types.ts:32](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-breadcrumbs/src/types.ts#L32)
+[types.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-breadcrumbs/src/types.ts#L35)

--- a/packages/framework/esm-breadcrumbs/docs/interfaces/BreadcrumbSettings.md
+++ b/packages/framework/esm-breadcrumbs/docs/interfaces/BreadcrumbSettings.md
@@ -61,7 +61,7 @@ ___
 
 ### title
 
-• **title**: `string` \| (`params`: `any`) => `string`
+• **title**: `string` \| (`params`: `any`) => `string` \| (`params`: `any`) => `Promise`<`string`\>
 
 The title of the breadcrumb.
 

--- a/packages/framework/esm-breadcrumbs/package.json
+++ b/packages/framework/esm-breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-breadcrumbs",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "The javascript module for breadcrumb registration",
   "browser": "dist/openmrs-esm-breadcrumbs.js",
@@ -43,6 +43,6 @@
     "@openmrs/esm-state": "3.x"
   },
   "devDependencies": {
-    "@openmrs/esm-state": "^3.1.12"
+    "@openmrs/esm-state": "^3.1.13"
   }
 }

--- a/packages/framework/esm-breadcrumbs/tsconfig.json
+++ b/packages/framework/esm-breadcrumbs/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "strictNullChecks": true,

--- a/packages/framework/esm-config/package.json
+++ b/packages/framework/esm-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-config",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "A configuration library for the OpenMRS Single-Spa framework.",
   "browser": "dist/openmrs-esm-module-config.js",
@@ -46,8 +46,8 @@
     "systemjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-globals": "^3.1.12",
-    "@openmrs/esm-state": "^3.1.12",
+    "@openmrs/esm-globals": "^3.1.13",
+    "@openmrs/esm-state": "^3.1.13",
     "@types/ramda": "^0.26.44",
     "@types/systemjs": "^6.1.0",
     "babel-plugin-ramda": "^2.0.0",

--- a/packages/framework/esm-config/tsconfig.json
+++ b/packages/framework/esm-config/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "strictNullChecks": true,

--- a/packages/framework/esm-error-handling/package.json
+++ b/packages/framework/esm-error-handling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-error-handling",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "An ES module to help with error handling",
   "browser": "dist/openmrs-esm-error-handling.js",
@@ -40,6 +40,6 @@
     "@openmrs/esm-globals": "3.x"
   },
   "devDependencies": {
-    "@openmrs/esm-globals": "^3.1.12"
+    "@openmrs/esm-globals": "^3.1.13"
   }
 }

--- a/packages/framework/esm-error-handling/tsconfig.json
+++ b/packages/framework/esm-error-handling/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "moduleResolution": "node",
@@ -14,8 +15,7 @@
       "es2016.array.include",
       "es2018"
     ],
-    "noEmit": true,
-    "target": "esnext"
+    "noEmit": true
   },
   "include": ["src/**/*", "__mocks__", "__mocks__"]
 }

--- a/packages/framework/esm-extensions/package.json
+++ b/packages/framework/esm-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-extensions",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "Coordinates extensions and extension points in the OpenMRS Frontend",
   "browser": "dist/openmrs-esm-extensions.js",
@@ -43,9 +43,9 @@
     "single-spa": "5.x"
   },
   "devDependencies": {
-    "@openmrs/esm-api": "^3.1.12",
-    "@openmrs/esm-config": "^3.1.12",
-    "@openmrs/esm-state": "^3.1.12",
+    "@openmrs/esm-api": "^3.1.13",
+    "@openmrs/esm-config": "^3.1.13",
+    "@openmrs/esm-state": "^3.1.13",
     "single-spa": "^5.9.2"
   }
 }

--- a/packages/framework/esm-extensions/tsconfig.json
+++ b/packages/framework/esm-extensions/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "strictNullChecks": true,

--- a/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
+++ b/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
@@ -63,7 +63,7 @@ Error.message
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:1023
+node_modules/typescript/lib/lib.es5.d.ts:974
 
 ___
 
@@ -77,7 +77,7 @@ Error.name
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:1022
+node_modules/typescript/lib/lib.es5.d.ts:973
 
 ___
 
@@ -111,7 +111,7 @@ Error.stack
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:1024
+node_modules/typescript/lib/lib.es5.d.ts:975
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/Config.md
+++ b/packages/framework/esm-framework/docs/interfaces/Config.md
@@ -41,7 +41,7 @@ Object.constructor
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:124
+node_modules/typescript/lib/lib.es5.d.ts:122
 
 ## Methods
 
@@ -67,7 +67,7 @@ Object.hasOwnProperty
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:139
+node_modules/typescript/lib/lib.es5.d.ts:137
 
 ___
 
@@ -93,7 +93,7 @@ Object.isPrototypeOf
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:145
+node_modules/typescript/lib/lib.es5.d.ts:143
 
 ___
 
@@ -119,7 +119,7 @@ Object.propertyIsEnumerable
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:151
+node_modules/typescript/lib/lib.es5.d.ts:149
 
 ___
 
@@ -139,7 +139,7 @@ Object.toLocaleString
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:130
+node_modules/typescript/lib/lib.es5.d.ts:128
 
 ___
 
@@ -159,7 +159,7 @@ Object.toString
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:127
+node_modules/typescript/lib/lib.es5.d.ts:125
 
 ___
 
@@ -179,4 +179,4 @@ Object.valueOf
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:133
+node_modules/typescript/lib/lib.es5.d.ts:131

--- a/packages/framework/esm-framework/docs/interfaces/ConfigObject.md
+++ b/packages/framework/esm-framework/docs/interfaces/ConfigObject.md
@@ -41,7 +41,7 @@ Object.constructor
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:124
+node_modules/typescript/lib/lib.es5.d.ts:122
 
 ## Methods
 
@@ -67,7 +67,7 @@ Object.hasOwnProperty
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:139
+node_modules/typescript/lib/lib.es5.d.ts:137
 
 ___
 
@@ -93,7 +93,7 @@ Object.isPrototypeOf
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:145
+node_modules/typescript/lib/lib.es5.d.ts:143
 
 ___
 
@@ -119,7 +119,7 @@ Object.propertyIsEnumerable
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:151
+node_modules/typescript/lib/lib.es5.d.ts:149
 
 ___
 
@@ -139,7 +139,7 @@ Object.toLocaleString
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:130
+node_modules/typescript/lib/lib.es5.d.ts:128
 
 ___
 
@@ -159,7 +159,7 @@ Object.toString
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:127
+node_modules/typescript/lib/lib.es5.d.ts:125
 
 ___
 
@@ -179,4 +179,4 @@ Object.valueOf
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:133
+node_modules/typescript/lib/lib.es5.d.ts:131

--- a/packages/framework/esm-framework/docs/interfaces/FetchResponse.md
+++ b/packages/framework/esm-framework/docs/interfaces/FetchResponse.md
@@ -52,7 +52,7 @@ Response.body
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2402
+node_modules/typescript/lib/lib.dom.d.ts:2444
 
 ___
 
@@ -66,7 +66,7 @@ Response.bodyUsed
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2403
+node_modules/typescript/lib/lib.dom.d.ts:2445
 
 ___
 
@@ -90,7 +90,7 @@ Response.headers
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11136
+node_modules/typescript/lib/lib.dom.d.ts:12143
 
 ___
 
@@ -104,7 +104,7 @@ Response.ok
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11137
+node_modules/typescript/lib/lib.dom.d.ts:12144
 
 ___
 
@@ -118,7 +118,7 @@ Response.redirected
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11138
+node_modules/typescript/lib/lib.dom.d.ts:12145
 
 ___
 
@@ -132,7 +132,7 @@ Response.status
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11139
+node_modules/typescript/lib/lib.dom.d.ts:12146
 
 ___
 
@@ -146,7 +146,7 @@ Response.statusText
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11140
+node_modules/typescript/lib/lib.dom.d.ts:12147
 
 ___
 
@@ -160,7 +160,7 @@ Response.type
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11141
+node_modules/typescript/lib/lib.dom.d.ts:12148
 
 ___
 
@@ -174,7 +174,7 @@ Response.url
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11142
+node_modules/typescript/lib/lib.dom.d.ts:12149
 
 ## Methods
 
@@ -192,7 +192,7 @@ Response.arrayBuffer
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2404
+node_modules/typescript/lib/lib.dom.d.ts:2446
 
 ___
 
@@ -210,7 +210,7 @@ Response.blob
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2405
+node_modules/typescript/lib/lib.dom.d.ts:2447
 
 ___
 
@@ -228,7 +228,7 @@ Response.clone
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11143
+node_modules/typescript/lib/lib.dom.d.ts:12150
 
 ___
 
@@ -246,7 +246,7 @@ Response.formData
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2406
+node_modules/typescript/lib/lib.dom.d.ts:2448
 
 ___
 
@@ -264,7 +264,7 @@ Response.json
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2407
+node_modules/typescript/lib/lib.dom.d.ts:2449
 
 ___
 
@@ -282,4 +282,4 @@ Response.text
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2408
+node_modules/typescript/lib/lib.dom.d.ts:2450

--- a/packages/framework/esm-framework/docs/interfaces/LoggedInUserFetchResponse.md
+++ b/packages/framework/esm-framework/docs/interfaces/LoggedInUserFetchResponse.md
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2402
+node_modules/typescript/lib/lib.dom.d.ts:2444
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2403
+node_modules/typescript/lib/lib.dom.d.ts:2445
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11136
+node_modules/typescript/lib/lib.dom.d.ts:12143
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11137
+node_modules/typescript/lib/lib.dom.d.ts:12144
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11138
+node_modules/typescript/lib/lib.dom.d.ts:12145
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11139
+node_modules/typescript/lib/lib.dom.d.ts:12146
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11140
+node_modules/typescript/lib/lib.dom.d.ts:12147
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11141
+node_modules/typescript/lib/lib.dom.d.ts:12148
 
 ___
 
@@ -170,7 +170,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11142
+node_modules/typescript/lib/lib.dom.d.ts:12149
 
 ## Methods
 
@@ -188,7 +188,7 @@ node_modules/typescript/lib/lib.dom.d.ts:11142
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2404
+node_modules/typescript/lib/lib.dom.d.ts:2446
 
 ___
 
@@ -206,7 +206,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2405
+node_modules/typescript/lib/lib.dom.d.ts:2447
 
 ___
 
@@ -224,7 +224,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:11143
+node_modules/typescript/lib/lib.dom.d.ts:12150
 
 ___
 
@@ -242,7 +242,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2406
+node_modules/typescript/lib/lib.dom.d.ts:2448
 
 ___
 
@@ -260,7 +260,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2407
+node_modules/typescript/lib/lib.dom.d.ts:2449
 
 ___
 
@@ -278,4 +278,4 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2408
+node_modules/typescript/lib/lib.dom.d.ts:2450

--- a/packages/framework/esm-framework/package.json
+++ b/packages/framework/esm-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-framework",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "browser": "dist/openmrs-esm-framework.js",
   "main": "src/index.ts",
@@ -35,16 +35,16 @@
     "access": "public"
   },
   "dependencies": {
-    "@openmrs/esm-api": "^3.1.12",
-    "@openmrs/esm-breadcrumbs": "^3.1.12",
-    "@openmrs/esm-config": "^3.1.12",
-    "@openmrs/esm-error-handling": "^3.1.12",
-    "@openmrs/esm-extensions": "^3.1.12",
-    "@openmrs/esm-globals": "^3.1.12",
-    "@openmrs/esm-offline": "^3.1.12",
-    "@openmrs/esm-react-utils": "^3.1.12",
-    "@openmrs/esm-state": "^3.1.12",
-    "@openmrs/esm-styleguide": "^3.1.12",
-    "@openmrs/esm-utils": "^3.1.12"
+    "@openmrs/esm-api": "^3.1.13",
+    "@openmrs/esm-breadcrumbs": "^3.1.13",
+    "@openmrs/esm-config": "^3.1.13",
+    "@openmrs/esm-error-handling": "^3.1.13",
+    "@openmrs/esm-extensions": "^3.1.13",
+    "@openmrs/esm-globals": "^3.1.13",
+    "@openmrs/esm-offline": "^3.1.13",
+    "@openmrs/esm-react-utils": "^3.1.13",
+    "@openmrs/esm-state": "^3.1.13",
+    "@openmrs/esm-styleguide": "^3.1.13",
+    "@openmrs/esm-utils": "^3.1.13"
   }
 }

--- a/packages/framework/esm-framework/tsconfig.json
+++ b/packages/framework/esm-framework/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "strictNullChecks": true,

--- a/packages/framework/esm-globals/package.json
+++ b/packages/framework/esm-globals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-globals",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "browser": "dist/openmrs-esm-globals.js",
   "main": "src/index.ts",

--- a/packages/framework/esm-globals/tsconfig.json
+++ b/packages/framework/esm-globals/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "strictNullChecks": true,

--- a/packages/framework/esm-offline/package.json
+++ b/packages/framework/esm-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "browser": "dist/openmrs-esm-offline.js",
@@ -37,10 +37,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@openmrs/esm-api": "^3.1.12",
-    "@openmrs/esm-globals": "^3.1.12",
-    "@openmrs/esm-state": "^3.1.12",
-    "@openmrs/esm-styleguide": "^3.1.12",
+    "@openmrs/esm-api": "^3.1.13",
+    "@openmrs/esm-globals": "^3.1.13",
+    "@openmrs/esm-state": "^3.1.13",
+    "@openmrs/esm-styleguide": "^3.1.13",
     "@types/uuid": "^8.3.0",
     "rxjs": "^6.5.3"
   },

--- a/packages/framework/esm-offline/tsconfig.json
+++ b/packages/framework/esm-offline/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "strictNullChecks": true,

--- a/packages/framework/esm-react-utils/package.json
+++ b/packages/framework/esm-react-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-react-utils",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "React utilities for OpenMRS.",
   "browser": "dist/openmrs-esm-react-utils.js",
@@ -54,11 +54,11 @@
     "react-i18next": "11.x"
   },
   "devDependencies": {
-    "@openmrs/esm-api": "^3.1.12",
-    "@openmrs/esm-config": "^3.1.12",
-    "@openmrs/esm-error-handling": "^3.1.12",
-    "@openmrs/esm-extensions": "^3.1.12",
-    "@openmrs/esm-globals": "^3.1.12",
+    "@openmrs/esm-api": "^3.1.13",
+    "@openmrs/esm-config": "^3.1.13",
+    "@openmrs/esm-error-handling": "^3.1.13",
+    "@openmrs/esm-extensions": "^3.1.13",
+    "@openmrs/esm-globals": "^3.1.13",
     "i18next": "^19.6.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/packages/framework/esm-react-utils/tsconfig.json
+++ b/packages/framework/esm-react-utils/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "strictNullChecks": true,

--- a/packages/framework/esm-state/package.json
+++ b/packages/framework/esm-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-state",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "Frontend stores & state management for OpenMRS",
   "browser": "dist/openmrs-esm-state.js",

--- a/packages/framework/esm-state/tsconfig.json
+++ b/packages/framework/esm-state/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "strictNullChecks": true,

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-styleguide",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "The styleguide for OpenMRS SPA",
   "browser": "dist/openmrs-esm-styleguide.js",
@@ -52,7 +52,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-extensions": "^3.1.12",
+    "@openmrs/esm-extensions": "^3.1.13",
     "@pickra/copy-code-block": "^1.1.7",
     "@storybook/addon-a11y": "^5.2.1",
     "@storybook/addon-knobs": "^5.2.1",

--- a/packages/framework/esm-styleguide/tsconfig.json
+++ b/packages/framework/esm-styleguide/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "strictNullChecks": true,

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-utils",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "browser": "dist/openmrs-esm-utils.js",

--- a/packages/framework/esm-utils/tsconfig.json
+++ b/packages/framework/esm-utils/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "strictNullChecks": true,

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-app-shell",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "main": "dist/openmrs.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@openmrs/esm-framework": "^3.1.12",
+    "@openmrs/esm-framework": "^3.1.13",
     "carbon-components": "10.31.0",
     "carbon-icons": "7.0.7",
     "dayjs": "^1.10.4",
@@ -57,11 +57,11 @@
     "workbox-window": "^6.1.5"
   },
   "devDependencies": {
-    "@openmrs/esm-devtools-app": "^3.1.12",
+    "@openmrs/esm-devtools-app": "^3.1.13",
     "@openmrs/esm-implementer-tools-app": "3.1.0",
-    "@openmrs/esm-login-app": "^3.1.12",
-    "@openmrs/esm-offline-tools-app": "^3.1.12",
-    "@openmrs/esm-primary-navigation-app": "^3.1.12",
+    "@openmrs/esm-login-app": "^3.1.13",
+    "@openmrs/esm-offline-tools-app": "^3.1.13",
+    "@openmrs/esm-primary-navigation-app": "^3.1.13",
     "webpack-pwa-manifest": "^4.3.0",
     "workbox-webpack-plugin": "^6.1.2"
   }

--- a/packages/shell/esm-app-shell/tsconfig.json
+++ b/packages/shell/esm-app-shell/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "esnext",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "jsx": "react",
     "strictNullChecks": true,

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "openmrs": "./dist/cli.js"
   },
+  "engines": {
+    "node": ">= 12.0.0"
+  },
   "scripts": {
     "start": "node ./dist/cli.js",
     "test": "jest --passWithNoTests",

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmrs",
-  "version": "3.1.12",
+  "version": "3.1.13",
   "license": "MPL-2.0",
   "main": "dist/index.js",
   "bin": {
@@ -31,7 +31,7 @@
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
-    "@openmrs/esm-app-shell": "^3.1.12",
+    "@openmrs/esm-app-shell": "^3.1.13",
     "@types/react": "^16.9.46",
     "@types/systemjs": "^6.1.0",
     "autoprefixer": "^9.6.1",

--- a/packages/tooling/openmrs/tsconfig.json
+++ b/packages/tooling/openmrs/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "CommonJS",
+    "target": "es2015",
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
     "jsx": "react",


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).


## Summary

Fixes the issue that the class constructor requires new to be invoked.

The issue was caused by TS transpiling to ES5, which, of course, is not what we want. I've changed the target to ES2015 (ES6). This adds support for classes, such that TS will not shim this and properly use `new` / `super` on it (natively).

## Screenshots

*None.*

## Related Issue

See https://issues.openmrs.org/browse/O3-941 for more details.

## Other

The change would only be required in the `app-shell`, but I find it consistent when the same target is used in all libs (and it should be used in the MFs, too).

Since Node 10 (and therefore Node 12) supports pretty much all the features I've also changed the `openmrs` target to use ES2015. Node 10 was deprecated end of April (EOL April 30th 2021) - hence I already went to suggest Node 12 (next LTS after 10) is the minimum for the tooling.
