### PR TITLE
Fix incorrect startDatetime when starting a new visit

### DIFF
--- a/packages/framework/esm-api/docs/interfaces/NewVisitPayload.md
+++ b/packages/framework/esm-api/docs/interfaces/NewVisitPayload.md
@@ -37,7 +37,7 @@ ___
 
 ### startDatetime
 
-• **startDatetime**: `Date`
+• **startDatetime**: `string`
 
 #### Defined in
 
@@ -47,7 +47,7 @@ ___
 
 ### stopDatetime
 
-• `Optional` **stopDatetime**: `Date`
+• `Optional` **stopDatetime**: `string`
 
 #### Defined in
 

--- a/packages/framework/esm-api/src/types/visit-resource.ts
+++ b/packages/framework/esm-api/src/types/visit-resource.ts
@@ -4,9 +4,9 @@ export interface NewVisitPayload {
   uuid?: string;
   location: string;
   patient?: string;
-  startDatetime: Date;
+  startDatetime: string;
   visitType: string;
-  stopDatetime?: Date;
+  stopDatetime?: string;
 }
 
 export type UpdateVisitPayload = NewVisitPayload & {};

--- a/packages/framework/esm-framework/docs/interfaces/NewVisitPayload.md
+++ b/packages/framework/esm-framework/docs/interfaces/NewVisitPayload.md
@@ -37,7 +37,7 @@ ___
 
 ### startDatetime
 
-• **startDatetime**: `Date`
+• **startDatetime**: `string`
 
 #### Defined in
 
@@ -47,7 +47,7 @@ ___
 
 ### stopDatetime
 
-• `Optional` **stopDatetime**: `Date`
+• `Optional` **stopDatetime**: `string`
 
 #### Defined in
 


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Change the type annotation for the `startDatetime` from `Date` to `string` as we're now converting it into an ISO 8601 string before POSTing. 

Currently, starting a new visit doesn't always record the correct visit `startDateTime`. Converting the provided date value to an ISO string prior to saving it fixes this.

The actual fix will happen in the [VisitForm](https://github.com/openmrs/openmrs-esm-patient-chart/blob/master/packages/esm-patient-chart-app/src/visit/visit-form/visit-form.component.tsx) component.