### PR TITLE
Fixes incorrect link to manifest in index.html

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -98,6 +98,7 @@ module.exports = (env, argv = {}) => {
       filename: "openmrs.js",
       chunkFilename: "[chunkhash].js",
       path: resolve(__dirname, outDir),
+      publicPath: "",
     },
     target: "web",
     devServer: {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

## Summary

Loading any MFE results in multiple errors in the server log and in the browser console related to the inability to load the manifest.json file.  Researching this, indeed the generated index.html is referencing "auto/manifest.xxx.json", whereas the file itself is not located in an "auto" directory, but in the same directory as "index.html".

Based [on reading here](https://stackoverflow.com/questions/65245185/new-to-webpackautoprefix-problem-with-webpack-manifest-plugin), the intended fix is to add output.publicPath: "" to the webpack configuration.

## Screenshots
In the server log, this appears like the following:

SpaServlet.getFile(166) |2022-03-11 14:32:21,589| File with path '/home/mseaton/openmrs/mirebalais/frontend/auto/manifest.d7f50154f66448287167e3a19324d47a.json' doesn't exist

This can easily be seen by loading an existing instance and viewing the JS console.

![image](https://user-images.githubusercontent.com/356297/157973560-d0359bc7-2da5-4dcc-91e6-6c0af3bfc6d8.png)

