### PR TITLE
BREAKING: Use extensionSlots as key in config instead of extensions

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/configuration/config-tree-for-module.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/config-tree-for-module.component.tsx
@@ -16,11 +16,11 @@ export function ConfigTreeForModule({
   return (
     <TreeContainer>
       <ExtensionSlotsConfigTree
-        extensionsConfig={config.extensions}
+        extensionsConfig={config.extensionSlots}
         moduleName={moduleName}
       />
       <ConfigSubtree
-        config={pickBy(config, (v, key) => key !== "extensions")}
+        config={pickBy(config, (v, key) => key !== "extensionSlots")}
         path={[moduleName]}
       />
     </TreeContainer>

--- a/packages/apps/esm-implementer-tools-app/src/configuration/configuration.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/configuration.component.tsx
@@ -101,11 +101,11 @@ export const Configuration: React.FC<ConfigurationProps> = () => {
     const result = cloneDeep(config);
     for (let slot of Object.values(extensionStore.slots)) {
       if (slot.moduleName) {
-        if (!result[slot.moduleName].extensions) {
-          result[slot.moduleName].extensions = {};
+        if (!result[slot.moduleName].extensionSlots) {
+          result[slot.moduleName].extensionSlots = {};
         }
-        if (!result[slot.moduleName].extensions[slot.name]) {
-          result[slot.moduleName].extensions[slot.name] = {};
+        if (!result[slot.moduleName].extensionSlots[slot.name]) {
+          result[slot.moduleName].extensionSlots[slot.name] = {};
         }
       }
     }

--- a/packages/apps/esm-implementer-tools-app/src/configuration/extension-slots-config-tree.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/extension-slots-config-tree.tsx
@@ -41,7 +41,7 @@ export function ExtensionSlotsConfigTree({
         <ExtensionSlotConfigTree
           key={slotName}
           config={extensionsConfig?.[slotName]}
-          path={[moduleName, "extensions", slotName]}
+          path={[moduleName, "extensionSlots", slotName]}
         />
       ))}
     </Subtree>

--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -844,7 +844,7 @@ describe("extension slot config", () => {
     // modules that define schemas.
     Config.provide({
       "foo-module": {
-        extensions: {
+        extensionSlots: {
           fooSlot: {
             add: ["bar", "baz"],
             remove: ["zap"],
@@ -874,7 +874,7 @@ describe("extension slot config", () => {
     });
     Config.provide({
       "foo-module": {
-        extensions: { fooSlot: { remove: ["bar"] } },
+        extensionSlots: { fooSlot: { remove: ["bar"] } },
       },
     });
     const config = await Config.getConfig("foo-module");
@@ -888,7 +888,7 @@ describe("extension slot config", () => {
     });
     Config.provide({
       "foo-module": {
-        extensions: { fooSlot: { remove: ["bar"] } },
+        extensionSlots: { fooSlot: { remove: ["bar"] } },
       },
     });
     await Config.getConfig("foo-module");
@@ -902,14 +902,14 @@ describe("extension slot config", () => {
     });
     Config.provide({
       "foo-module": {
-        extensions: { fooSlot: { remove: ["bar"] } },
+        extensionSlots: { fooSlot: { remove: ["bar"] } },
       },
     });
     const config = implementerToolsConfigStore.getState().config;
     expect(config).toStrictEqual({
       "foo-module": {
         foo: { _default: 0, _value: 0, _source: "default" },
-        extensions: {
+        extensionSlots: {
           fooSlot: {
             remove: { _value: ["bar"], _source: "provided" },
           },
@@ -921,11 +921,13 @@ describe("extension slot config", () => {
   it("validates that no other keys are present for the slot", async () => {
     Config.provide({
       "foo-module": {
-        extensions: { fooSlot: { quitar: ["bar"] } },
+        extensionSlots: { fooSlot: { quitar: ["bar"] } },
       },
     });
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringMatching(/foo-module.extensions.fooSlot.*invalid.*quitar/)
+      expect.stringMatching(
+        /foo-module.extensionSlots.fooSlot.*invalid.*quitar/
+      )
     );
   });
 });
@@ -971,7 +973,7 @@ describe("extension config", () => {
     const testConfig = {
       "ext-mod": { bar: "qux" },
       "slot-mod": {
-        extensions: {
+        extensionSlots: {
           barSlot: {
             configure: { "fooExt#id0": { baz: "quiz" } },
           },
@@ -1006,7 +1008,7 @@ describe("extension config", () => {
     const testConfig = {
       "ext-mod": { bar: "qux" },
       "slot-mod": {
-        extensions: {
+        extensionSlots: {
           barSlot: {
             configure: { "fooExt#id0": { beef: "bad" } },
           },

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -256,7 +256,8 @@ function getExtensionConfig(
   const providedConfigs = getProvidedConfigs(configState, tempConfigState);
   const slotModuleConfig = mergeConfigsFor(slotModuleName, providedConfigs);
   const configOverride =
-    slotModuleConfig?.extensions?.[slotName]?.configure?.[extensionId] ?? {};
+    slotModuleConfig?.extensionSlots?.[slotName]?.configure?.[extensionId] ??
+    {};
   const extensionModuleConfig = mergeConfigsFor(
     extensionModuleName,
     providedConfigs
@@ -269,7 +270,7 @@ function getExtensionConfig(
     extensionConfig,
     configState.devDefaultsAreOn
   );
-  delete config.extensions;
+  delete config.extensionSlots;
   return config;
 }
 
@@ -324,8 +325,8 @@ function getExtensionSlotConfigs(
     string,
     Record<string, ExtensionSlotConfig>
   > = Object.keys(allConfigs).reduce((obj, key) => {
-    if (allConfigs[key]?.extensions) {
-      obj[key] = allConfigs[key]?.extensions;
+    if (allConfigs[key]?.extensionSlots) {
+      obj[key] = allConfigs[key]?.extensionSlots;
     }
     return obj;
   }, {});
@@ -354,7 +355,7 @@ function validateExtensionSlotConfig(
   moduleName: string,
   slotName: string
 ): void {
-  const errorPrefix = `Extension slot config '${moduleName}.extensions.${slotName}`;
+  const errorPrefix = `Extension slot config '${moduleName}.extensionSlots.${slotName}`;
   const invalidKeys = Object.keys(config).filter(
     (k) => !["add", "remove", "order", "configure"].includes(k)
   );
@@ -510,7 +511,7 @@ function getConfigForModule(
   );
   validateConfig(schema, inputConfig, moduleName);
   const config = setDefaults(schema, inputConfig, configState.devDefaultsAreOn);
-  delete config.extensions;
+  delete config.extensionSlots;
   return config;
 }
 
@@ -544,7 +545,7 @@ const validateConfig = (
     const schemaPart = schema[key] as ConfigSchema;
 
     if (!schema.hasOwnProperty(key)) {
-      if (key !== "extensions") {
+      if (key !== "extensionSlots") {
         console.error(
           `Unknown config key '${thisKeyPath}' provided. Ignoring.`
         );

--- a/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
@@ -28,7 +28,7 @@ describe("Interaction between configuration and extension systems", () => {
     defineConfigSchema("esm-flintstone", {});
     provide({
       "esm-flintstone": {
-        extensions: {
+        extensionSlots: {
           "A slot": {
             add: ["Barney", "Betty"],
             order: ["Betty", "Wilma"],
@@ -62,7 +62,7 @@ describe("Interaction between configuration and extension systems", () => {
     provide({
       "esm-flintstone": {
         town: "Springfield",
-        extensions: {
+        extensionSlots: {
           "Future slot": {
             configure: {
               Wilma: {
@@ -106,7 +106,7 @@ describe("Interaction between configuration and extension systems", () => {
     attach("Flintstone slot", "pet#BabyPuss");
     provide({
       "esm-flintstone": {
-        extensions: {
+        extensionSlots: {
           "Flintstone slot": {
             configure: {
               "pet#Dino": {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This changes the key used to configure extension slots (and their extensions). It was `extensions`, which was confusing, because all the keys under it were actually slot names. It is now `extensionSlots`. So

```json
{
  "@openmrs/esm-patient-chart-app": {
    "extensions": {
      "patient-chart-allergies-dashboard-slot": {
        "add": [
          "obs-by-encounter-widget#hiv"
        ],
        "configure": {
          "obs-by-encounter-widget#hiv" : {
            "title" : "HIV Widget"
          }
        }
      }
    }
  }
}
```

must be changed to

```json
{
  "@openmrs/esm-patient-chart-app": {
    "extensionSlots": {
      "patient-chart-allergies-dashboard-slot": {
        "add": [
          "obs-by-encounter-widget#hiv"
        ],
        "configure": {
          "obs-by-encounter-widget#hiv" : {
            "title" : "HIV Widget"
          }
        }
      }
    }
  }
}
```

### Other

Marked "BREAKING" because it will break any existing config files using `extensions`.