### PR TITLE
O3-1157: Added field to search and select patient identifiers from implementer tools

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type-search.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type-search.tsx
@@ -33,6 +33,7 @@ export function PatientIdentifierTypeSearchBox({
   const handleUuidChange = (patientIdentifierType) => {
     setActivePatientIdentifierTypeUuid(patientIdentifierType.uuid);
     setPatientIdentifierTypeUuid(patientIdentifierType.uuid);
+    setSearchTerm("");
   };
 
   const handleSearchTermChange = debounce((searchTerm) => {
@@ -48,23 +49,6 @@ export function PatientIdentifierTypeSearchBox({
       return undefined;
     }
   }, [isLoading, searchTerm, patientIdentifierTypes]);
-
-  console.log(filteredResults);
-
-  // useEffect(() => {
-  //   const ac = new AbortController();
-
-  //   if (searchTerm && searchTerm.length >= 2) {
-  //     performPatientIdentifierTypeSearch(searchTerm).then(
-  //       ({ data: { results } }) => {
-  //         setSearchResults(results.slice(0, 9));
-  //       }
-  //     );
-  //   } else {
-  //     setSearchResults([]);
-  //   }
-  //   return () => ac.abort();
-  // }, [searchTerm]);
 
   return (
     <div>

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type-search.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type-search.tsx
@@ -1,0 +1,124 @@
+import React, { useState, useEffect, useMemo } from "react";
+import debounce from "lodash-es/debounce";
+import uniqueId from "lodash-es/uniqueId";
+import { usePatientIdentifierTypes } from "./patient-identifier-type.resource";
+import styles from "./uuid-search.scss";
+import { useTranslation } from "react-i18next";
+import {
+  Search,
+  StructuredListCell,
+  StructuredListRow,
+  StructuredListWrapper,
+} from "carbon-components-react";
+
+interface PatientIdentifierTypeSearchBoxProps {
+  value: string;
+  setPatientIdentifierTypeUuid: (patientIdentifierType) => void;
+}
+
+export function PatientIdentifierTypeSearchBox({
+  setPatientIdentifierTypeUuid,
+  value,
+}: PatientIdentifierTypeSearchBoxProps) {
+  const [searchTerm, setSearchTerm] = useState("");
+  const { data: patientIdentifierTypes, isLoading } =
+    usePatientIdentifierTypes();
+  const [activePatientIdentifierTypeUuid, setActivePatientIdentifierTypeUuid] =
+    useState<any>(value);
+  const { t } = useTranslation();
+  const searchTimeoutInMs = 300;
+
+  const id = useMemo(() => uniqueId(), []);
+
+  const handleUuidChange = (patientIdentifierType) => {
+    setActivePatientIdentifierTypeUuid(patientIdentifierType.uuid);
+    setPatientIdentifierTypeUuid(patientIdentifierType.uuid);
+  };
+
+  const handleSearchTermChange = debounce((searchTerm) => {
+    setSearchTerm(searchTerm);
+  }, searchTimeoutInMs);
+
+  const filteredResults = useMemo(() => {
+    if (!isLoading && searchTerm && searchTerm !== "") {
+      return patientIdentifierTypes?.filter((type) =>
+        type.display.toLowerCase().includes(searchTerm.toLowerCase())
+      );
+    } else {
+      return undefined;
+    }
+  }, [isLoading, searchTerm, patientIdentifierTypes]);
+
+  console.log(filteredResults);
+
+  // useEffect(() => {
+  //   const ac = new AbortController();
+
+  //   if (searchTerm && searchTerm.length >= 2) {
+  //     performPatientIdentifierTypeSearch(searchTerm).then(
+  //       ({ data: { results } }) => {
+  //         setSearchResults(results.slice(0, 9));
+  //       }
+  //     );
+  //   } else {
+  //     setSearchResults([]);
+  //   }
+  //   return () => ac.abort();
+  // }, [searchTerm]);
+
+  return (
+    <div>
+      {activePatientIdentifierTypeUuid && (
+        <p className={styles.activeUuid}>{activePatientIdentifierTypeUuid}</p>
+      )}
+      <div className={styles.autocomplete}>
+        <Search
+          id={`search-input-${id}`}
+          labelText=""
+          type="text"
+          size="sm"
+          placeholder={
+            !isLoading
+              ? t(
+                  "searchPersonAttributeHelperText",
+                  "Person attribute type name"
+                )
+              : t("loading", "Loading")
+          }
+          onChange={(event) => {
+            handleSearchTermChange(event.target.value);
+          }}
+          disabled={isLoading}
+        />
+        {searchTerm ? (
+          filteredResults?.length ? (
+            <StructuredListWrapper
+              selection
+              className={styles.listbox}
+              id={`searchbox-${id}`}
+            >
+              {filteredResults?.map((patientIdentifierType: any) => (
+                <StructuredListRow
+                  key={patientIdentifierType.uuid}
+                  role="option"
+                  onClick={() => {
+                    handleUuidChange(patientIdentifierType);
+                  }}
+                  aria-selected="true"
+                >
+                  <StructuredListCell className={styles.smallListCell}>
+                    {patientIdentifierType.display}
+                  </StructuredListCell>
+                </StructuredListRow>
+              ))}
+            </StructuredListWrapper>
+          ) : (
+            <p className={styles.bodyShort01}>
+              {t("noPersonAttributeFoundText", "No matching results found")}
+            </p>
+          )
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type-search.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type-search.tsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect, useMemo } from "react";
-import debounce from "lodash-es/debounce";
+import React, { useState, useMemo } from "react";
 import uniqueId from "lodash-es/uniqueId";
-import { usePatientIdentifierTypes } from "./patient-identifier-type.resource";
+import {
+  usePatientIdentifierTypes,
+  PatientIdentifierType,
+} from "./patient-identifier-type.resource";
 import styles from "./uuid-search.scss";
 import { useTranslation } from "react-i18next";
 import {
@@ -13,7 +15,7 @@ import {
 
 interface PatientIdentifierTypeSearchBoxProps {
   value: string;
-  setPatientIdentifierTypeUuid: (patientIdentifierType) => void;
+  setPatientIdentifierTypeUuid: (patientIdentifierTypeUuid) => void;
 }
 
 export function PatientIdentifierTypeSearchBox({
@@ -26,29 +28,27 @@ export function PatientIdentifierTypeSearchBox({
   const [activePatientIdentifierTypeUuid, setActivePatientIdentifierTypeUuid] =
     useState<any>(value);
   const { t } = useTranslation();
-  const searchTimeoutInMs = 300;
 
   const id = useMemo(() => uniqueId(), []);
 
-  const handleUuidChange = (patientIdentifierType) => {
+  const handleUuidChange = (patientIdentifierType: PatientIdentifierType) => {
     setActivePatientIdentifierTypeUuid(patientIdentifierType.uuid);
     setPatientIdentifierTypeUuid(patientIdentifierType.uuid);
     setSearchTerm("");
   };
 
-  const handleSearchTermChange = debounce((searchTerm) => {
-    setSearchTerm(searchTerm);
-  }, searchTimeoutInMs);
+  const handleSearchTermChange = (evt) => setSearchTerm(evt.target.value);
 
-  const filteredResults = useMemo(() => {
-    if (!isLoading && searchTerm && searchTerm !== "") {
-      return patientIdentifierTypes?.filter((type) =>
-        type.display.toLowerCase().includes(searchTerm.toLowerCase())
-      );
-    } else {
-      return undefined;
-    }
-  }, [isLoading, searchTerm, patientIdentifierTypes]);
+  const filteredResults: Array<PatientIdentifierType> | undefined =
+    useMemo(() => {
+      if (!isLoading && searchTerm && searchTerm !== "") {
+        return patientIdentifierTypes?.filter((type) =>
+          type.display.toLowerCase().includes(searchTerm.toLowerCase())
+        );
+      } else {
+        return undefined;
+      }
+    }, [isLoading, searchTerm, patientIdentifierTypes]);
 
   return (
     <div>
@@ -69,9 +69,8 @@ export function PatientIdentifierTypeSearchBox({
                 )
               : t("loading", "Loading")
           }
-          onChange={(event) => {
-            handleSearchTermChange(event.target.value);
-          }}
+          onChange={handleSearchTermChange}
+          value={searchTerm}
           disabled={isLoading}
         />
         {searchTerm ? (
@@ -81,7 +80,7 @@ export function PatientIdentifierTypeSearchBox({
               className={styles.listbox}
               id={`searchbox-${id}`}
             >
-              {filteredResults?.map((patientIdentifierType: any) => (
+              {filteredResults?.map((patientIdentifierType) => (
                 <StructuredListRow
                   key={patientIdentifierType.uuid}
                   role="option"

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type.resource.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type.resource.tsx
@@ -2,7 +2,7 @@ import useSWR from "swr";
 import { FetchResponse, openmrsFetch } from "@openmrs/esm-framework";
 import { useMemo } from "react";
 
-interface PatientIdentifierType {
+export interface PatientIdentifierType {
   uuid: string;
   display: string;
 }

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type.resource.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type.resource.tsx
@@ -1,0 +1,31 @@
+import useSWR from "swr";
+import { FetchResponse, openmrsFetch } from "@openmrs/esm-framework";
+import { useMemo } from "react";
+
+interface PatientIdentifierType {
+  uuid: string;
+  display: string;
+}
+
+interface PatientIdentifierTypeResponse {
+  results: Array<PatientIdentifierType>;
+}
+
+export function usePatientIdentifierTypes(): {
+  data: Array<PatientIdentifierType> | undefined;
+  isLoading: boolean;
+} {
+  const { data, error } = useSWR<
+    FetchResponse<PatientIdentifierTypeResponse>,
+    Error
+  >(`/ws/rest/v1/patientidentifiertype`, openmrsFetch);
+  const memoisedPatientIdentifierTypeData = useMemo(
+    () => ({
+      data: data?.data?.results,
+      isLoading: !data && !error,
+    }),
+    [data, error]
+  );
+
+  return memoisedPatientIdentifierTypeData;
+}

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/value-editor-field.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/value-editor-field.tsx
@@ -11,6 +11,7 @@ import { ExtensionSlotRemove } from "./extension-slot-remove";
 import { ObjectEditor } from "./object-editor";
 import { ExtensionSlotOrder } from "./extension-slot-order";
 import { PersonAttributeTypeSearchBox } from "./person-attribute-search";
+import { PatientIdentifierTypeSearchBox } from "./patient-identifier-type-search";
 
 export interface ValueEditorFieldProps {
   element: ConfigValueDescriptor;
@@ -56,6 +57,11 @@ export function ValueEditorField({
       setPersonAttributeUuid={(personAttributeTypeUuid) =>
         onChange(personAttributeTypeUuid)
       }
+    />
+  ) : valueType === Type.PatientIdentifierTypeUuid ? (
+    <PatientIdentifierTypeSearchBox
+      value={value}
+      setPatientIdentifierTypeUuid={(uuid) => onChange(uuid)}
     />
   ) : valueType === Type.Number ? (
     <NumberInput

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -680,6 +680,7 @@ function checkType(keyPath: string, _type: Type | undefined, value: any) {
       String: isString,
       UUID: isUuid,
       PersonAttributeTypeUuid: isUuid,
+      PatientIdentifierTypeUuid: isUuid,
     };
     runValidators(keyPath, [validator[_type]], value);
   }

--- a/packages/framework/esm-config/src/types.ts
+++ b/packages/framework/esm-config/src/types.ts
@@ -7,6 +7,7 @@ export enum Type {
   String = "String",
   UUID = "UUID",
   PersonAttributeTypeUuid = "PersonAttributeTypeUuid",
+  PatientIdentifierTypeUuid = "PatientIdentifierTypeUuid",
 }
 
 // Full-powered typing for Config and Schema trees depends on being able to


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
I have added a search field for searching and selecting a patient-identifier-type's UUID, similar to searching a concept UUID/ person-attribute-type UUID. Along with that, I've added the UUID validator for the field.

![image](https://user-images.githubusercontent.com/51502471/161567411-2fb94492-9350-46d2-b7b4-03d0455e5b85.png)


## Screenshots


## Related Issue
https://issues.openmrs.org/browse/O3-1157

## Other
<!-- Anything not covered above -->
