### PR TITLE
Fix dead link in extensions docs

### DIFF
--- a/docs/main/extensions.md
+++ b/docs/main/extensions.md
@@ -24,7 +24,7 @@ Read the above two lines until they resonate in your head like a mantra.
 Extensions get rendered into slots. An extension gets associated with a
 slot in one of the following ways:
 - The extension names the slot in its definition, under `slot[s]`
-- A call to [attach](useExtensionSlotMeta)
+- A call to [attach](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/docs/API.md#attach)
 - A system administrator adds the extension to the slot using the
   slot's `add` array
 


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Fix a dead link in the Extension System developer documentation. Should fix CI build failures as well.