### PR TITLE
Create mechanism for overriding webpack configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ yarn run:shell
 
 ```sh
 cd packages/apps/esm-[xyz]-app
-yarn start
+yarn serve
+# Use with [Import Map Overrides](https://openmrs.github.io/openmrs-esm-core/#/getting_started/setup?id=import-map-overrides)
 ```
 
 #### The tooling

--- a/packages/tooling/openmrs/default-webpack-config.js
+++ b/packages/tooling/openmrs/default-webpack-config.js
@@ -29,6 +29,10 @@ function makeIdent(name) {
   return name;
 }
 
+const overrides = {};
+const additionalPlugins = [];
+const additionalRules = [];
+
 module.exports = (env, argv = {}) => {
   const root = process.cwd();
   const { name, peerDependencies, browser, main, types } = require(resolve(
@@ -86,6 +90,7 @@ module.exports = (env, argv = {}) => {
           test: /\.(png|jpe?g|gif|svg)$/i,
           type: "asset/resource",
         },
+        ...additionalRules,
       ],
     },
     mode,
@@ -132,9 +137,29 @@ module.exports = (env, argv = {}) => {
           chunks: true,
         },
       }),
+      ...additionalPlugins,
     ],
     resolve: {
       extensions: [".tsx", ".ts", ".jsx", ".js", ".scss"],
     },
+    ...overrides,
   };
 };
+
+/**
+ * Add properties to this object to override any top-level key
+ * of the webpack config.
+ */
+module.exports.overrides = overrides;
+
+/**
+ * Add any additional webpack plugins to this array. They will
+ * be appended to `plugins`.
+ */
+module.exports.additionalPlugins = additionalPlugins;
+
+/**
+ * Add any additional module resolution rules to this array.
+ * They will be appended to `module.rules`.
+ */
+module.exports.additionalRules = additionalRules;


### PR DESCRIPTION
This allows a frontend module developer to do things like

```js
// webpack.config.js

const config = require("openmrs/default-webpack-config");

// This is required for react-pdf
config.additionalConfig.resolve = { fallback: { "stream": false } };

// This is a stupid example of an "override"
config.overrides.devServer = null;

module.exports = config;
```

