### PR TITLE
CurrentUserContext should always render children

### DIFF
--- a/packages/apps/esm-login-app/src/CurrentUserContext.tsx
+++ b/packages/apps/esm-login-app/src/CurrentUserContext.tsx
@@ -70,9 +70,5 @@ export const CurrentUserContext: React.FC = ({ children }) => {
     return () => sub.unsubscribe();
   }, []);
 
-  return (
-    <CurrentUser.Provider value={value}>
-      {!user.loading && children}
-    </CurrentUser.Provider>
-  );
+  return <CurrentUser.Provider value={value}>{children}</CurrentUser.Provider>;
 };


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Prior to this commit, the child nodes of the `CurrentUserContext` only render once loading is finished. However, in some circumstances, the `session` endpoint will return a 401 error instead of the response (e.g., when the user presents with a session cookie for an expired backend session). In these circumstances, the login screen will not render.

Since the `CurrentUserContext` is only used in the login app 🤞, it should be harmless to ensure it's children are always rendered.

Not 💯 convinced I haven't missed something, though.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
