### PR TITLE
Remove frontendDependency system; use peerDependencies for this

### DIFF
--- a/packages/apps/esm-devtools-app/src/index.ts
+++ b/packages/apps/esm-devtools-app/src/index.ts
@@ -2,10 +2,6 @@ import { getAsyncLifecycle } from "@openmrs/esm-framework";
 
 const importTranslation = () => Promise.resolve();
 
-const frontendDependencies = {
-  "@openmrs/esm-framework": process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   const options = {
     featureName: "devtools",
@@ -23,4 +19,4 @@ function setupOpenMRS() {
   };
 }
 
-export { setupOpenMRS, importTranslation, frontendDependencies };
+export { setupOpenMRS, importTranslation };

--- a/packages/apps/esm-implementer-tools-app/src/index.ts
+++ b/packages/apps/esm-implementer-tools-app/src/index.ts
@@ -1,9 +1,5 @@
 import { getAsyncLifecycle } from "@openmrs/esm-framework";
 
-const frontendDependencies = {
-  "@openmrs/esm-framework": process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   const moduleName = "@openmrs/esm-implementer-tools-app";
   const options = {
@@ -41,6 +37,6 @@ const importTranslation = require.context(
   "lazy"
 );
 
-export { setupOpenMRS, importTranslation, frontendDependencies };
+export { setupOpenMRS, importTranslation };
 
 export { default as ConfigEditButton } from "./config-edit-button/config-edit-button.component";

--- a/packages/apps/esm-login-app/src/index.ts
+++ b/packages/apps/esm-login-app/src/index.ts
@@ -12,10 +12,6 @@ const backendDependencies = {
   "webservices.rest": "^2.24.0",
 };
 
-const frontendDependencies = {
-  "@openmrs/esm-framework": process.env.FRAMEWORK_VERSION,
-};
-
 const sharedOnlineOfflineProps = {
   online: {
     isLoginEnabled: true,
@@ -82,9 +78,4 @@ function setupOpenMRS() {
   };
 }
 
-export {
-  setupOpenMRS,
-  importTranslation,
-  backendDependencies,
-  frontendDependencies,
-};
+export { setupOpenMRS, importTranslation, backendDependencies };

--- a/packages/apps/esm-offline-tools-app/src/index.ts
+++ b/packages/apps/esm-offline-tools-app/src/index.ts
@@ -19,10 +19,6 @@ const backendDependencies = {
   "webservices.rest": "^2.24.0",
 };
 
-const frontendDependencies = {
-  "@openmrs/esm-framework": process.env.FRAMEWORK_VERSION,
-};
-
 function setupOpenMRS() {
   const moduleName = "@openmrs/esm-offline-tools-app";
   const options = {
@@ -179,9 +175,4 @@ function setupOpenMRS() {
   };
 }
 
-export {
-  setupOpenMRS,
-  importTranslation,
-  backendDependencies,
-  frontendDependencies,
-};
+export { setupOpenMRS, importTranslation, backendDependencies };

--- a/packages/apps/esm-primary-navigation-app/src/index.ts
+++ b/packages/apps/esm-primary-navigation-app/src/index.ts
@@ -22,10 +22,6 @@ const backendDependencies = {
   "webservices.rest": "^2.2.0",
 };
 
-const frontendDependencies = {
-  "@openmrs/esm-framework": process.env.FRAMEWORK_VERSION,
-};
-
 const options = {
   featureName: "primary navigation",
   moduleName,
@@ -81,9 +77,4 @@ function setupOpenMRS() {
   };
 }
 
-export {
-  setupOpenMRS,
-  importTranslation,
-  backendDependencies,
-  frontendDependencies,
-};
+export { setupOpenMRS, importTranslation, backendDependencies };

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -43,8 +43,8 @@
   },
   "peerDependencies": {
     "dayjs": "1.x",
-    "rxjs": "6.x",
-    "i18next": "19.x"
+    "i18next": "19.x",
+    "rxjs": "6.x"
   },
   "dependencies": {
     "semver": "^7.3.2"

--- a/packages/framework/esm-utils/src/version.test.ts
+++ b/packages/framework/esm-utils/src/version.test.ts
@@ -50,4 +50,16 @@ describe("Version utilities", () => {
     const result = isVersionSatisfied("^2.24.0", "2.24.0.7e24fb");
     expect(result).toBe(true);
   });
+
+  it("Is satisfied with major version caret specifier and pre", () => {
+    const result = isVersionSatisfied("^3", "3.1.14-pre.3");
+  });
+
+  it("Is satisfied with major version caret specifier and pre and a build number", () => {
+    const result = isVersionSatisfied("^3", "3.1.14.7e24fb-pre.3");
+  });
+
+  it("Is satisfied with major version caret specifier and a build number", () => {
+    const result = isVersionSatisfied("^3", "3.1.14.7e24fb");
+  });
 });

--- a/packages/framework/esm-utils/src/version.ts
+++ b/packages/framework/esm-utils/src/version.ts
@@ -10,8 +10,8 @@ function normalizeFullVersion(version: string) {
   const prerelease = idx >= 0;
 
   if (prerelease) {
-    const ver = normalizeOnlyVersion(version.substr(0, idx));
-    const pre = version.substr(idx + 1);
+    const ver = normalizeOnlyVersion(version.slice(0, idx));
+    const pre = version.slice(idx + 1);
     return `${ver}-${pre}`;
   }
 

--- a/packages/shell/esm-app-shell/src/apps.ts
+++ b/packages/shell/esm-app-shell/src/apps.ts
@@ -3,7 +3,6 @@ import {
   attach,
   checkStatus,
   getCustomProps,
-  isVersionSatisfied,
   PageDefinition,
   registerExtension,
   ResourceLoader,
@@ -11,10 +10,6 @@ import {
 import { registerApplication } from "single-spa";
 import { routePrefix, routeRegex, wrapLifecycle } from "./helpers";
 import type { Activator, ActivatorDefinition } from "./types";
-
-const providedDeps = {
-  "@openmrs/esm-framework": process.env.FRAMEWORK_VERSION,
-};
 
 const pages: Array<PageDefinition> = [];
 
@@ -92,36 +87,10 @@ function getLoader(
   return load;
 }
 
-function satisfiesDependencies(deps: Record<string, string>) {
-  for (const depName of Object.keys(deps)) {
-    const requiredDep = deps[depName];
-    const providedDep = providedDeps[depName];
-
-    if (!providedDep) {
-      console.warn(`Missing dependency "${depName}".`);
-      return false;
-    }
-
-    if (!isVersionSatisfied(requiredDep, providedDep)) {
-      console.warn(
-        `Unsatisfied dependency constraint for "${depName}". Available "${providedDep}", but required "${requiredDep}".`
-      );
-      return false;
-    }
-  }
-
-  return true;
-}
-
 export function registerApp(appName: string, appExports: System.Module) {
   const setup = appExports.setupOpenMRS;
-  const dependencies = appExports.frontendDependencies ?? {};
 
-  if (!satisfiesDependencies(dependencies)) {
-    console.error(
-      `The MF "${appName}" failed to meet the requirements for its dependencies. It will be ignored.`
-    );
-  } else if (typeof setup === "function") {
+  if (typeof setup === "function") {
     const result = trySetup(appName, setup);
 
     if (result && typeof result === "object") {


### PR DESCRIPTION
This removes the frontend dependency checking system. Now that we use module federation, frontend dependency versions are already checked. See the warnings below, which come from the module federation version checking system.

![image](https://user-images.githubusercontent.com/1031876/150286271-a35e51c5-93e5-4b20-93f0-f36310c163db.png)
