### PR TITLE
Add context to global error notifications

### DIFF
--- a/packages/framework/esm-error-handling/docs/API.md
+++ b/packages/framework/esm-error-handling/docs/API.md
@@ -34,7 +34,7 @@
 
 #### Defined in
 
-[index.ts:31](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-error-handling/src/index.ts#L31)
+[index.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-error-handling/src/index.ts#L39)
 
 ___
 
@@ -80,4 +80,4 @@ ___
 
 #### Defined in
 
-[index.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-error-handling/src/index.ts#L24)
+[index.ts:32](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-error-handling/src/index.ts#L32)

--- a/packages/framework/esm-error-handling/src/index.ts
+++ b/packages/framework/esm-error-handling/src/index.ts
@@ -24,7 +24,7 @@ window.onunhandledrejection = function (error) {
   console.error(`Unhandled rejection error: ${error.reason}.`);
   dispatchNotificationShown({
     critical: true,
-    title: "Oops! An unhandled rejection occurred.",
+    title: "Oops! An unexpected error occurred.",
     description: "Please find the error description in your browser console.",
   });
 };

--- a/packages/framework/esm-error-handling/src/index.ts
+++ b/packages/framework/esm-error-handling/src/index.ts
@@ -8,16 +8,24 @@ export function handleApiError() {
   };
 }
 
-window.onerror = function () {
+window.onerror = function (message, source, error) {
+  console.error(
+    `Global error: ${message}.\nSource: ${source}.\nError: ${error}`
+  );
   dispatchNotificationShown({
-    description: "Oops! An unexpected error occurred.",
+    critical: true,
+    title: "Oops! An unexpected error occurred",
+    description: "Please find the error description in your browser console.",
   });
   return false;
 };
 
-window.onunhandledrejection = function () {
+window.onunhandledrejection = function (error) {
+  console.error(`Unhandled rejection error: ${error.reason}.`);
   dispatchNotificationShown({
-    description: "Oops! An unexpected error occurred.",
+    critical: true,
+    title: "Oops! An unhandled rejection occurred.",
+    description: "Please find the error description in your browser console.",
   });
 };
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1424,7 +1424,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-error-handling/src/index.ts:31](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-error-handling/src/index.ts#L31)
+[packages/framework/esm-error-handling/src/index.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-error-handling/src/index.ts#L39)
 
 ___
 
@@ -1677,7 +1677,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-globals/src/events.ts:81](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L81)
+[packages/framework/esm-globals/src/events.ts:79](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L79)
 
 ___
 
@@ -2977,7 +2977,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-error-handling/src/index.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-error-handling/src/index.ts#L24)
+[packages/framework/esm-error-handling/src/index.ts:32](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-error-handling/src/index.ts#L32)
 
 ___
 
@@ -3313,7 +3313,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-globals/src/events.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L87)
+[packages/framework/esm-globals/src/events.ts:85](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L85)
 
 ___
 
@@ -3394,7 +3394,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-globals/src/events.ts:95](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L95)
+[packages/framework/esm-globals/src/events.ts:93](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L93)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/ShowNotificationEvent.md
+++ b/packages/framework/esm-framework/docs/interfaces/ShowNotificationEvent.md
@@ -7,6 +7,7 @@
 ### Properties
 
 - [action](ShowNotificationEvent.md#action)
+- [critical](ShowNotificationEvent.md#critical)
 - [description](ShowNotificationEvent.md#description)
 - [kind](ShowNotificationEvent.md#kind)
 - [millis](ShowNotificationEvent.md#millis)
@@ -16,31 +17,41 @@
 
 ### action
 
-• `Optional` **action**: `any`
+• `Optional` **action**: `ReactNode`
 
 #### Defined in
 
-[packages/framework/esm-globals/src/events.ts:61](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L61)
+[packages/framework/esm-globals/src/events.ts:64](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L64)
+
+___
+
+### critical
+
+• `Optional` **critical**: `boolean`
+
+#### Defined in
+
+[packages/framework/esm-globals/src/events.ts:62](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L62)
 
 ___
 
 ### description
 
-• **description**: `any`
+• **description**: `ReactNode`
 
 #### Defined in
 
-[packages/framework/esm-globals/src/events.ts:52](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L52)
+[packages/framework/esm-globals/src/events.ts:60](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L60)
 
 ___
 
 ### kind
 
-• `Optional` **kind**: ``"error"`` \| ``"info"`` \| ``"info-square"`` \| ``"success"`` \| ``"warning"`` \| ``"warning-alt"``
+• `Optional` **kind**: `AlertType`
 
 #### Defined in
 
-[packages/framework/esm-globals/src/events.ts:53](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L53)
+[packages/framework/esm-globals/src/events.ts:61](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L61)
 
 ___
 
@@ -50,7 +61,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-globals/src/events.ts:62](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L62)
+[packages/framework/esm-globals/src/events.ts:65](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L65)
 
 ___
 
@@ -60,4 +71,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-globals/src/events.ts:60](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L60)
+[packages/framework/esm-globals/src/events.ts:63](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L63)

--- a/packages/framework/esm-framework/docs/interfaces/ShowToastEvent.md
+++ b/packages/framework/esm-framework/docs/interfaces/ShowToastEvent.md
@@ -6,6 +6,7 @@
 
 ### Properties
 
+- [critical](ShowToastEvent.md#critical)
 - [description](ShowToastEvent.md#description)
 - [kind](ShowToastEvent.md#kind)
 - [millis](ShowToastEvent.md#millis)
@@ -13,23 +14,33 @@
 
 ## Properties
 
-### description
+### critical
 
-• **description**: `any`
+• `Optional` **critical**: `boolean`
 
 #### Defined in
 
-[packages/framework/esm-globals/src/events.ts:66](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L66)
+[packages/framework/esm-globals/src/events.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L71)
+
+___
+
+### description
+
+• **description**: `ReactNode`
+
+#### Defined in
+
+[packages/framework/esm-globals/src/events.ts:69](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L69)
 
 ___
 
 ### kind
 
-• `Optional` **kind**: ``"error"`` \| ``"info"`` \| ``"info-square"`` \| ``"success"`` \| ``"warning"`` \| ``"warning-alt"``
+• `Optional` **kind**: `AlertType`
 
 #### Defined in
 
-[packages/framework/esm-globals/src/events.ts:67](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L67)
+[packages/framework/esm-globals/src/events.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L70)
 
 ___
 
@@ -39,7 +50,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-globals/src/events.ts:75](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L75)
+[packages/framework/esm-globals/src/events.ts:73](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L73)
 
 ___
 
@@ -49,4 +60,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-globals/src/events.ts:74](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L74)
+[packages/framework/esm-globals/src/events.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L72)

--- a/packages/framework/esm-globals/docs/API.md
+++ b/packages/framework/esm-globals/docs/API.md
@@ -95,7 +95,7 @@ ___
 
 #### Defined in
 
-[events.ts:81](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L81)
+[events.ts:79](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L79)
 
 ___
 
@@ -227,7 +227,7 @@ ___
 
 #### Defined in
 
-[events.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L87)
+[events.ts:85](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L85)
 
 ___
 
@@ -279,4 +279,4 @@ ___
 
 #### Defined in
 
-[events.ts:95](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L95)
+[events.ts:93](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L93)

--- a/packages/framework/esm-globals/docs/interfaces/ShowNotificationEvent.md
+++ b/packages/framework/esm-globals/docs/interfaces/ShowNotificationEvent.md
@@ -7,6 +7,7 @@
 ### Properties
 
 - [action](ShowNotificationEvent.md#action)
+- [critical](ShowNotificationEvent.md#critical)
 - [description](ShowNotificationEvent.md#description)
 - [kind](ShowNotificationEvent.md#kind)
 - [millis](ShowNotificationEvent.md#millis)
@@ -16,31 +17,41 @@
 
 ### action
 
-• `Optional` **action**: `any`
+• `Optional` **action**: `ReactNode`
 
 #### Defined in
 
-[events.ts:61](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L61)
+[events.ts:64](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L64)
+
+___
+
+### critical
+
+• `Optional` **critical**: `boolean`
+
+#### Defined in
+
+[events.ts:62](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L62)
 
 ___
 
 ### description
 
-• **description**: `any`
+• **description**: `ReactNode`
 
 #### Defined in
 
-[events.ts:52](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L52)
+[events.ts:60](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L60)
 
 ___
 
 ### kind
 
-• `Optional` **kind**: ``"error"`` \| ``"info"`` \| ``"info-square"`` \| ``"success"`` \| ``"warning"`` \| ``"warning-alt"``
+• `Optional` **kind**: `AlertType`
 
 #### Defined in
 
-[events.ts:53](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L53)
+[events.ts:61](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L61)
 
 ___
 
@@ -50,7 +61,7 @@ ___
 
 #### Defined in
 
-[events.ts:62](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L62)
+[events.ts:65](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L65)
 
 ___
 
@@ -60,4 +71,4 @@ ___
 
 #### Defined in
 
-[events.ts:60](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L60)
+[events.ts:63](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L63)

--- a/packages/framework/esm-globals/docs/interfaces/ShowToastEvent.md
+++ b/packages/framework/esm-globals/docs/interfaces/ShowToastEvent.md
@@ -6,6 +6,7 @@
 
 ### Properties
 
+- [critical](ShowToastEvent.md#critical)
 - [description](ShowToastEvent.md#description)
 - [kind](ShowToastEvent.md#kind)
 - [millis](ShowToastEvent.md#millis)
@@ -13,23 +14,33 @@
 
 ## Properties
 
-### description
+### critical
 
-• **description**: `any`
+• `Optional` **critical**: `boolean`
 
 #### Defined in
 
-[events.ts:66](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L66)
+[events.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L71)
+
+___
+
+### description
+
+• **description**: `ReactNode`
+
+#### Defined in
+
+[events.ts:69](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L69)
 
 ___
 
 ### kind
 
-• `Optional` **kind**: ``"error"`` \| ``"info"`` \| ``"info-square"`` \| ``"success"`` \| ``"warning"`` \| ``"warning-alt"``
+• `Optional` **kind**: `AlertType`
 
 #### Defined in
 
-[events.ts:67](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L67)
+[events.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L70)
 
 ___
 
@@ -39,7 +50,7 @@ ___
 
 #### Defined in
 
-[events.ts:75](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L75)
+[events.ts:73](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L73)
 
 ___
 
@@ -49,4 +60,4 @@ ___
 
 #### Defined in
 
-[events.ts:74](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L74)
+[events.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/events.ts#L72)

--- a/packages/framework/esm-globals/src/events.ts
+++ b/packages/framework/esm-globals/src/events.ts
@@ -48,29 +48,27 @@ export function subscribePrecacheStaticDependencies(
     window.removeEventListener(precacheStaticDependenciesEventName, handler);
 }
 
+type AlertType =
+  | "error"
+  | "info"
+  | "info-square"
+  | "success"
+  | "warning"
+  | "warning-alt";
+
 export interface ShowNotificationEvent {
-  description: any;
-  kind?:
-    | "error"
-    | "info"
-    | "info-square"
-    | "success"
-    | "warning"
-    | "warning-alt";
+  description: React.ReactNode;
+  kind?: AlertType;
+  critical?: boolean;
   title?: string;
-  action?: any;
+  action?: React.ReactNode;
   millis?: number;
 }
 
 export interface ShowToastEvent {
-  description: any;
-  kind?:
-    | "error"
-    | "info"
-    | "info-square"
-    | "success"
-    | "warning"
-    | "warning-alt";
+  description: React.ReactNode;
+  kind?: AlertType;
+  critical?: boolean;
   title?: string;
   millis?: number;
 }


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x]  I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Log error messages for `window.onerror` and `window.onunhandledrejection` errors in the browser console. This change adds some much-needed context to the error messages and represents a big improvement over what exists currently.

Also, this PR updates type annotation definitions for `ShowNotificationEvent` and `ShowToastEvent`.

