### PR TITLE
(feat) Add options parameter to translateFrom

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -3977,7 +3977,7 @@ ___
 
 ### translateFrom
 
-▸ **translateFrom**(`moduleName`, `key`, `fallback?`): `string`
+▸ **translateFrom**(`moduleName`, `key`, `fallback?`, `options?`): `string`
 
 #### Parameters
 
@@ -3986,6 +3986,7 @@ ___
 | `moduleName` | `string` |
 | `key` | `string` |
 | `fallback?` | `string` |
+| `options?` | `object` |
 
 #### Returns
 
@@ -4551,7 +4552,7 @@ a route listener is set up to update the patient whenever the route changes.
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/usePatient.ts:86](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/usePatient.ts#L86)
+[packages/framework/esm-react-utils/src/usePatient.ts:91](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/usePatient.ts#L91)
 
 ___
 

--- a/packages/framework/esm-utils/src/translate.ts
+++ b/packages/framework/esm-utils/src/translate.ts
@@ -3,11 +3,14 @@ import _i18n from "i18next";
 export function translateFrom(
   moduleName: string,
   key: string,
-  fallback?: string
+  fallback?: string,
+  options?: object
 ) {
   const i18n: typeof _i18n = (_i18n as any).default || _i18n;
-  return i18n.t(key, {
+  const tOptions = {
     ns: moduleName,
     defaultValue: fallback,
-  });
+    ...options,
+  };
+  return i18n.t(key, tOptions);
 }

--- a/packages/framework/esm-utils/src/translate.ts
+++ b/packages/framework/esm-utils/src/translate.ts
@@ -7,10 +7,9 @@ export function translateFrom(
   options?: object
 ) {
   const i18n: typeof _i18n = (_i18n as any).default || _i18n;
-  const tOptions = {
+  return i18n.t(key, {
     ns: moduleName,
     defaultValue: fallback,
     ...options,
-  };
-  return i18n.t(key, tOptions);
+  });
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests, or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Makes it so the `translateFrom` function can be used with strings that require variable interpolations.
