### PR TITLE
BREAKING: (feat) Allow inversion of useOnClickOutside

### DIFF
--- a/packages/framework/esm-react-utils/src/useOnClickOutside.tsx
+++ b/packages/framework/esm-react-utils/src/useOnClickOutside.tsx
@@ -2,7 +2,8 @@ import { useRef, useEffect } from "react";
 
 export function useOnClickOutside<T extends HTMLElement = HTMLElement>(
   handler: (event: Event) => void,
-  active = true
+  active = true,
+  invert = false
 ) {
   const ref = useRef<T>(null);
 
@@ -11,7 +12,7 @@ export function useOnClickOutside<T extends HTMLElement = HTMLElement>(
       const listener = (event: Event) => {
         const el = ref?.current;
 
-        if (el?.contains(event.target as Node)) {
+        if (el?.contains(event.target as Node) === !invert) {
           handler(event);
         }
       };

--- a/packages/framework/esm-react-utils/src/useOnClickOutside.tsx
+++ b/packages/framework/esm-react-utils/src/useOnClickOutside.tsx
@@ -9,7 +9,7 @@ export function useOnClickOutside<T extends HTMLElement = HTMLElement>(
   useEffect(() => {
     if (active) {
       const listener = (event: Event) => {
-        if (ref?.current?.contains(event.target as Node) {
+        if (ref?.current?.contains(event.target as Node)) {
             return;
         }
 

--- a/packages/framework/esm-react-utils/src/useOnClickOutside.tsx
+++ b/packages/framework/esm-react-utils/src/useOnClickOutside.tsx
@@ -2,19 +2,18 @@ import { useRef, useEffect } from "react";
 
 export function useOnClickOutside<T extends HTMLElement = HTMLElement>(
   handler: (event: Event) => void,
-  active = true,
-  invert = false
+  active = true
 ) {
   const ref = useRef<T>(null);
 
   useEffect(() => {
     if (active) {
       const listener = (event: Event) => {
-        const el = ref?.current;
-
-        if (el?.contains(event.target as Node) === !invert) {
-          handler(event);
+        if (ref?.current?.contains(event.target as Node) {
+            return;
         }
+
+        handler(event);
       };
 
       window.addEventListener(`click`, listener);


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
 There was need to create an inversion of [useOnClickOutside](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/useOnClickOutside.tsx) to handle other components on Dom beyond the referenced component.  Please fill free to checkout https://openmrs.slack.com/archives/CHP5QAE5R/p1648509416725489
 
 I needed this functionality when i was working with https://github.com/openmrs/openmrs-esm-patient-management/pull/136 
cc @ibacher @brandones @ZacButko  
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
