### PR TITLE
(chore) openmrs tool should depend on pinned version of webpack-config

### DIFF
--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -15,7 +15,7 @@
     "test": "jest --passWithNoTests",
     "build": "tsc",
     "lint": "eslint src --ext ts,tsx",
-    "version": "yarn add @openmrs/esm-app-shell@$npm_package_version --exact"
+    "postversion": "yarn add @openmrs/esm-app-shell@$npm_package_version @openmrs/esm-webpack-config@$npm_package_version --exact"
   },
   "repository": {
     "type": "git",
@@ -34,7 +34,7 @@
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
     "@openmrs/esm-app-shell": "3.2.0",
-    "@openmrs/webpack-config": "^3.2.0",
+    "@openmrs/webpack-config": "3.2.0",
     "@types/react": "^16.9.46",
     "@types/systemjs": "^6.1.0",
     "autoprefixer": "^10.4.2",


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This updates the `openmrs` tool to depend on a  fixed version of `@openmrs/webpack-config` updated every time the `version` command is run.

Without enforcing fixed versions of dependencies on `@openmrs/*` dependencies, we can end up with conflicting transitive dependencies, especially when trying to pin things to non-released versions.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
