### PR TITLE
BREAKING: Update the extensions API

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/configuration/value-editors/extension-slot-remove.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/value-editors/extension-slot-remove.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { MultiSelect } from "carbon-components-react";
-import { useAssignedExtensionIds } from "@openmrs/esm-framework";
+import { useAssignedExtensions } from "@openmrs/esm-framework";
 
 export function ExtensionSlotRemove({
   slotName,
@@ -8,7 +8,7 @@ export function ExtensionSlotRemove({
   value,
   setValue,
 }) {
-  const assignedIds = useAssignedExtensionIds(slotName);
+  const assignedIds = useAssignedExtensions(slotName).map((e) => e.id);
 
   return (
     <MultiSelect.Filterable

--- a/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import styles from "./styles.css";
 import Close16 from "@carbon/icons-react/es/close/16";
-import { useExtensionStore, useStore } from "@openmrs/esm-framework";
+import { useExtensionInternalStore, useStore } from "@openmrs/esm-framework";
 import { Button } from "carbon-components-react";
 import { Portal } from "./portal";
 import { ExtensionOverlay } from "./extension-overlay.component";
 import { ImplementerToolsStore, implementerToolsStore } from "../store";
 
 export function UiEditor() {
-  const { slots, extensions } = useExtensionStore();
+  const { slots, extensions } = useExtensionInternalStore();
   const { isOpen: implementerToolsIsOpen } = useStore(implementerToolsStore);
 
   return (

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -3,8 +3,8 @@ import {
   LoggedInUser,
   useLayoutType,
   ExtensionSlot,
-  useAssignedExtensionIds,
   ConfigurableLink,
+  useAssignedExtensions,
 } from "@openmrs/esm-framework";
 import {
   HeaderContainer,
@@ -40,7 +40,7 @@ const Navbar: React.FC<NavbarProps> = ({
   session,
 }) => {
   const layout = useLayoutType();
-  const navMenuItems = useAssignedExtensionIds("nav-menu-slot");
+  const navMenuItems = useAssignedExtensions("nav-menu-slot").map((e) => e.id);
 
   const [activeHeaderPanel, setActiveHeaderPanel] = useState<string>(null);
 

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -175,6 +175,7 @@ const Navbar: React.FC<NavbarProps> = ({
     layout,
     hidePanel,
     togglePanel,
+    onLogout,
   ]);
 
   return <div>{session && <HeaderContainer render={render} />}</div>;

--- a/packages/apps/esm-primary-navigation-app/src/root.component.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/root.component.test.tsx
@@ -11,7 +11,7 @@ const mockSessionObservable = of({ data: mockSession });
 
 jest.mock("@openmrs/esm-framework", () => ({
   openmrsFetch: jest.fn().mockResolvedValue({}),
-  useAssignedExtensionIds: jest.fn().mockResolvedValue([]),
+  useAssignedExtensions: jest.fn().mockResolvedValue([]),
   createErrorHandler: jest.fn(),
   openmrsObservableFetch: jest.fn(),
   getCurrentUser: jest.fn(() => mockUserObservable),

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -260,6 +260,7 @@ export function getAssignedExtensions(
     extensions.push({
       id,
       name,
+      moduleName: extension.moduleName,
       meta: extension.meta,
       online: extension.online,
       offline: extension.offline,

--- a/packages/framework/esm-extensions/src/store.ts
+++ b/packages/framework/esm-extensions/src/store.ts
@@ -70,6 +70,7 @@ export interface ExtensionSlotState {
 export interface AssignedExtension {
   id: string;
   name: string;
+  moduleName: string;
   meta: ExtensionMeta;
   online?: boolean | object;
   offline?: boolean | object;

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -2487,7 +2487,7 @@ extension system.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:128](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L128)
+[packages/framework/esm-extensions/src/store.ts:129](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L129)
 
 ___
 
@@ -3954,21 +3954,15 @@ ___
 
 ▸ `Const` **useExtensionStore**(): `T`
 
-The implementation of this will soon undergo a breaking change.
-This will return an `ExtensionStore` rather than `ExtensionInternalStore`.
-
 #### Returns
 
 `T`
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useExtensionStore.ts:11](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/useExtensionStore.ts#L11)
+[packages/framework/esm-react-utils/src/useExtensionStore.ts:4](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/useExtensionStore.ts#L4)
 
 ▸ `Const` **useExtensionStore**(`actions`): `T` & [`BoundActions`](API.md#boundactions)
-
-The implementation of this will soon undergo a breaking change.
-This will return an `ExtensionStore` rather than `ExtensionInternalStore`.
 
 #### Parameters
 
@@ -3982,12 +3976,9 @@ This will return an `ExtensionStore` rather than `ExtensionInternalStore`.
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useExtensionStore.ts:11](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/useExtensionStore.ts#L11)
+[packages/framework/esm-react-utils/src/useExtensionStore.ts:4](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/useExtensionStore.ts#L4)
 
 ▸ `Const` **useExtensionStore**(`actions?`): `T` & [`BoundActions`](API.md#boundactions)
-
-The implementation of this will soon undergo a breaking change.
-This will return an `ExtensionStore` rather than `ExtensionInternalStore`.
 
 #### Parameters
 
@@ -4001,7 +3992,7 @@ This will return an `ExtensionStore` rather than `ExtensionInternalStore`.
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useExtensionStore.ts:11](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/useExtensionStore.ts#L11)
+[packages/framework/esm-react-utils/src/useExtensionStore.ts:4](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/useExtensionStore.ts#L4)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/AssignedExtension.md
+++ b/packages/framework/esm-framework/docs/interfaces/AssignedExtension.md
@@ -8,6 +8,7 @@
 
 - [id](AssignedExtension.md#id)
 - [meta](AssignedExtension.md#meta)
+- [moduleName](AssignedExtension.md#modulename)
 - [name](AssignedExtension.md#name)
 - [offline](AssignedExtension.md#offline)
 - [online](AssignedExtension.md#online)
@@ -27,6 +28,16 @@ ___
 ### meta
 
 • **meta**: [`ExtensionMeta`](ExtensionMeta.md)
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/store.ts:74](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L74)
+
+___
+
+### moduleName
+
+• **moduleName**: `string`
 
 #### Defined in
 
@@ -50,7 +61,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:75](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L75)
+[packages/framework/esm-extensions/src/store.ts:76](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L76)
 
 ___
 
@@ -60,4 +71,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:74](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L74)
+[packages/framework/esm-extensions/src/store.ts:75](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L75)

--- a/packages/framework/esm-framework/docs/interfaces/ConnectedExtension.md
+++ b/packages/framework/esm-framework/docs/interfaces/ConnectedExtension.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:79](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L79)
+[packages/framework/esm-extensions/src/store.ts:80](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L80)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:81](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L81)
+[packages/framework/esm-extensions/src/store.ts:82](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L82)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:80](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L80)
+[packages/framework/esm-extensions/src/store.ts:81](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L81)

--- a/packages/framework/esm-react-utils/src/useExtensionStore.ts
+++ b/packages/framework/esm-react-utils/src/useExtensionStore.ts
@@ -1,13 +1,6 @@
-import {
-  ExtensionInternalStore,
-  getExtensionInternalStore,
-} from "@openmrs/esm-extensions";
+import { ExtensionStore, getExtensionStore } from "@openmrs/esm-extensions";
 import { createUseStore } from "./createUseStore";
 
-/**
- * The implementation of this will soon undergo a breaking change.
- * This will return an `ExtensionStore` rather than `ExtensionInternalStore`.
- */
-export const useExtensionStore = createUseStore<ExtensionInternalStore>(
-  getExtensionInternalStore()
+export const useExtensionStore = createUseStore<ExtensionStore>(
+  getExtensionStore()
 );


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests, or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Updates `useExtensionStore` to return the extension store rather than the internal extension store. 

**Must be merged together with https://github.com/openmrs/openmrs-esm-patient-chart/pull/578** 

No expected impact on OHRI, patient-management, or home.
