### PR TITLE
Release v3.3.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,7 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.2.0",
+  "version": "3.3.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/packages/apps/esm-devtools-app/package.json
+++ b/packages/apps/esm-devtools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-devtools-app",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "Dev tools for frontend devs using OpenMRS",
   "browser": "dist/openmrs-esm-devtools-app.js",
@@ -43,7 +43,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.2.0",
+    "@openmrs/esm-framework": "^3.3.0",
     "@types/carbon-components-react": "^7.24.0",
     "carbon-components": "10.31.0",
     "carbon-icons": "7.0.7",

--- a/packages/apps/esm-implementer-tools-app/package.json
+++ b/packages/apps/esm-implementer-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-implementer-tools-app",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "The admin interface for OpenMRS Frontend",
   "browser": "dist/openmrs-esm-implementer-tools-app.js",
@@ -51,7 +51,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.2.0",
+    "@openmrs/esm-framework": "^3.3.0",
     "@types/carbon-components-react": "^7.24.0",
     "jest": "^26.6.3",
     "react": "^16.13.1",

--- a/packages/apps/esm-login-app/package.json
+++ b/packages/apps/esm-login-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-login-app",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "The login microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-login-app.js",
@@ -52,7 +52,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.2.0",
+    "@openmrs/esm-framework": "^3.3.0",
     "@types/carbon-components-react": "^7.24.0",
     "@types/react-router-dom": "^5.1.7",
     "jest": "^26.6.3",

--- a/packages/apps/esm-offline-tools-app/package.json
+++ b/packages/apps/esm-offline-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline-tools-app",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "The offline tools microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-offline-tools-app.js",
@@ -53,7 +53,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.2.0",
+    "@openmrs/esm-framework": "^3.3.0",
     "@types/carbon-components-react": "^7.24.0",
     "@types/lodash-es": "^4.17.5",
     "@types/react-router-dom": "^5.1.7",

--- a/packages/apps/esm-primary-navigation-app/package.json
+++ b/packages/apps/esm-primary-navigation-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-primary-navigation-app",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "Main navbar microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-primary-navigation-app.js",
@@ -51,7 +51,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.2.0",
+    "@openmrs/esm-framework": "^3.3.0",
     "@types/carbon-components-react": "^7.24.0",
     "@types/react-router-dom": "^5.1.7",
     "jest": "^26.6.3",

--- a/packages/framework/esm-api/package.json
+++ b/packages/framework/esm-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-api",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "The javascript module for interacting with the OpenMRS API",
   "browser": "dist/openmrs-esm-api.js",
@@ -44,9 +44,9 @@
     "@openmrs/esm-error-handling": "3.x"
   },
   "devDependencies": {
-    "@openmrs/esm-config": "^3.2.0",
-    "@openmrs/esm-error-handling": "^3.2.0",
-    "@openmrs/esm-state": "^3.2.0",
+    "@openmrs/esm-config": "^3.3.0",
+    "@openmrs/esm-error-handling": "^3.3.0",
+    "@openmrs/esm-state": "^3.3.0",
     "@types/fhir": "0.0.31",
     "rxjs": "^6.5.3"
   }

--- a/packages/framework/esm-breadcrumbs/package.json
+++ b/packages/framework/esm-breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-breadcrumbs",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "The javascript module for breadcrumb registration",
   "browser": "dist/openmrs-esm-breadcrumbs.js",
@@ -42,6 +42,6 @@
     "@openmrs/esm-state": "3.x"
   },
   "devDependencies": {
-    "@openmrs/esm-state": "^3.2.0"
+    "@openmrs/esm-state": "^3.3.0"
   }
 }

--- a/packages/framework/esm-config/package.json
+++ b/packages/framework/esm-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-config",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "A configuration library for the OpenMRS Single-Spa framework.",
   "browser": "dist/openmrs-esm-module-config.js",
@@ -45,8 +45,8 @@
     "systemjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-globals": "^3.2.0",
-    "@openmrs/esm-state": "^3.2.0",
+    "@openmrs/esm-globals": "^3.3.0",
+    "@openmrs/esm-state": "^3.3.0",
     "@types/ramda": "^0.26.44",
     "@types/systemjs": "^6.1.0",
     "babel-plugin-ramda": "^2.0.0",

--- a/packages/framework/esm-error-handling/package.json
+++ b/packages/framework/esm-error-handling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-error-handling",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "An ES module to help with error handling",
   "browser": "dist/openmrs-esm-error-handling.js",
@@ -39,6 +39,6 @@
     "@openmrs/esm-globals": "3.x"
   },
   "devDependencies": {
-    "@openmrs/esm-globals": "^3.2.0"
+    "@openmrs/esm-globals": "^3.3.0"
   }
 }

--- a/packages/framework/esm-extensions/package.json
+++ b/packages/framework/esm-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-extensions",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "Coordinates extensions and extension points in the OpenMRS Frontend",
   "browser": "dist/openmrs-esm-extensions.js",
@@ -42,9 +42,9 @@
     "single-spa": "5.x"
   },
   "devDependencies": {
-    "@openmrs/esm-api": "^3.2.0",
-    "@openmrs/esm-config": "^3.2.0",
-    "@openmrs/esm-state": "^3.2.0",
+    "@openmrs/esm-api": "^3.3.0",
+    "@openmrs/esm-config": "^3.3.0",
+    "@openmrs/esm-state": "^3.3.0",
     "single-spa": "^5.9.2"
   },
   "dependencies": {

--- a/packages/framework/esm-framework/package.json
+++ b/packages/framework/esm-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-framework",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "browser": "dist/openmrs-esm-framework.js",
   "main": "src/index.ts",
@@ -35,17 +35,17 @@
     "access": "public"
   },
   "dependencies": {
-    "@openmrs/esm-api": "^3.2.0",
-    "@openmrs/esm-breadcrumbs": "^3.2.0",
-    "@openmrs/esm-config": "^3.2.0",
-    "@openmrs/esm-error-handling": "^3.2.0",
-    "@openmrs/esm-extensions": "^3.2.0",
-    "@openmrs/esm-globals": "^3.2.0",
-    "@openmrs/esm-offline": "^3.2.0",
-    "@openmrs/esm-react-utils": "^3.2.0",
-    "@openmrs/esm-state": "^3.2.0",
-    "@openmrs/esm-styleguide": "^3.2.0",
-    "@openmrs/esm-utils": "^3.2.0",
+    "@openmrs/esm-api": "^3.3.0",
+    "@openmrs/esm-breadcrumbs": "^3.3.0",
+    "@openmrs/esm-config": "^3.3.0",
+    "@openmrs/esm-error-handling": "^3.3.0",
+    "@openmrs/esm-extensions": "^3.3.0",
+    "@openmrs/esm-globals": "^3.3.0",
+    "@openmrs/esm-offline": "^3.3.0",
+    "@openmrs/esm-react-utils": "^3.3.0",
+    "@openmrs/esm-state": "^3.3.0",
+    "@openmrs/esm-styleguide": "^3.3.0",
+    "@openmrs/esm-utils": "^3.3.0",
     "dayjs": "^1.10.7"
   }
 }

--- a/packages/framework/esm-globals/package.json
+++ b/packages/framework/esm-globals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-globals",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "browser": "dist/openmrs-esm-globals.js",
   "main": "src/index.ts",

--- a/packages/framework/esm-offline/package.json
+++ b/packages/framework/esm-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "browser": "dist/openmrs-esm-offline.js",
@@ -36,10 +36,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@openmrs/esm-api": "^3.2.0",
-    "@openmrs/esm-globals": "^3.2.0",
-    "@openmrs/esm-state": "^3.2.0",
-    "@openmrs/esm-styleguide": "^3.2.0",
+    "@openmrs/esm-api": "^3.3.0",
+    "@openmrs/esm-globals": "^3.3.0",
+    "@openmrs/esm-state": "^3.3.0",
+    "@openmrs/esm-styleguide": "^3.3.0",
     "@types/uuid": "^8.3.0",
     "rxjs": "^6.5.3"
   },

--- a/packages/framework/esm-react-utils/package.json
+++ b/packages/framework/esm-react-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-react-utils",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "React utilities for OpenMRS.",
   "browser": "dist/openmrs-esm-react-utils.js",
@@ -53,11 +53,11 @@
     "react-i18next": "11.x"
   },
   "devDependencies": {
-    "@openmrs/esm-api": "^3.2.0",
-    "@openmrs/esm-config": "^3.2.0",
-    "@openmrs/esm-error-handling": "^3.2.0",
-    "@openmrs/esm-extensions": "^3.2.0",
-    "@openmrs/esm-globals": "^3.2.0",
+    "@openmrs/esm-api": "^3.3.0",
+    "@openmrs/esm-config": "^3.3.0",
+    "@openmrs/esm-error-handling": "^3.3.0",
+    "@openmrs/esm-extensions": "^3.3.0",
+    "@openmrs/esm-globals": "^3.3.0",
     "i18next": "^19.6.0",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",

--- a/packages/framework/esm-state/package.json
+++ b/packages/framework/esm-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-state",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "Frontend stores & state management for OpenMRS",
   "browser": "dist/openmrs-esm-state.js",

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-styleguide",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "The styleguide for OpenMRS SPA",
   "browser": "dist/openmrs-esm-styleguide.js",
@@ -51,7 +51,7 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-extensions": "^3.2.0",
+    "@openmrs/esm-extensions": "^3.3.0",
     "@pickra/copy-code-block": "^1.1.7",
     "@storybook/addon-a11y": "^5.2.1",
     "@storybook/addon-knobs": "^5.2.1",

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-utils",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "browser": "dist/openmrs-esm-utils.js",

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-app-shell",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "main": "dist/openmrs.js",
   "scripts": {
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@openmrs/esm-framework": "^3.2.0",
+    "@openmrs/esm-framework": "^3.3.0",
     "carbon-components": "10.31.0",
     "carbon-icons": "7.0.7",
     "dayjs": "^1.10.4",
@@ -57,11 +57,11 @@
     "workbox-window": "^6.1.5"
   },
   "devDependencies": {
-    "@openmrs/esm-devtools-app": "^3.2.0",
-    "@openmrs/esm-implementer-tools-app": "^3.2.0",
-    "@openmrs/esm-login-app": "^3.2.0",
-    "@openmrs/esm-offline-tools-app": "^3.2.0",
-    "@openmrs/esm-primary-navigation-app": "^3.2.0",
+    "@openmrs/esm-devtools-app": "^3.3.0",
+    "@openmrs/esm-implementer-tools-app": "^3.3.0",
+    "@openmrs/esm-login-app": "^3.3.0",
+    "@openmrs/esm-offline-tools-app": "^3.3.0",
+    "@openmrs/esm-primary-navigation-app": "^3.3.0",
     "webpack-pwa-manifest": "^4.3.0",
     "workbox-webpack-plugin": "^6.1.2"
   }

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmrs",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "main": "dist/index.js",
   "bin": {
@@ -35,7 +35,7 @@
     "@babel/preset-env": "^7.11.0",
     "@babel/preset-react": "^7.10.4",
     "@babel/preset-typescript": "^7.10.4",
-    "@openmrs/esm-app-shell": "3.2.0",
+    "@openmrs/esm-app-shell": "3.3.0",
     "@types/react": "^16.9.46",
     "@types/systemjs": "^6.1.0",
     "autoprefixer": "^10.4.2",


### PR DESCRIPTION
- Fix bug where extensions weren't updating with props [\#318](https://github.com/openmrs/openmrs-esm-core/pull/318) ([brandones](https://github.com/brandones))
- Make it possible to override properties of each webpack rule [\#315](https://github.com/openmrs/openmrs-esm-core/pull/315) ([brandones](https://github.com/brandones))
- \(docs\) Added reference to short link: om.rs/dev3docs [\#314](https://github.com/openmrs/openmrs-esm-core/pull/314) ([gracepotma](https://github.com/gracepotma))
- Add FAQ to docs [\#311](https://github.com/openmrs/openmrs-esm-core/pull/311) ([brandones](https://github.com/brandones))
- chore: Fix build of esm-styleguide on CI [\#310](https://github.com/openmrs/openmrs-esm-core/pull/310) ([ibacher](https://github.com/ibacher))
- Update to PostCSS 8 [\#308](https://github.com/openmrs/openmrs-esm-core/pull/308) ([ibacher](https://github.com/ibacher))
- BREAKING O3-806: Migrate from openmrs-spa.org -\> dev3.openmrs.org [\#302](https://github.com/openmrs/openmrs-esm-core/pull/302) ([ibacher](https://github.com/ibacher))