### PR TITLE
(fix) O3-1173: Patient Chart fails to load on tablet

### DIFF
--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -40,19 +40,16 @@ function updateExtensionOutputStore(
 ) {
   const slots: Record<string, ExtensionSlotState> = {};
   for (let [slotName, slot] of Object.entries(internalState.slots)) {
-    // Only include registered slots
-    if (slot.moduleName) {
-      const { config } = getExtensionSlotConfigFromStore(
-        extensionSlotConfigs,
-        slot.name
-      );
-      const assignedExtensions = getAssignedExtensionsFromData(
-        slotName,
-        internalState,
-        config
-      );
-      slots[slotName] = { moduleName: slot.moduleName, assignedExtensions };
-    }
+    const { config } = getExtensionSlotConfigFromStore(
+      extensionSlotConfigs,
+      slot.name
+    );
+    const assignedExtensions = getAssignedExtensionsFromData(
+      slotName,
+      internalState,
+      config
+    );
+    slots[slotName] = { moduleName: slot.moduleName, assignedExtensions };
   }
   if (!isEqual(extensionStore.getState().slots, slots)) {
     extensionStore.setState({ slots });

--- a/packages/framework/esm-extensions/src/store.ts
+++ b/packages/framework/esm-extensions/src/store.ts
@@ -63,7 +63,7 @@ export interface ExtensionStore {
 }
 
 export interface ExtensionSlotState {
-  moduleName: string;
+  moduleName?: string;
   assignedExtensions: Array<AssignedExtension>;
 }
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1801,7 +1801,7 @@ writing a module for a specific implementation.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:154](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L154)
+[packages/framework/esm-extensions/src/extensions.ts:151](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L151)
 
 ___
 
@@ -2095,7 +2095,7 @@ Avoid using this. Extension attachments should be considered declarative.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:185](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L185)
+[packages/framework/esm-extensions/src/extensions.ts:182](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L182)
 
 ___
 
@@ -2117,7 +2117,7 @@ Avoid using this. Extension attachments should be considered declarative.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:209](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L209)
+[packages/framework/esm-extensions/src/extensions.ts:206](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L206)
 
 ___
 
@@ -2249,7 +2249,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:300](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L300)
+[packages/framework/esm-extensions/src/extensions.ts:297](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L297)
 
 ___
 
@@ -2373,7 +2373,7 @@ A list of extensions that should be rendered
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:267](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L267)
+[packages/framework/esm-extensions/src/extensions.ts:264](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L264)
 
 ___
 
@@ -2440,7 +2440,7 @@ getExtensionNameFromId("baz")
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:98](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L98)
+[packages/framework/esm-extensions/src/extensions.ts:95](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L95)
 
 ___
 
@@ -2460,7 +2460,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:111](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L111)
+[packages/framework/esm-extensions/src/extensions.ts:108](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L108)
 
 ___
 
@@ -2481,7 +2481,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:103](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L103)
+[packages/framework/esm-extensions/src/extensions.ts:100](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L100)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotState.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotState.md
@@ -23,7 +23,7 @@ ___
 
 ### moduleName
 
-• **moduleName**: `string`
+• `Optional` **moduleName**: `string`
 
 #### Defined in
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This is fixed by allowing metas to be fetched for extensions that are not mounted yet. I can't think of any real reason not to allow that.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue

https://issues.openmrs.org/browse/O3-1173
