### PR TITLE
(fix) Ensure that all validators are part of framework mock

### DIFF
--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -10,7 +10,11 @@ export {
   formatTime,
   age,
 } from "@openmrs/esm-utils";
-export { interpolateString, interpolateUrl } from "@openmrs/esm-config";
+export {
+  interpolateString,
+  interpolateUrl,
+  validators,
+} from "@openmrs/esm-config";
 
 window.i18next = { ...window.i18next, language: "en" };
 
@@ -148,13 +152,6 @@ export enum Type {
   String = "String",
   UUID = "UUID",
 }
-
-export const validators = {
-  isBoolean: jest.fn(),
-  isString: jest.fn(),
-  isUuid: jest.fn(),
-  isObject: jest.fn(),
-};
 
 let configSchema = {};
 function getDefaults(schema) {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Some validators are left out. Validators are trivial and can be included as-is in the mock.
