### PR TITLE
(feat) Return updated `patientUuid` from usePatient

### DIFF
--- a/packages/framework/esm-react-utils/src/usePatient.ts
+++ b/packages/framework/esm-react-utils/src/usePatient.ts
@@ -146,7 +146,7 @@ export function usePatient(patientUuid?: string) {
   return {
     isLoading: state.isLoadingPatient,
     patient: state.patient,
-    patientUuid: patientUuid ?? null,
+    patientUuid: patientUuid ?? state.patientUuid,
     error: state.err,
   };
 }


### PR DESCRIPTION
## Requirements

- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
- [x] I checked for feature overlap with [**existing widgets**](https://om.rs/directory).

## Summary

Presently, `usePatient` does not return the updated `patientUuid` whenever the route changes. This commit updates `usePatient` to return the latest updated `patientUuid` value.