### PR TITLE
Mock fixup

### DIFF
--- a/packages/framework/esm-framework/__mocks__/fileMock.js
+++ b/packages/framework/esm-framework/__mocks__/fileMock.js
@@ -1,0 +1,1 @@
+module.exports = "test-file-stub";

--- a/packages/framework/esm-framework/jest.config.js
+++ b/packages/framework/esm-framework/jest.config.js
@@ -1,9 +1,10 @@
 module.exports = {
   transform: {
-    "^.+\\.tsx?$": "babel-jest",
+    "^.+\\.(j|t)sx?$": "babel-jest",
   },
   moduleNameMapper: {
     "\\.(s?css)$": "identity-obj-proxy",
+    "\\.(svg)$": "<rootDir>/__mocks__/fileMock.js",
     "lodash-es/(.*)": "lodash/$1",
   },
   setupFilesAfterEnv: ["<rootDir>/src/integration-tests/setup-tests.ts"],

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -2,8 +2,52 @@ import React from "react";
 import type {} from "@openmrs/esm-globals";
 import createStore, { Store } from "unistore";
 import { never, of } from "rxjs";
-import dayjs from "dayjs";
+export {
+  parseDate,
+  formatDate,
+  formatDatetime,
+  formatTime,
+} from "@openmrs/esm-utils";
 
+window.i18next = { ...window.i18next, language: "en" };
+
+/* esm-globals */
+
+export function setupPaths(config: any) {
+  window.openmrsBase = config.apiUrl;
+  window.spaBase = config.spaPath;
+  window.spaEnv = config.env || "production";
+  window.spaVersion = process.env.BUILD_VERSION;
+  window.getOpenmrsSpaBase = () => `${window.spaBase}/`;
+}
+
+/* esm-utils */
+export function isVersionSatisfied() {
+  return true;
+}
+
+/* esm-api */
+export const setSessionLocation = jest.fn(() => Promise.resolve());
+
+export const openmrsFetch = jest.fn(() => new Promise(() => {}));
+
+export const openmrsObservableFetch = jest.fn(() =>
+  of({ data: { entry: [] } })
+);
+
+export const getCurrentPatient = jest.fn(() =>
+  jest.fn().mockReturnValue(never())
+);
+
+export function getCurrentUser() {
+  return of({ authenticated: false });
+}
+
+export const newWorkspaceItem = jest.fn();
+
+export const fhirBaseUrl = "/ws/fhir2/R4";
+
+/* esm-state */
 interface StoreEntity {
   value: Store<any>;
   active: boolean;
@@ -14,12 +58,6 @@ export type MockedStore<T> = Store<T> & { resetMock: () => void };
 const initialStates: Record<string, any> = {};
 
 const availableStores: Record<string, StoreEntity> = {};
-
-export function isVersionSatisfied() {
-  return true;
-}
-
-export const setSessionLocation = jest.fn(() => Promise.resolve());
 
 export const mockStores = availableStores;
 
@@ -83,6 +121,7 @@ function instrumentedStore<T>(name: string, store: Store<T>) {
   } as any as MockedStore<T>;
 }
 
+/* esm-config */
 export const configInternalStore = createGlobalStore("config-internal", {
   devDefaultsAreOn: false,
 });
@@ -139,23 +178,51 @@ export function defineConfigSchema(moduleName, schema) {
   configSchema = schema;
 }
 
+export const navigate = jest.fn();
+
+export const interpolateString = jest.fn();
+
+export const ConfigurableLink = jest
+  .fn()
+  .mockImplementation((config: { to: string; children: React.ReactNode }) => (
+    <a href={interpolateString(config.to)}>{config.children}</a>
+  ));
+
+/* esm-error-handling */
 export const createErrorHandler = () => jest.fn().mockReturnValue(never());
 
 export const reportError = jest.fn().mockImplementation((error) => {
   throw error;
 });
 
+/* esm-extensions */
+
+export const attach = jest.fn();
+export const detach = jest.fn();
+export const detachAll = jest.fn();
+
 export const switchTo = jest.fn();
 
-export const UserHasAccessReact = (props: any) => props.children;
+export const ExtensionSlot = ({ children }) => <>{children}</>;
 
-export const openmrsFetch = jest.fn(() => new Promise(() => {}));
+export const Extension = jest.fn().mockImplementation((props: any) => <slot />);
 
-export const openmrsObservableFetch = jest.fn(() =>
-  of({ data: { entry: [] } })
-);
+export const getExtensionStore = () =>
+  getGlobalStore("extensions", { slots: {} });
 
-export const setIsUIEditorEnabled = (boolean): void => {};
+export const getExtensionInternalStore = () =>
+  getGlobalStore("extensions-internal", {
+    slots: {},
+    extensions: {},
+  });
+
+/* esm-react-utils */
+
+export const ComponentContext = React.createContext(null);
+
+export const openmrsComponentDecorator = jest
+  .fn()
+  .mockImplementation(() => (component) => component);
 
 export const useCurrentPatient = jest.fn(() => [null, null, null, null]);
 
@@ -170,49 +237,6 @@ export const useExtensionSlot = jest.fn(() => ({
 }));
 
 export const useExtension = jest.fn(() => [React.createRef(), undefined]);
-
-export const getCurrentPatient = jest.fn(() =>
-  jest.fn().mockReturnValue(never())
-);
-
-export function getCurrentUser() {
-  return of({ authenticated: false });
-}
-
-export const navigate = jest.fn();
-
-export const interpolateString = jest.fn();
-
-export const getCurrentPatientUuid = jest.fn();
-
-export const newWorkspaceItem = jest.fn();
-
-export const fhirBaseUrl = "/ws/fhir2/R4";
-
-export const ExtensionSlot = ({ children }) => <>{children}</>;
-
-export const Extension = jest.fn().mockImplementation((props: any) => <slot />);
-
-export const ConfigurableLink = jest
-  .fn()
-  .mockImplementation((config: { to: string; children: React.ReactNode }) => (
-    <a href={interpolateString(config.to)}>{config.children}</a>
-  ));
-
-export const getExtensionStore = () =>
-  getGlobalStore("extensions", { slots: {} });
-
-export const getExtensionInternalStore = () =>
-  getGlobalStore("extensions-internal", {
-    slots: {},
-    extensions: {},
-  });
-
-export const ComponentContext = React.createContext(null);
-
-export const openmrsComponentDecorator = jest
-  .fn()
-  .mockImplementation(() => (component) => component);
 
 export const UserHasAccess = jest.fn().mockImplementation((props: any) => {
   return props.children;
@@ -234,21 +258,6 @@ export const useStore = (store: Store<any>, actions) => {
   return { ...state, ...actions };
 };
 
-export const showNotification = jest.fn();
-export const showToast = jest.fn();
-
-export function setupPaths(config: any) {
-  window.openmrsBase = config.apiUrl;
-  window.spaBase = config.spaPath;
-  window.spaEnv = config.env || "production";
-  window.spaVersion = process.env.BUILD_VERSION;
-  window.getOpenmrsSpaBase = () => `${window.spaBase}/`;
-}
-
-export const attach = jest.fn();
-export const detach = jest.fn();
-export const detachAll = jest.fn();
-
 export const usePagination = jest.fn().mockImplementation(() => ({
   currentPage: 1,
   goTo: () => {},
@@ -257,27 +266,7 @@ export const usePagination = jest.fn().mockImplementation(() => ({
 
 export const useVisitTypes = jest.fn(() => []);
 
-export const formatDate = jest.fn((date: Date, mode) => {
-  if (!mode || mode == "standard") {
-    return dayjs(date).format("DD-MMM-YYYY");
-  }
-  if (mode == "wide") {
-    return dayjs(date).format("DD - MMM - YYYY");
-  }
-  if (mode == "no day") {
-    return dayjs(date).format("MMM YYYY");
-  }
-  if (mode == "no year") {
-    return dayjs(date).format("DD MMM");
-  }
-  console.warn("Unknown formatDate mode: ", mode);
-  return dayjs(date).format("DD-MMM-YYYY");
-});
+/* esm-styleguide */
 
-export const formatTime = jest.fn((date: Date) => {
-  return dayjs(date).format("HH:mm");
-});
-
-export const formatDatetime = jest.fn((date: Date, mode) => {
-  return formatDate(date, mode) + " " + formatTime(date);
-});
+export const showNotification = jest.fn();
+export const showToast = jest.fn();

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -35,10 +35,6 @@ export const openmrsObservableFetch = jest.fn(() =>
   of({ data: { entry: [] } })
 );
 
-export const getCurrentPatient = jest.fn(() =>
-  jest.fn().mockReturnValue(never())
-);
-
 export function getCurrentUser() {
   return of({ authenticated: false });
 }
@@ -235,8 +231,6 @@ export const useExtensionSlot = jest.fn(() => ({
   attachedExtensionSlotName: "",
   extensionIdsToRender: [],
 }));
-
-export const useExtension = jest.fn(() => [React.createRef(), undefined]);
 
 export const UserHasAccess = jest.fn().mockImplementation((props: any) => {
   return props.children;

--- a/packages/framework/esm-framework/src/mock-test.test.ts
+++ b/packages/framework/esm-framework/src/mock-test.test.ts
@@ -1,0 +1,17 @@
+/**
+ * A test that validates that `@openmrs/esm-framework/mock` has
+ * the same API as `@openmrs/esm-framework`.
+ *
+ * Disabled because the mock is nowhere close to having the same
+ * API. You can change `xit` to `it` to run the test and see a
+ * comparison of the exports of the two modules.
+ */
+
+import * as real from "./index";
+import * as mock from "../mock";
+
+describe("@openmrs/esm-framework/mock", () => {
+  xit("should have the same exports as @openmrs/esm-framework", () => {
+    expect(new Set(Object.keys(real))).toEqual(new Set(Object.keys(mock)));
+  });
+});


### PR DESCRIPTION
Exports the esm-utils functions as their own mocks. Organizes the mocks file some. Adds an easy way to compare the real API to the mock API of `@openmrs/esm-framework`. Removes some mocks for things that don't exist any more.