### PR TITLE
Login app should interpolate template strings in configured logo URL

### DIFF
--- a/packages/apps/esm-login-app/src/config-schema.ts
+++ b/packages/apps/esm-login-app/src/config-schema.ts
@@ -56,7 +56,8 @@ export const configSchema = {
       _type: Type.String,
       _default: null,
       _description:
-        "A path or URL to an image. Defaults to the OpenMRS SVG sprite.",
+        "A path or URL to an image. If null, will use the OpenMRS SVG sprite.",
+      _validators: [validators.isUrl],
     },
     alt: {
       _type: Type.String,

--- a/packages/apps/esm-login-app/src/login/login.component.tsx
+++ b/packages/apps/esm-login-app/src/login/login.component.tsx
@@ -4,7 +4,7 @@ import ArrowRight24 from "@carbon/icons-react/es/arrow--right/24";
 import { Button, TextInput } from "carbon-components-react";
 import { RouteComponentProps } from "react-router-dom";
 import { useTranslation } from "react-i18next";
-import { useConfig } from "@openmrs/esm-framework";
+import { useConfig, interpolateUrl } from "@openmrs/esm-framework";
 import { performLogin } from "./login.resource";
 import { useCurrentUser } from "../CurrentUserContext";
 import type { StaticContext } from "react-router";
@@ -117,7 +117,7 @@ const Login: React.FC<LoginProps> = ({ history, location, isLoginEnabled }) => {
 
   const logo = config.logo.src ? (
     <img
-      src={config.logo.src}
+      src={interpolateUrl(config.logo.src)}
       alt={config.logo.alt}
       className={styles["logo-img"]}
     />


### PR DESCRIPTION
This allows implementers to set the logo to a URL containing a template, like `"${openmrsSpaBase}/mylogo.png"`.