### PR TITLE
(fix) Consider relative URLs when scanning the importmap for assets.

### DIFF
--- a/packages/shell/esm-app-shell/src/service-worker/import-map-utils.ts
+++ b/packages/shell/esm-app-shell/src/service-worker/import-map-utils.ts
@@ -46,7 +46,9 @@ function getUrlsFromBuildManifests(
   // Using a try/catch here seems better to me than doing defensive checks on every field/type in the response.
   try {
     const results: Array<string> = [];
-    const baseUrlForFiles = getUrlOfFileParentDir(new URL(importMapAddress));
+    const baseUrlForFiles = getUrlOfFileParentDir(
+      new URL(importMapAddress, self.location.href)
+    );
 
     for (const chunk of buildManifest.chunks ?? []) {
       for (const file of chunk.files ?? []) {
@@ -56,6 +58,12 @@ function getUrlsFromBuildManifests(
 
     return results;
   } catch (e) {
+    console.error(
+      "[SW] Failed to determine the dependencies of the module with the URL %s. Not precaching any of the module's assets. Error: ",
+      importMapAddress,
+      e
+    );
+
     return [];
   }
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

## Summary
Add support for import map URLs relative to the service worker. This should fix an issue with files not being correctly precached on app load  in environments which don't use absolute URLs in the import map.