### PR TITLE
(fix) Restore missing side menu on tablet

### DIFF
--- a/packages/apps/esm-login-app/__mocks__/locations.mock.ts
+++ b/packages/apps/esm-login-app/__mocks__/locations.mock.ts
@@ -372,3 +372,26 @@ export const mockLoginLocations = {
     ],
   },
 };
+
+export const mockSoleLoginLocation = {
+  data: {
+    id: "301b3ad6-868a-48a6-bc3f-aaa8aa3f891z",
+    total: 1,
+    link: [
+      {
+        relation: "self",
+        url: "http://openmrs:8080/openmrs/ws/fhir2/R4/Location?_count=50&_summary=data&_tag=login%20location",
+      },
+    ],
+    entry: [
+      {
+        resource: {
+          id: "44c3efb0-2583-4c80-a79e-1f756a03c0a1",
+          status: "active",
+          name: "Outpatient Clinic",
+          description: "Outpatient Clinic",
+        },
+      },
+    ],
+  },
+};

--- a/packages/apps/esm-login-app/src/choose-location/choose-location.component.tsx
+++ b/packages/apps/esm-login-app/src/choose-location/choose-location.component.tsx
@@ -39,6 +39,7 @@ export const ChooseLocation: React.FC<ChooseLocationProps> = ({
         : Promise.resolve();
 
       sessionDefined.then(() => {
+        // console.log("referrer: ", referrer);
         if (referrer && referrer !== "/") {
           navigate({ to: "${openmrsSpaBase}" + referrer });
         }

--- a/packages/apps/esm-login-app/src/choose-location/choose-location.test.tsx
+++ b/packages/apps/esm-login-app/src/choose-location/choose-location.test.tsx
@@ -1,40 +1,13 @@
-import {
-  screen,
-  waitFor,
-  waitForElementToBeRemoved,
-} from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
 import renderWithRouter from "../test-helpers/render-with-router";
 import { navigate, openmrsFetch, useConfig } from "@openmrs/esm-framework";
-import { mockLoginLocations } from "../../__mocks__/locations.mock";
+import { mockSoleLoginLocation } from "../../__mocks__/locations.mock";
 import { mockConfig } from "../../__mocks__/config.mock";
 import ChooseLocation from "./choose-location.component";
 
 const mockedNavigate = navigate as jest.Mock;
 const mockedOpenmrsFetch = openmrsFetch as jest.Mock;
 const mockedUseConfig = useConfig as jest.Mock;
-
-const mockSoleLoginLocation = {
-  data: {
-    id: "301b3ad6-868a-48a6-bc3f-aaa8aa3f891z",
-    total: 1,
-    link: [
-      {
-        relation: "self",
-        url: "http://openmrs:8080/openmrs/ws/fhir2/R4/Location?_count=50&_summary=data&_tag=login%20location",
-      },
-    ],
-    entry: [
-      {
-        resource: {
-          id: "44c3efb0-2583-4c80-a79e-1f756a03c0a1",
-          status: "active",
-          name: "Outpatient Clinic",
-          description: "Outpatient Clinic",
-        },
-      },
-    ],
-  },
-};
 
 jest.mock("../CurrentUserContext", () => ({
   useCurrentUser() {
@@ -47,46 +20,15 @@ jest.mock("../CurrentUserContext", () => ({
 describe("ChooseLocation: ", () => {
   beforeEach(() => {
     mockedUseConfig.mockReturnValue(mockConfig);
-    mockedOpenmrsFetch.mockReturnValue(mockLoginLocations);
   });
 
-  it("renders a location picker showing a list of the available login locations", async () => {
-    const locationMock = {
-      state: {
-        referrer: "/home/patient-search",
-      },
-    };
-
-    renderWithRouter(ChooseLocation, {
-      location: locationMock,
-      isLoginEnabled: true,
-    });
-
-    await waitForLoadingToFinish();
-
-    const searchbox = screen.getByRole("search", {
-      name: /search for a location/i,
-    });
-    expect(searchbox).toBeInTheDocument();
-    expect(screen.getByText(/welcome testy mctesterface/i)).toBeInTheDocument();
-    expect(
-      screen.getByText(/select your location from the list below/i)
-    ).toBeInTheDocument();
-
-    const loginLocations = mockLoginLocations.data.entry.map(
-      (entry) => entry.resource.name
-    );
-    loginLocations.map((location) =>
-      expect(screen.getByRole("radio", { name: location })).toBeInTheDocument()
-    );
-
-    expect(
-      screen.getByRole("button", { name: /confirm/i })
-    ).toBeInTheDocument();
+  afterEach(() => {
+    mockedOpenmrsFetch.mockReset();
+    mockedNavigate.mockReset();
   });
 
   it("auto-selects the location and navigates away from the page when only one login location is available", async () => {
-    mockedOpenmrsFetch.mockReturnValue(mockSoleLoginLocation);
+    mockedOpenmrsFetch.mockReturnValueOnce(mockSoleLoginLocation);
 
     renderWithRouter(ChooseLocation, { isLoginEnabled: true });
 
@@ -98,7 +40,7 @@ describe("ChooseLocation: ", () => {
   });
 
   it("skips rendering the location picker if `chooseLocation.enabled` is set to `false`", async () => {
-    mockedUseConfig.mockReturnValue({
+    mockedUseConfig.mockReturnValueOnce({
       ...mockConfig,
       chooseLocation: {
         enabled: false,
@@ -115,19 +57,7 @@ describe("ChooseLocation: ", () => {
   });
 
   it("skips rendering the location picker if there are no login locations available", async () => {
-    mockedOpenmrsFetch.mockReturnValue({
-      data: {
-        id: "301b3ad6-868a-48a6-bc3f-aaa8aa3f891z",
-        total: 0,
-        link: [
-          {
-            relation: "self",
-            url: "http://openmrs:8080/openmrs/ws/fhir2/R4/Location?_count=50&_summary=data&_tag=login%20location",
-          },
-        ],
-        entry: [],
-      },
-    });
+    mockedOpenmrsFetch.mockReturnValueOnce(mockSoleLoginLocation);
 
     renderWithRouter(ChooseLocation, { isLoginEnabled: true });
 
@@ -139,8 +69,7 @@ describe("ChooseLocation: ", () => {
   });
 
   it("redirects back to the referring URL when available", async () => {
-    mockedUseConfig.mockReturnValue(mockConfig);
-    mockedOpenmrsFetch.mockReturnValue(mockSoleLoginLocation);
+    mockedOpenmrsFetch.mockReturnValueOnce(mockSoleLoginLocation);
 
     const locationMock = {
       state: {
@@ -163,7 +92,7 @@ describe("ChooseLocation: ", () => {
   it("redirects to custom path if configured", async () => {
     const redirectUrl = "${openmrsSpaBase}/foo";
 
-    mockedOpenmrsFetch.mockReturnValue(mockSoleLoginLocation);
+    mockedOpenmrsFetch.mockReturnValueOnce(mockSoleLoginLocation);
     mockedUseConfig.mockReturnValue({
       ...mockConfig,
       links: {
@@ -185,8 +114,7 @@ describe("ChooseLocation: ", () => {
       search: "?returnToUrl=/openmrs/spa/home",
     };
 
-    mockedOpenmrsFetch.mockReturnValue(mockSoleLoginLocation);
-    mockedUseConfig.mockReturnValue(mockConfig);
+    mockedOpenmrsFetch.mockReturnValueOnce(mockSoleLoginLocation);
 
     renderWithRouter(ChooseLocation, {
       location: locationMock,
@@ -200,12 +128,3 @@ describe("ChooseLocation: ", () => {
     );
   });
 });
-
-function waitForLoadingToFinish() {
-  return waitForElementToBeRemoved(
-    () => [...screen.queryAllByRole(/progressbar/i)],
-    {
-      timeout: 4000,
-    }
-  );
-}

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
@@ -39,7 +39,7 @@ const SideMenuPanel: React.FC<SideMenuPanelProps> = ({
         className={styles.link}
       >
         <ExtensionSlot extensionSlotName="global-nav-menu-slot" />
-        <ExtensionSlot extensionSlotName="nav-menu-slot" />
+        <ExtensionSlot extensionSlotName="patient-chart-dashboard-slot" />
       </SideNav>
     )
   );

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -40,7 +40,9 @@ const Navbar: React.FC<NavbarProps> = ({
   session,
 }) => {
   const layout = useLayoutType();
-  const navMenuItems = useAssignedExtensions("nav-menu-slot").map((e) => e.id);
+  const navMenuItems = useAssignedExtensions(
+    "patient-chart-dashboard-slot"
+  ).map((e) => e.id);
 
   const [activeHeaderPanel, setActiveHeaderPanel] = useState<string>(null);
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR fixes an issue where the side menu was not appearing in the tablet viewport. It does so by changing the referenced extension slot from `nav-menu-slot` to `patient-chart-dashboard-slot`. This change allows the navbar component to show a hamburger menu in the top left-hand corner of the page. Clicking on this hamburger menu then displays the side menu.

## Video

https://user-images.githubusercontent.com/8509731/160919679-e60b60b5-a018-49d0-aa70-ffe002341fcf.mp4

## Related Issue
https://issues.openmrs.org/browse/O3-1176
