### PR TITLE
(fix) O3-1061: Patient Chart is re-rendering on each page change

### DIFF
--- a/packages/framework/esm-react-utils/src/usePatient.ts
+++ b/packages/framework/esm-react-utils/src/usePatient.ts
@@ -1,4 +1,4 @@
-import { useEffect, useReducer } from "react";
+import { useEffect, useMemo, useReducer } from "react";
 import { fetchCurrentPatient, PatientUuid } from "@openmrs/esm-api";
 
 type NullablePatient = fhir.Patient | null;
@@ -133,10 +133,13 @@ export function usePatient(patientUuid?: string) {
 
   useEffect(() => {
     const handleRouteUpdate = (evt) => {
-      dispatch({
-        type: ActionTypes.loadPatient,
-        patientUuid: getPatientUuidFromUrl(),
-      });
+      const newPatientUuid = getPatientUuidFromUrl();
+      if (newPatientUuid != state.patientUuid) {
+        dispatch({
+          type: ActionTypes.loadPatient,
+          patientUuid: newPatientUuid,
+        });
+      }
     };
     window.addEventListener("single-spa:routing-event", handleRouteUpdate);
     return () =>


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests, or is validated by existing tests.

## Summary

Ensures that the patient object is not reloaded unnecessarily. Reloading the patient object was causing the patient header to reload in the patient chart every time the dashboard was changed.

## Related Issue
https://issues.openmrs.org/browse/O3-1061
