### PR TITLE
Make it possible to override properties of each webpack rule

### DIFF
--- a/docs/main/faq.md
+++ b/docs/main/faq.md
@@ -7,6 +7,7 @@ In a repository using Yarn:
 ```
 yarn upgrade @openmrs/esm-framework openmrs  // to upgrade
 git checkout package.json  // to reset the version specifiers to 'next'
+yarn  // to re-create the lockfile
 ```
 
 ### How do I keep my local dev server up to date?

--- a/packages/tooling/openmrs/default-webpack-config.js
+++ b/packages/tooling/openmrs/default-webpack-config.js
@@ -4,7 +4,7 @@ const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const { DefinePlugin, container } = require("webpack");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const { StatsWriterPlugin } = require("webpack-stats-plugin");
-const { mergeWith, isArray } = require("lodash");
+const { merge, mergeWith, isArray } = require("lodash");
 
 const production = "production";
 const { ModuleFederationPlugin } = container;
@@ -32,6 +32,10 @@ function makeIdent(name) {
 
 const overrides = {};
 const additionalConfig = {};
+const scriptRuleConfig = {};
+const cssRuleConfig = {};
+const scssRuleConfig = {};
+const assetRuleConfig = {};
 
 module.exports = (env, argv = {}) => {
   const root = process.cwd();
@@ -67,29 +71,41 @@ module.exports = (env, argv = {}) => {
     target: "web",
     module: {
       rules: [
-        {
-          test: /\.m?(js|ts|tsx)$/,
-          exclude: /(node_modules|bower_components)/,
-          use: {
-            loader: require.resolve("babel-loader"),
+        merge(
+          {
+            test: /\.m?(js|ts|tsx)$/,
+            exclude: /(node_modules|bower_components)/,
+            use: {
+              loader: require.resolve("babel-loader"),
+            },
           },
-        },
-        {
-          test: /\.css$/,
-          use: [require.resolve("style-loader"), cssLoader],
-        },
-        {
-          test: /\.s[ac]ss$/i,
-          use: [
-            require.resolve("style-loader"),
-            cssLoader,
-            { loader: require.resolve("sass-loader") },
-          ],
-        },
-        {
-          test: /\.(png|jpe?g|gif|svg)$/i,
-          type: "asset/resource",
-        },
+          scriptRuleConfig
+        ),
+        merge(
+          {
+            test: /\.css$/,
+            use: [require.resolve("style-loader"), cssLoader],
+          },
+          cssRuleConfig
+        ),
+        merge(
+          {
+            test: /\.s[ac]ss$/i,
+            use: [
+              require.resolve("style-loader"),
+              cssLoader,
+              { loader: require.resolve("sass-loader") },
+            ],
+          },
+          scssRuleConfig
+        ),
+        merge(
+          {
+            test: /\.(png|jpe?g|gif|svg)$/i,
+            type: "asset/resource",
+          },
+          assetRuleConfig
+        ),
       ],
     },
     mode,
@@ -164,3 +180,31 @@ module.exports.additionalConfig = additionalConfig;
  * Make sure to modify this object and not reassign it.
  */
 module.exports.overrides = overrides;
+
+/**
+ * This object will be merged into the webpack rule governing
+ * the loading of JS, JSX, TS, etc. files.
+ * Make sure to modify this object and not reassign it.
+ */
+module.exports.scriptRuleConfig = scriptRuleConfig;
+
+/**
+ * This object will be merged into the webpack rule governing
+ * the loading of CSS files.
+ * Make sure to modify this object and not reassign it.
+ */
+module.exports.cssRuleConfig = cssRuleConfig;
+
+/**
+ * This object will be merged into the webpack rule governing
+ * the loading of SCSS files.
+ * Make sure to modify this object and not reassign it.
+ */
+module.exports.scssRuleConfig = scssRuleConfig;
+
+/**
+ * This object will be merged into the webpack rule governing
+ * the loading of static asset files.
+ * Make sure to modify this object and not reassign it.
+ */
+module.exports.assetRuleConfig = assetRuleConfig;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests, or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Makes it possible to override the properties of specific webpack rules. This is being added so that external libraries can be processed through babel using e.g.

```js
const config = module.exports = require("openmrs/default-webpack-config");
config.scriptRuleConfig.exclude = /(node_modules[^\/@openmrs\/esm-patient-common-lib])/;
module.exports = config;
```
