### PR TITLE
(fix): Change breadcrumbs background color

### DIFF
--- a/packages/framework/esm-styleguide/src/components/_breadcrumbs.scss
+++ b/packages/framework/esm-styleguide/src/components/_breadcrumbs.scss
@@ -1,5 +1,8 @@
+@import "~@openmrs/esm-styleguide/src/vars";
+
 nav.breadcrumbs-container {
   padding: 1rem;
+  background-color: $ui-01;
 
   ol li {
     display: inline-flex;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests, or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Change the background of the breadcrumbs menu to $ui-01 as outlined in the designs.

## Screenshots

> Before
<img width="958" alt="Screenshot 2022-02-11 at 02 49 25" src="https://user-images.githubusercontent.com/8509731/153516693-8de4e8be-1467-4521-9791-e6c7206839a3.png">

> After
It's a subtle change - note how the breadcrumbs menu now blends in with the patient banner.

<img width="958" alt="Screenshot 2022-02-11 at 02 48 01" src="https://user-images.githubusercontent.com/8509731/153516752-880441bb-5b7a-4dfa-8f13-0e25115501c0.png">

