### PR TITLE
Add time options to formatDate 

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -113,6 +113,7 @@
 - [DateInput](API.md#dateinput)
 - [ExtensionSlotProps](API.md#extensionslotprops)
 - [FormatDateMode](API.md#formatdatemode)
+- [FormatDateOptions](API.md#formatdateoptions)
 - [KnownOmrsServiceWorkerEvents](API.md#knownomrsserviceworkerevents)
 - [KnownOmrsServiceWorkerMessages](API.md#knownomrsserviceworkermessages)
 - [LayoutType](API.md#layouttype)
@@ -399,6 +400,22 @@ ___
 #### Defined in
 
 [packages/framework/esm-utils/src/omrs-dates.ts:154](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L154)
+
+___
+
+### FormatDateOptions
+
+Ƭ **FormatDateOptions**: `Object`
+
+#### Type declaration
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `time` | `boolean` \| ``"for today"`` | Whether the time should be included in the output always (`true`), never (`false`), or only when the input date is today (`for today`). |
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:156](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L156)
 
 ___
 
@@ -1706,15 +1723,23 @@ ___
 
 ### formatDate
 
-▸ **formatDate**(`date`, `mode?`): `string`
+▸ **formatDate**(`date`, `mode?`, `options?`): `string`
 
 Formats the input date according to the current locale and the
 given format mode.
 
-`standard`: "13 Dec 2021"
-`no year`:  "13 Dec"
-`no day`:   "Dec 2021"
-`wide`:     "13 — Dec — 2021"
+- `standard`: "13 Dec 2021"
+- `no year`:  "13 Dec"
+- `no day`:   "Dec 2021"
+- `wide`:     "13 — Dec — 2021"
+
+Regardless of the mode, if the date is today, then "Today" is produced
+(in the locale language).
+
+Can be used to format a date with time, also, by providing `options`.
+By default, the time is included only when the input date is today.
+The time is appended with a comma and a space. This agrees with the
+output of `Date.prototype.toLocaleString` for *most* locales.
 
 #### Parameters
 
@@ -1722,6 +1747,7 @@ given format mode.
 | :------ | :------ | :------ |
 | `date` | `Date` | `undefined` |
 | `mode` | [`FormatDateMode`](API.md#formatdatemode) | `"standard"` |
+| `options` | [`FormatDateOptions`](API.md#formatdateoptions) | `undefined` |
 
 #### Returns
 
@@ -1729,7 +1755,7 @@ given format mode.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:165](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L165)
+[packages/framework/esm-utils/src/omrs-dates.ts:184](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L184)
 
 ___
 
@@ -1758,7 +1784,7 @@ output of `Date.prototype.toLocaleString` for *most* locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:227](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L227)
+[packages/framework/esm-utils/src/omrs-dates.ts:254](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L254)
 
 ___
 
@@ -1781,7 +1807,7 @@ Formats the input as a time, according to the current locale.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:211](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L211)
+[packages/framework/esm-utils/src/omrs-dates.ts:238](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-utils/src/omrs-dates.ts#L238)
 
 ___
 

--- a/packages/framework/esm-utils/src/omrs-dates.test.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.test.ts
@@ -64,7 +64,7 @@ describe("Openmrs Dates", () => {
 
   it("formats dates with respect to the locale", () => {
     timezoneMock.register("UTC");
-    const testDate = new Date("2021-12-09");
+    const testDate = new Date("2021-12-09T13:15:33");
     window.i18next.language = "en";
     expect(formatDate(testDate)).toEqual("09-Dec-2021");
     expect(formatDate(testDate, "no day")).toEqual("Dec 2021");
@@ -79,6 +79,32 @@ describe("Openmrs Dates", () => {
     expect(formatDate(testDate)).toEqual("09 Des 2021");
     window.i18next.language = "ru";
     expect(formatDate(testDate, "wide")).toEqual("09 — дек. — 2021 г.");
+  });
+
+  it("respects the `time` option", () => {
+    timezoneMock.register("UTC");
+    const testDate = new Date("2021-12-09T13:15:33");
+    const today = new Date();
+    today.setHours(15);
+    today.setMinutes(22);
+    window.i18next.language = "en";
+    expect(formatDate(testDate)).toEqual("09-Dec-2021");
+    expect(formatDate(testDate, "standard", { time: true })).toEqual(
+      "09-Dec-2021, 01:15 PM"
+    );
+    expect(formatDate(testDate, "standard", { time: false })).toEqual(
+      "09-Dec-2021"
+    );
+    expect(formatDate(testDate, "standard", { time: "for today" })).toEqual(
+      "09-Dec-2021"
+    );
+    expect(formatDate(today, "standard", { time: true })).toEqual(
+      "Today, 03:22 PM"
+    );
+    expect(formatDate(today, "standard", { time: false })).toEqual("Today");
+    expect(formatDate(today, "standard", { time: "for today" })).toEqual(
+      "Today, 03:22 PM"
+    );
   });
 
   it("formats times with respect to the locale", () => {

--- a/packages/framework/esm-utils/src/omrs-dates.test.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.test.ts
@@ -49,15 +49,17 @@ describe("Openmrs Dates", () => {
 
   it("formats 'Today' with respect to the locale", () => {
     const testDate = new Date();
+    testDate.setHours(15);
+    testDate.setMinutes(22);
     window.i18next.language = "en";
-    expect(formatDate(testDate)).toEqual("Today");
-    expect(formatDate(testDate, "no day")).toEqual("Today");
-    expect(formatDate(testDate, "no year")).toEqual("Today");
-    expect(formatDate(testDate, "wide")).toEqual("Today");
+    expect(formatDate(testDate)).toEqual("Today, 03:22 PM");
+    expect(formatDate(testDate, "no day")).toEqual("Today, 03:22 PM");
+    expect(formatDate(testDate, "no year")).toEqual("Today, 03:22 PM");
+    expect(formatDate(testDate, "wide")).toEqual("Today, 03:22 PM");
     window.i18next.language = "sw";
-    expect(formatDate(testDate)).toEqual("Leo");
+    expect(formatDate(testDate)).toEqual("Leo, 15:22");
     window.i18next.language = "ru";
-    expect(formatDate(testDate)).toEqual("Сегодня");
+    expect(formatDate(testDate)).toEqual("Сегодня, 15:22");
   });
 
   it("formats dates with respect to the locale", () => {


### PR DESCRIPTION
## Summary

This adds an `options` parameter to `formatDate`, with a `time` parameter that can be used to control when the time should be appended to the date. By default, the time is appended only when the date is "Today."