### PR TITLE
(fix) Fix logo alignment in the navbar

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/logo/logo.component.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/logo/logo.component.scss
@@ -1,0 +1,4 @@
+.logo {
+  display: flex;
+  align-items: center;
+}

--- a/packages/apps/esm-primary-navigation-app/src/components/logo/logo.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/logo/logo.component.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { useConfig } from "@openmrs/esm-framework";
+import styles from "./logo.component.scss";
 
 const Logo: React.FC = () => {
   const { logo } = useConfig();
@@ -7,7 +8,13 @@ const Logo: React.FC = () => {
   return (
     <>
       {logo?.src ? (
-        <img src={logo.src} alt={logo.alt} width={110} height={40} />
+        <img
+          className={styles.logo}
+          src={logo.src}
+          alt={logo.alt}
+          width={110}
+          height={40}
+        />
       ) : logo?.name ? (
         logo.name
       ) : (


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

The app logo should be centre-aligned in a flex container to match the look and feel of the rest of the elements in the navigation bar. Note that this change does not affect SVG logos.

## Screenshots

> Before
<img width="920" alt="Screenshot 2022-02-01 at 15 58 25" src="https://user-images.githubusercontent.com/8509731/151973382-db7b7d61-44ad-4da7-b9b4-7abbfe638704.png">

> After
<img width="920" alt="Screenshot 2022-02-01 at 15 55 30" src="https://user-images.githubusercontent.com/8509731/151973407-69505a1e-680b-48af-8938-21e2d55becd7.png">
