### PR TITLE
03-1125: (bug) fix current visit retaining previous patient visit-data

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.component.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.component.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen, wait } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import ChangeLocale from "./change-locale.component";
 
 const allowedLocales = ["en", "fr", "it", "pt"];
@@ -32,7 +32,7 @@ describe(`<ChangeLocale />`, () => {
     fireEvent.change(screen.getByLabelText(/Select locale/i), {
       target: { value: "en" },
     });
-    await wait(() =>
+    await waitFor(() =>
       expect(postUserPropertiesMock).toHaveBeenCalledWith(
         user.uuid,
         { defaultLocale: "en" },

--- a/packages/apps/esm-primary-navigation-app/src/root.component.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/root.component.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { fireEvent, render, screen, wait } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { of } from "rxjs";
 import { isDesktop } from "./utils";
 import { mockUser } from "../__mocks__/mock-user";
@@ -8,7 +8,6 @@ import Root from "./root.component";
 
 const mockUserObservable = of(mockUser);
 const mockSessionObservable = of({ data: mockSession });
-
 jest.mock("@openmrs/esm-framework", () => ({
   openmrsFetch: jest.fn().mockResolvedValue({}),
   useAssignedExtensions: jest.fn().mockReturnValue([]),
@@ -72,7 +71,7 @@ describe(`<Root />`, () => {
     });
 
     it("does not render side menu button if desktop", async () => {
-      await wait(() =>
+      await waitFor(() =>
         expect(screen.queryAllByLabelText("Open menu")).toHaveLength(0)
       );
     });

--- a/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts
@@ -13,19 +13,20 @@ import {
   Visit,
 } from "../types";
 
+export const defaultVisitCustomRepresentation =
+  "custom:(uuid,encounters:(uuid,encounterDatetime," +
+  "form:(uuid,name),location:ref," +
+  "encounterType:ref,encounterProviders:(uuid,display," +
+  "provider:(uuid,display))),patient:(uuid,uuid)," +
+  "visitType:(uuid,name,display),attributes:(uuid,display,value),location:(uuid,name,display),startDatetime," +
+  "stopDatetime)";
+
 export function getVisitsForPatient(
   patientUuid: string,
   abortController: AbortController,
   v?: string
 ): Observable<FetchResponse<{ results: Array<Visit> }>> {
-  const custom =
-    v ||
-    "custom:(uuid,encounters:(uuid,encounterDatetime," +
-      "form:(uuid,name),location:ref," +
-      "encounterType:ref,encounterProviders:(uuid,display," +
-      "provider:(uuid,display))),patient:(uuid,uuid)," +
-      "visitType:(uuid,name,display),attributes:(uuid,display,value),location:(uuid,name,display),startDatetime," +
-      "stopDatetime)";
+  const custom = v ?? defaultVisitCustomRepresentation;
 
   return openmrsObservableFetch(
     `/ws/rest/v1/visit?patient=${patientUuid}&v=${custom}`,

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -501,6 +501,16 @@ ___
 
 ## API Variables
 
+### defaultVisitCustomRepresentation
+
+• **defaultVisitCustomRepresentation**: `string`
+
+#### Defined in
+
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L16)
+
+___
+
 ### fhir
 
 • **fhir**: `FhirClient`
@@ -532,7 +542,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:77](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L77)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:78](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L78)
 
 ___
 
@@ -877,7 +887,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L16)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L24)
 
 ___
 
@@ -1062,7 +1072,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:48](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L48)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L49)
 
 ___
 
@@ -1145,7 +1155,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:62](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L62)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:63](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L63)
 
 ___
 
@@ -4257,28 +4267,27 @@ ___
 
 ### useVisit
 
-▸ **useVisit**(`patientUuid`, `includeInactive?`): `VisitReturnType`
+▸ **useVisit**(`patientUuid`): `VisitReturnType`
 
 This React hook returns a visit object. If the `patientUuid` is provided
-as a parameter, then the visits, currentVisit, error and mutate function
+as a parameter, then the currentVisit, error and mutate function
 for that patient visit is returned.
 
 #### Parameters
 
-| Name | Type | Default value | Description |
-| :------ | :------ | :------ | :------ |
-| `patientUuid` | `string` | `undefined` | Unique patient identifier `string` |
-| `includeInactive` | `boolean` | `false` | Boolean that specifies whether to include Inactive visits `boolean`, defaults to false |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `patientUuid` | `string` | Unique patient identifier `string` |
 
 #### Returns
 
 `VisitReturnType`
 
-Object {`visits`, `error` `isValidating`, `currentVisit`, `mutate`}
+Object {`error` `isValidating`, `currentVisit`, `mutate`}
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useVisit.ts:27](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/useVisit.ts#L27)
+[packages/framework/esm-react-utils/src/useVisit.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/useVisit.ts#L22)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -4257,26 +4257,28 @@ ___
 
 ### useVisit
 
-▸ **useVisit**(`patientUuid`): `Object`
+▸ **useVisit**(`patientUuid`, `includeInactive?`): `VisitReturnType`
+
+This React hook returns a visit object. If the `patientUuid` is provided
+as a parameter, then the visits, currentVisit, error and mutate function
+for that patient visit is returned.
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `patientUuid` | `string` |
+| Name | Type | Default value | Description |
+| :------ | :------ | :------ | :------ |
+| `patientUuid` | `string` | `undefined` | Unique patient identifier `string` |
+| `includeInactive` | `boolean` | `false` | Boolean that specifies whether to include Inactive visits `boolean`, defaults to false |
 
 #### Returns
 
-`Object`
+`VisitReturnType`
 
-| Name | Type |
-| :------ | :------ |
-| `currentVisit` | ``null`` \| [`Visit`](interfaces/Visit.md) |
-| `error` | ``null`` |
+Object {`visits`, `error` `isValidating`, `currentVisit`, `mutate`}
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useVisit.ts:11](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/useVisit.ts#L11)
+[packages/framework/esm-react-utils/src/useVisit.ts:27](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/useVisit.ts#L27)
 
 ___
 

--- a/packages/framework/esm-framework/docs/enums/VisitMode.md
+++ b/packages/framework/esm-framework/docs/enums/VisitMode.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:88](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L88)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:89](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L89)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:89](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L89)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:90](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L90)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L87)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:88](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L88)

--- a/packages/framework/esm-framework/docs/enums/VisitStatus.md
+++ b/packages/framework/esm-framework/docs/enums/VisitStatus.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:93](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L93)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:94](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L94)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:94](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L94)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:95](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L95)

--- a/packages/framework/esm-framework/docs/interfaces/VisitItem.md
+++ b/packages/framework/esm-framework/docs/interfaces/VisitItem.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:83](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L83)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:84](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L84)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:80](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L80)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:81](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L81)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:82](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L82)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:83](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L83)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:81](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L81)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:82](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L82)

--- a/packages/framework/esm-react-utils/src/useVisit.ts
+++ b/packages/framework/esm-react-utils/src/useVisit.ts
@@ -1,43 +1,34 @@
-import { openmrsFetch, Visit } from "@openmrs/esm-api";
+import {
+  defaultVisitCustomRepresentation,
+  openmrsFetch,
+  Visit,
+} from "@openmrs/esm-api";
 import useSWR from "swr";
 
 interface VisitReturnType {
-  visits: Array<Visit>;
   error: Error;
   mutate: () => void;
   isValidating: boolean;
   currentVisit: Visit | null;
 }
 
-const defaultVisitCustomRepresentation =
-  "custom:(uuid,encounters:(uuid,encounterDatetime," +
-  "form:(uuid,name),location:ref," +
-  "encounterType:ref,encounterProviders:(uuid,display," +
-  "provider:(uuid,display))),patient:(uuid,uuid)," +
-  "visitType:(uuid,name,display),attributes:(uuid,display,value),location:(uuid,name,display),startDatetime," +
-  "stopDatetime)";
 /**
  * This React hook returns a visit object. If the `patientUuid` is provided
- * as a parameter, then the visits, currentVisit, error and mutate function
+ * as a parameter, then the currentVisit, error and mutate function
  * for that patient visit is returned.
  * @param patientUuid Unique patient identifier `string`
- * @param includeInactive Boolean that specifies whether to include Inactive visits `boolean`, defaults to false
- * @returns Object {`visits`, `error` `isValidating`, `currentVisit`, `mutate`}
+ * @returns Object {`error` `isValidating`, `currentVisit`, `mutate`}
  */
-export function useVisit(
-  patientUuid: string,
-  includeInactive: boolean = false
-): VisitReturnType {
+export function useVisit(patientUuid: string): VisitReturnType {
   const { data, error, mutate, isValidating } = useSWR<{
     data: { results: Array<Visit> };
   }>(
-    `/ws/rest/v1/visit?patient=${patientUuid}&v=${defaultVisitCustomRepresentation}&includeInactive=${includeInactive}`,
+    `/ws/rest/v1/visit?patient=${patientUuid}&v=${defaultVisitCustomRepresentation}&includeInactive=false`,
     openmrsFetch
   );
 
-  const visits = data?.data.results ?? [];
   const currentVisit =
     data?.data.results.find((visit) => visit.stopDatetime === null) ?? null;
 
-  return { visits, error, mutate, isValidating, currentVisit };
+  return { error, mutate, isValidating, currentVisit };
 }

--- a/packages/framework/esm-react-utils/src/useVisit.ts
+++ b/packages/framework/esm-react-utils/src/useVisit.ts
@@ -1,49 +1,43 @@
-import { useState, useEffect } from "react";
-import dayjs from "dayjs";
-import {
-  getVisitsForPatient,
-  getStartedVisit,
-  VisitMode,
-  VisitStatus,
-  Visit,
-} from "@openmrs/esm-api";
+import { openmrsFetch, Visit } from "@openmrs/esm-api";
+import useSWR from "swr";
 
-export function useVisit(patientUuid: string) {
-  const [currentVisit, setCurrentVisit] = useState<Visit | null>(null);
-  const [error, setError] = useState(null);
+interface VisitReturnType {
+  visits: Array<Visit>;
+  error: Error;
+  mutate: () => void;
+  isValidating: boolean;
+  currentVisit: Visit | null;
+}
 
-  useEffect(() => {
-    const sub = getStartedVisit.subscribe((visit) => {
-      if (visit) {
-        setCurrentVisit(visit?.visitData ?? null);
-      } else {
-        setCurrentVisit(null);
-      }
-    });
+const defaultVisitCustomRepresentation =
+  "custom:(uuid,encounters:(uuid,encounterDatetime," +
+  "form:(uuid,name),location:ref," +
+  "encounterType:ref,encounterProviders:(uuid,display," +
+  "provider:(uuid,display))),patient:(uuid,uuid)," +
+  "visitType:(uuid,name,display),attributes:(uuid,display,value),location:(uuid,name,display),startDatetime," +
+  "stopDatetime)";
+/**
+ * This React hook returns a visit object. If the `patientUuid` is provided
+ * as a parameter, then the visits, currentVisit, error and mutate function
+ * for that patient visit is returned.
+ * @param patientUuid Unique patient identifier `string`
+ * @param includeInactive Boolean that specifies whether to include Inactive visits `boolean`, defaults to false
+ * @returns Object {`visits`, `error` `isValidating`, `currentVisit`, `mutate`}
+ */
+export function useVisit(
+  patientUuid: string,
+  includeInactive: boolean = false
+): VisitReturnType {
+  const { data, error, mutate, isValidating } = useSWR<{
+    data: { results: Array<Visit> };
+  }>(
+    `/ws/rest/v1/visit?patient=${patientUuid}&v=${defaultVisitCustomRepresentation}&includeInactive=${includeInactive}`,
+    openmrsFetch
+  );
 
-    return () => sub.unsubscribe();
-  }, [patientUuid]);
+  const visits = data?.data.results ?? [];
+  const currentVisit =
+    data?.data.results.find((visit) => visit.stopDatetime === null) ?? null;
 
-  useEffect(() => {
-    const abortController = new AbortController();
-    const sub = getVisitsForPatient(patientUuid, abortController).subscribe(
-      ({ data }) => {
-        const currentVisit = data.results.find(
-          (visit) => visit.stopDatetime === null
-        );
-
-        if (currentVisit) {
-          getStartedVisit.next({
-            mode: VisitMode.LOADING,
-            visitData: currentVisit,
-            status: VisitStatus.ONGOING,
-          });
-        }
-      },
-      setError
-    );
-    return () => sub && sub.unsubscribe();
-  }, [patientUuid]);
-
-  return { currentVisit, error };
+  return { visits, error, mutate, isValidating, currentVisit };
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests, or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR addresses a number of things

- remove dependency on `rxjs`
- update `useVisit` hook to fix bug where, on searching a different patient, the previous patient `visit` data would still be displayed as the patient's visit. This is seen on the `active-visit-tag.component` on patient chart
- provide mechanism to pass in current visit. useful when entering retrospective data.

## Screenshots
![current-visit](https://user-images.githubusercontent.com/28008754/155013192-f44a8e89-86f8-4d0f-b923-ad958bb862a3.gif)

## Related Issue
[https://issues.openmrs.org/projects/MF/issues/O3-1125](https://issues.openmrs.org/projects/MF/issues/O3-1125)


## Other
<!-- Anything not covered above -->
