### PR TITLE
(fix) Don't crash when a slot is registered before its extensions

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "ci:publish": "lerna publish from-package --yes",
     "release": "lerna version --no-git-tag-version",
     "build": "turbo run build",
-    "build:apps": "turbo run build --scope '@openmrs/*-app'",
+    "build:apps": "turbo run build --filter='@openmrs/*-app'",
     "setup": "lerna bootstrap && turbo run build && lerna clean --yes && lerna bootstrap",
     "verify": "turbo run lint && turbo run test && turbo run typescript",
     "prettier": "prettier \"packages/**/src/**/*\" --write",

--- a/packages/framework/esm-extensions/jest.config.js
+++ b/packages/framework/esm-extensions/jest.config.js
@@ -1,7 +1,8 @@
 module.exports = {
-  setupFiles: ["<rootDir>/src/setup-tests.js"],
+  transform: {
+    "^.+\\.(j|t)sx?$": ["@swc/jest"],
+  },
   moduleNameMapper: {
     "lodash-es/(.*)": "lodash/$1",
-    "@openmrs/esm-config": "<rootDir>/__mocks__/openmrs-esm-config.mock.tsx",
   },
 };

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -1,0 +1,10 @@
+import { attach, registerExtensionSlot } from "./extensions";
+
+describe("extensions system", () => {
+  it("shouldn't crash when a slot is registered before the extensions that go in it", () => {
+    attach("mario-slot", "mario-hat");
+    expect(() =>
+      registerExtensionSlot("mario-module", "mario-slot")
+    ).not.toThrow();
+  });
+});

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -309,15 +309,18 @@ function getAssignedExtensionsFromSlotData(
     );
     const name = getExtensionNameFromId(id);
     const extension = internalState.extensions[name];
-    extensions.push({
-      id,
-      name,
-      moduleName: extension.moduleName,
-      config: extensionConfig,
-      meta: extension.meta,
-      online: extension.online,
-      offline: extension.offline,
-    });
+    // if the extension has not been registered yet, do not include it
+    if (extension) {
+      extensions.push({
+        id,
+        name,
+        moduleName: extension.moduleName,
+        config: extensionConfig,
+        meta: extension.meta,
+        online: extension.online,
+        offline: extension.offline,
+      });
+    }
   }
   return extensions;
 }

--- a/packages/framework/esm-extensions/src/setup-tests.js
+++ b/packages/framework/esm-extensions/src/setup-tests.js
@@ -1,7 +1,0 @@
-window.System = {
-  import: (name) => import(name),
-};
-
-window.openmrsBase = "/openmrs";
-window.spaBase = "/spa";
-window.getOpenmrsSpaBase = () => "/openmrs/spa/";

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -2067,7 +2067,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:325](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L325)
+[packages/framework/esm-extensions/src/extensions.ts:328](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L328)
 
 ___
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

If a slot has an attachment and is registered before an extension to which it is attached, it should not crash. Rather, the slot should simply not receive the unregistered extension.

## Other

This comes up when [creating dashboards via configuration](https://github.com/openmrs/openmrs-esm-patient-chart/pull/653).
