### PR TITLE
(fix) Add missing swr dep to esm-react-utils

### DIFF
--- a/packages/framework/esm-react-utils/package.json
+++ b/packages/framework/esm-react-utils/package.json
@@ -39,7 +39,8 @@
   },
   "dependencies": {
     "lodash-es": "^4.17.21",
-    "single-spa-react": "^4.1.1"
+    "single-spa-react": "^4.1.1",
+    "swr": "^1.2.2"
   },
   "peerDependencies": {
     "@openmrs/esm-api": "3.x",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16425,7 +16425,7 @@ svgo@^2.7.0:
     picocolors "^1.0.0"
     stable "^0.1.8"
 
-swr@^1.0.1:
+swr@^1.0.1, swr@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/swr/-/swr-1.2.2.tgz#6cae09928d30593a7980d80f85823e57468fac5d"
   integrity sha512-ky0BskS/V47GpW8d6RU7CPsr6J8cr7mQD6+do5eky3bM0IyJaoi3vO8UhvrzJaObuTlGhPl2szodeB2dUd76Xw==


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

The missing dependency causes downstream failures for any app running core:

![MicrosoftTeams-image](https://user-images.githubusercontent.com/1031876/157769117-9574953b-4b6c-4ca8-98af-821c3a89324b.png)

