### PR TITLE
(fix) Don't crash if app dist/ dir doesn't exist

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -56,8 +56,12 @@ function checkDirectoryExists(dirName) {
 }
 
 function checkDirectoryHasContents(dirName) {
-  const contents = readdirSync(dirName);
-  return contents.length > 0;
+  if (checkDirectoryExists(dirName)) {
+    const contents = readdirSync(dirName);
+    return contents.length > 0;
+  } else {
+    return false;
+  }
 }
 
 module.exports = (env, argv = {}) => {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

`yarn run:shell` shouldn't crash if apps haven't been built yet.
