### PR TITLE
O3-951: Major lag caused by updateConfigExtensionStore

### DIFF
--- a/packages/apps/esm-devtools-app/package.json
+++ b/packages/apps/esm-devtools-app/package.json
@@ -12,7 +12,7 @@
     "debug": "npm run serve",
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx"
   },

--- a/packages/apps/esm-implementer-tools-app/package.json
+++ b/packages/apps/esm-implementer-tools-app/package.json
@@ -12,7 +12,7 @@
     "debug": "npm run serve",
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx",
     "extract-translations": "i18next 'src/**/*.component.tsx'"

--- a/packages/apps/esm-login-app/package.json
+++ b/packages/apps/esm-login-app/package.json
@@ -12,7 +12,7 @@
     "debug": "npm run serve",
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx",
     "extract-translations": "i18next 'src/**/*.component.tsx'"

--- a/packages/apps/esm-offline-tools-app/package.json
+++ b/packages/apps/esm-offline-tools-app/package.json
@@ -12,7 +12,7 @@
     "debug": "npm run serve",
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx",
     "extract-translations": "i18next 'src/**/*.component.tsx'"

--- a/packages/apps/esm-primary-navigation-app/package.json
+++ b/packages/apps/esm-primary-navigation-app/package.json
@@ -12,7 +12,7 @@
     "debug": "npm run serve",
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx",
     "extract-translations": "i18next 'src/**/*.component.tsx'"

--- a/packages/framework/esm-api/docs/classes/OpenmrsFetchError.md
+++ b/packages/framework/esm-api/docs/classes/OpenmrsFetchError.md
@@ -63,7 +63,7 @@ Error.message
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:974
+node_modules/typescript/lib/lib.es5.d.ts:1023
 
 ___
 
@@ -77,7 +77,7 @@ Error.name
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:973
+node_modules/typescript/lib/lib.es5.d.ts:1022
 
 ___
 
@@ -111,7 +111,7 @@ Error.stack
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:975
+node_modules/typescript/lib/lib.es5.d.ts:1024
 
 ___
 

--- a/packages/framework/esm-api/docs/interfaces/FetchResponse.md
+++ b/packages/framework/esm-api/docs/interfaces/FetchResponse.md
@@ -52,7 +52,7 @@ Response.body
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2444
+node_modules/typescript/lib/lib.dom.d.ts:2402
 
 ___
 
@@ -66,7 +66,7 @@ Response.bodyUsed
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2445
+node_modules/typescript/lib/lib.dom.d.ts:2403
 
 ___
 
@@ -90,7 +90,7 @@ Response.headers
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12143
+node_modules/typescript/lib/lib.dom.d.ts:11136
 
 ___
 
@@ -104,7 +104,7 @@ Response.ok
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12144
+node_modules/typescript/lib/lib.dom.d.ts:11137
 
 ___
 
@@ -118,7 +118,7 @@ Response.redirected
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12145
+node_modules/typescript/lib/lib.dom.d.ts:11138
 
 ___
 
@@ -132,7 +132,7 @@ Response.status
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12146
+node_modules/typescript/lib/lib.dom.d.ts:11139
 
 ___
 
@@ -146,7 +146,7 @@ Response.statusText
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12147
+node_modules/typescript/lib/lib.dom.d.ts:11140
 
 ___
 
@@ -160,7 +160,7 @@ Response.type
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12148
+node_modules/typescript/lib/lib.dom.d.ts:11141
 
 ___
 
@@ -174,7 +174,7 @@ Response.url
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12149
+node_modules/typescript/lib/lib.dom.d.ts:11142
 
 ## Methods
 
@@ -192,7 +192,7 @@ Response.arrayBuffer
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2446
+node_modules/typescript/lib/lib.dom.d.ts:2404
 
 ___
 
@@ -210,7 +210,7 @@ Response.blob
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2447
+node_modules/typescript/lib/lib.dom.d.ts:2405
 
 ___
 
@@ -228,7 +228,7 @@ Response.clone
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12150
+node_modules/typescript/lib/lib.dom.d.ts:11143
 
 ___
 
@@ -246,7 +246,7 @@ Response.formData
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2448
+node_modules/typescript/lib/lib.dom.d.ts:2406
 
 ___
 
@@ -264,7 +264,7 @@ Response.json
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2449
+node_modules/typescript/lib/lib.dom.d.ts:2407
 
 ___
 
@@ -282,4 +282,4 @@ Response.text
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2450
+node_modules/typescript/lib/lib.dom.d.ts:2408

--- a/packages/framework/esm-api/docs/interfaces/LoggedInUserFetchResponse.md
+++ b/packages/framework/esm-api/docs/interfaces/LoggedInUserFetchResponse.md
@@ -44,7 +44,7 @@
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2444
+node_modules/typescript/lib/lib.dom.d.ts:2402
 
 ___
 
@@ -58,7 +58,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2445
+node_modules/typescript/lib/lib.dom.d.ts:2403
 
 ___
 
@@ -86,7 +86,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12143
+node_modules/typescript/lib/lib.dom.d.ts:11136
 
 ___
 
@@ -100,7 +100,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12144
+node_modules/typescript/lib/lib.dom.d.ts:11137
 
 ___
 
@@ -114,7 +114,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12145
+node_modules/typescript/lib/lib.dom.d.ts:11138
 
 ___
 
@@ -128,7 +128,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12146
+node_modules/typescript/lib/lib.dom.d.ts:11139
 
 ___
 
@@ -142,7 +142,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12147
+node_modules/typescript/lib/lib.dom.d.ts:11140
 
 ___
 
@@ -156,7 +156,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12148
+node_modules/typescript/lib/lib.dom.d.ts:11141
 
 ___
 
@@ -170,7 +170,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12149
+node_modules/typescript/lib/lib.dom.d.ts:11142
 
 ## Methods
 
@@ -188,7 +188,7 @@ node_modules/typescript/lib/lib.dom.d.ts:12149
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2446
+node_modules/typescript/lib/lib.dom.d.ts:2404
 
 ___
 
@@ -206,7 +206,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2447
+node_modules/typescript/lib/lib.dom.d.ts:2405
 
 ___
 
@@ -224,7 +224,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:12150
+node_modules/typescript/lib/lib.dom.d.ts:11143
 
 ___
 
@@ -242,7 +242,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2448
+node_modules/typescript/lib/lib.dom.d.ts:2406
 
 ___
 
@@ -260,7 +260,7 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2449
+node_modules/typescript/lib/lib.dom.d.ts:2407
 
 ___
 
@@ -278,4 +278,4 @@ ___
 
 #### Defined in
 
-node_modules/typescript/lib/lib.dom.d.ts:2450
+node_modules/typescript/lib/lib.dom.d.ts:2408

--- a/packages/framework/esm-api/package.json
+++ b/packages/framework/esm-api/package.json
@@ -10,7 +10,7 @@
     "document": "../../../document.sh esm-api",
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx"
   },

--- a/packages/framework/esm-breadcrumbs/package.json
+++ b/packages/framework/esm-breadcrumbs/package.json
@@ -10,7 +10,7 @@
     "document": "../../../document.sh esm-breadcrumbs",
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx"
   },

--- a/packages/framework/esm-config/docs/API.md
+++ b/packages/framework/esm-config/docs/API.md
@@ -297,7 +297,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:135](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L135)
+[packages/framework/esm-config/src/module-config/module-config.ts:172](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L172)
 
 ___
 
@@ -305,9 +305,8 @@ ___
 
 ▸ **getConfig**(`moduleName`): `Promise`<[`Config`](interfaces/Config.md)\>
 
-A promise-based way to access the config as soon as it is fully loaded
-from the import-map. If it is already loaded, resolves the config in its
-present state.
+A promise-based way to access the config as soon as it is fully loaded.
+If it is already loaded, resolves the config in its present state.
 
 In general you should use the Unistore-based API provided by
 `getConfigStore`, which allows creating a subscription so that you always
@@ -328,7 +327,7 @@ of the execution of a function.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:164](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L164)
+[packages/framework/esm-config/src/module-config/module-config.ts:200](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L200)
 
 ___
 
@@ -419,17 +418,18 @@ ___
 
 ### processConfig
 
-▸ **processConfig**(`schema`, `providedConfig`, `keyPathContext`): [`Config`](interfaces/Config.md)
+▸ **processConfig**(`schema`, `providedConfig`, `keyPathContext`, `devDefaultsAreOn?`): [`Config`](interfaces/Config.md)
 
 Validate and interpolate defaults for `providedConfig` according to `schema`
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `schema` | [`ConfigSchema`](interfaces/ConfigSchema.md) | a configuration schema |
-| `providedConfig` | [`ConfigObject`](interfaces/ConfigObject.md) | an object of config values (without the top-level module name) |
-| `keyPathContext` | `string` | a dot-deparated string which helps the user figure out where     the provided config came from |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `schema` | [`ConfigSchema`](interfaces/ConfigSchema.md) | `undefined` | a configuration schema |
+| `providedConfig` | [`ConfigObject`](interfaces/ConfigObject.md) | `undefined` | an object of config values (without the top-level module name) |
+| `keyPathContext` | `string` | `undefined` | a dot-deparated string which helps the user figure out where     the provided config came from |
+| `devDefaultsAreOn` | `boolean` | `false` | - |
 
 #### Returns
 
@@ -437,7 +437,7 @@ Validate and interpolate defaults for `providedConfig` according to `schema`
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:186](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L186)
+[packages/framework/esm-config/src/module-config/module-config.ts:222](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L222)
 
 ___
 
@@ -458,7 +458,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:143](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L143)
+[packages/framework/esm-config/src/module-config/module-config.ts:180](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L180)
 
 ___
 

--- a/packages/framework/esm-config/docs/interfaces/Config.md
+++ b/packages/framework/esm-config/docs/interfaces/Config.md
@@ -41,7 +41,7 @@ Object.constructor
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:122
+node_modules/typescript/lib/lib.es5.d.ts:124
 
 ## Methods
 
@@ -67,7 +67,7 @@ Object.hasOwnProperty
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:137
+node_modules/typescript/lib/lib.es5.d.ts:139
 
 ___
 
@@ -93,7 +93,7 @@ Object.isPrototypeOf
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:143
+node_modules/typescript/lib/lib.es5.d.ts:145
 
 ___
 
@@ -119,7 +119,7 @@ Object.propertyIsEnumerable
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:149
+node_modules/typescript/lib/lib.es5.d.ts:151
 
 ___
 
@@ -139,7 +139,7 @@ Object.toLocaleString
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:128
+node_modules/typescript/lib/lib.es5.d.ts:130
 
 ___
 
@@ -159,7 +159,7 @@ Object.toString
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:125
+node_modules/typescript/lib/lib.es5.d.ts:127
 
 ___
 
@@ -179,4 +179,4 @@ Object.valueOf
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:131
+node_modules/typescript/lib/lib.es5.d.ts:133

--- a/packages/framework/esm-config/docs/interfaces/ConfigObject.md
+++ b/packages/framework/esm-config/docs/interfaces/ConfigObject.md
@@ -41,7 +41,7 @@ Object.constructor
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:122
+node_modules/typescript/lib/lib.es5.d.ts:124
 
 ## Methods
 
@@ -67,7 +67,7 @@ Object.hasOwnProperty
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:137
+node_modules/typescript/lib/lib.es5.d.ts:139
 
 ___
 
@@ -93,7 +93,7 @@ Object.isPrototypeOf
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:143
+node_modules/typescript/lib/lib.es5.d.ts:145
 
 ___
 
@@ -119,7 +119,7 @@ Object.propertyIsEnumerable
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:149
+node_modules/typescript/lib/lib.es5.d.ts:151
 
 ___
 
@@ -139,7 +139,7 @@ Object.toLocaleString
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:128
+node_modules/typescript/lib/lib.es5.d.ts:130
 
 ___
 
@@ -159,7 +159,7 @@ Object.toString
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:125
+node_modules/typescript/lib/lib.es5.d.ts:127
 
 ___
 
@@ -179,4 +179,4 @@ Object.valueOf
 
 #### Defined in
 
-node_modules/typescript/lib/lib.es5.d.ts:131
+node_modules/typescript/lib/lib.es5.d.ts:133

--- a/packages/framework/esm-config/package.json
+++ b/packages/framework/esm-config/package.json
@@ -10,7 +10,7 @@
     "document": "../../../document.sh esm-config",
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx"
   },

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -28,6 +28,7 @@ import {
   temporaryConfigStore,
 } from "./state";
 import type {} from "@openmrs/esm-globals";
+import { TemporaryConfigStore } from "..";
 
 /**
  * Store setup
@@ -44,56 +45,86 @@ import type {} from "@openmrs/esm-globals";
  * This code sets up the subscriptions so that when an input store changes,
  * the correct set of output stores are updated.
  *
- * NB: You will notice that none of the `compute...` functions below explicitly
- * take `temporaryConfigStore` state as an input. They do make use of
- * `temporaryConfigStore`, however it is obtained in `getProvidedConfigs`.
- * It would probably be better to make the functions pure.
+ * All `compute...` functions except `computeExtensionConfigs` are pure
+ * (or are supposed to be). `computeExtensionConfigs` calls `getGlobalStore`,
+ * which creates stores.
  */
-computeModuleConfig(configInternalStore.getState());
-configInternalStore.subscribe(computeModuleConfig);
-temporaryConfigStore.subscribe(() =>
-  computeModuleConfig(configInternalStore.getState())
+computeModuleConfig(
+  configInternalStore.getState(),
+  temporaryConfigStore.getState()
+);
+configInternalStore.subscribe((configState) =>
+  computeModuleConfig(configState, temporaryConfigStore.getState())
+);
+temporaryConfigStore.subscribe((tempConfigState) =>
+  computeModuleConfig(configInternalStore.getState(), tempConfigState)
 );
 
-computeImplementerToolsConfig(configInternalStore.getState());
-configInternalStore.subscribe(computeImplementerToolsConfig);
-temporaryConfigStore.subscribe(() =>
-  computeImplementerToolsConfig(configInternalStore.getState())
+computeImplementerToolsConfig(
+  configInternalStore.getState(),
+  temporaryConfigStore.getState()
+);
+configInternalStore.subscribe((configState) =>
+  computeImplementerToolsConfig(configState, temporaryConfigStore.getState())
+);
+temporaryConfigStore.subscribe((tempConfigState) =>
+  computeImplementerToolsConfig(configInternalStore.getState(), tempConfigState)
 );
 
-computeExtensionSlotConfigs(configInternalStore.getState());
-configInternalStore.subscribe(computeExtensionSlotConfigs);
-temporaryConfigStore.subscribe(() =>
-  computeExtensionSlotConfigs(configInternalStore.getState())
+computeExtensionSlotConfigs(
+  configInternalStore.getState(),
+  temporaryConfigStore.getState()
+);
+configInternalStore.subscribe((configState) =>
+  computeExtensionSlotConfigs(configState, temporaryConfigStore.getState())
+);
+temporaryConfigStore.subscribe((tempConfigState) =>
+  computeExtensionSlotConfigs(configInternalStore.getState(), tempConfigState)
 );
 
 computeExtensionConfigs(
   configInternalStore.getState(),
-  configExtensionStore.getState()
+  configExtensionStore.getState(),
+  temporaryConfigStore.getState()
 );
 configInternalStore.subscribe((configState) =>
-  computeExtensionConfigs(configState, configExtensionStore.getState())
+  computeExtensionConfigs(
+    configState,
+    configExtensionStore.getState(),
+    temporaryConfigStore.getState()
+  )
 );
 configExtensionStore.subscribe((extensionState) =>
-  computeExtensionConfigs(configInternalStore.getState(), extensionState)
-);
-temporaryConfigStore.subscribe(() =>
   computeExtensionConfigs(
     configInternalStore.getState(),
-    configExtensionStore.getState()
+    extensionState,
+    temporaryConfigStore.getState()
+  )
+);
+temporaryConfigStore.subscribe((tempConfigState) =>
+  computeExtensionConfigs(
+    configInternalStore.getState(),
+    configExtensionStore.getState(),
+    tempConfigState
   )
 );
 
-function computeModuleConfig(state: ConfigInternalStore) {
+function computeModuleConfig(
+  state: ConfigInternalStore,
+  tempState: TemporaryConfigStore
+) {
   for (let moduleName of Object.keys(state.schemas)) {
-    const config = getConfigForModule(moduleName);
+    const config = getConfigForModule(moduleName, state, tempState);
     const moduleStore = getConfigStore(moduleName);
     moduleStore.setState({ loaded: true, config });
   }
 }
 
-function computeExtensionSlotConfigs(state: ConfigInternalStore) {
-  const slotConfigsByModule = getExtensionSlotConfigs();
+function computeExtensionSlotConfigs(
+  state: ConfigInternalStore,
+  tempState: TemporaryConfigStore
+) {
+  const slotConfigsByModule = getExtensionSlotConfigs(state, tempState);
   for (let [moduleName, extensionSlotConfigs] of Object.entries(
     slotConfigsByModule
   )) {
@@ -102,14 +133,18 @@ function computeExtensionSlotConfigs(state: ConfigInternalStore) {
   }
 }
 
-function computeImplementerToolsConfig(state: ConfigInternalStore) {
-  const config = getImplementerToolsConfig();
+function computeImplementerToolsConfig(
+  state: ConfigInternalStore,
+  tempConfigState: TemporaryConfigStore
+) {
+  const config = getImplementerToolsConfig(state, tempConfigState);
   implementerToolsConfigStore.setState({ config });
 }
 
 function computeExtensionConfigs(
   configState: ConfigInternalStore,
-  extensionState: ConfigExtensionStore
+  extensionState: ConfigExtensionStore,
+  tempConfigState: TemporaryConfigStore
 ) {
   for (let extension of extensionState.mountedExtensions) {
     const extensionStore = getExtensionConfigStore(
@@ -122,7 +157,8 @@ function computeExtensionConfigs(
       extension.extensionModuleName,
       extension.slotName,
       extension.extensionId,
-      configState
+      configState,
+      tempConfigState
     );
     extensionStore.setState({ loaded: true, config });
   }
@@ -149,9 +185,8 @@ export function provide(config: Config, sourceName = "provided") {
 }
 
 /**
- * A promise-based way to access the config as soon as it is fully loaded
- * from the import-map. If it is already loaded, resolves the config in its
- * present state.
+ * A promise-based way to access the config as soon as it is fully loaded.
+ * If it is already loaded, resolves the config in its present state.
  *
  * In general you should use the Unistore-based API provided by
  * `getConfigStore`, which allows creating a subscription so that you always
@@ -187,10 +222,11 @@ export function getConfig(moduleName: string): Promise<Config> {
 export function processConfig(
   schema: ConfigSchema,
   providedConfig: ConfigObject,
-  keyPathContext: string
+  keyPathContext: string,
+  devDefaultsAreOn: boolean = false
 ) {
   validateConfig(schema, providedConfig, keyPathContext);
-  const config = setDefaults(schema, providedConfig);
+  const config = setDefaults(schema, providedConfig, devDefaultsAreOn);
   return config;
 }
 
@@ -216,32 +252,37 @@ function getExtensionConfig(
   extensionModuleName: string,
   slotName: string,
   extensionId: string,
-  configState: ConfigInternalStore
+  configState: ConfigInternalStore,
+  tempConfigState: TemporaryConfigStore
 ) {
-  const slotModuleConfig = mergeConfigsFor(
-    slotModuleName,
-    getProvidedConfigs()
-  );
+  const providedConfigs = getProvidedConfigs(configState, tempConfigState);
+  const slotModuleConfig = mergeConfigsFor(slotModuleName, providedConfigs);
   const configOverride =
     slotModuleConfig?.extensions?.[slotName]?.configure?.[extensionId] ?? {};
   const extensionModuleConfig = mergeConfigsFor(
     extensionModuleName,
-    getProvidedConfigs()
+    providedConfigs
   );
   const extensionConfig = mergeConfigs([extensionModuleConfig, configOverride]);
   const schema = configState.schemas[extensionModuleName]; // TODO: validate that a schema exists for the module
   validateConfig(schema, extensionConfig, extensionModuleName);
-  const config = setDefaults(schema, extensionConfig);
+  const config = setDefaults(
+    schema,
+    extensionConfig,
+    configState.devDefaultsAreOn
+  );
   delete config.extensions;
   return config;
 }
 
-function getImplementerToolsConfig(): Record<string, Config> {
-  const state = configInternalStore.getState();
-  let result = getSchemaWithValuesAndSources(clone(state.schemas));
+function getImplementerToolsConfig(
+  configState: ConfigInternalStore,
+  tempConfigState: TemporaryConfigStore
+): Record<string, Config> {
+  let result = getSchemaWithValuesAndSources(clone(configState.schemas));
   const configsAndSources = [
-    ...state.providedConfigs.map((c) => [c.config, c.source]),
-    [temporaryConfigStore.getState().config, "temporary config"],
+    ...configState.providedConfigs.map((c) => [c.config, c.source]),
+    [tempConfigState.config, "temporary config"],
   ] as Array<[Config, string]>;
   for (let [config, source] of configsAndSources) {
     result = mergeConfigs([result, createValuesAndSourcesTree(config, source)]);
@@ -274,11 +315,13 @@ function createValuesAndSourcesTree(config: ConfigObject, source: string) {
   }
 }
 
-function getExtensionSlotConfigs(): Record<
-  string,
-  Record<string, ExtensionSlotConfigObject>
-> {
-  const allConfigs = mergeConfigs(getProvidedConfigs());
+function getExtensionSlotConfigs(
+  configState: ConfigInternalStore,
+  tempConfigState: TemporaryConfigStore
+): Record<string, Record<string, ExtensionSlotConfigObject>> {
+  const allConfigs = mergeConfigs(
+    getProvidedConfigs(configState, tempConfigState)
+  );
   const slotConfigPerModule: Record<
     string,
     Record<string, ExtensionSlotConfig>
@@ -361,11 +404,13 @@ function validateExtensionSlotConfig(
   }
 }
 
-function getProvidedConfigs(): Array<Config> {
-  const state = configInternalStore.getState();
+function getProvidedConfigs(
+  configState: ConfigInternalStore,
+  tempConfigState: TemporaryConfigStore
+): Array<Config> {
   return [
-    ...state.providedConfigs.map((c) => c.config),
-    temporaryConfigStore.getState().config,
+    ...configState.providedConfigs.map((c) => c.config),
+    tempConfigState.config,
   ];
 }
 
@@ -447,16 +492,22 @@ function validateConfigSchema(
   }
 }
 
-function getConfigForModule(moduleName: string): ConfigObject {
-  const state = configInternalStore.getState();
-  if (!state.schemas.hasOwnProperty(moduleName)) {
+function getConfigForModule(
+  moduleName: string,
+  configState: ConfigInternalStore,
+  tempConfigState: TemporaryConfigStore
+): ConfigObject {
+  if (!configState.schemas.hasOwnProperty(moduleName)) {
     throw Error("No config schema has been defined for " + moduleName);
   }
 
-  const schema = state.schemas[moduleName];
-  const inputConfig = mergeConfigsFor(moduleName, getProvidedConfigs());
+  const schema = configState.schemas[moduleName];
+  const inputConfig = mergeConfigsFor(
+    moduleName,
+    getProvidedConfigs(configState, tempConfigState)
+  );
   validateConfig(schema, inputConfig, moduleName);
-  const config = setDefaults(schema, inputConfig);
+  const config = setDefaults(schema, inputConfig, configState.devDefaultsAreOn);
   delete config.extensions;
   return config;
 }
@@ -595,9 +646,12 @@ function runValidators(
 }
 
 // Recursively fill in the config with values from the schema.
-const setDefaults = (schema: ConfigSchema, inputConfig: Config) => {
+const setDefaults = (
+  schema: ConfigSchema,
+  inputConfig: Config,
+  devDefaultsAreOn: boolean
+) => {
   const config = clone(inputConfig);
-  const devDefaultsAreOn = configInternalStore.getState().devDefaultsAreOn;
 
   if (!schema) {
     return config;
@@ -629,14 +683,15 @@ const setDefaults = (schema: ConfigSchema, inputConfig: Config) => {
       if (configPart && hasObjectSchema(elements)) {
         if (schemaPart._type === Type.Array) {
           const configWithDefaults = configPart.map((conf: Config) =>
-            setDefaults(elements, conf)
+            setDefaults(elements, conf, devDefaultsAreOn)
           );
           config[key] = configWithDefaults;
         } else if (schemaPart._type === Type.Object) {
           for (let objectKey of Object.keys(configPart)) {
             configPart[objectKey] = setDefaults(
               elements,
-              configPart[objectKey]
+              configPart[objectKey],
+              devDefaultsAreOn
             );
           }
         }
@@ -648,7 +703,11 @@ const setDefaults = (schema: ConfigSchema, inputConfig: Config) => {
       const selectedConfigPart = config.hasOwnProperty(key) ? configPart : {};
 
       if (isOrdinaryObject(selectedConfigPart)) {
-        config[key] = setDefaults(schemaPart, selectedConfigPart);
+        config[key] = setDefaults(
+          schemaPart,
+          selectedConfigPart,
+          devDefaultsAreOn
+        );
       }
     }
   }

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -121,7 +121,8 @@ function computeExtensionConfigs(
       extension.slotModuleName,
       extension.extensionModuleName,
       extension.slotName,
-      extension.extensionId
+      extension.extensionId,
+      configState
     );
     extensionStore.setState({ loaded: true, config });
   }
@@ -214,7 +215,8 @@ function getExtensionConfig(
   slotModuleName: string,
   extensionModuleName: string,
   slotName: string,
-  extensionId: string
+  extensionId: string,
+  configState: ConfigInternalStore
 ) {
   const slotModuleConfig = mergeConfigsFor(
     slotModuleName,
@@ -227,7 +229,7 @@ function getExtensionConfig(
     getProvidedConfigs()
   );
   const extensionConfig = mergeConfigs([extensionModuleConfig, configOverride]);
-  const schema = configInternalStore.getState().schemas[extensionModuleName]; // TODO: validate that a schema exists for the module
+  const schema = configState.schemas[extensionModuleName]; // TODO: validate that a schema exists for the module
   validateConfig(schema, extensionConfig, extensionModuleName);
   const config = setDefaults(schema, extensionConfig);
   delete config.extensions;

--- a/packages/framework/esm-error-handling/package.json
+++ b/packages/framework/esm-error-handling/package.json
@@ -10,7 +10,7 @@
     "document": "../../../document.sh esm-error-handling",
     "test": "jest --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx"
   },

--- a/packages/framework/esm-extensions/docs/API.md
+++ b/packages/framework/esm-extensions/docs/API.md
@@ -63,7 +63,7 @@
 
 #### Defined in
 
-[store.ts:82](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L82)
+[store.ts:83](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L83)
 
 ___
 
@@ -83,7 +83,7 @@ ___
 
 #### Defined in
 
-[store.ts:77](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L77)
+[store.ts:78](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L78)
 
 ## Functions
 
@@ -508,4 +508,4 @@ ___
 
 #### Defined in
 
-[store.ts:86](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L86)
+[store.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L87)

--- a/packages/framework/esm-extensions/docs/interfaces/ExtensionInfo.md
+++ b/packages/framework/esm-extensions/docs/interfaces/ExtensionInfo.md
@@ -35,7 +35,7 @@ indexed by slotModuleName and slotName.
 
 #### Defined in
 
-[store.ts:26](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L26)
+[store.ts:27](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L27)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[store.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L15)
+[store.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L16)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[store.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L14)
+[store.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L15)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[store.ts:12](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L12)
+[store.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L13)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[store.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L18)
+[store.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L19)
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 #### Defined in
 
-[store.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L17)
+[store.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L18)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[store.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L16)
+[store.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L17)
 
 ## Methods
 
@@ -137,4 +137,4 @@ ___
 
 #### Defined in
 
-[store.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L13)
+[store.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L14)

--- a/packages/framework/esm-extensions/docs/interfaces/ExtensionInstance.md
+++ b/packages/framework/esm-extensions/docs/interfaces/ExtensionInstance.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[store.ts:30](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L30)
+[store.ts:31](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L31)

--- a/packages/framework/esm-extensions/docs/interfaces/ExtensionRegistration.md
+++ b/packages/framework/esm-extensions/docs/interfaces/ExtensionRegistration.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[store.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L15)
+[store.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L16)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[store.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L14)
+[store.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L15)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[store.ts:12](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L12)
+[store.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L13)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[store.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L18)
+[store.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L19)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[store.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L17)
+[store.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L18)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[store.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L16)
+[store.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L17)
 
 ## Methods
 
@@ -95,4 +95,4 @@ ___
 
 #### Defined in
 
-[store.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L13)
+[store.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L14)

--- a/packages/framework/esm-extensions/docs/interfaces/ExtensionSlotInfo.md
+++ b/packages/framework/esm-extensions/docs/interfaces/ExtensionSlotInfo.md
@@ -23,7 +23,7 @@ However, not all of these extension IDs should be rendered.
 
 #### Defined in
 
-[store.ts:74](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L74)
+[store.ts:75](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L75)
 
 ___
 
@@ -35,7 +35,7 @@ The mapping of modules / extension slot instances where the extension slot has b
 
 #### Defined in
 
-[store.ts:67](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L67)
+[store.ts:68](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L68)
 
 ___
 
@@ -47,4 +47,4 @@ The name under which the extension slot has been registered.
 
 #### Defined in
 
-[store.ts:63](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L63)
+[store.ts:64](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L64)

--- a/packages/framework/esm-extensions/docs/interfaces/ExtensionSlotInstance.md
+++ b/packages/framework/esm-extensions/docs/interfaces/ExtensionSlotInstance.md
@@ -22,7 +22,7 @@ An example may be an extension which is added to the slot via the configuration.
 
 #### Defined in
 
-[store.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L46)
+[store.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L47)
 
 ___
 
@@ -34,7 +34,7 @@ A set allowing explicit ordering of the `assignedIds`.
 
 #### Defined in
 
-[store.ts:56](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L56)
+[store.ts:57](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L57)
 
 ___
 
@@ -48,4 +48,4 @@ An example may be an extension which is removed from the slot via the configurat
 
 #### Defined in
 
-[store.ts:52](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L52)
+[store.ts:53](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L53)

--- a/packages/framework/esm-extensions/docs/interfaces/ExtensionStore.md
+++ b/packages/framework/esm-extensions/docs/interfaces/ExtensionStore.md
@@ -19,7 +19,7 @@ Extensions indexed by name
 
 #### Defined in
 
-[store.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L37)
+[store.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L38)
 
 ___
 
@@ -31,4 +31,4 @@ Slots indexed by name
 
 #### Defined in
 
-[store.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L35)
+[store.ts:36](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L36)

--- a/packages/framework/esm-extensions/jest.config.js
+++ b/packages/framework/esm-extensions/jest.config.js
@@ -1,6 +1,7 @@
 module.exports = {
   setupFiles: ["<rootDir>/src/setup-tests.js"],
   moduleNameMapper: {
+    "lodash-es/(.*)": "lodash/$1",
     "@openmrs/esm-config": "<rootDir>/__mocks__/openmrs-esm-config.mock.tsx",
   },
 };

--- a/packages/framework/esm-extensions/package.json
+++ b/packages/framework/esm-extensions/package.json
@@ -47,5 +47,8 @@
     "@openmrs/esm-config": "^3.1.14",
     "@openmrs/esm-state": "^3.1.14",
     "single-spa": "^5.9.2"
+  },
+  "dependencies": {
+    "lodash-es": "^4.17.21"
   }
 }

--- a/packages/framework/esm-extensions/package.json
+++ b/packages/framework/esm-extensions/package.json
@@ -10,7 +10,7 @@
     "document": "../../../document.sh esm-extensions",
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx"
   },

--- a/packages/framework/esm-extensions/src/store.ts
+++ b/packages/framework/esm-extensions/src/store.ts
@@ -1,3 +1,4 @@
+import isEqual from "lodash-es/isEqual";
 import {
   configExtensionStore,
   ConfigExtensionStoreElement,
@@ -124,5 +125,14 @@ function updateConfigExtensionStore(extensionState: ExtensionStore) {
       }
     }
   }
-  configExtensionStore.setState({ mountedExtensions: configExtensionRecords });
+  if (
+    !isEqual(
+      configExtensionStore.getState().mountedExtensions,
+      configExtensionRecords
+    )
+  ) {
+    configExtensionStore.setState({
+      mountedExtensions: configExtensionRecords,
+    });
+  }
 }

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -451,7 +451,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:82](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L82)
+[packages/framework/esm-extensions/src/store.ts:83](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L83)
 
 ___
 
@@ -747,7 +747,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:77](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L77)
+[packages/framework/esm-extensions/src/store.ts:78](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L78)
 
 ___
 
@@ -1556,7 +1556,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:135](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L135)
+[packages/framework/esm-config/src/module-config/module-config.ts:172](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L172)
 
 ___
 
@@ -1826,9 +1826,8 @@ ___
 
 ▸ **getConfig**(`moduleName`): `Promise`<[`Config`](interfaces/Config.md)\>
 
-A promise-based way to access the config as soon as it is fully loaded
-from the import-map. If it is already loaded, resolves the config in its
-present state.
+A promise-based way to access the config as soon as it is fully loaded.
+If it is already loaded, resolves the config in its present state.
 
 In general you should use the Unistore-based API provided by
 `getConfigStore`, which allows creating a subscription so that you always
@@ -1849,7 +1848,7 @@ of the execution of a function.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:164](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L164)
+[packages/framework/esm-config/src/module-config/module-config.ts:200](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L200)
 
 ___
 
@@ -2618,17 +2617,18 @@ ___
 
 ### processConfig
 
-▸ **processConfig**(`schema`, `providedConfig`, `keyPathContext`): [`Config`](interfaces/Config.md)
+▸ **processConfig**(`schema`, `providedConfig`, `keyPathContext`, `devDefaultsAreOn?`): [`Config`](interfaces/Config.md)
 
 Validate and interpolate defaults for `providedConfig` according to `schema`
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `schema` | [`ConfigSchema`](interfaces/ConfigSchema.md) | a configuration schema |
-| `providedConfig` | [`ConfigObject`](interfaces/ConfigObject.md) | an object of config values (without the top-level module name) |
-| `keyPathContext` | `string` | a dot-deparated string which helps the user figure out where     the provided config came from |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `schema` | [`ConfigSchema`](interfaces/ConfigSchema.md) | `undefined` | a configuration schema |
+| `providedConfig` | [`ConfigObject`](interfaces/ConfigObject.md) | `undefined` | an object of config values (without the top-level module name) |
+| `keyPathContext` | `string` | `undefined` | a dot-deparated string which helps the user figure out where     the provided config came from |
+| `devDefaultsAreOn` | `boolean` | `false` | - |
 
 #### Returns
 
@@ -2636,7 +2636,7 @@ Validate and interpolate defaults for `providedConfig` according to `schema`
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:186](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L186)
+[packages/framework/esm-config/src/module-config/module-config.ts:222](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L222)
 
 ___
 
@@ -2657,7 +2657,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:143](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L143)
+[packages/framework/esm-config/src/module-config/module-config.ts:180](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L180)
 
 ___
 
@@ -3735,7 +3735,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:86](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L86)
+[packages/framework/esm-extensions/src/store.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L87)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionInfo.md
@@ -35,7 +35,7 @@ indexed by slotModuleName and slotName.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:26](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L26)
+[packages/framework/esm-extensions/src/store.ts:27](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L27)
 
 ___
 
@@ -49,7 +49,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L15)
+[packages/framework/esm-extensions/src/store.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L16)
 
 ___
 
@@ -63,7 +63,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L14)
+[packages/framework/esm-extensions/src/store.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L15)
 
 ___
 
@@ -77,7 +77,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:12](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L12)
+[packages/framework/esm-extensions/src/store.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L13)
 
 ___
 
@@ -91,7 +91,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L18)
+[packages/framework/esm-extensions/src/store.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L19)
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L17)
+[packages/framework/esm-extensions/src/store.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L18)
 
 ___
 
@@ -119,7 +119,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L16)
+[packages/framework/esm-extensions/src/store.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L17)
 
 ## Methods
 
@@ -137,4 +137,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L13)
+[packages/framework/esm-extensions/src/store.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L14)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionInstance.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionInstance.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:30](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L30)
+[packages/framework/esm-extensions/src/store.ts:31](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L31)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionRegistration.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionRegistration.md
@@ -31,7 +31,7 @@
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L15)
+[packages/framework/esm-extensions/src/store.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L16)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L14)
+[packages/framework/esm-extensions/src/store.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L15)
 
 ___
 
@@ -51,7 +51,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:12](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L12)
+[packages/framework/esm-extensions/src/store.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L13)
 
 ___
 
@@ -61,7 +61,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L18)
+[packages/framework/esm-extensions/src/store.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L19)
 
 ___
 
@@ -71,7 +71,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L17)
+[packages/framework/esm-extensions/src/store.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L18)
 
 ___
 
@@ -81,7 +81,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L16)
+[packages/framework/esm-extensions/src/store.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L17)
 
 ## Methods
 
@@ -95,4 +95,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L13)
+[packages/framework/esm-extensions/src/store.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L14)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotInfo.md
@@ -23,7 +23,7 @@ However, not all of these extension IDs should be rendered.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:74](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L74)
+[packages/framework/esm-extensions/src/store.ts:75](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L75)
 
 ___
 
@@ -35,7 +35,7 @@ The mapping of modules / extension slot instances where the extension slot has b
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:67](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L67)
+[packages/framework/esm-extensions/src/store.ts:68](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L68)
 
 ___
 
@@ -47,4 +47,4 @@ The name under which the extension slot has been registered.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:63](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L63)
+[packages/framework/esm-extensions/src/store.ts:64](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L64)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotInstance.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotInstance.md
@@ -22,7 +22,7 @@ An example may be an extension which is added to the slot via the configuration.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L46)
+[packages/framework/esm-extensions/src/store.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L47)
 
 ___
 
@@ -34,7 +34,7 @@ A set allowing explicit ordering of the `assignedIds`.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:56](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L56)
+[packages/framework/esm-extensions/src/store.ts:57](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L57)
 
 ___
 
@@ -48,4 +48,4 @@ An example may be an extension which is removed from the slot via the configurat
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:52](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L52)
+[packages/framework/esm-extensions/src/store.ts:53](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L53)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionStore.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionStore.md
@@ -19,7 +19,7 @@ Extensions indexed by name
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L37)
+[packages/framework/esm-extensions/src/store.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L38)
 
 ___
 
@@ -31,4 +31,4 @@ Slots indexed by name
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L35)
+[packages/framework/esm-extensions/src/store.ts:36](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L36)

--- a/packages/framework/esm-framework/jest.config.js
+++ b/packages/framework/esm-framework/jest.config.js
@@ -4,8 +4,7 @@ module.exports = {
   },
   moduleNameMapper: {
     "\\.(s?css)$": "identity-obj-proxy",
-    "lodash-es": "lodash",
-    "lodash-es/(.*)": "lodash/\1",
+    "lodash-es/(.*)": "lodash/$1",
   },
   setupFilesAfterEnv: ["<rootDir>/src/integration-tests/setup-tests.ts"],
 };

--- a/packages/framework/esm-framework/package.json
+++ b/packages/framework/esm-framework/package.json
@@ -9,7 +9,7 @@
     "document": "../../../document.sh esm-framework",
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx"
   },

--- a/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
@@ -44,7 +44,6 @@ describe("Interaction between configuration and extension systems", () => {
     await waitFor(() => expect(screen.getByText("Betty")).toBeInTheDocument());
     const slot = screen.getByTestId("slot");
     const extensions = slot.childNodes;
-    screen.debug();
     expect(extensions[0]).toHaveTextContent("Betty");
     expect(extensions[1]).toHaveTextContent("Wilma");
     expect(extensions[2]).toHaveTextContent("Barney");

--- a/packages/framework/esm-globals/package.json
+++ b/packages/framework/esm-globals/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "document": "../../../document.sh esm-globals",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx"
   },

--- a/packages/framework/esm-offline/package.json
+++ b/packages/framework/esm-offline/package.json
@@ -10,7 +10,7 @@
     "document": "../../../document.sh esm-offline",
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx"
   },

--- a/packages/framework/esm-react-utils/package.json
+++ b/packages/framework/esm-react-utils/package.json
@@ -10,7 +10,7 @@
     "document": "../../../document.sh esm-react-utils",
     "test": "jest --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "lint": "eslint src"
   },
   "keywords": [

--- a/packages/framework/esm-state/package.json
+++ b/packages/framework/esm-state/package.json
@@ -10,7 +10,7 @@
     "document": "../../../document.sh esm-state",
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx"
   },

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -12,7 +12,7 @@
     "start:storybook": "start-storybook --port 7000",
     "build:storybook": "build-storybook",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "lint": "eslint src"
   },
   "keywords": [

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -11,7 +11,7 @@
     "document": "../../../document.sh esm-utils",
     "test": "jest --config jest.config.js --passWithNoTests",
     "build": "webpack --mode=production",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx"
   },

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -10,7 +10,7 @@
     "build:production": "cross-env OMRS_ESM_IMPORTMAP_URL=\"https://spa-modules.nyc3.digitaloceanspaces.com/import-map.json\" OMRS_CONFIG_URLS=\"https://spa-modules.nyc3.digitaloceanspaces.com/@openmrs/config/config.json\" OMRS_OFFLINE=\"enable\" NODE_ENV=\"production\" webpack --mode production",
     "build:development": "cross-env OMRS_OFFLINE=\"enable\" NODE_ENV=\"development\" webpack --mode development",
     "build": "npm run build:production && npm run build:development",
-    "analyze": "webpack --mode=production --env.analyze=true",
+    "analyze": "webpack --mode=production --env analyze=true",
     "watch": "webpack serve --mode development",
     "lint": "eslint src --ext ts,tsx"
   },


### PR DESCRIPTION
## Summary

This improves the performance of loading extensions. The actual fix is in the first commit; I recommend reviewing this PR per-commit. The commits have been organized to facilitate that.

The fix prevents unnecessary calls to `configExtensionStore.setState`, which was causing lots of churn in the React reconciler. This improves the performance of clicking the user menu by about 70%; reducing the response time from about 500ms to about 140ms (when using `run:shell`, which uses a development build of React).

## Screenshots

These are profiles of what happens when you click the user menu.

Before
![Screenshot from 2021-12-02 20-26-55](https://user-images.githubusercontent.com/1031876/144673028-59428789-3708-4746-ba96-a4512d140b27.png)

After
![Screenshot from 2021-12-02 21-47-41](https://user-images.githubusercontent.com/1031876/144673048-7dd6d390-ea65-4254-92dc-c1b4068c780f.png)

## Related Issue

https://issues.openmrs.org/browse/O3-951

