### PR TITLE
Added mock setSessionLocation to pass the tests

### DIFF
--- a/packages/apps/esm-login-app/__mocks__/locations.mock.ts
+++ b/packages/apps/esm-login-app/__mocks__/locations.mock.ts
@@ -395,3 +395,5 @@ export const mockSoleLoginLocation = {
     ],
   },
 };
+
+export const mockSetSessionLocation = Promise.resolve();

--- a/packages/apps/esm-login-app/src/choose-location/choose-location.test.tsx
+++ b/packages/apps/esm-login-app/src/choose-location/choose-location.test.tsx
@@ -1,7 +1,10 @@
 import { waitFor } from "@testing-library/react";
 import renderWithRouter from "../test-helpers/render-with-router";
 import { navigate, openmrsFetch, useConfig } from "@openmrs/esm-framework";
-import { mockSoleLoginLocation } from "../../__mocks__/locations.mock";
+import {
+  mockSetSessionLocation,
+  mockSoleLoginLocation,
+} from "../../__mocks__/locations.mock";
 import { mockConfig } from "../../__mocks__/config.mock";
 import ChooseLocation from "./choose-location.component";
 
@@ -29,6 +32,7 @@ describe("ChooseLocation: ", () => {
 
   it("auto-selects the location and navigates away from the page when only one login location is available", async () => {
     mockedOpenmrsFetch.mockReturnValueOnce(mockSoleLoginLocation);
+    mockedOpenmrsFetch.mockReturnValueOnce(mockSetSessionLocation);
 
     renderWithRouter(ChooseLocation, { isLoginEnabled: true });
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
My previous PR #371 was failing the tests, so I have created a new mock mocking the setSessionLocation when 
`auto-selects the location and navigates away from the page when only one login location is available`

## Screenshots
None

## Related Issue
https://issues.openmrs.org/projects/O3/issues/O3-1222

## Other
None
