### PR TITLE
Switch from brand-light-01 to brand-03

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -41,7 +41,7 @@
 .bx--btn--tertiary:hover,
 .bx--btn--tertiary:active,
 .bx--btn--tertiary:focus {
-  @include brand-light-01(background-color);
+  @include brand-03(background-color);
 }
 
 .bx--btn--primary:hover {
@@ -49,13 +49,13 @@
 }
 
 .bx--btn--tertiary {
-  @include brand-light-01(color);
+  @include brand-03(color);
 }
 
 .bx--btn--tertiary,
 .bx--btn--primary:focus,
 .bx--btn--tertiary:focus {
-  @include brand-light-01(border-color);
+  @include brand-03(border-color);
 }
 
 .bx--btn--tertiary:hover,
@@ -106,13 +106,13 @@
 
 .bx--pagination-nav__page:not(.bx--pagination-nav__page--direction) {
   &::after {
-    @include brand-light-01(background-color);
+    @include brand-03(background-color);
   }
 }
 
 .bx--pagination-nav__page .bx--pagination-nav__page--active,
 .bx--pagination-nav__page:focus {
-  outline: 2px solid var(--brand-light-01);
+  outline: 2px solid var(--brand-03);
 }
 
 /* Content Switcher */
@@ -158,16 +158,16 @@
 .bx--tabs--scrollable
   .bx--tabs--scrollable__nav-item--selected
   .bx--tabs--scrollable__nav-link:focus {
-  border-bottom: 2px solid var(--brand-light-01);
+  border-bottom: 2px solid var(--brand-03);
 }
 
 .bx--tabs--scrollable.bx--tabs--scrollable--container
   .bx--tabs--scrollable__nav-item--selected
   .bx--tabs--scrollable__nav-link {
-  box-shadow: inset 0 2px 0 0 var(--brand-light-01);
+  box-shadow: inset 0 2px 0 0 var(--brand-03);
 }
 
 .bx--tabs--scrollable .bx--tabs--scrollable__nav-link:active,
 .bx--tabs--scrollable .bx--tabs--scrollable__nav-link:focus {
-  outline: 2px solid var(--brand-light-01);
+  outline: 2px solid var(--brand-03);
 }

--- a/packages/framework/esm-styleguide/src/_vars.scss
+++ b/packages/framework/esm-styleguide/src/_vars.scss
@@ -34,15 +34,15 @@ $labeldropdown: #c6c6c6;
   #{$property}: var(--brand-02);
 }
 
-@mixin brand-light-01($property) {
+@mixin brand-03($property) {
   #{$property}: #007d79;
-  #{$property}: var(--brand-light-01);
+  #{$property}: var(--brand-03;
 }
 
 :root {
   --brand-01: #005d5d;
   --brand-02: #004144;
-  --brand-light-01: #007d79;
+  --brand-03: #007d79;
 }
 
 $breakpoint-phone-min: 0px;

--- a/packages/framework/esm-styleguide/src/_vars.scss
+++ b/packages/framework/esm-styleguide/src/_vars.scss
@@ -36,7 +36,7 @@ $labeldropdown: #c6c6c6;
 
 @mixin brand-03($property) {
   #{$property}: #007d79;
-  #{$property}: var(--brand-03;
+  #{$property}: var(--brand-03);
 }
 
 :root {


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

<!--
Required.
Please describe what problems your PR addresses.
-->

Removes `brand-light-01` in favour of `brand-03`. This was used in another commit and I've come around to it being the better option here.

## Screenshots

_None._

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->

## Related Issue

_None._

<!--
Optional.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->

## Other

_None._

<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
