### PR TITLE
Fix bug where extensions weren't updating with props

### DIFF
--- a/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
+++ b/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
@@ -87,7 +87,7 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
           {children ?? <Extension state={stateRef.current} />}
         </ComponentContext.Provider>
       )),
-    [select, extensions, extensionSlotName]
+    [select, extensions, extensionSlotName, stateRef.current]
   );
 
   return (


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests, or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Remember https://github.com/openmrs/openmrs-esm-core/pull/297 ? I was wrong. Here's the thing:

It is not advisable to put refs in dependency arrays because ref value changes won't trigger re-renders (using "render" in the React sense of a component function run). Change state or props and the component re-renders. But ref values can change arbitrarily and the component won't notice.

However! Once the component *does* re-render, it *is* able to compare the values in the dependency array—to ask, "has this ref value changed since the last time I saw it?" We were relying on that to cause the extensions to re-mount when new props come in. Extensions won't re-render or re-mount *in response to* prop changes. But they will re-mount if they happen to re-render for another reason, and the props have changed.

## Screenshots

![props-update](https://user-images.githubusercontent.com/1031876/153536274-d096f6d5-193f-452e-8994-b366f4c6527a.gif)

