### PR TITLE
Add global nav slot to left nav bar

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
@@ -38,6 +38,7 @@ const SideMenuPanel: React.FC<SideMenuPanelProps> = ({
         isChildOfHeader={expanded}
         className={styles.link}
       >
+        <ExtensionSlot extensionSlotName="global-nav-menu-slot" />
         <ExtensionSlot extensionSlotName="nav-menu-slot" />
       </SideNav>
     )


### PR DESCRIPTION
Presently, we have a single slot which is essentially overridden by a route (e.g. /chart) to allow route specific navigation items to be added to the nav bar. This adds a new slot (above the existing page specific slot) which can be used across mf's to add global links to that will always be present independent of the route. Designs are forthcoming for how this navigation will look like but this sets the foundation to allow this to happen.

## Requirements

- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [ ] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->

## Screenshots

_None._

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->

## Related Issue

_None._

<!--
Optional.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->

## Other

_None._

<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
