### PR TITLE
3.3.0

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -7,7 +7,7 @@
   ],
   "npmClient": "yarn",
   "useWorkspaces": true,
-  "version": "3.2.0",
+  "version": "3.3.0",
   "command": {
     "publish": {
       "verifyAccess": false

--- a/packages/apps/esm-devtools-app/package.json
+++ b/packages/apps/esm-devtools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-devtools-app",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "Dev tools for frontend devs using OpenMRS",
   "browser": "dist/openmrs-esm-devtools-app.js",
@@ -44,8 +44,8 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.2.0",
-    "@openmrs/webpack-config": "^3.2.0",
+    "@openmrs/esm-framework": "^3.3.0",
+    "@openmrs/webpack-config": "^3.3.0",
     "@types/carbon-components-react": "^7.24.0",
     "carbon-components": "10.31.0",
     "carbon-icons": "7.0.7",

--- a/packages/apps/esm-implementer-tools-app/package.json
+++ b/packages/apps/esm-implementer-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-implementer-tools-app",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "The admin interface for OpenMRS Frontend",
   "browser": "dist/openmrs-esm-implementer-tools-app.js",
@@ -52,8 +52,8 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.2.0",
-    "@openmrs/webpack-config": "^3.2.0",
+    "@openmrs/esm-framework": "^3.3.0",
+    "@openmrs/webpack-config": "^3.3.0",
     "@types/carbon-components-react": "^7.24.0",
     "ace-builds": "^1.4.14",
     "jest": "^26.6.3",

--- a/packages/apps/esm-login-app/package.json
+++ b/packages/apps/esm-login-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-login-app",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "The login microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-login-app.js",
@@ -53,8 +53,8 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.2.0",
-    "@openmrs/webpack-config": "^3.2.0",
+    "@openmrs/esm-framework": "^3.3.0",
+    "@openmrs/webpack-config": "^3.3.0",
     "@types/carbon-components-react": "^7.24.0",
     "@types/react-router-dom": "^5.1.7",
     "jest": "^26.6.3",

--- a/packages/apps/esm-offline-tools-app/package.json
+++ b/packages/apps/esm-offline-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline-tools-app",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "The offline tools microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-offline-tools-app.js",
@@ -54,8 +54,8 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.2.0",
-    "@openmrs/webpack-config": "^3.2.0",
+    "@openmrs/esm-framework": "^3.3.0",
+    "@openmrs/webpack-config": "^3.3.0",
     "@types/carbon-components-react": "^7.24.0",
     "@types/lodash-es": "^4.17.5",
     "@types/react-router-dom": "^5.1.7",

--- a/packages/apps/esm-primary-navigation-app/package.json
+++ b/packages/apps/esm-primary-navigation-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-primary-navigation-app",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "Main navbar microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-primary-navigation-app.js",
@@ -52,8 +52,8 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-framework": "^3.2.0",
-    "@openmrs/webpack-config": "^3.2.0",
+    "@openmrs/esm-framework": "^3.3.0",
+    "@openmrs/webpack-config": "^3.3.0",
     "@types/carbon-components-react": "^7.24.0",
     "@types/react-router-dom": "^5.1.7",
     "jest": "^26.6.3",

--- a/packages/framework/esm-api/package.json
+++ b/packages/framework/esm-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-api",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "The javascript module for interacting with the OpenMRS API",
   "browser": "dist/openmrs-esm-api.js",
@@ -44,9 +44,9 @@
     "@openmrs/esm-error-handling": "3.x"
   },
   "devDependencies": {
-    "@openmrs/esm-config": "^3.2.0",
-    "@openmrs/esm-error-handling": "^3.2.0",
-    "@openmrs/esm-state": "^3.2.0",
+    "@openmrs/esm-config": "^3.3.0",
+    "@openmrs/esm-error-handling": "^3.3.0",
+    "@openmrs/esm-state": "^3.3.0",
     "@types/fhir": "0.0.31",
     "rxjs": "^6.5.3"
   }

--- a/packages/framework/esm-breadcrumbs/package.json
+++ b/packages/framework/esm-breadcrumbs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-breadcrumbs",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "The javascript module for breadcrumb registration",
   "browser": "dist/openmrs-esm-breadcrumbs.js",
@@ -42,6 +42,6 @@
     "@openmrs/esm-state": "3.x"
   },
   "devDependencies": {
-    "@openmrs/esm-state": "^3.2.0"
+    "@openmrs/esm-state": "^3.3.0"
   }
 }

--- a/packages/framework/esm-config/package.json
+++ b/packages/framework/esm-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-config",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "A configuration library for the OpenMRS Single-Spa framework.",
   "browser": "dist/openmrs-esm-module-config.js",
@@ -45,8 +45,8 @@
     "systemjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-globals": "^3.2.0",
-    "@openmrs/esm-state": "^3.2.0",
+    "@openmrs/esm-globals": "^3.3.0",
+    "@openmrs/esm-state": "^3.3.0",
     "@types/ramda": "^0.26.44",
     "@types/systemjs": "^6.1.0",
     "babel-plugin-ramda": "^2.0.0",

--- a/packages/framework/esm-error-handling/package.json
+++ b/packages/framework/esm-error-handling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-error-handling",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "An ES module to help with error handling",
   "browser": "dist/openmrs-esm-error-handling.js",
@@ -39,6 +39,6 @@
     "@openmrs/esm-globals": "3.x"
   },
   "devDependencies": {
-    "@openmrs/esm-globals": "^3.2.0"
+    "@openmrs/esm-globals": "^3.3.0"
   }
 }

--- a/packages/framework/esm-extensions/package.json
+++ b/packages/framework/esm-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-extensions",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "Coordinates extensions and extension points in the OpenMRS Frontend",
   "browser": "dist/openmrs-esm-extensions.js",
@@ -42,9 +42,9 @@
     "single-spa": "5.x"
   },
   "devDependencies": {
-    "@openmrs/esm-api": "^3.2.0",
-    "@openmrs/esm-config": "^3.2.0",
-    "@openmrs/esm-state": "^3.2.0",
+    "@openmrs/esm-api": "^3.3.0",
+    "@openmrs/esm-config": "^3.3.0",
+    "@openmrs/esm-state": "^3.3.0",
     "single-spa": "^5.9.2"
   },
   "dependencies": {

--- a/packages/framework/esm-framework/package.json
+++ b/packages/framework/esm-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-framework",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "browser": "dist/openmrs-esm-framework.js",
   "main": "src/index.ts",
@@ -35,17 +35,17 @@
     "access": "public"
   },
   "dependencies": {
-    "@openmrs/esm-api": "^3.2.0",
-    "@openmrs/esm-breadcrumbs": "^3.2.0",
-    "@openmrs/esm-config": "^3.2.0",
-    "@openmrs/esm-error-handling": "^3.2.0",
-    "@openmrs/esm-extensions": "^3.2.0",
-    "@openmrs/esm-globals": "^3.2.0",
-    "@openmrs/esm-offline": "^3.2.0",
-    "@openmrs/esm-react-utils": "^3.2.0",
-    "@openmrs/esm-state": "^3.2.0",
-    "@openmrs/esm-styleguide": "^3.2.0",
-    "@openmrs/esm-utils": "^3.2.0",
+    "@openmrs/esm-api": "^3.3.0",
+    "@openmrs/esm-breadcrumbs": "^3.3.0",
+    "@openmrs/esm-config": "^3.3.0",
+    "@openmrs/esm-error-handling": "^3.3.0",
+    "@openmrs/esm-extensions": "^3.3.0",
+    "@openmrs/esm-globals": "^3.3.0",
+    "@openmrs/esm-offline": "^3.3.0",
+    "@openmrs/esm-react-utils": "^3.3.0",
+    "@openmrs/esm-state": "^3.3.0",
+    "@openmrs/esm-styleguide": "^3.3.0",
+    "@openmrs/esm-utils": "^3.3.0",
     "dayjs": "^1.10.7"
   }
 }

--- a/packages/framework/esm-globals/package.json
+++ b/packages/framework/esm-globals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-globals",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "browser": "dist/openmrs-esm-globals.js",
   "main": "src/index.ts",

--- a/packages/framework/esm-offline/package.json
+++ b/packages/framework/esm-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "browser": "dist/openmrs-esm-offline.js",
@@ -36,10 +36,10 @@
     "access": "public"
   },
   "devDependencies": {
-    "@openmrs/esm-api": "^3.2.0",
-    "@openmrs/esm-globals": "^3.2.0",
-    "@openmrs/esm-state": "^3.2.0",
-    "@openmrs/esm-styleguide": "^3.2.0",
+    "@openmrs/esm-api": "^3.3.0",
+    "@openmrs/esm-globals": "^3.3.0",
+    "@openmrs/esm-state": "^3.3.0",
+    "@openmrs/esm-styleguide": "^3.3.0",
     "@types/uuid": "^8.3.0",
     "rxjs": "^6.5.3"
   },

--- a/packages/framework/esm-react-utils/package.json
+++ b/packages/framework/esm-react-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-react-utils",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "React utilities for OpenMRS.",
   "browser": "dist/openmrs-esm-react-utils.js",
@@ -48,18 +48,18 @@
     "@openmrs/esm-error-handling": "3.x",
     "@openmrs/esm-extensions": "3.x",
     "@openmrs/esm-globals": "3.x",
+    "dayjs": "1.x",
     "i18next": "19.x",
     "react": "16.x",
     "react-dom": "16.x",
-    "react-i18next": "11.x",
-    "dayjs": "1.x"
+    "react-i18next": "11.x"
   },
   "devDependencies": {
-    "@openmrs/esm-api": "^3.2.0",
-    "@openmrs/esm-config": "^3.2.0",
-    "@openmrs/esm-error-handling": "^3.2.0",
-    "@openmrs/esm-extensions": "^3.2.0",
-    "@openmrs/esm-globals": "^3.2.0",
+    "@openmrs/esm-api": "^3.3.0",
+    "@openmrs/esm-config": "^3.3.0",
+    "@openmrs/esm-error-handling": "^3.3.0",
+    "@openmrs/esm-extensions": "^3.3.0",
+    "@openmrs/esm-globals": "^3.3.0",
     "dayjs": "^1.10.8",
     "i18next": "^19.6.0",
     "react": "^16.13.1",

--- a/packages/framework/esm-state/package.json
+++ b/packages/framework/esm-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-state",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "Frontend stores & state management for OpenMRS",
   "browser": "dist/openmrs-esm-state.js",

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-styleguide",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "The styleguide for OpenMRS SPA",
   "browser": "dist/openmrs-esm-styleguide.js",
@@ -53,9 +53,9 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
-    "@openmrs/esm-extensions": "^3.2.0",
-    "@openmrs/esm-react-utils": "^3.2.0",
-    "@openmrs/esm-state": "^3.2.0",
+    "@openmrs/esm-extensions": "^3.3.0",
+    "@openmrs/esm-react-utils": "^3.3.0",
+    "@openmrs/esm-state": "^3.3.0",
     "@pickra/copy-code-block": "^1.1.7",
     "@storybook/addon-a11y": "^5.2.1",
     "@storybook/addon-knobs": "^5.2.1",

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-utils",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "browser": "dist/openmrs-esm-utils.js",

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-app-shell",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "main": "dist/openmrs.js",
   "scripts": {
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@openmrs/esm-framework": "3.2.0",
+    "@openmrs/esm-framework": "^3.3.0",
     "carbon-components": "10.31.0",
     "carbon-icons": "7.0.7",
     "dayjs": "^1.10.4",
@@ -58,11 +58,11 @@
     "workbox-window": "^6.1.5"
   },
   "devDependencies": {
-    "@openmrs/esm-devtools-app": "^3.2.0",
-    "@openmrs/esm-implementer-tools-app": "^3.2.0",
-    "@openmrs/esm-login-app": "^3.2.0",
-    "@openmrs/esm-offline-tools-app": "^3.2.0",
-    "@openmrs/esm-primary-navigation-app": "^3.2.0",
+    "@openmrs/esm-devtools-app": "^3.3.0",
+    "@openmrs/esm-implementer-tools-app": "^3.3.0",
+    "@openmrs/esm-login-app": "^3.3.0",
+    "@openmrs/esm-offline-tools-app": "^3.3.0",
+    "@openmrs/esm-primary-navigation-app": "^3.3.0",
     "webpack-pwa-manifest": "^4.3.0",
     "workbox-webpack-plugin": "^6.1.2"
   }

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmrs",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "main": "dist/index.js",
   "bin": {
@@ -33,8 +33,8 @@
   "homepage": "https://github.com/openmrs/openmrs-esm-core#readme",
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
-    "@openmrs/esm-app-shell": "3.2.0",
-    "@openmrs/webpack-config": "3.2.0",
+    "@openmrs/esm-app-shell": "^3.3.0",
+    "@openmrs/webpack-config": "^3.3.0",
     "@types/react": "^16.9.46",
     "@types/systemjs": "^6.1.0",
     "autoprefixer": "^10.4.2",

--- a/packages/tooling/webpack-config/package.json
+++ b/packages/tooling/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/webpack-config",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "license": "MPL-2.0",
   "main": "dist/index.js",
   "types": "src/index.ts",


### PR DESCRIPTION
## What's Changed
* Update to PostCSS 8 by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/308
* BREAKING O3-806: Migrate from openmrs-spa.org -> dev3.openmrs.org by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/302
* chore: Fix build of esm-styleguide on CI by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/310
* Add FAQ to docs by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/311
* (docs) Added reference to short link: om.rs/dev3docs by @gracepotma in https://github.com/openmrs/openmrs-esm-core/pull/314
* Make it possible to override properties of each webpack rule by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/315
* Fix bug where extensions weren't updating with props by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/318
* (fix): Logo should have a left margin of 1rem by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/316
* (fix): Change breadcrumbs background color by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/317
* Take an absolute shot in the dark at fixing the build by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/321
* feat: O3-1031: Offline Actions within the Patient Chart by @manuelroemer in https://github.com/openmrs/openmrs-esm-core/pull/313
* Removed unnecessary data from ExternalRefLinks in primary navigation's configuration by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/312
* O3-908 - Combine meta and index by @FlorianRappl in https://github.com/openmrs/openmrs-esm-core/pull/324
* (docs) Removed FAB link by @gracepotma in https://github.com/openmrs/openmrs-esm-core/pull/328
* (docs) Improve instructions for linking the framework by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/319
* (fix) Bug where usePatient was causing superfluous refetches by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/327
* (feat) Add options parameter to translateFrom by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/329
* (docs) Fill out contributing docs from RFC-20 text by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/326
* (fix): O3-1112: Offline actions don't display offline registered patients correctly by @manuelroemer in https://github.com/openmrs/openmrs-esm-core/pull/331
* (docs) Add support for module categories; remove cruft by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/330
* O3-1001: Added support for searching person attribute and returning the respective UUID by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/325
* O3-1123: Improvements to Implementor tools's design by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/333
* UI FIX for searching UUIDs in implementer's tools(e.g. concepts, personattributetype) and better readability of data by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/334
* Simplify extension system again by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/335
* (fix) O3-1136: Left nav contents disappearing after resizing the screen by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/336
* (docs) Update import map overrides guidance by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/338
* BREAKING: Update the extensions API by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/337
* (docs) Remove errant comma from PR template by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/339
* (fix): Fix the failing test from 099f618 by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/341
* App shell should depend on exact framework version by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/340
* 03-1125: (bug) fix current visit retaining previous patient visit-data by @donaldkibet in https://github.com/openmrs/openmrs-esm-core/pull/332
* (test) Enhancements to tests in the login app by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/342
* O3-104 Login ESM should have tests for config values by @nanfuka in https://github.com/openmrs/openmrs-esm-core/pull/345
* (chore): Update vulnerable dependencies by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/348
* (chore): Update `react-i18next` mock in login app by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/347
* Added type validator for PersonAttributeTypeUuid and small UI fixes by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/349
* (chore) Improvements to mocks by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/350
* (chore) Fix CI build for pre-release by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/352
* BREAKING: Use extensionSlots as key in config instead of extensions by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/351
* (fix) Add missing swr dep to esm-react-utils by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/353
* (feat) O3-1164  Should be able to edit config JSON in implementer tools by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/354
* Fixes incorrect link to manifest in index.html by @mseaton in https://github.com/openmrs/openmrs-esm-core/pull/355
* (enhancement) update `useVisit` hook by @donaldkibet in https://github.com/openmrs/openmrs-esm-core/pull/356
* (fix) App not hot updating with slot config changes by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/357
* (fix) O3-1173: Patient Chart fails to load on tablet by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/359
* O3-953: Location picker does not show all locations by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/343
* (test) Restore location picker tests by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/361
* (feat) Add support for extension config schemas by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/358
* (chore) Fix file names in login app by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/362
* (fix) Update importmap to latest version from dev3. by @manuelroemer in https://github.com/openmrs/openmrs-esm-core/pull/363
* Added error checks and fixed the count of the results shown in the location picker by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/364
* (docs) Improve extension declaration documentation by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/365
* (docs) Fix comment format in FAQ shell code sample by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/367
* (feat) Extension config should be available from the store by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/366
* (bugfix) Client Redirect from '/' to '/home' by @ZacButko in https://github.com/openmrs/openmrs-esm-core/pull/368
* (fix) Service Worker Housekeeping: Remove Unused SW Events | Fix SW Startup Cycle During Initial Load by @manuelroemer in https://github.com/openmrs/openmrs-esm-core/pull/369
* (docs) Add note to setup about troubleshooting inotify by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/370
* Search locations in the location picker not only on the basis of prefixes by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/371
* BREAKING: (feat) Allow inversion of useOnClickOutside by @jnsereko in https://github.com/openmrs/openmrs-esm-core/pull/373
* (fix) Restore missing side menu on tablet by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/375
* (fix) Loosen UUID validation by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/372
* CurrentUserContext should always render children by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/378
* Delineate public vs private API of esm-framework by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/376
* Added mock setSessionLocation to pass the tests by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/377
* (test): useOnClickOutside test by @jnsereko in https://github.com/openmrs/openmrs-esm-core/pull/379
* Revert "Delineate public vs private API of esm-framework" by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/381
* (fix) Precache importmap as part of the static dependency lifecycle | Remove obsolete XMLHttpRequest patches by @manuelroemer in https://github.com/openmrs/openmrs-esm-core/pull/383
* (fix) Consider relative URLs when scanning the importmap for assets. by @manuelroemer in https://github.com/openmrs/openmrs-esm-core/pull/386
* Delineate public vs private API of esm-framework - attempt #2 by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/382
* O3-857: Login should redirect to the specified page if the user has access by @jnsereko in https://github.com/openmrs/openmrs-esm-core/pull/385
* (fix) webpack rules so that @openmrs/esm-framework/src/internal is shared correctly by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/388
* O3-1157: Added field to search and select patient identifiers from implementer tools by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/380
* (feat) Unify session types by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/387
* (feat) move from babel -> swc by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/389
* Allow a slot to obtain its assigned extensions even if not all those extensions are registered yet by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/391
* O3-1258  Fatal errors cause crash loop by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/390
* (chore) migrate to turbo by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/392
* (chore) Re-add enough Babel that webpack-config works by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/393
* (docs) Update README to remove reference to lerna run build by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/395
* O3-1205: Changed the position of the App menu and Hide toobar ToolTip by @abertnamanya in https://github.com/openmrs/openmrs-esm-core/pull/384
* (chore) O3-1262: Fix yarn:run-shell by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/396
* (chore) openmrs tool should depend on pinned version of webpack-config by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/397
* (fix) Update import map and provide docs for how to do it by @manuelroemer in https://github.com/openmrs/openmrs-esm-core/pull/399
* (fix) Don't crash when a slot is registered before its extensions by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/398
* (fix) Remove 'name' attribute from esm-offline patient chart dashboard by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/400
* Add `showModal` mock to esm-framework/mock by @donaldkibet in https://github.com/openmrs/openmrs-esm-core/pull/403
* (fix) Don't crash if app dist/ dir doesn't exist by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/401
* (chore) Add useSession mock by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/404
* (feat) Offline Registered Patients in Offline Tools Card | Sync Queue Functions for Retrieving Full Sync Item | Sync Queue Manipulation Tests  by @manuelroemer in https://github.com/openmrs/openmrs-esm-core/pull/402
* (fix) O3-1224  Tablet mode: Side navigation widgets fails to identify the user ID by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/406
* (fix) Update import map refs by @manuelroemer in https://github.com/openmrs/openmrs-esm-core/pull/407
* (chore) Remove deprecated useSessionUser alias by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/405
* Fix broken docs links by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/411
* Create unified left nav system by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/410
* (docs) Fix headers for GitHub Docs site by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/412
* (fix) Add missing dependencies to esm-styleguide by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/414
* Add `age` function to esm-framework/mock by @donaldkibet in https://github.com/openmrs/openmrs-esm-core/pull/415

## New Contributors
* @nanfuka made their first contribution in https://github.com/openmrs/openmrs-esm-core/pull/345
* @mseaton made their first contribution in https://github.com/openmrs/openmrs-esm-core/pull/355
* @jnsereko made their first contribution in https://github.com/openmrs/openmrs-esm-core/pull/373
* @abertnamanya made their first contribution in https://github.com/openmrs/openmrs-esm-core/pull/384

**Full Changelog**: https://github.com/openmrs/openmrs-esm-core/compare/v3.2.0...v3.3.0