### PR TITLE
(test) Restore location picker tests

### DIFF
--- a/packages/apps/esm-login-app/__mocks__/config.mock.ts
+++ b/packages/apps/esm-login-app/__mocks__/config.mock.ts
@@ -7,6 +7,7 @@ export const mockConfig = {
   chooseLocation: {
     enabled: true,
     numberToShow: 3,
+    useLoginLocationTag: true,
   },
   logo: {
     src: null,

--- a/packages/apps/esm-login-app/__mocks__/locations.mock.ts
+++ b/packages/apps/esm-login-app/__mocks__/locations.mock.ts
@@ -1,0 +1,374 @@
+export const mockLoginLocations = {
+  data: {
+    resourceType: "Bundle",
+    id: "301b3ad6-868a-48a6-bc3f-aaa8aa3f89a6",
+    meta: {
+      lastUpdated: "2022-03-17T07:47:02.272+00:00",
+      tag: [
+        {
+          system: "http://terminology.hl7.org/CodeSystem/v3-ObservationValue",
+          code: "SUBSETTED",
+          display: "Resource encoded in summary mode",
+        },
+      ],
+    },
+    type: "searchset",
+    total: 4,
+    link: [
+      {
+        relation: "self",
+        url: "http://openmrs:8080/openmrs/ws/fhir2/R4/Location?_count=50&_summary=data&_tag=login%20location",
+      },
+    ],
+    entry: [
+      {
+        fullUrl:
+          "http://openmrs:8080/openmrs/ws/fhir2/R4/Location/44c3efb0-2583-4c80-a79e-1f756a03c0a1",
+        resource: {
+          resourceType: "Location",
+          id: "44c3efb0-2583-4c80-a79e-1f756a03c0a1",
+          meta: {
+            tag: [
+              {
+                system: "http://fhir.openmrs.org/ext/location-tag",
+                code: "Login Location",
+                display:
+                  "When a user logs in and chooses a session location, they may only choose one with this tag",
+              },
+              {
+                system: "http://fhir.openmrs.org/ext/location-tag",
+                code: "Facility Location",
+              },
+              {
+                system:
+                  "http://terminology.hl7.org/CodeSystem/v3-ObservationValue",
+                code: "SUBSETTED",
+                display: "Resource encoded in summary mode",
+              },
+            ],
+          },
+          contained: [
+            {
+              resourceType: "Provenance",
+              id: "e6f5d190-5a5a-4e1f-b34b-20a3480a6e1b",
+              meta: {
+                tag: [
+                  {
+                    system:
+                      "http://terminology.hl7.org/CodeSystem/v3-ObservationValue",
+                    code: "SUBSETTED",
+                    display: "Resource encoded in summary mode",
+                  },
+                ],
+              },
+              recorded: "2022-02-23T22:44:33.000+00:00",
+              activity: {
+                coding: [
+                  {
+                    system:
+                      "http://terminology.hl7.org/CodeSystemv3-DataOperation",
+                    code: "CREATE",
+                    display: "create",
+                  },
+                ],
+              },
+              agent: [
+                {
+                  type: {
+                    coding: [
+                      {
+                        system:
+                          "http://terminology.hl7.org/CodeSystemprovenance-participant-type",
+                        code: "author",
+                        display: "Author",
+                      },
+                    ],
+                  },
+                  role: [
+                    {
+                      coding: [
+                        {
+                          system:
+                            "http://terminology.hl7.org/CodeSystemv3-ParticipationType",
+                          code: "AUT",
+                          display: "author",
+                        },
+                      ],
+                    },
+                  ],
+                  who: {
+                    reference:
+                      "Practitioner/A4F30A1B-5EB9-11DF-A648-37A07F9C90FB",
+                    type: "Practitioner",
+                    display: "Super User",
+                  },
+                },
+              ],
+            },
+          ],
+          status: "active",
+          name: "Outpatient Clinic",
+          description: "Outpatient Clinic",
+        },
+      },
+      {
+        fullUrl:
+          "http://openmrs:8080/openmrs/ws/fhir2/R4/Location/ba685651-ed3b-4e63-9b35-78893060758a",
+        resource: {
+          resourceType: "Location",
+          id: "ba685651-ed3b-4e63-9b35-78893060758a",
+          meta: {
+            tag: [
+              {
+                system: "http://fhir.openmrs.org/ext/location-tag",
+                code: "Login Location",
+                display:
+                  "When a user logs in and chooses a session location, they may only choose one with this tag",
+              },
+              {
+                system:
+                  "http://terminology.hl7.org/CodeSystem/v3-ObservationValue",
+                code: "SUBSETTED",
+                display: "Resource encoded in summary mode",
+              },
+            ],
+          },
+          contained: [
+            {
+              resourceType: "Provenance",
+              id: "621310a4-4c42-46eb-83e8-46e4a61cf250",
+              meta: {
+                tag: [
+                  {
+                    system:
+                      "http://terminology.hl7.org/CodeSystem/v3-ObservationValue",
+                    code: "SUBSETTED",
+                    display: "Resource encoded in summary mode",
+                  },
+                ],
+              },
+              recorded: "2022-02-23T22:44:33.000+00:00",
+              activity: {
+                coding: [
+                  {
+                    system:
+                      "http://terminology.hl7.org/CodeSystemv3-DataOperation",
+                    code: "CREATE",
+                    display: "create",
+                  },
+                ],
+              },
+              agent: [
+                {
+                  type: {
+                    coding: [
+                      {
+                        system:
+                          "http://terminology.hl7.org/CodeSystemprovenance-participant-type",
+                        code: "author",
+                        display: "Author",
+                      },
+                    ],
+                  },
+                  role: [
+                    {
+                      coding: [
+                        {
+                          system:
+                            "http://terminology.hl7.org/CodeSystemv3-ParticipationType",
+                          code: "AUT",
+                          display: "author",
+                        },
+                      ],
+                    },
+                  ],
+                  who: {
+                    reference:
+                      "Practitioner/A4F30A1B-5EB9-11DF-A648-37A07F9C90FB",
+                    type: "Practitioner",
+                    display: "Super User",
+                  },
+                },
+              ],
+            },
+          ],
+          status: "active",
+          name: "Inpatient Ward",
+          description: "Inpatient Ward",
+        },
+      },
+      {
+        fullUrl:
+          "http://openmrs:8080/openmrs/ws/fhir2/R4/Location/8d9045ad-50f0-45b8-93c8-3ed4bce19dbf",
+        resource: {
+          resourceType: "Location",
+          id: "8d9045ad-50f0-45b8-93c8-3ed4bce19dbf",
+          meta: {
+            tag: [
+              {
+                system: "http://fhir.openmrs.org/ext/location-tag",
+                code: "Login Location",
+                display:
+                  "When a user logs in and chooses a session location, they may only choose one with this tag",
+              },
+              {
+                system:
+                  "http://terminology.hl7.org/CodeSystem/v3-ObservationValue",
+                code: "SUBSETTED",
+                display: "Resource encoded in summary mode",
+              },
+            ],
+          },
+          contained: [
+            {
+              resourceType: "Provenance",
+              id: "307f2319-cf8a-419d-9c0d-94fbe385e214",
+              meta: {
+                tag: [
+                  {
+                    system:
+                      "http://terminology.hl7.org/CodeSystem/v3-ObservationValue",
+                    code: "SUBSETTED",
+                    display: "Resource encoded in summary mode",
+                  },
+                ],
+              },
+              recorded: "2022-02-23T22:44:33.000+00:00",
+              activity: {
+                coding: [
+                  {
+                    system:
+                      "http://terminology.hl7.org/CodeSystemv3-DataOperation",
+                    code: "CREATE",
+                    display: "create",
+                  },
+                ],
+              },
+              agent: [
+                {
+                  type: {
+                    coding: [
+                      {
+                        system:
+                          "http://terminology.hl7.org/CodeSystemprovenance-participant-type",
+                        code: "author",
+                        display: "Author",
+                      },
+                    ],
+                  },
+                  role: [
+                    {
+                      coding: [
+                        {
+                          system:
+                            "http://terminology.hl7.org/CodeSystemv3-ParticipationType",
+                          code: "AUT",
+                          display: "author",
+                        },
+                      ],
+                    },
+                  ],
+                  who: {
+                    reference:
+                      "Practitioner/A4F30A1B-5EB9-11DF-A648-37A07F9C90FB",
+                    type: "Practitioner",
+                    display: "Super User",
+                  },
+                },
+              ],
+            },
+          ],
+          status: "active",
+          name: "Mobile Clinic",
+          description: "Mobile Clinic",
+        },
+      },
+      {
+        fullUrl:
+          "http://openmrs:8080/openmrs/ws/fhir2/R4/Location/1ce1b7d4-c865-4178-82b0-5932e51503d6",
+        resource: {
+          resourceType: "Location",
+          id: "1ce1b7d4-c865-4178-82b0-5932e51503d6",
+          meta: {
+            tag: [
+              {
+                system: "http://fhir.openmrs.org/ext/location-tag",
+                code: "Login Location",
+                display:
+                  "When a user logs in and chooses a session location, they may only choose one with this tag",
+              },
+              {
+                system:
+                  "http://terminology.hl7.org/CodeSystem/v3-ObservationValue",
+                code: "SUBSETTED",
+                display: "Resource encoded in summary mode",
+              },
+            ],
+          },
+          contained: [
+            {
+              resourceType: "Provenance",
+              id: "d82a66d0-2c79-4679-8330-dac32aa1209c",
+              meta: {
+                tag: [
+                  {
+                    system:
+                      "http://terminology.hl7.org/CodeSystem/v3-ObservationValue",
+                    code: "SUBSETTED",
+                    display: "Resource encoded in summary mode",
+                  },
+                ],
+              },
+              recorded: "2022-02-23T22:44:33.000+00:00",
+              activity: {
+                coding: [
+                  {
+                    system:
+                      "http://terminology.hl7.org/CodeSystemv3-DataOperation",
+                    code: "CREATE",
+                    display: "create",
+                  },
+                ],
+              },
+              agent: [
+                {
+                  type: {
+                    coding: [
+                      {
+                        system:
+                          "http://terminology.hl7.org/CodeSystemprovenance-participant-type",
+                        code: "author",
+                        display: "Author",
+                      },
+                    ],
+                  },
+                  role: [
+                    {
+                      coding: [
+                        {
+                          system:
+                            "http://terminology.hl7.org/CodeSystemv3-ParticipationType",
+                          code: "AUT",
+                          display: "author",
+                        },
+                      ],
+                    },
+                  ],
+                  who: {
+                    reference:
+                      "Practitioner/A4F30A1B-5EB9-11DF-A648-37A07F9C90FB",
+                    type: "Practitioner",
+                    display: "Super User",
+                  },
+                },
+              ],
+            },
+          ],
+          status: "active",
+          name: "Community Outreach",
+          description: "Community Outreach",
+        },
+      },
+    ],
+  },
+};

--- a/packages/apps/esm-login-app/jest.config.js
+++ b/packages/apps/esm-login-app/jest.config.js
@@ -9,5 +9,5 @@ module.exports = {
     "\\.(s?css)$": "identity-obj-proxy",
     "^lodash-es/(.*)$": "lodash/$1",
   },
-  setupFiles: ["<rootDir>/src/setup-tests.js"],
+  setupFilesAfterEnv: ["<rootDir>/src/setupTests.ts"],
 };

--- a/packages/apps/esm-login-app/src/choose-location/choose-location.component.tsx
+++ b/packages/apps/esm-login-app/src/choose-location/choose-location.component.tsx
@@ -54,10 +54,10 @@ export const ChooseLocation: React.FC<ChooseLocationProps> = ({
 
   useEffect(() => {
     if (!isLoading) {
-      if (!config.chooseLocation.enabled || locationData.length === 1) {
+      if (!config.chooseLocation.enabled || locationData?.length === 1) {
         changeLocation(locationData[0]?.resource.id);
       }
-      if (!isLoading && !locationData.length) {
+      if (!isLoading && !locationData?.length) {
         changeLocation();
       }
     }

--- a/packages/apps/esm-login-app/src/choose-location/choose-location.resource.ts
+++ b/packages/apps/esm-login-app/src/choose-location/choose-location.resource.ts
@@ -5,16 +5,10 @@ import {
   FetchResponse,
   showNotification,
 } from "@openmrs/esm-framework";
-import { LocationEntry, LocationResponse } from "../types";
 import useSwrInfinite from "swr/infinite";
+import { LocationEntry, LocationResponse } from "../types";
 
-const fhirLocationUrl = `${fhirBaseUrl}/Location?_summary=data`;
-
-export function useLoginLocations(
-  useLoginLocationTag: boolean,
-  count: number = 0,
-  searchQuery: string = ""
-): {
+interface LoginLocationData {
   locationData: Array<LocationEntry>;
   isLoading: boolean;
   totalResults: number;
@@ -23,26 +17,41 @@ export function useLoginLocations(
   setPage: (
     size: number | ((_size: number) => number)
   ) => Promise<FetchResponse<LocationResponse>[]>;
-} {
+}
+
+const fhirLocationUrl = `${fhirBaseUrl}/Location?_summary=data`;
+
+export function useLoginLocations(
+  useLoginLocationTag: boolean,
+  count: number = 0,
+  searchQuery: string = ""
+): LoginLocationData {
   const getUrl = (page, prevPageData: FetchResponse<LocationResponse>) => {
     if (
       prevPageData &&
       !prevPageData?.data?.link?.some((link) => link.relation === "next")
-    )
+    ) {
       return null;
+    }
+
     let url = fhirLocationUrl;
+
     if (count) {
       url += `&_count=${count}`;
     }
+
     if (page) {
       url += `&_getpagesoffset=${page * count}`;
     }
+
     if (useLoginLocationTag) {
       url += "&_tag=login location";
     }
+
     if (typeof searchQuery === "string" && searchQuery != "") {
       url += `&name=${searchQuery}`;
     }
+
     return url;
   };
 
@@ -52,7 +61,6 @@ export function useLoginLocations(
   >(getUrl, openmrsFetch);
 
   if (error) {
-    console.error(error.message);
     showNotification({
       title: error.name,
       description: error.message,
@@ -64,12 +72,12 @@ export function useLoginLocations(
     setSize(1);
   }, [searchQuery, setSize]);
 
-  const returnValue = useMemo(() => {
+  const memoizedLocationData = useMemo(() => {
     return {
       locationData: data
         ? [].concat(...data?.map((resp) => resp?.data?.entry))
         : null,
-      isLoading: !data,
+      isLoading: !data && !error,
       totalResults: data?.[0]?.data?.total ?? null,
       hasMore: data?.length
         ? data?.[data.length - 1]?.data?.link.some(
@@ -81,5 +89,5 @@ export function useLoginLocations(
     };
   }, [data, isValidating, setSize]);
 
-  return returnValue;
+  return memoizedLocationData;
 }

--- a/packages/apps/esm-login-app/src/choose-location/choose-location.test.tsx
+++ b/packages/apps/esm-login-app/src/choose-location/choose-location.test.tsx
@@ -201,7 +201,7 @@ describe("ChooseLocation: ", () => {
   });
 });
 
-export function waitForLoadingToFinish() {
+function waitForLoadingToFinish() {
   return waitForElementToBeRemoved(
     () => [...screen.queryAllByRole(/progressbar/i)],
     {

--- a/packages/apps/esm-login-app/src/choose-location/choose-location.test.tsx
+++ b/packages/apps/esm-login-app/src/choose-location/choose-location.test.tsx
@@ -1,0 +1,211 @@
+import {
+  screen,
+  waitFor,
+  waitForElementToBeRemoved,
+} from "@testing-library/react";
+import renderWithRouter from "../test-helpers/render-with-router";
+import { navigate, openmrsFetch, useConfig } from "@openmrs/esm-framework";
+import { mockLoginLocations } from "../../__mocks__/locations.mock";
+import { mockConfig } from "../../__mocks__/config.mock";
+import ChooseLocation from "./choose-location.component";
+
+const mockedNavigate = navigate as jest.Mock;
+const mockedOpenmrsFetch = openmrsFetch as jest.Mock;
+const mockedUseConfig = useConfig as jest.Mock;
+
+const mockSoleLoginLocation = {
+  data: {
+    id: "301b3ad6-868a-48a6-bc3f-aaa8aa3f891z",
+    total: 1,
+    link: [
+      {
+        relation: "self",
+        url: "http://openmrs:8080/openmrs/ws/fhir2/R4/Location?_count=50&_summary=data&_tag=login%20location",
+      },
+    ],
+    entry: [
+      {
+        resource: {
+          id: "44c3efb0-2583-4c80-a79e-1f756a03c0a1",
+          status: "active",
+          name: "Outpatient Clinic",
+          description: "Outpatient Clinic",
+        },
+      },
+    ],
+  },
+};
+
+jest.mock("../CurrentUserContext", () => ({
+  useCurrentUser() {
+    return {
+      display: "Testy McTesterface",
+    };
+  },
+}));
+
+describe("ChooseLocation: ", () => {
+  beforeEach(() => {
+    mockedUseConfig.mockReturnValue(mockConfig);
+    mockedOpenmrsFetch.mockReturnValue(mockLoginLocations);
+  });
+
+  it("renders a location picker showing a list of the available login locations", async () => {
+    const locationMock = {
+      state: {
+        referrer: "/home/patient-search",
+      },
+    };
+
+    renderWithRouter(ChooseLocation, {
+      location: locationMock,
+      isLoginEnabled: true,
+    });
+
+    await waitForLoadingToFinish();
+
+    const searchbox = screen.getByRole("search", {
+      name: /search for a location/i,
+    });
+    expect(searchbox).toBeInTheDocument();
+    expect(screen.getByText(/welcome testy mctesterface/i)).toBeInTheDocument();
+    expect(
+      screen.getByText(/select your location from the list below/i)
+    ).toBeInTheDocument();
+
+    const loginLocations = mockLoginLocations.data.entry.map(
+      (entry) => entry.resource.name
+    );
+    loginLocations.map((location) =>
+      expect(screen.getByRole("radio", { name: location })).toBeInTheDocument()
+    );
+
+    expect(
+      screen.getByRole("button", { name: /confirm/i })
+    ).toBeInTheDocument();
+  });
+
+  it("auto-selects the location and navigates away from the page when only one login location is available", async () => {
+    mockedOpenmrsFetch.mockReturnValue(mockSoleLoginLocation);
+
+    renderWithRouter(ChooseLocation, { isLoginEnabled: true });
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith({
+        to: "${openmrsSpaBase}/home",
+      })
+    );
+  });
+
+  it("skips rendering the location picker if `chooseLocation.enabled` is set to `false`", async () => {
+    mockedUseConfig.mockReturnValue({
+      ...mockConfig,
+      chooseLocation: {
+        enabled: false,
+      },
+    });
+
+    renderWithRouter(ChooseLocation, { isLoginEnabled: true });
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith({
+        to: "${openmrsSpaBase}/home",
+      })
+    );
+  });
+
+  it("skips rendering the location picker if there are no login locations available", async () => {
+    mockedOpenmrsFetch.mockReturnValue({
+      data: {
+        id: "301b3ad6-868a-48a6-bc3f-aaa8aa3f891z",
+        total: 0,
+        link: [
+          {
+            relation: "self",
+            url: "http://openmrs:8080/openmrs/ws/fhir2/R4/Location?_count=50&_summary=data&_tag=login%20location",
+          },
+        ],
+        entry: [],
+      },
+    });
+
+    renderWithRouter(ChooseLocation, { isLoginEnabled: true });
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith({
+        to: "${openmrsSpaBase}/home",
+      })
+    );
+  });
+
+  it("redirects back to the referring URL when available", async () => {
+    mockedUseConfig.mockReturnValue(mockConfig);
+    mockedOpenmrsFetch.mockReturnValue(mockSoleLoginLocation);
+
+    const locationMock = {
+      state: {
+        referrer: "/home/patient-search",
+      },
+    };
+
+    renderWithRouter(ChooseLocation, {
+      location: locationMock,
+      isLoginEnabled: true,
+    });
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith({
+        to: "${openmrsSpaBase}" + locationMock.state.referrer,
+      })
+    );
+  });
+
+  it("redirects to custom path if configured", async () => {
+    const redirectUrl = "${openmrsSpaBase}/foo";
+
+    mockedOpenmrsFetch.mockReturnValue(mockSoleLoginLocation);
+    mockedUseConfig.mockReturnValue({
+      ...mockConfig,
+      links: {
+        loginSuccess: redirectUrl,
+      },
+    });
+
+    renderWithRouter(ChooseLocation, { isLoginEnabled: true });
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith({
+        to: redirectUrl,
+      })
+    );
+  });
+
+  it("redirects to the `returnToUrl` URL query parameter when available", async () => {
+    const locationMock = {
+      search: "?returnToUrl=/openmrs/spa/home",
+    };
+
+    mockedOpenmrsFetch.mockReturnValue(mockSoleLoginLocation);
+    mockedUseConfig.mockReturnValue(mockConfig);
+
+    renderWithRouter(ChooseLocation, {
+      location: locationMock,
+      isLoginEnabled: true,
+    });
+
+    await waitFor(() =>
+      expect(mockedNavigate).toHaveBeenCalledWith({
+        to: "/openmrs/spa/home",
+      })
+    );
+  });
+});
+
+export function waitForLoadingToFinish() {
+  return waitForElementToBeRemoved(
+    () => [...screen.queryAllByRole(/progressbar/i)],
+    {
+      timeout: 4000,
+    }
+  );
+}

--- a/packages/apps/esm-login-app/src/loading/loading.component.tsx
+++ b/packages/apps/esm-login-app/src/loading/loading.component.tsx
@@ -4,7 +4,12 @@ import styles from "./loading.component.scss";
 
 const LoadingIcon: React.FC = () => (
   <div className={styles["centerLoadingSVG"]}>
-    <Loading description="Active loading indicator" withOverlay={false} small />
+    <Loading
+      description="Active loading indicator"
+      role="progressbar"
+      withOverlay={false}
+      small
+    />
   </div>
 );
 

--- a/packages/apps/esm-login-app/src/login/login.component.test.tsx
+++ b/packages/apps/esm-login-app/src/login/login.component.test.tsx
@@ -1,5 +1,3 @@
-import "@testing-library/jest-dom";
-import Login from "./login.component";
 import { useState } from "react";
 import { waitFor, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
@@ -8,6 +6,7 @@ import { performLogin } from "./login.resource";
 import { useCurrentUser } from "../CurrentUserContext";
 import { mockConfig } from "../../__mocks__/config.mock";
 import renderWithRouter from "../test-helpers/render-with-router";
+import Login from "./login.component";
 
 const mockedLogin = performLogin as jest.Mock;
 
@@ -136,6 +135,7 @@ describe(`<Login />`, () => {
       expect(wrapper.history.location.pathname).toBe("/login/location")
     );
   });
+
   it("respects the logo configuration", () => {
     const customLogoConfig = {
       src: "https://some-image-host.com/foo.png",

--- a/packages/apps/esm-login-app/src/setup-tests.js
+++ b/packages/apps/esm-login-app/src/setup-tests.js
@@ -1,5 +1,0 @@
-window.openmrsBase = "/openmrs";
-window.spaBase = "/spa";
-window.getOpenmrsSpaBase = () => "/openmrs/spa/";
-const { getComputedStyle } = window;
-window.getComputedStyle = (elt) => getComputedStyle(elt);

--- a/packages/apps/esm-login-app/src/setupTests.ts
+++ b/packages/apps/esm-login-app/src/setupTests.ts
@@ -1,0 +1,15 @@
+import "@testing-library/jest-dom";
+
+declare global {
+  interface Window {
+    openmrsBase: string;
+    spaBase: string;
+  }
+}
+
+const { getComputedStyle } = window;
+window.getComputedStyle = (element) => getComputedStyle(element);
+window.openmrsBase = "/openmrs";
+window.spaBase = "/spa";
+window.getOpenmrsSpaBase = () => "/openmrs/spa/";
+window.HTMLElement.prototype.scrollIntoView = jest.fn();


### PR DESCRIPTION
This PR does the following:

## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR:

- Restores and updates tests for the `ChooseLocation` component.
- Updates the jest setup file to include overrides for the `window` object and a `jest-dom` import to enable extended jest matcher syntax in tests.
- Adds improved type annotations to the `useLoginLocations` hook.
- Introduces some minor code fixes.

## Screenshots

<img width="1085" alt="Screenshot 2022-03-17 at 13 27 41" src="https://user-images.githubusercontent.com/8509731/158789833-5433da11-3e5c-4aab-8302-fb9ba598072b.png">