### PR TITLE
Make URL query parameter for language 'lang' instead of 'lng'

### DIFF
--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -73,6 +73,7 @@ export function setupI18n() {
       },
       detection: {
         order: ["querystring", "htmlTag", "localStorage", "navigator"],
+        lookupQuerystring: "lang",
       },
       fallbackLng: "en",
     });


### PR DESCRIPTION
This brings it into agreement with RefApp 2.x.