### PR TITLE
(bug) fix typo on openmrs-resource interface

### DIFF
--- a/packages/framework/esm-api/src/types/openmrs-resource.ts
+++ b/packages/framework/esm-api/src/types/openmrs-resource.ts
@@ -17,7 +17,7 @@ export interface SessionUser {
 export interface User {
   display: string;
   link: Array<string>;
-  persion: any;
+  person: any;
   priviliges: any;
   resourceVersion: any;
   roles: Array<any>;

--- a/packages/framework/esm-framework/docs/interfaces/User.md
+++ b/packages/framework/esm-framework/docs/interfaces/User.md
@@ -8,7 +8,7 @@
 
 - [display](User.md#display)
 - [link](User.md#link)
-- [persion](User.md#persion)
+- [person](User.md#person)
 - [priviliges](User.md#priviliges)
 - [resourceVersion](User.md#resourceversion)
 - [roles](User.md#roles)
@@ -38,9 +38,9 @@ ___
 
 ___
 
-### persion
+### person
 
-• **persion**: `any`
+• **person**: `any`
 
 #### Defined in
 


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

## Summary

- Fix typo on the `openmrs-resource`  `persion` => `person`

## Screenshots

_None._

<!--
Optional.
If possible, please insert any screenshots/videos of your changes here.
Don't forget to remove the *None.* above if you do fill this section.
-->

## Related Issue

_None._

<!--
Optional.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->

## Other

_None._

<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
