### PR TITLE
Update context switcher hover styling

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -132,8 +132,8 @@
 
   &:focus,
   &:hover {
-    background-color: $interactive-01;
-    color: $ui-background;
+    background-color: #edf5ff;
+    color: $interactive-01;
   }
 
   &.bx--content-switcher--selected {

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -132,12 +132,12 @@
 
   &:focus,
   &:hover {
-    background-color: #edf5ff;
+    background-color: $color-blue-10;
     color: $interactive-01;
   }
 
   &.bx--content-switcher--selected {
-    background-color: #edf5ff;
+    background-color: $color-blue-10;
     border: 1px solid $interactive-01;
     color: $interactive-01;
   }

--- a/packages/framework/esm-styleguide/src/_vars.scss
+++ b/packages/framework/esm-styleguide/src/_vars.scss
@@ -10,6 +10,7 @@ $color-gray-30: #c6c6c6;
 $color-gray-70: #525252;
 $color-gray-100: #161616;
 $color-blue-60-2: #0f62fe;
+$color-blue-10: #edf5ff;
 $color-yellow-50: #feecae;
 $carbon--red-50: #fa4d56;
 $inverse-link: #78a9ff;


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

## Summary

- Update the style for the hover state of content-switcher, this is as a result of not matching with the designs which @Ciarán Duffy pointed out

## Screenshots

![enhancement](https://user-images.githubusercontent.com/28008754/148224775-683a5406-a8c8-4cdc-b76f-fbb51ca0cf88.gif)


<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->

## Related Issue

_None._

<!--
Optional.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->

## Other

_None._

<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
