### PR TITLE
chore: Fix build of esm-styleguide on CI

### DIFF
--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -56,10 +56,12 @@
     "@storybook/addon-a11y": "^5.2.1",
     "@storybook/addon-knobs": "^5.2.1",
     "@storybook/html": "^5.2.1",
+    "autoprefixer": "^10.4.2",
     "carbon-components": "10.31.0",
     "carbon-icons": "7.0.7",
     "css-minimizer-webpack-plugin": "^1.2.0",
     "highlight.js": "^9.15.10",
+    "postcss": "^8.4.6",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "rxjs": "^6.5.3"


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary
<!-- Please describe what problems your PR addresses. -->

For some reason, the esm-styleguide is picking up on the updated autoprefixer and postcss and so is failing but only when on pre-release version. This PR adds autoprefixer and postcss as explicit rather than implicit devDependencies of the esm-styleguide, which seems to solve the problem.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
