### PR TITLE
(bug) fix wrong brand-03 css variable

### DIFF
--- a/packages/framework/esm-styleguide/src/brand.ts
+++ b/packages/framework/esm-styleguide/src/brand.ts
@@ -20,7 +20,7 @@ export function setupBranding() {
     if (store.loaded && store.config) {
       setGlobalCSSVariable("--brand-01", store.config["Brand color #1"]);
       setGlobalCSSVariable("--brand-02", store.config["Brand color #2"]);
-      setGlobalCSSVariable("--brand-light-01", store.config["Brand color #3"]);
+      setGlobalCSSVariable("--brand-03", store.config["Brand color #3"]);
     }
   });
 


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

- At the moment css color variable `--brand-03` is wrongly mapped to `--brand-light-01`. updating to match correct mapping

## Screenshots

![brand-03](https://user-images.githubusercontent.com/28008754/151230916-7627d370-3b89-4497-bcf3-3b5e9508916c.gif)



## Related Issue

_None._

<!--
Optional.
If present, please link any related issue here, e.g. "https://issues.openmrs.org/browse/123").
Don't forget to remove the *None.* above if you do fill this section.
-->

## Other

_None._

<!--
Optional.
Anything else that isn't covered by one of the sections above.
Don't forget to remove the *None.* above if you do fill this section.
-->
