### PR TITLE
Create functions for locale-sensitive date formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "lerna": "^3.20.2",
     "prettier": "^2.0.5",
     "pretty-quick": "^3.0.0",
+    "timezone-mock": "^1.2.2",
     "typedoc": "0.21.4",
     "typedoc-plugin-markdown": "^3.6.0",
     "typedoc-plugin-no-inherit": "^1.3.0",

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -700,7 +700,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:133](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L133)
+[packages/framework/esm-utils/src/omrs-dates.ts:138](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L138)
 
 ___
 
@@ -710,7 +710,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:129](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L129)
+[packages/framework/esm-utils/src/omrs-dates.ts:134](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L134)
 
 ___
 
@@ -720,7 +720,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:137](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L137)
+[packages/framework/esm-utils/src/omrs-dates.ts:142](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L142)
 
 ___
 
@@ -730,7 +730,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:124](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L124)
+[packages/framework/esm-utils/src/omrs-dates.ts:129](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L129)
 
 ___
 
@@ -740,7 +740,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:142](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L142)
+[packages/framework/esm-utils/src/omrs-dates.ts:147](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L147)
 
 ___
 
@@ -750,7 +750,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:147](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L147)
+[packages/framework/esm-utils/src/omrs-dates.ts:152](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L152)
 
 ___
 
@@ -1794,7 +1794,7 @@ https://tc39.es/ecma402/#datetimeformat-objects
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:165](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L165)
+[packages/framework/esm-utils/src/omrs-dates.ts:170](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L170)
 
 ___
 
@@ -1817,7 +1817,7 @@ Formats the input as a time, according to the current locale.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:178](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L178)
+[packages/framework/esm-utils/src/omrs-dates.ts:183](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L183)
 
 ___
 
@@ -3618,6 +3618,7 @@ ___
 
 ▸ **toOmrsDateFormat**(`date`, `format?`): `string`
 
+**`deprecated`** use `formatDate(date, DATE_FORMAT_YYYY_MMM_D)`
 Formats the input as a date string. By default the format "YYYY-MMM-DD" is used.
 
 #### Parameters
@@ -3633,7 +3634,7 @@ Formats the input as a date string. By default the format "YYYY-MMM-DD" is used.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:120](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L120)
+[packages/framework/esm-utils/src/omrs-dates.ts:125](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L125)
 
 ___
 
@@ -3641,6 +3642,7 @@ ___
 
 ▸ **toOmrsDayDateFormat**(`date`): `string`
 
+**`deprecated`** use `formatDate(date, DATE_FORMAT_YYYY_MMM_D)`
 Formats the input as a date string using the format "DD - MMM - YYYY".
 
 #### Parameters
@@ -3655,7 +3657,7 @@ Formats the input as a date string using the format "DD - MMM - YYYY".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:106](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L106)
+[packages/framework/esm-utils/src/omrs-dates.ts:109](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L109)
 
 ___
 
@@ -3686,6 +3688,7 @@ ___
 
 ▸ **toOmrsTimeString**(`date`): `string`
 
+**`deprecated`** use `formatTime`
 Formats the input as a time string using the format "HH:mm A".
 
 #### Parameters
@@ -3700,7 +3703,7 @@ Formats the input as a time string using the format "HH:mm A".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:99](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L99)
+[packages/framework/esm-utils/src/omrs-dates.ts:101](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L101)
 
 ___
 
@@ -3708,6 +3711,7 @@ ___
 
 ▸ **toOmrsTimeString24**(`date`): `string`
 
+**`deprecated`** use `formatTime`
 Formats the input as a time string using the format "HH:mm".
 
 #### Parameters
@@ -3722,7 +3726,7 @@ Formats the input as a time string using the format "HH:mm".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:92](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L92)
+[packages/framework/esm-utils/src/omrs-dates.ts:93](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L93)
 
 ___
 
@@ -3730,6 +3734,7 @@ ___
 
 ▸ **toOmrsYearlessDateFormat**(`date`): `string`
 
+**`deprecated`** use `formatDate(date, DATE_FORMAT_MMM_D)`
 Formats the input as a date string using the format "DD-MMM".
 
 #### Parameters
@@ -3744,7 +3749,7 @@ Formats the input as a date string using the format "DD-MMM".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:113](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L113)
+[packages/framework/esm-utils/src/omrs-dates.ts:117](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L117)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -389,7 +389,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L16)
+[packages/framework/esm-utils/src/omrs-dates.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L20)
 
 ___
 
@@ -409,7 +409,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:143](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L143)
+[packages/framework/esm-utils/src/omrs-dates.ts:147](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L147)
 
 ___
 
@@ -1740,7 +1740,7 @@ given format mode.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:154](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L154)
+[packages/framework/esm-utils/src/omrs-dates.ts:158](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L158)
 
 ___
 
@@ -1769,7 +1769,7 @@ output of `Date.prototype.toLocaleString` for *most* locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:216](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L216)
+[packages/framework/esm-utils/src/omrs-dates.ts:220](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L220)
 
 ___
 
@@ -1792,7 +1792,7 @@ Formats the input as a time, according to the current locale.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:200](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L200)
+[packages/framework/esm-utils/src/omrs-dates.ts:204](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L204)
 
 ___
 
@@ -2515,7 +2515,7 @@ The format should be YYYY-MM-DDTHH:mm:ss.SSSZZ
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L24)
+[packages/framework/esm-utils/src/omrs-dates.ts:28](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L28)
 
 ___
 
@@ -2535,7 +2535,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:61](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L61)
+[packages/framework/esm-utils/src/omrs-dates.ts:65](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L65)
 
 ___
 
@@ -3565,7 +3565,7 @@ Converts the object to a date object if it is a valid ISO date time string.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:68](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L68)
+[packages/framework/esm-utils/src/omrs-dates.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L72)
 
 ___
 
@@ -3609,7 +3609,7 @@ Formats the input as a date string. By default the format "YYYY-MMM-DD" is used.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:125](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L125)
+[packages/framework/esm-utils/src/omrs-dates.ts:129](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L129)
 
 ___
 
@@ -3632,7 +3632,7 @@ Formats the input as a date string using the format "DD - MMM - YYYY".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:109](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L109)
+[packages/framework/esm-utils/src/omrs-dates.ts:113](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L113)
 
 ___
 
@@ -3655,7 +3655,7 @@ Formats the input as a date time string using the format "YYYY-MM-DDTHH:mm:ss.SS
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:79](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L79)
+[packages/framework/esm-utils/src/omrs-dates.ts:83](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L83)
 
 ___
 
@@ -3678,7 +3678,7 @@ Formats the input as a time string using the format "HH:mm A".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:101](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L101)
+[packages/framework/esm-utils/src/omrs-dates.ts:105](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L105)
 
 ___
 
@@ -3701,7 +3701,7 @@ Formats the input as a time string using the format "HH:mm".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:93](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L93)
+[packages/framework/esm-utils/src/omrs-dates.ts:97](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L97)
 
 ___
 
@@ -3724,7 +3724,7 @@ Formats the input as a date string using the format "DD-MMM".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:117](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L117)
+[packages/framework/esm-utils/src/omrs-dates.ts:121](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L121)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -389,7 +389,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L20)
+[packages/framework/esm-utils/src/omrs-dates.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L19)
 
 ___
 
@@ -409,7 +409,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:147](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L147)
+[packages/framework/esm-utils/src/omrs-dates.ts:146](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L146)
 
 ___
 
@@ -1740,7 +1740,7 @@ given format mode.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:158](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L158)
+[packages/framework/esm-utils/src/omrs-dates.ts:157](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L157)
 
 ___
 
@@ -1769,7 +1769,7 @@ output of `Date.prototype.toLocaleString` for *most* locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:220](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L220)
+[packages/framework/esm-utils/src/omrs-dates.ts:219](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L219)
 
 ___
 
@@ -1792,7 +1792,7 @@ Formats the input as a time, according to the current locale.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:204](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L204)
+[packages/framework/esm-utils/src/omrs-dates.ts:203](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L203)
 
 ___
 
@@ -2515,7 +2515,7 @@ The format should be YYYY-MM-DDTHH:mm:ss.SSSZZ
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:28](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L28)
+[packages/framework/esm-utils/src/omrs-dates.ts:27](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L27)
 
 ___
 
@@ -2535,7 +2535,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:65](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L65)
+[packages/framework/esm-utils/src/omrs-dates.ts:64](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L64)
 
 ___
 
@@ -3565,7 +3565,7 @@ Converts the object to a date object if it is a valid ISO date time string.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L72)
+[packages/framework/esm-utils/src/omrs-dates.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L71)
 
 ___
 
@@ -3609,7 +3609,7 @@ Formats the input as a date string. By default the format "YYYY-MMM-DD" is used.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:129](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L129)
+[packages/framework/esm-utils/src/omrs-dates.ts:128](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L128)
 
 ___
 
@@ -3632,7 +3632,7 @@ Formats the input as a date string using the format "DD - MMM - YYYY".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:113](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L113)
+[packages/framework/esm-utils/src/omrs-dates.ts:112](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L112)
 
 ___
 
@@ -3655,7 +3655,7 @@ Formats the input as a date time string using the format "YYYY-MM-DDTHH:mm:ss.SS
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:83](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L83)
+[packages/framework/esm-utils/src/omrs-dates.ts:82](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L82)
 
 ___
 
@@ -3678,7 +3678,7 @@ Formats the input as a time string using the format "HH:mm A".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:105](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L105)
+[packages/framework/esm-utils/src/omrs-dates.ts:104](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L104)
 
 ___
 
@@ -3701,7 +3701,7 @@ Formats the input as a time string using the format "HH:mm".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:97](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L97)
+[packages/framework/esm-utils/src/omrs-dates.ts:96](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L96)
 
 ___
 
@@ -3724,7 +3724,7 @@ Formats the input as a date string using the format "DD-MMM".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:121](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L121)
+[packages/framework/esm-utils/src/omrs-dates.ts:120](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L120)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -114,6 +114,7 @@
 - [CurrentPatient](API.md#currentpatient)
 - [DateInput](API.md#dateinput)
 - [ExtensionSlotProps](API.md#extensionslotprops)
+- [FormatDateMode](API.md#formatdatemode)
 - [KnownOmrsServiceWorkerEvents](API.md#knownomrsserviceworkerevents)
 - [KnownOmrsServiceWorkerMessages](API.md#knownomrsserviceworkermessages)
 - [LayoutType](API.md#layouttype)
@@ -142,12 +143,6 @@
 ### Other Variables
 
 - [ComponentContext](API.md#componentcontext)
-- [DATE\_FORMAT\_MMM\_D](API.md#date_format_mmm_d)
-- [DATE\_FORMAT\_YYYY\_MMM](API.md#date_format_yyyy_mmm)
-- [DATE\_FORMAT\_YYYY\_MMMM\_D](API.md#date_format_yyyy_mmmm_d)
-- [DATE\_FORMAT\_YYYY\_MMM\_D](API.md#date_format_yyyy_mmm_d)
-- [DATE\_FORMAT\_YYYY\_MM\_DD](API.md#date_format_yyyy_mm_dd)
-- [DATE\_FORMAT\_YY\_MM\_DD](API.md#date_format_yy_mm_dd)
 - [Extension](API.md#extension)
 - [ExtensionSlot](API.md#extensionslot)
 - [UserHasAccess](API.md#userhasaccess)
@@ -209,6 +204,7 @@
 - [dispatchNotificationShown](API.md#dispatchnotificationshown)
 - [dispatchPrecacheStaticDependencies](API.md#dispatchprecachestaticdependencies)
 - [formatDate](API.md#formatdate)
+- [formatDatetime](API.md#formatdatetime)
 - [formatTime](API.md#formattime)
 - [generateOfflineUuid](API.md#generateofflineuuid)
 - [getAppState](API.md#getappstate)
@@ -404,6 +400,16 @@ ___
 #### Defined in
 
 [packages/framework/esm-react-utils/src/ExtensionSlot.tsx:54](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L54)
+
+___
+
+### FormatDateMode
+
+Ƭ **FormatDateMode**: ``"standard"`` \| ``"no year"`` \| ``"no day"`` \| ``"wide"``
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:143](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L143)
 
 ___
 
@@ -691,66 +697,6 @@ Available to all components. Provided by `openmrsComponentDecorator`.
 #### Defined in
 
 [packages/framework/esm-react-utils/src/ComponentContext.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ComponentContext.ts#L17)
-
-___
-
-### DATE\_FORMAT\_MMM\_D
-
-• `Const` **DATE\_FORMAT\_MMM\_D**: `Intl.DateTimeFormatOptions`
-
-#### Defined in
-
-[packages/framework/esm-utils/src/omrs-dates.ts:138](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L138)
-
-___
-
-### DATE\_FORMAT\_YYYY\_MMM
-
-• `Const` **DATE\_FORMAT\_YYYY\_MMM**: `Intl.DateTimeFormatOptions`
-
-#### Defined in
-
-[packages/framework/esm-utils/src/omrs-dates.ts:134](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L134)
-
-___
-
-### DATE\_FORMAT\_YYYY\_MMMM\_D
-
-• `Const` **DATE\_FORMAT\_YYYY\_MMMM\_D**: `Intl.DateTimeFormatOptions`
-
-#### Defined in
-
-[packages/framework/esm-utils/src/omrs-dates.ts:142](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L142)
-
-___
-
-### DATE\_FORMAT\_YYYY\_MMM\_D
-
-• `Const` **DATE\_FORMAT\_YYYY\_MMM\_D**: `Intl.DateTimeFormatOptions`
-
-#### Defined in
-
-[packages/framework/esm-utils/src/omrs-dates.ts:129](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L129)
-
-___
-
-### DATE\_FORMAT\_YYYY\_MM\_DD
-
-• `Const` **DATE\_FORMAT\_YYYY\_MM\_DD**: `Intl.DateTimeFormatOptions`
-
-#### Defined in
-
-[packages/framework/esm-utils/src/omrs-dates.ts:147](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L147)
-
-___
-
-### DATE\_FORMAT\_YY\_MM\_DD
-
-• `Const` **DATE\_FORMAT\_YY\_MM\_DD**: `Intl.DateTimeFormatOptions`
-
-#### Defined in
-
-[packages/framework/esm-utils/src/omrs-dates.ts:152](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L152)
 
 ___
 
@@ -1771,22 +1717,22 @@ ___
 
 ### formatDate
 
-▸ **formatDate**(`date`, `options?`): `string`
+▸ **formatDate**(`date`, `mode?`): `string`
 
 Formats the input date according to the current locale and the
-given format. The default format has a 4-digit year and an
-abbreviated month name.
+given format mode.
 
-Documentation for the `options` parameter, which is a
-DateTimeFormat object, can be found here:
-https://tc39.es/ecma402/#datetimeformat-objects
+`standard`: "13 Dec 2021"
+`no year`:  "13 Dec"
+`no day`:   "Dec 2021"
+`wide`:     "13 — Dec — 2021"
 
 #### Parameters
 
-| Name | Type | Description |
+| Name | Type | Default value |
 | :------ | :------ | :------ |
-| `date` | `Date` | The date to be formatted |
-| `options` | `Intl.DateTimeFormatOptions` | A DateTimeFormat object |
+| `date` | `Date` | `undefined` |
+| `mode` | [`FormatDateMode`](API.md#formatdatemode) | `"standard"` |
 
 #### Returns
 
@@ -1794,7 +1740,36 @@ https://tc39.es/ecma402/#datetimeformat-objects
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:170](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L170)
+[packages/framework/esm-utils/src/omrs-dates.ts:154](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L154)
+
+___
+
+### formatDatetime
+
+▸ **formatDatetime**(`date`, `mode?`): `string`
+
+Formats the input into a string showing the date and time, according
+to the current locale. The `mode` parameter is as described for
+`formatDate`.
+
+This is created by concatenating the results of `formatDate`
+and `formatTime` with a comma and space. This agrees with the
+output of `Date.prototype.toLocaleString` for *most* locales.
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `date` | `Date` | `undefined` |
+| `mode` | [`FormatDateMode`](API.md#formatdatemode) | `"standard"` |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:216](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L216)
 
 ___
 
@@ -1817,7 +1792,7 @@ Formats the input as a time, according to the current locale.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:183](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L183)
+[packages/framework/esm-utils/src/omrs-dates.ts:200](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L200)
 
 ___
 
@@ -3618,7 +3593,7 @@ ___
 
 ▸ **toOmrsDateFormat**(`date`, `format?`): `string`
 
-**`deprecated`** use `formatDate(date, DATE_FORMAT_YYYY_MMM_D)`
+**`deprecated`** use `formatDate(date)`
 Formats the input as a date string. By default the format "YYYY-MMM-DD" is used.
 
 #### Parameters
@@ -3642,7 +3617,7 @@ ___
 
 ▸ **toOmrsDayDateFormat**(`date`): `string`
 
-**`deprecated`** use `formatDate(date, DATE_FORMAT_YYYY_MMM_D)`
+**`deprecated`** use `formatDate(date, "wide")`
 Formats the input as a date string using the format "DD - MMM - YYYY".
 
 #### Parameters
@@ -3734,7 +3709,7 @@ ___
 
 ▸ **toOmrsYearlessDateFormat**(`date`): `string`
 
-**`deprecated`** use `formatDate(date, DATE_FORMAT_MMM_D)`
+**`deprecated`** use `formatDate(date, "no year")`
 Formats the input as a date string using the format "DD-MMM".
 
 #### Parameters

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -142,6 +142,12 @@
 ### Other Variables
 
 - [ComponentContext](API.md#componentcontext)
+- [DATE\_FORMAT\_MMM\_D](API.md#date_format_mmm_d)
+- [DATE\_FORMAT\_YYYY\_MMM](API.md#date_format_yyyy_mmm)
+- [DATE\_FORMAT\_YYYY\_MMMM\_D](API.md#date_format_yyyy_mmmm_d)
+- [DATE\_FORMAT\_YYYY\_MMM\_D](API.md#date_format_yyyy_mmm_d)
+- [DATE\_FORMAT\_YYYY\_MM\_DD](API.md#date_format_yyyy_mm_dd)
+- [DATE\_FORMAT\_YY\_MM\_DD](API.md#date_format_yy_mm_dd)
 - [Extension](API.md#extension)
 - [ExtensionSlot](API.md#extensionslot)
 - [UserHasAccess](API.md#userhasaccess)
@@ -202,6 +208,8 @@
 - [dispatchNetworkRequestFailed](API.md#dispatchnetworkrequestfailed)
 - [dispatchNotificationShown](API.md#dispatchnotificationshown)
 - [dispatchPrecacheStaticDependencies](API.md#dispatchprecachestaticdependencies)
+- [formatDate](API.md#formatdate)
+- [formatTime](API.md#formattime)
 - [generateOfflineUuid](API.md#generateofflineuuid)
 - [getAppState](API.md#getappstate)
 - [getAssignedIds](API.md#getassignedids)
@@ -385,7 +393,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L8)
+[packages/framework/esm-utils/src/omrs-dates.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L16)
 
 ___
 
@@ -683,6 +691,66 @@ Available to all components. Provided by `openmrsComponentDecorator`.
 #### Defined in
 
 [packages/framework/esm-react-utils/src/ComponentContext.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ComponentContext.ts#L17)
+
+___
+
+### DATE\_FORMAT\_MMM\_D
+
+• `Const` **DATE\_FORMAT\_MMM\_D**: `Intl.DateTimeFormatOptions`
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:133](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L133)
+
+___
+
+### DATE\_FORMAT\_YYYY\_MMM
+
+• `Const` **DATE\_FORMAT\_YYYY\_MMM**: `Intl.DateTimeFormatOptions`
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:129](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L129)
+
+___
+
+### DATE\_FORMAT\_YYYY\_MMMM\_D
+
+• `Const` **DATE\_FORMAT\_YYYY\_MMMM\_D**: `Intl.DateTimeFormatOptions`
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:137](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L137)
+
+___
+
+### DATE\_FORMAT\_YYYY\_MMM\_D
+
+• `Const` **DATE\_FORMAT\_YYYY\_MMM\_D**: `Intl.DateTimeFormatOptions`
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:124](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L124)
+
+___
+
+### DATE\_FORMAT\_YYYY\_MM\_DD
+
+• `Const` **DATE\_FORMAT\_YYYY\_MM\_DD**: `Intl.DateTimeFormatOptions`
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:142](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L142)
+
+___
+
+### DATE\_FORMAT\_YY\_MM\_DD
+
+• `Const` **DATE\_FORMAT\_YY\_MM\_DD**: `Intl.DateTimeFormatOptions`
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:147](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L147)
 
 ___
 
@@ -1701,6 +1769,58 @@ ___
 
 ___
 
+### formatDate
+
+▸ **formatDate**(`date`, `options?`): `string`
+
+Formats the input date according to the current locale and the
+given format. The default format has a 4-digit year and an
+abbreviated month name.
+
+Documentation for the `options` parameter, which is a
+DateTimeFormat object, can be found here:
+https://tc39.es/ecma402/#datetimeformat-objects
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `date` | `Date` | The date to be formatted |
+| `options` | `Intl.DateTimeFormatOptions` | A DateTimeFormat object |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:165](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L165)
+
+___
+
+### formatTime
+
+▸ **formatTime**(`date`): `string`
+
+Formats the input as a time, according to the current locale.
+12-hour or 24-hour clock depends on locale.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `date` | `Date` |
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:178](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L178)
+
+___
+
 ### generateOfflineUuid
 
 ▸ **generateOfflineUuid**(): `string`
@@ -2420,7 +2540,7 @@ The format should be YYYY-MM-DDTHH:mm:ss.SSSZZ
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L16)
+[packages/framework/esm-utils/src/omrs-dates.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L24)
 
 ___
 
@@ -2440,7 +2560,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:53](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L53)
+[packages/framework/esm-utils/src/omrs-dates.ts:61](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L61)
 
 ___
 
@@ -3470,7 +3590,7 @@ Converts the object to a date object if it is a valid ISO date time string.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:60](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L60)
+[packages/framework/esm-utils/src/omrs-dates.ts:68](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L68)
 
 ___
 
@@ -3513,7 +3633,7 @@ Formats the input as a date string. By default the format "YYYY-MMM-DD" is used.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:112](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L112)
+[packages/framework/esm-utils/src/omrs-dates.ts:120](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L120)
 
 ___
 
@@ -3535,7 +3655,7 @@ Formats the input as a date string using the format "DD - MMM - YYYY".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:98](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L98)
+[packages/framework/esm-utils/src/omrs-dates.ts:106](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L106)
 
 ___
 
@@ -3558,7 +3678,7 @@ Formats the input as a date time string using the format "YYYY-MM-DDTHH:mm:ss.SS
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L71)
+[packages/framework/esm-utils/src/omrs-dates.ts:79](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L79)
 
 ___
 
@@ -3580,7 +3700,7 @@ Formats the input as a time string using the format "HH:mm A".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:91](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L91)
+[packages/framework/esm-utils/src/omrs-dates.ts:99](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L99)
 
 ___
 
@@ -3602,7 +3722,7 @@ Formats the input as a time string using the format "HH:mm".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:84](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L84)
+[packages/framework/esm-utils/src/omrs-dates.ts:92](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L92)
 
 ___
 
@@ -3624,7 +3744,7 @@ Formats the input as a date string using the format "DD-MMM".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:105](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L105)
+[packages/framework/esm-utils/src/omrs-dates.ts:113](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L113)
 
 ___
 

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -43,7 +43,8 @@
   },
   "peerDependencies": {
     "dayjs": "1.x",
-    "rxjs": "6.x"
+    "rxjs": "6.x",
+    "i18next": "19.x"
   },
   "dependencies": {
     "semver": "^7.3.2"

--- a/packages/framework/esm-utils/src/omrs-dates.test.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.test.ts
@@ -6,6 +6,9 @@ import {
 import dayjs from "dayjs";
 import timezoneMock from "timezone-mock";
 import { formatDate, formatDatetime, formatTime } from ".";
+import { i18n } from "i18next";
+
+window.i18next = { language: "en" } as i18n;
 
 describe("Openmrs Dates", () => {
   it("converts js Date object to omrs date string version", () => {
@@ -46,44 +49,44 @@ describe("Openmrs Dates", () => {
 
   it("formats 'Today' with respect to the locale", () => {
     const testDate = new Date();
-    window.i18next = { language: "en" };
+    window.i18next.language = "en";
     expect(formatDate(testDate)).toEqual("Today");
     expect(formatDate(testDate, "no day")).toEqual("Today");
     expect(formatDate(testDate, "no year")).toEqual("Today");
     expect(formatDate(testDate, "wide")).toEqual("Today");
-    window.i18next = { language: "sw" };
+    window.i18next.language = "sw";
     expect(formatDate(testDate)).toEqual("Leo");
-    window.i18next = { language: "ru" };
+    window.i18next.language = "ru";
     expect(formatDate(testDate)).toEqual("Сегодня");
   });
 
   it("formats dates with respect to the locale", () => {
     timezoneMock.register("UTC");
     const testDate = new Date("2021-12-09");
-    window.i18next = { language: "en" };
+    window.i18next.language = "en";
     expect(formatDate(testDate)).toEqual("09-Dec-2021");
     expect(formatDate(testDate, "no day")).toEqual("Dec 2021");
     expect(formatDate(testDate, "no year")).toEqual("09 Dec");
     expect(formatDate(testDate, "wide")).toEqual("09 — Dec — 2021");
-    window.i18next = { language: "fr" };
+    window.i18next.language = "fr";
     expect(formatDate(testDate)).toEqual("09 déc. 2021");
     expect(formatDate(testDate, "no day")).toEqual("déc. 2021");
     expect(formatDate(testDate, "no year")).toEqual("09 déc.");
     expect(formatDate(testDate, "wide")).toEqual("09 — déc. — 2021");
-    window.i18next = { language: "sw" };
+    window.i18next.language = "sw";
     expect(formatDate(testDate)).toEqual("09 Des 2021");
-    window.i18next = { language: "ru" };
+    window.i18next.language = "ru";
     expect(formatDate(testDate, "wide")).toEqual("09 — дек. — 2021 г.");
   });
 
   it("formats times with respect to the locale", () => {
     timezoneMock.register("Australia/Adelaide");
     const testDate = new Date("2021-12-09T13:15:33");
-    window.i18next = { language: "en" };
+    window.i18next.language = "en";
     expect(formatTime(testDate)).toEqual("01:15 PM");
-    window.i18next = { language: "es-CO" };
+    window.i18next.language = "es-CO";
     expect(formatTime(testDate)).toMatch(/1:15 p.\sm./); // it's not a normal space between the 'p.' and 'm.'
-    window.i18next = { language: "es-MX" };
+    window.i18next.language = "es-MX";
     expect(formatTime(testDate)).toEqual("13:15");
   });
 
@@ -93,10 +96,10 @@ describe("Openmrs Dates", () => {
     const todayDate = new Date();
     todayDate.setHours(15);
     todayDate.setMinutes(20);
-    window.i18next = { language: "en" };
+    window.i18next.language = "en";
     expect(formatDatetime(testDate)).toEqual("09-Feb-2022, 01:15 PM");
     expect(formatDatetime(todayDate)).toEqual("Today, 03:20 PM");
-    window.i18next = { language: "ht" };
+    window.i18next.language = "ht";
     expect(formatDatetime(testDate)).toEqual("09 févr. 2022, 13:15");
     expect(formatDatetime(todayDate)).toEqual("Aujourd’hui, 15:20");
   });

--- a/packages/framework/esm-utils/src/omrs-dates.test.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.test.ts
@@ -90,9 +90,14 @@ describe("Openmrs Dates", () => {
   it("formats datetimes with respect to the locale", () => {
     timezoneMock.register("US/Pacific");
     const testDate = new Date("2022-02-09T13:15:33");
+    const todayDate = new Date();
+    todayDate.setHours(15);
+    todayDate.setMinutes(20);
     window.i18next = { language: "en" };
     expect(formatDatetime(testDate)).toEqual("09-Feb-2022, 01:15 PM");
+    expect(formatDatetime(todayDate)).toEqual("Today, 03:20 PM");
     window.i18next = { language: "ht" };
     expect(formatDatetime(testDate)).toEqual("09 févr. 2022, 13:15");
+    expect(formatDatetime(todayDate)).toEqual("Aujourd’hui, 15:20");
   });
 });

--- a/packages/framework/esm-utils/src/omrs-dates.test.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.test.ts
@@ -4,6 +4,17 @@ import {
   isOmrsDateStrict,
 } from "./omrs-dates";
 import dayjs from "dayjs";
+import timezoneMock from "timezone-mock";
+import {
+  DATE_FORMAT_MMM_D,
+  DATE_FORMAT_YYYY_MMM,
+  DATE_FORMAT_YYYY_MMMM_D,
+  DATE_FORMAT_YYYY_MMM_D,
+  DATE_FORMAT_YYYY_MM_DD,
+  DATE_FORMAT_YY_MM_DD,
+  formatDate,
+  formatTime,
+} from ".";
 
 describe("Openmrs Dates", () => {
   it("converts js Date object to omrs date string version", () => {
@@ -40,5 +51,30 @@ describe("Openmrs Dates", () => {
       "YYYY-MM-DDTHH:mm:ss.SSSZZ"
     ).toDate();
     expect(toOmrsIsoString(date, true)).toEqual("2018-03-18T21:05:03.999+0000");
+  });
+
+  it("formats dates with respect to the locale", () => {
+    timezoneMock.register("UTC");
+    window.i18next = { language: "fr" };
+    const testDate = new Date("2021-12-09");
+    expect(formatDate(testDate, DATE_FORMAT_YYYY_MMM_D)).toEqual("9 déc. 2021");
+    expect(formatDate(testDate, DATE_FORMAT_YYYY_MMM)).toEqual("déc. 2021");
+    expect(formatDate(testDate, DATE_FORMAT_MMM_D)).toEqual("9 déc.");
+    expect(formatDate(testDate, DATE_FORMAT_YYYY_MMMM_D)).toEqual(
+      "9 décembre 2021"
+    );
+    expect(formatDate(testDate, DATE_FORMAT_YYYY_MM_DD)).toEqual("09/12/2021");
+    expect(formatDate(testDate, DATE_FORMAT_YY_MM_DD)).toEqual("09/12/21");
+    window.i18next = { language: "sw" };
+    expect(formatDate(testDate, DATE_FORMAT_YYYY_MMM_D)).toEqual("9 Des 2021");
+  });
+
+  it("formats times with respect to the locale", () => {
+    timezoneMock.register("Australia/Adelaide");
+    const testDate = new Date("2021-12-09T13:15:33");
+    window.i18next = { language: "es-CO" };
+    expect(formatTime(testDate)).toMatch(/1:15 p.\sm./); // it's not a normal space between the 'p.' and 'm.'
+    window.i18next = { language: "es-MX" };
+    expect(formatTime(testDate)).toMatch(/13:15/);
   });
 });

--- a/packages/framework/esm-utils/src/omrs-dates.test.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.test.ts
@@ -13,6 +13,7 @@ import {
   DATE_FORMAT_YYYY_MM_DD,
   DATE_FORMAT_YY_MM_DD,
   formatDate,
+  formatDatetime,
   formatTime,
 } from ".";
 
@@ -76,5 +77,12 @@ describe("Openmrs Dates", () => {
     expect(formatTime(testDate)).toMatch(/1:15 p.\sm./); // it's not a normal space between the 'p.' and 'm.'
     window.i18next = { language: "es-MX" };
     expect(formatTime(testDate)).toMatch(/13:15/);
+  });
+
+  xit("formats datetimes with respect to the locale [disabled because of https://github.com/Jimbly/timezone-mock/issues/53]", () => {
+    timezoneMock.register("US/Pacific");
+    const testDate = new Date("2022-02-09T13:15:33");
+    window.i18next = { language: "ht" };
+    expect(formatDatetime(testDate)).toEqual("9 feb. 2022 á 13:15");
   });
 });

--- a/packages/framework/esm-utils/src/omrs-dates.test.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.test.ts
@@ -5,17 +5,7 @@ import {
 } from "./omrs-dates";
 import dayjs from "dayjs";
 import timezoneMock from "timezone-mock";
-import {
-  DATE_FORMAT_MMM_D,
-  DATE_FORMAT_YYYY_MMM,
-  DATE_FORMAT_YYYY_MMMM_D,
-  DATE_FORMAT_YYYY_MMM_D,
-  DATE_FORMAT_YYYY_MM_DD,
-  DATE_FORMAT_YY_MM_DD,
-  formatDate,
-  formatDatetime,
-  formatTime,
-} from ".";
+import { formatDate, formatDatetime, formatTime } from ".";
 
 describe("Openmrs Dates", () => {
   it("converts js Date object to omrs date string version", () => {
@@ -54,35 +44,55 @@ describe("Openmrs Dates", () => {
     expect(toOmrsIsoString(date, true)).toEqual("2018-03-18T21:05:03.999+0000");
   });
 
+  it("formats 'Today' with respect to the locale", () => {
+    const testDate = new Date();
+    window.i18next = { language: "en" };
+    expect(formatDate(testDate)).toEqual("Today");
+    expect(formatDate(testDate, "no day")).toEqual("Today");
+    expect(formatDate(testDate, "no year")).toEqual("Today");
+    expect(formatDate(testDate, "wide")).toEqual("Today");
+    window.i18next = { language: "sw" };
+    expect(formatDate(testDate)).toEqual("Leo");
+    window.i18next = { language: "ru" };
+    expect(formatDate(testDate)).toEqual("Сегодня");
+  });
+
   it("formats dates with respect to the locale", () => {
     timezoneMock.register("UTC");
-    window.i18next = { language: "fr" };
     const testDate = new Date("2021-12-09");
-    expect(formatDate(testDate, DATE_FORMAT_YYYY_MMM_D)).toEqual("9 déc. 2021");
-    expect(formatDate(testDate, DATE_FORMAT_YYYY_MMM)).toEqual("déc. 2021");
-    expect(formatDate(testDate, DATE_FORMAT_MMM_D)).toEqual("9 déc.");
-    expect(formatDate(testDate, DATE_FORMAT_YYYY_MMMM_D)).toEqual(
-      "9 décembre 2021"
-    );
-    expect(formatDate(testDate, DATE_FORMAT_YYYY_MM_DD)).toEqual("09/12/2021");
-    expect(formatDate(testDate, DATE_FORMAT_YY_MM_DD)).toEqual("09/12/21");
+    window.i18next = { language: "en" };
+    expect(formatDate(testDate)).toEqual("09-Dec-2021");
+    expect(formatDate(testDate, "no day")).toEqual("Dec 2021");
+    expect(formatDate(testDate, "no year")).toEqual("09 Dec");
+    expect(formatDate(testDate, "wide")).toEqual("09 — Dec — 2021");
+    window.i18next = { language: "fr" };
+    expect(formatDate(testDate)).toEqual("09 déc. 2021");
+    expect(formatDate(testDate, "no day")).toEqual("déc. 2021");
+    expect(formatDate(testDate, "no year")).toEqual("09 déc.");
+    expect(formatDate(testDate, "wide")).toEqual("09 — déc. — 2021");
     window.i18next = { language: "sw" };
-    expect(formatDate(testDate, DATE_FORMAT_YYYY_MMM_D)).toEqual("9 Des 2021");
+    expect(formatDate(testDate)).toEqual("09 Des 2021");
+    window.i18next = { language: "ru" };
+    expect(formatDate(testDate, "wide")).toEqual("09 — дек. — 2021 г.");
   });
 
   it("formats times with respect to the locale", () => {
     timezoneMock.register("Australia/Adelaide");
     const testDate = new Date("2021-12-09T13:15:33");
+    window.i18next = { language: "en" };
+    expect(formatTime(testDate)).toEqual("01:15 PM");
     window.i18next = { language: "es-CO" };
     expect(formatTime(testDate)).toMatch(/1:15 p.\sm./); // it's not a normal space between the 'p.' and 'm.'
     window.i18next = { language: "es-MX" };
-    expect(formatTime(testDate)).toMatch(/13:15/);
+    expect(formatTime(testDate)).toEqual("13:15");
   });
 
-  xit("formats datetimes with respect to the locale [disabled because of https://github.com/Jimbly/timezone-mock/issues/53]", () => {
+  it("formats datetimes with respect to the locale", () => {
     timezoneMock.register("US/Pacific");
     const testDate = new Date("2022-02-09T13:15:33");
+    window.i18next = { language: "en" };
+    expect(formatDatetime(testDate)).toEqual("09-Feb-2022, 01:15 PM");
     window.i18next = { language: "ht" };
-    expect(formatDatetime(testDate)).toEqual("9 feb. 2022 á 13:15");
+    expect(formatDatetime(testDate)).toEqual("09 févr. 2022, 13:15");
   });
 });

--- a/packages/framework/esm-utils/src/omrs-dates.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.ts
@@ -1,3 +1,8 @@
+/**
+ * @module
+ * @category Date and time
+ */
+import { i18n } from "i18next";
 import dayjs from "dayjs";
 import utc from "dayjs/plugin/utc";
 import isToday from "dayjs/plugin/isToday";
@@ -7,9 +12,7 @@ dayjs.extend(isToday);
 
 declare global {
   interface Window {
-    i18next: {
-      language: string;
-    };
+    i18next: i18n;
   }
 }
 

--- a/packages/framework/esm-utils/src/omrs-dates.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.ts
@@ -5,6 +5,14 @@ import isToday from "dayjs/plugin/isToday";
 dayjs.extend(utc);
 dayjs.extend(isToday);
 
+declare global {
+  interface Window {
+    i18next: {
+      language: string;
+    };
+  }
+}
+
 export type DateInput = string | number | Date;
 
 const isoFormat = "YYYY-MM-DDTHH:mm:ss.SSSZZ";
@@ -111,4 +119,75 @@ export function toOmrsYearlessDateFormat(date: DateInput) {
  */
 export function toOmrsDateFormat(date: DateInput, format = "YYYY-MMM-DD") {
   return dayjs(date).format(format);
+}
+
+export const DATE_FORMAT_YYYY_MMM_D: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+};
+export const DATE_FORMAT_YYYY_MMM: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+};
+export const DATE_FORMAT_MMM_D: Intl.DateTimeFormatOptions = {
+  month: "short",
+  day: "numeric",
+};
+export const DATE_FORMAT_YYYY_MMMM_D: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "long",
+  day: "numeric",
+};
+export const DATE_FORMAT_YYYY_MM_DD: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "2-digit",
+  day: "2-digit",
+};
+export const DATE_FORMAT_YY_MM_DD: Intl.DateTimeFormatOptions = {
+  year: "2-digit",
+  month: "2-digit",
+  day: "2-digit",
+};
+
+/**
+ * Formats the input date according to the current locale and the
+ * given format. The default format has a 4-digit year and an
+ * abbreviated month name.
+ *
+ * Documentation for the `options` parameter, which is a
+ * DateTimeFormat object, can be found here:
+ * https://tc39.es/ecma402/#datetimeformat-objects
+ *
+ * @param date The date to be formatted
+ * @param options A DateTimeFormat object
+ */
+export function formatDate(
+  date: Date,
+  options: Intl.DateTimeFormatOptions = DATE_FORMAT_YYYY_MMM_D
+) {
+  return date.toLocaleDateString(getLocale(), options);
+}
+
+/**
+ * Formats the input as a time, according to the current locale.
+ * 12-hour or 24-hour clock depends on locale.
+ *
+ * @param date
+ */
+export function formatTime(date: Date) {
+  return date.toLocaleTimeString(getLocale(), {
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+function getLocale() {
+  let language = window.i18next.language;
+  language = language.replace("_", "-");
+  // hack for `ht` until https://unicode-org.atlassian.net/browse/CLDR-14956 is fixed
+  if (language === "ht") {
+    language = "fr-HT";
+  }
+  return language;
 }

--- a/packages/framework/esm-utils/src/omrs-dates.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.ts
@@ -177,10 +177,10 @@ export function formatDate(date: Date, mode: FormatDateMode = "standard") {
     let localeString = date.toLocaleDateString(locale, options);
     if (locale == "en-GB" && mode == "standard") {
       // Custom formatting for English. Use hyphens instead of spaces.
-      localeString = localeString.replaceAll(" ", "-");
+      localeString = localeString.replace(/ /g, "-");
     }
     if (mode == "wide") {
-      localeString = localeString.replaceAll(" ", " — "); // space-emdash-space
+      localeString = localeString.replace(/ /g, " — "); // space-emdash-space
       if (/ru.*/.test(locale)) {
         // Remove the extra em-dash that gets added between the year and the suffix 'r.'
         const len = localeString.length;

--- a/packages/framework/esm-utils/src/omrs-dates.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.ts
@@ -87,6 +87,7 @@ export function toOmrsIsoString(date: DateInput, toUTC = false): string {
 }
 
 /**
+ * @deprecated use `formatTime`
  * Formats the input as a time string using the format "HH:mm".
  */
 export function toOmrsTimeString24(date: DateInput) {
@@ -94,6 +95,7 @@ export function toOmrsTimeString24(date: DateInput) {
 }
 
 /**
+ * @deprecated use `formatTime`
  * Formats the input as a time string using the format "HH:mm A".
  */
 export function toOmrsTimeString(date: DateInput) {
@@ -101,6 +103,7 @@ export function toOmrsTimeString(date: DateInput) {
 }
 
 /**
+ * @deprecated use `formatDate(date, DATE_FORMAT_YYYY_MMM_D)`
  * Formats the input as a date string using the format "DD - MMM - YYYY".
  */
 export function toOmrsDayDateFormat(date: DateInput) {
@@ -108,6 +111,7 @@ export function toOmrsDayDateFormat(date: DateInput) {
 }
 
 /**
+ * @deprecated use `formatDate(date, DATE_FORMAT_MMM_D)`
  * Formats the input as a date string using the format "DD-MMM".
  */
 export function toOmrsYearlessDateFormat(date: DateInput) {
@@ -115,6 +119,7 @@ export function toOmrsYearlessDateFormat(date: DateInput) {
 }
 
 /**
+ * @deprecated use `formatDate(date, DATE_FORMAT_YYYY_MMM_D)`
  * Formats the input as a date string. By default the format "YYYY-MMM-DD" is used.
  */
 export function toOmrsDateFormat(date: DateInput, format = "YYYY-MMM-DD") {

--- a/packages/framework/esm-utils/src/omrs-dates.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.ts
@@ -187,6 +187,21 @@ export function formatTime(date: Date) {
   });
 }
 
+export const DATETIME_FORMAT_YYYY_MMM_D: Intl.DateTimeFormatOptions = {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "numeric",
+};
+
+export function formatDatetime(
+  date: Date,
+  options: Intl.DateTimeFormatOptions = DATETIME_FORMAT_YYYY_MMM_D
+) {
+  return date.toLocaleString(getLocale(), options);
+}
+
 function getLocale() {
   let language = window.i18next.language;
   language = language.replace("_", "-");

--- a/yarn.lock
+++ b/yarn.lock
@@ -16514,6 +16514,11 @@ timers-browserify@^2.0.4:
   dependencies:
     setimmediate "^1.0.4"
 
+timezone-mock@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/timezone-mock/-/timezone-mock-1.2.2.tgz#d7e047b30827ba34e4824bf3d6ff88ffc284b4fb"
+  integrity sha512-/tKX2gEuZHs/APPLLryuwBfMBa7esdfIICqHVmcnCr7tMfl3X+L8aXzuAsnaoB6nIFQp9N03e5Gt1QiKPlUmPw==
+
 timm@^1.6.1:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/timm/-/timm-1.7.1.tgz#96bab60c7d45b5a10a8a4d0f0117c6b7e5aff76f"


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

## Summary

This creates date and time formatting functions which are locale sensitive and which limit the available formats to those recommended by the design team.
