### PR TITLE
Add parseDate function

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -13,6 +13,7 @@
   - [Design Conventions](/main/carbon.md)
   - [Dependencies](/main/deps.md)
   - [Retrieving and Posting Data](/main/data.md)
+  - [Dates](/main/dates.md)
   - [Extension System](/main/extensions.md)
   - [Configuration System](/main/config.md)
   - [Sharing State](/main/state.md)

--- a/docs/main/dates.md
+++ b/docs/main/dates.md
@@ -1,0 +1,29 @@
+# Working with Dates
+
+The OpenMRS Frontend Framework provides several utilities for working with
+dates. These have been designed with locale-sensitivity as a key concern.
+Acceptable date formats vary by language and region, and these functions
+are intended to accomodate that variation.
+
+## Formatting for display
+
+Date objects can be displayed in a variety of standard formats using the
+[formatDate](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/docs/API.md#formatdate),
+[formatTime](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/docs/API.md#formattime), and
+[formatDatetime](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/docs/API.md#formatdatetime)
+functions. These functions format dates in ways that are both adaptable
+(using the `mode` parameter) and localized according to the user's locale.
+
+## Formatting to send to the server
+
+Dates sent in the request body via `openmrsFetch` are automatically
+formatted into ISO-8601 format.
+
+## Parsing
+
+The ISO-8601 date strings sent by the server can be parsed into Javascript
+`Date` objects using the
+[parseDate](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/docs/API.md#parsedate)
+function. This uses [dayjs](https://day.js.org/docs/en/parse/string) for
+parsing.
+

--- a/docs/main/dates.md
+++ b/docs/main/dates.md
@@ -14,6 +14,11 @@ Date objects can be displayed in a variety of standard formats using the
 functions. These functions format dates in ways that are both adaptable
 (using the `mode` parameter) and localized according to the user's locale.
 
+Date strings produced by these formatting functions should never be
+used for comparisons or other kinds of date math. It is recommended
+to format dates for display as close to the "view" or "render" as
+possible to minimize the risk of this happening.
+
 ## Formatting to send to the server
 
 Dates sent in the request body via `openmrsFetch` are automatically

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -245,6 +245,7 @@
 - [messageOmrsServiceWorker](API.md#messageomrsserviceworker)
 - [openVisitsNoteWorkspace](API.md#openvisitsnoteworkspace)
 - [openmrsComponentDecorator](API.md#openmrscomponentdecorator)
+- [parseDate](API.md#parsedate)
 - [patchXMLHttpRequest](API.md#patchxmlhttprequest)
 - [processConfig](API.md#processconfig)
 - [provide](API.md#provide)
@@ -397,7 +398,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:146](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L146)
+[packages/framework/esm-utils/src/omrs-dates.ts:154](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L154)
 
 ___
 
@@ -1728,7 +1729,7 @@ given format mode.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:157](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L157)
+[packages/framework/esm-utils/src/omrs-dates.ts:165](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L165)
 
 ___
 
@@ -1757,7 +1758,7 @@ output of `Date.prototype.toLocaleString` for *most* locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:219](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L219)
+[packages/framework/esm-utils/src/omrs-dates.ts:227](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L227)
 
 ___
 
@@ -1780,7 +1781,7 @@ Formats the input as a time, according to the current locale.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:203](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L203)
+[packages/framework/esm-utils/src/omrs-dates.ts:211](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L211)
 
 ___
 
@@ -2682,6 +2683,29 @@ ___
 #### Defined in
 
 [packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx:71](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx#L71)
+
+___
+
+### parseDate
+
+▸ **parseDate**(`dateString`): `Date`
+
+Utility function to parse an arbitrary string into a date.
+Uses `dayjs(dateString)`.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `dateString` | `string` |
+
+#### Returns
+
+`Date`
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:136](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L136)
 
 ___
 

--- a/packages/framework/esm-utils/src/omrs-dates.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.ts
@@ -129,6 +129,14 @@ export function toOmrsDateFormat(date: DateInput, format = "YYYY-MMM-DD") {
   return dayjs(date).format(format);
 }
 
+/**
+ * Utility function to parse an arbitrary string into a date.
+ * Uses `dayjs(dateString)`.
+ */
+export function parseDate(dateString: string) {
+  return dayjs(dateString).toDate();
+}
+
 const DATE_FORMAT_YYYY_MMM_DD = {
   year: "numeric",
   month: "short",


### PR DESCRIPTION
I'm suggesting that we have this separate `parseDate` function rather than having `formatDate` accept strings and implicitly parse them. I think it's helpful to have to be explicit about what form a date is in. It should reduce the probability of certain kinds of errors, like running `formatDate` on the same date twice (we can't guarantee it's idempotent).