### PR TITLE
Allow a slot to obtain its assigned extensions even if not all those extensions are registered yet

### DIFF
--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -351,13 +351,13 @@ function calculateAssignedIds(
       const ai = getOrder(
         idA,
         idOrder,
-        extensions[getExtensionNameFromId(idA)].order,
+        extensions[getExtensionNameFromId(idA)]?.order,
         attachedIds
       );
       const bi = getOrder(
         idB,
         idOrder,
-        extensions[getExtensionNameFromId(idB)].order,
+        extensions[getExtensionNameFromId(idB)]?.order,
         attachedIds
       );
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Fixes a bug where it was possible for the whole application to crash if a slot tried to obtain its extension assignments before all those extensions had been registered.
