### PR TITLE
O3-1145: Person attribute labels should be loaded from the backend

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/configuration/value-editors/array-editor.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/value-editors/array-editor.tsx
@@ -67,8 +67,7 @@ export function ArrayEditor({
             </StructuredListRow>
           ))}
           <StructuredListRow>
-            <StructuredListCell></StructuredListCell>
-            <StructuredListCell className={styles.buttonCell}>
+            <StructuredListCell>
               <Button
                 renderIcon={Add16}
                 size="sm"

--- a/packages/apps/esm-implementer-tools-app/src/configuration/value-editors/concept-search.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/value-editors/concept-search.tsx
@@ -1,10 +1,7 @@
 import React, { useState, useEffect, useMemo } from "react";
 import debounce from "lodash-es/debounce";
 import uniqueId from "lodash-es/uniqueId";
-import {
-  fetchConceptByUuid,
-  performConceptSearch,
-} from "./concept-search.resource";
+import { performConceptSearch } from "./concept-search.resource";
 import styles from "./uuid-search.scss";
 import {
   Search,
@@ -75,7 +72,6 @@ export function ConceptSearchBox({ setConcept, value }: ConceptSearchBoxProps) {
           aria-controls={`searchbox-${id}`}
           aria-expanded={searchResults.length > 0}
           placeholder={t("searchConceptHelperText", "Concept Name")}
-          autoFocus
           onChange={($event) => {
             handleSearchTermChange($event.target.value);
           }}

--- a/packages/apps/esm-implementer-tools-app/src/configuration/value-editors/person-attribute-search.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/value-editors/person-attribute-search.tsx
@@ -12,7 +12,6 @@ import {
   StructuredListWrapper,
 } from "carbon-components-react";
 import { ValueEditorField } from "./value-editor-field";
-import { DisplayValue } from "../display-value";
 import { Type } from "@openmrs/esm-framework";
 import { ConceptSearchBox } from "./concept-search";
 
@@ -137,20 +136,32 @@ export function PersonAttributeTypeSearchBox({
             {t("noPersonAttributeFoundText", "No matching results found")}
           </p>
         )}
-        {activePersonAttribute.name && activePersonAttribute.uuid && (
-          <DisplayValue
-            value={{
-              name: activePersonAttribute.name,
-              uuid: activePersonAttribute.uuid,
-            }}
-          />
-        )}
       </div>
       <div>
         <StructuredListWrapper>
           <StructuredListBody>
+            {activePersonAttribute.name && (
+              <StructuredListRow>
+                <StructuredListCell>
+                  {t("nameField", "name")}
+                </StructuredListCell>
+                <StructuredListCell>
+                  {activePersonAttribute.name}
+                </StructuredListCell>
+              </StructuredListRow>
+            )}
+            {activePersonAttribute.uuid && (
+              <StructuredListRow>
+                <StructuredListCell>
+                  {t("uuidField", "uuid")}
+                </StructuredListCell>
+                <StructuredListCell>
+                  {activePersonAttribute.uuid}
+                </StructuredListCell>
+              </StructuredListRow>
+            )}
             <StructuredListRow>
-              <StructuredListCell>{t("type", "type")}</StructuredListCell>
+              <StructuredListCell>{t("typeField", "type")}</StructuredListCell>
               <StructuredListCell>
                 <ValueEditorField
                   element={{
@@ -166,7 +177,9 @@ export function PersonAttributeTypeSearchBox({
               </StructuredListCell>
             </StructuredListRow>
             <StructuredListRow>
-              <StructuredListCell>{t("concept", "concept")}</StructuredListCell>
+              <StructuredListCell>
+                {t("conceptField", "concept")}
+              </StructuredListCell>
               <StructuredListCell>
                 <ConceptSearchBox
                   value={activePersonAttribute.concept}

--- a/packages/apps/esm-implementer-tools-app/src/configuration/value-editors/uuid-search.scss
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/value-editors/uuid-search.scss
@@ -11,7 +11,7 @@
 .autocomplete,
 .autocomplete > [role="combobox"] {
   position: relative;
-  width: 20em;
+  min-width: 20rem;
 }
 
 .listbox {

--- a/packages/apps/esm-implementer-tools-app/src/configuration/value-editors/value-editor-field.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/value-editors/value-editor-field.tsx
@@ -53,8 +53,8 @@ export function ValueEditorField({
   ) : valueType === Type.PersonAttributeTypeUuid ? (
     <PersonAttributeTypeSearchBox
       value={value}
-      setPersonAttributeUuid={(personAttributeTypeUuid) =>
-        onChange(personAttributeTypeUuid)
+      setPersonAttributeUuid={(personAttributeType) =>
+        onChange(personAttributeType)
       }
     />
   ) : valueType === Type.Number ? (


### PR DESCRIPTION
This PR is an extension to #325.
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
In the work done in #325, the user can fetch the UUID of the person-attribute-type from the backend but filled the name of the attribute-type manually. In this PR, I have made changes such that when a user fetches the attribute type by UUID from the backend, the name field will also be filled from the backend's response.

## Screenshots
https://www.loom.com/share/2e2ecd6d5c1e4f19b61c84829971d867

## Related Issue
https://issues.openmrs.org/browse/O3-1143

## Other
<!-- Anything not covered above -->
