### PR TITLE
Allow Proxying with Additional Cookies

### DIFF
--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -210,10 +210,15 @@ async function setupServiceWorker() {
     `${window.getOpenmrsSpaBase()}service-worker.js`
   );
   registerSwEvents(sw);
+  await triggerOfflineMode();
+}
 
+async function triggerOfflineMode() {
   if (navigator.onLine) {
     try {
-      await Promise.all([precacheImportMap(), precacheSharedApiEndpoints()]);
+      if (localStorage.getItem("CAN_GO_OFFLINE") === "true") {
+        await Promise.all([precacheImportMap(), precacheSharedApiEndpoints()]);
+      }
     } catch (e) {
       showNotification({
         critical: true,

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -19,6 +19,7 @@ const production = "production";
 const allowedSuffixes = ["-app", "-widgets"];
 const { ModuleFederationPlugin } = container;
 
+const openmrsAddCookie = process.env.OMRS_ADD_COOKIE;
 const openmrsApiUrl = removeTrailingSlash(
   process.env.OMRS_API_URL || "/openmrs"
 );
@@ -92,7 +93,7 @@ module.exports = (env, argv = {}) => {
     target: "web",
     devServer: {
       compress: true,
-      open: [`${openmrsPublicPath}/`.substr(1)],
+      open: [`${openmrsPublicPath}/`.substring(1)],
       devMiddleware: {
         publicPath: `${openmrsPublicPath}/`,
       },
@@ -109,6 +110,13 @@ module.exports = (env, argv = {}) => {
           context: [`${openmrsApiUrl}/**`, `!${openmrsPublicPath}/**`],
           target: openmrsProxyTarget,
           changeOrigin: true,
+          onProxyReq(proxyReq) {
+            if (openmrsAddCookie) {
+              const origCookie = proxyReq.getHeader("cookie");
+              const newCookie = `${origCookie};${openmrsAddCookie}`;
+              proxyReq.setHeader("cookie", newCookie);
+            }
+          },
         },
       ],
     },

--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -47,6 +47,9 @@ yargs.command(
       .string("backend")
       .default("backend", "https://openmrs-spa.org/")
       .describe("backend", "The backend to proxy API requests to.")
+      .string("add-cookie")
+      .default("add-cookie", "")
+      .describe("add-cookie", "Additional cookies to provide when proxying.")
       .boolean("support-offline")
       .describe(
         "support-offline",
@@ -105,6 +108,7 @@ yargs.command(
       configUrls: args["config-url"],
       pageTitle: args["page-title"],
       supportOffline: args["support-offline"],
+      addCookie: args["add-cookie"],
       ...args,
       importmap: proxyImportmap(
         await mergeImportmap(
@@ -137,6 +141,9 @@ yargs.command(
       .string("backend")
       .default("backend", "https://openmrs-spa.org/")
       .describe("backend", "The backend to proxy API requests to.")
+      .string("add-cookie")
+      .default("add-cookie", "")
+      .describe("add-cookie", "Additional cookies to provide when proxying.")
       .string("spa-path")
       .default("spa-path", "/openmrs/spa/")
       .describe("spa-path", "The path of the application on the target server.")
@@ -178,6 +185,7 @@ yargs.command(
       apiUrl: args["api-url"],
       spaPath: args["spa-path"],
       configUrls: args["config-url"],
+      addCookie: args["add-cookie"],
       ...args,
       importmap: proxyImportmap(
         await mergeImportmap(
@@ -331,10 +339,17 @@ yargs.command(
       .string("backend")
       .default("backend", "https://openmrs-spa.org/")
       .describe("backend", "The backend to proxy API requests to.")
+      .string("add-cookie")
+      .default("add-cookie", "")
+      .describe("add-cookie", "Additional cookies to provide when proxying.")
       .boolean("open")
       .default("open", false)
       .describe("open", "Immediately opens the SPA page URL in the browser."),
-  (args) => runCommand("runStart", { ...args })
+  (args) =>
+    runCommand("runStart", {
+      addCookie: args["add-cookie"],
+      ...args,
+    })
 );
 
 yargs

--- a/packages/tooling/openmrs/src/commands/debug.ts
+++ b/packages/tooling/openmrs/src/commands/debug.ts
@@ -15,6 +15,7 @@ export interface DebugArgs {
   spaPath: string;
   apiUrl: string;
   configUrls: Array<string>;
+  addCookie: string;
 }
 
 export function runDebug(args: DebugArgs) {
@@ -28,6 +29,7 @@ export function runDebug(args: DebugArgs) {
     supportOffline: args.supportOffline,
     spaPath: args.spaPath,
     configUrls: args.configUrls,
+    addCookie: args.addCookie,
     env: "development",
   });
 

--- a/packages/tooling/openmrs/src/commands/develop.ts
+++ b/packages/tooling/openmrs/src/commands/develop.ts
@@ -20,10 +20,11 @@ export interface DevelopArgs {
   spaPath: string;
   apiUrl: string;
   configUrls: Array<string>;
+  addCookie: string;
 }
 
 export function runDevelop(args: DevelopArgs) {
-  const { backend, host, port, open, importmap, configUrls } = args;
+  const { backend, host, port, open, importmap, configUrls, addCookie } = args;
   const apiUrl = removeTrailingSlash(args.apiUrl);
   const spaPath = removeTrailingSlash(args.spaPath);
   const app = express();
@@ -100,6 +101,13 @@ export function runDevelop(args: DevelopArgs) {
       {
         target: backend,
         changeOrigin: true,
+        onProxyReq(proxyReq) {
+          if (addCookie) {
+            const origCookie = proxyReq.getHeader("cookie");
+            const newCookie = `${origCookie};${addCookie}`;
+            proxyReq.setHeader("cookie", newCookie);
+          }
+        },
       }
     )
   );

--- a/packages/tooling/openmrs/src/commands/start.ts
+++ b/packages/tooling/openmrs/src/commands/start.ts
@@ -10,10 +10,11 @@ export interface StartArgs {
   host: string;
   open: boolean;
   backend: string;
+  addCookie: string;
 }
 
 export function runStart(args: StartArgs) {
-  const { backend, host, port, open } = args;
+  const { backend, host, port, open, addCookie } = args;
   const app = express();
   const source = resolve(
     require.resolve("@openmrs/esm-app-shell/package.json"),
@@ -30,6 +31,13 @@ export function runStart(args: StartArgs) {
     createProxyMiddleware([`/openmrs/**`, `!${spaPath}/**`], {
       target: backend,
       changeOrigin: true,
+      onProxyReq(proxyReq) {
+        if (addCookie) {
+          const origCookie = proxyReq.getHeader("cookie");
+          const newCookie = `${origCookie};${addCookie}`;
+          proxyReq.setHeader("cookie", newCookie);
+        }
+      },
     })
   );
   app.get("/*", (_, res) => res.sendFile(index));

--- a/packages/tooling/openmrs/src/utils/config.ts
+++ b/packages/tooling/openmrs/src/utils/config.ts
@@ -11,6 +11,7 @@ export interface WebpackOptions {
   configUrls?: Array<string>;
   env?: string;
   coreAppsDir?: string;
+  addCookie?: string;
 }
 
 export function loadWebpackConfig(options: WebpackOptions = {}) {
@@ -30,6 +31,10 @@ export function loadWebpackConfig(options: WebpackOptions = {}) {
 
   if (typeof options.pageTitle === "string") {
     variables.OMRS_PAGE_TITLE = options.pageTitle;
+  }
+
+  if (typeof options.addCookie === "string") {
+    variables.OMRS_ADD_COOKIE = options.addCookie;
   }
 
   if (typeof options.supportOffline === "boolean") {


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

For some environments we need to supply additional parts when proxying the request. For instance, due to some protection layer we'll need a cookie that is then read by a load balancer in front of the actual OpenMRS backend.

## Screenshots

_None._

## Related Issue

_None._

## Other

_None._
