### PR TITLE
(docs) Remove errant comma from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,22 @@
 ## Requirements
-
 - [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
 
 #### For changes to apps
-
 - [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
 
 #### If applicable
-
 - [ ] My work includes tests or is validated by existing tests.
 - [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.
 
 ## Summary
-
 <!-- Please describe what problems your PR addresses. -->
 
 ## Screenshots
-
 <!-- Required if you are making UI changes. -->
 
 ## Related Issue
-
 <!-- Paste the link to the Jira ticket here if one exists. -->
 <!-- https://issues.openmrs.org/browse/O3- -->
 
 ## Other
-
 <!-- Anything not covered above -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,22 +1,29 @@
 ## Requirements
+
 - [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
 
 #### For changes to apps
+
 - [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).
 
 #### If applicable
-- [ ] My work includes tests, or is validated by existing tests.
+
+- [ ] My work includes tests or is validated by existing tests.
 - [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.
 
 ## Summary
+
 <!-- Please describe what problems your PR addresses. -->
 
 ## Screenshots
+
 <!-- Required if you are making UI changes. -->
 
 ## Related Issue
+
 <!-- Paste the link to the Jira ticket here if one exists. -->
 <!-- https://issues.openmrs.org/browse/O3- -->
 
 ## Other
+
 <!-- Anything not covered above -->

--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,4 @@ docs/
 *.ico
 *.ejs
 packages/esm-styleguide/src/**/*.html
+.github/


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR removes an errant comma that gets flagged by Grammarly as a grammatical error. The spacing changes in the diff are incidental and appear to come from Prettier.

## Screenshot

<img width="884" alt="Screenshot 2022-02-28 at 16 19 08" src="https://user-images.githubusercontent.com/8509731/155990037-0f611fbf-0005-457d-bd66-8dac379e7ac2.png">

