### PR TITLE
(fix) Precache importmap as part of the static dependency lifecycle | Remove obsolete XMLHttpRequest patches

### DIFF
--- a/packages/apps/esm-offline-tools-app/translations/en.json
+++ b/packages/apps/esm-offline-tools-app/translations/en.json
@@ -19,8 +19,8 @@
   "offlineActionsTableAction": "Action",
   "offlineActionsTableCreatedOn": "Date & Time",
   "offlineActionsTableDeleteAction": "Delete action",
-  "offlineActionsTableDeleteActions_one": "Delete {count} actions",
-  "offlineActionsTableDeleteActions_other": "Delete {count} actions",
+  "offlineActionsTableDeleteActions": "Delete {count} actions",
+  "offlineActionsTableDeleteActions_plural": "Delete {count} actions",
   "offlineActionsTableError": "Error",
   "offlineActionsTablePatient": "Patient",
   "offlineActionsUpdateOfflinePatients": "Update offline patients",
@@ -32,5 +32,7 @@
   "offlinePatientSyncDetailsFallbackErrorMessage": "Unknown error.",
   "offlinePatientSyncDetailsHeader": "Offline patient details",
   "offlineReady": "Offline Ready",
-  "offlineToolsAppMenuLink": "Offline tools"
+  "offlineToolsAppMenuLink": "Offline tools",
+  "offlineActionsTableDeleteActions_one": "Delete {count} actions",
+  "offlineActionsTableDeleteActions_other": "Delete {count} actions"
 }

--- a/packages/framework/esm-offline/src/index.ts
+++ b/packages/framework/esm-offline/src/index.ts
@@ -2,7 +2,6 @@ export * from "./service-worker";
 export * from "./service-worker-http-headers";
 export * from "./service-worker-messaging";
 export * from "./mode";
-export * from "./patches";
 export * from "./sync";
 export * from "./uuid";
 export * from "./offline-patient-data";

--- a/packages/framework/esm-offline/src/patches.ts
+++ b/packages/framework/esm-offline/src/patches.ts
@@ -1,7 +1,0 @@
-export function patchXMLHttpRequest() {
-  const send = XMLHttpRequest.prototype.send;
-
-  XMLHttpRequest.prototype.send = function (...args) {
-    return send.apply(this, args);
-  };
-}

--- a/packages/shell/esm-app-shell/src/index.ts
+++ b/packages/shell/esm-app-shell/src/index.ts
@@ -1,14 +1,7 @@
 import "@openmrs/esm-styleguide/dist/openmrs-esm-styleguide.css";
-import {
-  patchXMLHttpRequest,
-  setupPaths,
-  setupUtils,
-  SpaConfig,
-} from "@openmrs/esm-framework";
+import { setupPaths, setupUtils, SpaConfig } from "@openmrs/esm-framework";
 
 declare var __webpack_public_path__: string;
-
-patchXMLHttpRequest();
 
 function wireSpaPaths() {
   const baseElement = document.createElement("base");

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -210,7 +210,6 @@ async function setupOffline() {
     await registerOmrsServiceWorker(
       `${window.getOpenmrsSpaBase()}service-worker.js`
     );
-    await precacheImportMap();
     await activateOfflineCapability();
     setupOfflineStaticDependencyPrecaching();
   } catch (e) {
@@ -221,14 +220,6 @@ async function setupOffline() {
       description: `There was an error while initializing the website's offline mode. You can try reloading the page later.`,
     });
   }
-}
-
-async function precacheImportMap() {
-  const importMap = await window.importMapOverrides.getCurrentPageMap();
-  await messageOmrsServiceWorker({
-    type: "onImportMapChanged",
-    importMap,
-  });
 }
 
 function setupOfflineStaticDependencyPrecaching() {
@@ -265,6 +256,8 @@ function subscribeOnlineAndLoginChange(
 }
 
 async function precacheGlobalStaticDependencies() {
+  await precacheImportMap();
+
   // By default, cache the session endpoint.
   // This ensures that a lot of user/session related functions also work offline.
   const sessionPathUrl = new URL(
@@ -284,6 +277,14 @@ async function precacheGlobalStaticDependencies() {
       e
     )
   );
+}
+
+async function precacheImportMap() {
+  const importMap = await window.importMapOverrides.getCurrentPageMap();
+  await messageOmrsServiceWorker({
+    type: "onImportMapChanged",
+    importMap,
+  });
 }
 
 function setupOfflineCssClasses() {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Precaches the app's importmap references as part of the static dependency lifecycle. This has multiple advantages: In the future when we introduce a "Refresh cache" feature, these refs will be updated. It further prevents some issues where currently the system tried to cache deps while offline (which obviously fails).
In addition, I remove some old patches which have been added to make the network request interception of the service worker work with the esm-form-entry-app module. These are no longer required since the approach changed.
