### PR TITLE
Minor performance improvements to ExtensionSlot

### DIFF
--- a/docs/main/config.md
+++ b/docs/main/config.md
@@ -63,7 +63,7 @@ defineConfigSchema("@openmrs/esm-hologram-doctor", {
     color: {
       _type: Type.Boolean,
       _default: false,
-      _description: "Whether the cologram supports color display."
+      _description: "Whether the hologram supports color display."
     }
   }
 }

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -732,7 +732,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:51](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L51)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:53](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L53)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -732,7 +732,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:53](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L53)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:55](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L55)
 
 ___
 

--- a/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
+++ b/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
@@ -48,7 +48,9 @@ export interface ExtensionSlotBaseProps {
 export type ExtensionSlotProps = ExtensionSlotBaseProps &
   React.HTMLAttributes<HTMLDivElement>;
 
-const defaultSelect = (e) => e;
+function defaultSelect(extensions: Array<ConnectedExtension>) {
+  return extensions;
+}
 
 export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
   extensionSlotName,

--- a/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
+++ b/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
@@ -48,9 +48,11 @@ export interface ExtensionSlotBaseProps {
 export type ExtensionSlotProps = ExtensionSlotBaseProps &
   React.HTMLAttributes<HTMLDivElement>;
 
+const defaultSelect = (e) => e;
+
 export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
   extensionSlotName,
-  select = (e) => e,
+  select = defaultSelect,
   children,
   state,
   style,
@@ -65,8 +67,9 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
     stateRef.current = state;
   }
 
-  const content = useMemo(
-    () =>
+  const content = useMemo(() => {
+    console.log("creating new Context and Extension instance");
+    return (
       extensionSlotName &&
       select(extensions).map((extension) => (
         <ComponentContext.Provider
@@ -82,9 +85,9 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
         >
           {children ?? <Extension state={stateRef.current} />}
         </ComponentContext.Provider>
-      )),
-    [select, extensions, extensionSlotName, stateRef.current]
-  );
+      ))
+    );
+  }, [select, extensions, extensionSlotName]);
 
   return (
     <div

--- a/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
+++ b/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
@@ -69,9 +69,8 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
     stateRef.current = state;
   }
 
-  const content = useMemo(() => {
-    console.log("creating new Context and Extension instance");
-    return (
+  const content = useMemo(
+    () =>
       extensionSlotName &&
       select(extensions).map((extension) => (
         <ComponentContext.Provider
@@ -87,9 +86,9 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
         >
           {children ?? <Extension state={stateRef.current} />}
         </ComponentContext.Provider>
-      ))
-    );
-  }, [select, extensions, extensionSlotName]);
+      )),
+    [select, extensions, extensionSlotName]
+  );
 
   return (
     <div


### PR DESCRIPTION
A couple minor performance improvements to the `ExtensionSlot` implementation.

One I had messed up in https://github.com/openmrs/openmrs-esm-core/pull/236 . I hadn't realized that defining `defaultSelect` inline would cause render churning.

The other is a result of the observations that 1. refs should [generally not](https://epicreact.dev/why-you-shouldnt-put-refs-in-a-dependency-array/) be used in dependency arrays and 2. props changing should not cause the Extension component to re-render.