### PR TITLE
(fix): Logo should have a left margin of 1rem

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.scss
@@ -22,3 +22,7 @@
   padding: $spacing-04;
   margin-right: $spacing-02;
 }
+
+.spacedLogo {
+  margin-left: 1rem;
+}

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -84,7 +84,9 @@ const Navbar: React.FC<NavbarProps> = ({
             />
           )}
           <ConfigurableLink to="${openmrsSpaBase}/home">
-            <Logo />
+            <div className={showHamburger ? "" : styles.spacedLogo}>
+              <Logo />
+            </div>
           </ConfigurableLink>
           <ExtensionSlot
             className={styles.dividerOverride}


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Applies a `1rem` left margin to the app logo in the navbar when in the desktop viewport as outlined in Ciaran's design QA doc https://www.notion.so/Patient-Summary-7e91d9b019a24e07b27301aa8164c323.

## Screenshots

<img width="258" alt="Screenshot 2022-02-11 at 01 54 03" src="https://user-images.githubusercontent.com/8509731/153510533-1f02249d-0b56-4879-b419-1ccb2148620a.png">

