### PR TITLE
(fix) O3-1224  Tablet mode: Side navigation widgets fails to identify the user ID

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useRef } from "react";
+import React, { useEffect, useMemo, useRef } from "react";
 import styles from "./side-menu-panel.component.scss";
-import { ExtensionSlot } from "@openmrs/esm-framework";
+import { ExtensionSlot, usePatient } from "@openmrs/esm-framework";
 import { SideNav, SideNavProps } from "carbon-components-react";
 
 interface SideMenuPanelProps extends SideNavProps {
@@ -12,6 +12,12 @@ const SideMenuPanel: React.FC<SideMenuPanelProps> = ({
   hidePanel,
 }) => {
   const menuRef = useRef(null);
+  const { patientUuid } = usePatient();
+  const patientChartBasePath = `${window.spaBase}/patient/:patientUuid/chart`;
+  const basePath = useMemo(
+    () => patientChartBasePath.replace(":patientUuid", patientUuid),
+    [patientUuid]
+  );
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {
@@ -39,7 +45,10 @@ const SideMenuPanel: React.FC<SideMenuPanelProps> = ({
         className={styles.link}
       >
         <ExtensionSlot extensionSlotName="global-nav-menu-slot" />
-        <ExtensionSlot extensionSlotName="patient-chart-dashboard-slot" />
+        <ExtensionSlot
+          extensionSlotName="patient-chart-dashboard-slot"
+          state={{ basePath }}
+        />
       </SideNav>
     )
   );


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This fixes the [hack](https://github.com/openmrs/openmrs-esm-core/pull/375) to make the side nav work in tablet mode. It was missing the patient info.

This is all a temporary hack; I am working on a better solution now but want to get this fix in quickly.

## Screenshots

![Peek 2022-04-21 14-30](https://user-images.githubusercontent.com/1031876/164556590-f1a631bd-f9cd-47e7-a91f-006649df9ab8.gif)


## Related Issue
https://issues.openmrs.org/browse/O3-1224
