### PR TITLE
Don't load the polyfill for url

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -159,7 +159,13 @@ module.exports = (env, argv = {}) => {
     resolve: {
       mainFields: ["module", "main"],
       extensions: [".ts", ".tsx", ".js", ".jsx"],
-      fallback: { http: false, stream: false, https: false, zlib: false },
+      fallback: {
+        http: false,
+        stream: false,
+        https: false,
+        zlib: false,
+        url: false,
+      },
     },
     plugins: [
       new CleanWebpackPlugin(),


### PR DESCRIPTION
This fixes things so that the SDK won't break when executing `npx openmrs@next build`.

Error this is fixing can be [found here on Slack](https://openmrs.slack.com/archives/C02Q7G0A5PE/p1641485421004000?thread_ts=1641485325.003900&cid=C02Q7G0A5PE).