### PR TITLE
(fix) Config: Improvements to validator system

### DIFF
--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -100,6 +100,30 @@ describe("defineConfigSchema", () => {
     expect(console.error).not.toHaveBeenCalled();
   });
 
+  it("runs top-level validators on resolved config", () => {
+    const schema = {
+      foo: {
+        _type: Type.String,
+        _default: "bar-value",
+      },
+      fooStart: {
+        _type: Type.String,
+        _default: "bar",
+      },
+      _validators: [
+        validator(
+          (v) => v.foo.startsWith(v.fooStart),
+          "The value of `foo` must start with the value of `fooStart`."
+        ),
+      ],
+    };
+    Config.defineConfigSchema("foo-module", schema);
+    Config.provide({ "foo-module": { foo: "bar" } });
+    expect(console.error).toHaveBeenCalledWith(
+      /The value of `foo` must begin with 'foo'./
+    );
+  });
+
   it("logs an error if a non-function validator is provided", () => {
     const schema = {
       bar: { _default: [], _validators: [false] },

--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -386,6 +386,19 @@ describe("getConfig", () => {
     );
   });
 
+  it("tolerates defaults that don't pass validation", async () => {
+    Config.defineConfigSchema("foo-module", {
+      foo: {
+        _default: null,
+        _validators: [
+          validator((val) => val.startsWith("thi"), "must start with 'thi'"),
+        ],
+      },
+    });
+    await Config.getConfig("foo-module");
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
   it("validators pass", async () => {
     Config.defineConfigSchema("foo-module", {
       foo: {

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -696,7 +696,9 @@ function runAllValidatorsInConfigTree(
 ) {
   // If `!schema`, there should have been a structural validation error printed already.
   if (schema) {
-    runValidators(keyPath, schema._validators, config);
+    if (config !== schema._default) {
+      runValidators(keyPath, schema._validators, config);
+    }
 
     if (isOrdinaryObject(config)) {
       for (const key of Object.keys(config)) {

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -280,8 +280,9 @@ export function processConfig(
   keyPathContext: string,
   devDefaultsAreOn: boolean = false
 ) {
-  validateConfig(schema, providedConfig, keyPathContext);
+  validateStructure(schema, providedConfig, keyPathContext);
   const config = setDefaults(schema, providedConfig, devDefaultsAreOn);
+  runAllValidatorsInConfigTree(schema, config, keyPathContext);
   return config;
 }
 
@@ -326,12 +327,13 @@ function computeExtensionConfig(
   // TODO: validate that a schema exists for the module
   const schema =
     extensionConfigSchema ?? configState.schemas[extensionModuleName];
-  validateConfig(schema, combinedConfig, nameOfSchemaSource);
+  validateStructure(schema, combinedConfig, nameOfSchemaSource);
   const config = setDefaults(
     schema,
     combinedConfig,
     configState.devDefaultsAreOn
   );
+  runAllValidatorsInConfigTree(schema, config, nameOfSchemaSource);
   delete config.extensionSlots;
   return config;
 }
@@ -571,8 +573,9 @@ function getConfigForModule(
     moduleName,
     getProvidedConfigs(configState, tempConfigState)
   );
-  validateConfig(schema, inputConfig, moduleName);
+  validateStructure(schema, inputConfig, moduleName);
   const config = setDefaults(schema, inputConfig, configState.devDefaultsAreOn);
+  runAllValidatorsInConfigTree(schema, config, moduleName);
   delete config.extensionSlots;
   return config;
 }
@@ -593,10 +596,13 @@ function mergeConfigs(configs: Array<Config>) {
   return mergeDeepAll({}, configs) as Config;
 }
 
-// Recursively check the provided config tree to make sure that all
-// of the provided properties exist in the schema. Run validators
-// where present in the schema.
-function validateConfig(
+/**
+ * Recursively check the provided config tree to make sure that all
+ * of the provided properties exist in the schema, and that types are
+ * correct. Does not run validators yet, since those will be run on
+ * the config with the defaults filled in.
+ */
+function validateStructure(
   schema: ConfigSchema,
   config: ConfigObject,
   keyPath = ""
@@ -617,35 +623,34 @@ function validateConfig(
       continue;
     }
 
-    validateConfigElement(schemaPart, value, thisKeyPath);
+    validateBranchStructure(schemaPart, value, thisKeyPath);
   }
 }
 
-function validateConfigElement(
+function validateBranchStructure(
   schemaPart: ConfigSchema,
   value: any,
   keyPath: string
 ) {
   checkType(keyPath, schemaPart._type, value);
-  runValidators(keyPath, schemaPart._validators, value);
 
   if (isOrdinaryObject(value)) {
     // structurally validate only if there's elements specified
-    // or there's a `_default` value, which indicates a freeform object
+    // or there's no `_default` value (which would indicate a freeform object)
     if (schemaPart._type === Type.Object) {
-      validateDictionary(schemaPart, value, keyPath);
+      validateDictionaryStructure(schemaPart, value, keyPath);
     } else if (!schemaPart.hasOwnProperty("_default")) {
       // recurse to validate nested object structure
-      validateConfig(schemaPart, value, keyPath);
+      validateStructure(schemaPart, value, keyPath);
     }
   } else {
     if (schemaPart._type === Type.Array) {
-      validateArray(schemaPart, value, keyPath);
+      validateArrayStructure(schemaPart, value, keyPath);
     }
   }
 }
 
-function validateDictionary(
+function validateDictionaryStructure(
   dictionarySchema: ConfigSchema,
   config: ConfigObject,
   keyPath: string
@@ -653,12 +658,12 @@ function validateDictionary(
   if (dictionarySchema._elements) {
     for (const key of Object.keys(config)) {
       const value = config[key];
-      validateConfig(dictionarySchema._elements, value, `${keyPath}.${key}`);
+      validateStructure(dictionarySchema._elements, value, `${keyPath}.${key}`);
     }
   }
 }
 
-function validateArray(
+function validateArrayStructure(
   arraySchema: ConfigSchema,
   value: ConfigObject,
   keyPath: string
@@ -666,7 +671,7 @@ function validateArray(
   // if there is an array element object schema, verify that elements match it
   if (hasObjectSchema(arraySchema._elements)) {
     for (let i = 0; i < value.length; i++) {
-      validateConfigElement(
+      validateBranchStructure(
         arraySchema._elements,
         value[i],
         `${keyPath}[${i}]`
@@ -676,11 +681,43 @@ function validateArray(
 
   for (let i = 0; i < value.length; i++) {
     checkType(`${keyPath}[${i}]`, arraySchema._elements?._type, value[i]);
-    runValidators(
-      `${keyPath}[${i}]`,
-      arraySchema._elements?._validators,
-      value[i]
-    );
+  }
+}
+
+/**
+ * Run all the validators in the config tree. This should be run
+ * on the config object after it has been filled in with all the defaults, since
+ * higher-level validators may refer to default values.
+ */
+function runAllValidatorsInConfigTree(
+  schema: ConfigSchema,
+  config: ConfigObject,
+  keyPath = ""
+) {
+  // If `!schema`, there should have been a structural validation error printed already.
+  if (schema) {
+    runValidators(keyPath, schema._validators, config);
+
+    if (isOrdinaryObject(config)) {
+      for (const key of Object.keys(config)) {
+        const value = config[key];
+        const thisKeyPath = keyPath + "." + key;
+        const schemaPart = schema[key] as ConfigSchema;
+        if (schema._type === Type.Object && schema._elements) {
+          runAllValidatorsInConfigTree(schema._elements, value, thisKeyPath);
+        } else {
+          runAllValidatorsInConfigTree(schemaPart, value, thisKeyPath);
+        }
+      }
+    } else if (Array.isArray(config) && schema._elements) {
+      for (let i = 0; i < config.length; i++) {
+        runAllValidatorsInConfigTree(
+          schema._elements,
+          config[i],
+          `${keyPath}[${i}]`
+        );
+      }
+    }
   }
 }
 
@@ -712,15 +749,13 @@ function runValidators(
         const validatorResult = validator(value);
 
         if (typeof validatorResult === "string") {
-          if (!keyPath.includes(".")) {
+          if (typeof value === "object") {
             console.error(
               `Invalid configuration for ${keyPath}: ${validatorResult}`
             );
           } else {
-            const valueString =
-              typeof value === "object" ? JSON.stringify(value) : value;
             console.error(
-              `Invalid configuration value ${valueString} for ${keyPath}: ${validatorResult}`
+              `Invalid configuration value ${value} for ${keyPath}: ${validatorResult}`
             );
           }
         }

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -601,6 +601,7 @@ function validateConfig(
   config: ConfigObject,
   keyPath = ""
 ) {
+  // validate each constituent element
   for (const key of Object.keys(config)) {
     const value = config[key];
     const thisKeyPath = keyPath + "." + key;
@@ -711,15 +712,23 @@ function runValidators(
         const validatorResult = validator(value);
 
         if (typeof validatorResult === "string") {
-          const valueString =
-            typeof value === "object" ? JSON.stringify(value) : value;
-          console.error(
-            `Invalid configuration value ${valueString} for ${keyPath}: ${validatorResult}`
-          );
+          if (!keyPath.includes(".")) {
+            console.error(
+              `Invalid configuration for ${keyPath}: ${validatorResult}`
+            );
+          } else {
+            const valueString =
+              typeof value === "object" ? JSON.stringify(value) : value;
+            console.error(
+              `Invalid configuration value ${valueString} for ${keyPath}: ${validatorResult}`
+            );
+          }
         }
       }
     } catch (e) {
-      console.error(`Skipping invalid validator at "${keyPath}".`);
+      console.error(
+        `Skipping invalid validator at "${keyPath}". Encountered error\n\t${e}`
+      );
     }
   }
 }
@@ -760,7 +769,7 @@ const setDefaults = (
       const elements = schemaPart._elements;
 
       if (configPart && hasObjectSchema(elements)) {
-        if (schemaPart._type === Type.Array) {
+        if (schemaPart._type === Type.Array && Array.isArray(configPart)) {
           const configWithDefaults = configPart.map((conf: Config) =>
             setDefaults(elements, conf, devDefaultsAreOn)
           );

--- a/packages/framework/esm-config/src/validators/validator.ts
+++ b/packages/framework/esm-config/src/validators/validator.ts
@@ -1,13 +1,38 @@
 /** @module @category Config Validation */
 import { Validator, ValidatorFunction } from "../types";
 
+/**
+ * Constructs a custom validator.
+ *
+ * ### Example
+ *
+ * ```typescript
+ * {
+ *   foo: {
+ *     _default: 0,
+ *     _validators: [
+ *       validator(val => val >= 0, "Must not be negative.")
+ *     ]
+ *   }
+ * }
+ * ```
+ * @param validationFunction Takes the configured value as input. Returns true
+ *    if it is valid, false otherwise.
+ * @param message A string message that explains why the value is invalid. Can
+ *    also be a function that takes the value as input and returns a string.
+ * @returns A validator ready for use in a config schema
+ */
 export function validator(
   validationFunction: ValidatorFunction,
-  message: string
+  message: string | ((value: any) => string)
 ): Validator {
   return (value) => {
     if (!validationFunction(value)) {
-      return message;
+      if (typeof message === "function") {
+        return message(value);
+      } else {
+        return message;
+      }
     }
   };
 }

--- a/packages/framework/esm-config/src/validators/validators.test.ts
+++ b/packages/framework/esm-config/src/validators/validators.test.ts
@@ -1,9 +1,16 @@
-import { isUrl, isUrlWithTemplateParameters } from "./validators";
+import {
+  inRange,
+  isUrl,
+  isUrlWithTemplateParameters,
+  oneOf,
+} from "./validators";
 
 describe("all validators", () => {
   it("fail on undefined", () => {
+    expect(inRange(0, 10)(undefined)).toMatch(/.*/);
     expect(isUrl(undefined)).toMatch(/.*/);
     expect(isUrlWithTemplateParameters(["foo"])(undefined)).toMatch(/.*/);
+    expect(oneOf(["foo", "bar"])(undefined)).toMatch(/.*/);
   });
 });
 
@@ -20,5 +27,15 @@ describe("isUrl", () => {
     expect(isUrl("${foo}/bad")).toMatch(
       /allowed template parameters are \${openmrsBase}, \${openmrsSpaBase}/i
     );
+  });
+});
+
+describe("oneOf", () => {
+  it("accepts one of the valid options", () => {
+    expect(oneOf(["foo", "bar"])("foo")).toBeUndefined();
+  });
+
+  it("rejects anything else", () => {
+    expect(oneOf(["foo", "bar"])("baz")).toMatch(/one of.*foo.*bar/i);
   });
 });

--- a/packages/framework/esm-config/src/validators/validators.ts
+++ b/packages/framework/esm-config/src/validators/validators.ts
@@ -45,7 +45,7 @@ export const isUrlWithTemplateParameters = (
     }
 
     return true;
-  }, "should be a URL or path. The allowed template parameters are " + allowedParams.map((p) => "${" + p + "}").join(", "));
+  }, "Should be a URL or path. The allowed template parameters are " + allowedParams.map((p) => "${" + p + "}").join(", "));
 };
 
 /**
@@ -55,8 +55,20 @@ export const isUrlWithTemplateParameters = (
  */
 export const isUrl = isUrlWithTemplateParameters([]);
 
+/**
+ * Verifies that the value is one of the allowed options.
+ * @param allowedValues The list of allowable values
+ */
+export const oneOf = (allowedValues: Array<any>) => {
+  return validator(
+    (val) => allowedValues.includes(val),
+    `Must be one of the following: '${allowedValues.join("', '")}'.`
+  );
+};
+
 export const validators = {
   inRange,
   isUrl,
   isUrlWithTemplateParameters,
+  oneOf,
 };

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -53,6 +53,7 @@
 - [inRange](API.md#inrange)
 - [isUrl](API.md#isurl)
 - [isUrlWithTemplateParameters](API.md#isurlwithtemplateparameters)
+- [oneOf](API.md#oneof)
 - [validator](API.md#validator)
 
 ### Date and Time Functions
@@ -590,10 +591,11 @@ ___
 | `inRange` | (`min`: `number`, `max`: `number`) => [`Validator`](API.md#validator) |
 | `isUrl` | [`Validator`](API.md#validator) |
 | `isUrlWithTemplateParameters` | (`allowedTemplateParameters`: `string`[]) => [`Validator`](API.md#validator) |
+| `oneOf` | (`allowedValues`: `any`[]) => [`Validator`](API.md#validator) |
 
 #### Defined in
 
-[packages/framework/esm-config/src/validators/validators.ts:58](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/validators/validators.ts#L58)
+[packages/framework/esm-config/src/validators/validators.ts:69](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/validators/validators.ts#L69)
 
 ___
 
@@ -1667,16 +1669,17 @@ parameters, plus any specified in `allowedTemplateParameters`.
 
 ___
 
-### validator
+### oneOf
 
-▸ **validator**(`validationFunction`, `message`): [`Validator`](API.md#validator)
+▸ `Const` **oneOf**(`allowedValues`): [`Validator`](API.md#validator)
+
+Verifies that the value is one of the allowed options.
 
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `validationFunction` | [`ValidatorFunction`](API.md#validatorfunction) |
-| `message` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `allowedValues` | `any`[] | The list of allowable values |
 
 #### Returns
 
@@ -1684,7 +1687,45 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/validators/validator.ts:4](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/validators/validator.ts#L4)
+[packages/framework/esm-config/src/validators/validators.ts:62](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/validators/validators.ts#L62)
+
+___
+
+### validator
+
+▸ **validator**(`validationFunction`, `message`): [`Validator`](API.md#validator)
+
+Constructs a custom validator.
+
+### Example
+
+```typescript
+{
+  foo: {
+    _default: 0,
+    _validators: [
+      validator(val => val >= 0, "Must not be negative.")
+    ]
+  }
+}
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `validationFunction` | [`ValidatorFunction`](API.md#validatorfunction) | Takes the configured value as input. Returns true    if it is valid, false otherwise. |
+| `message` | `string` \| (`value`: `any`) => `string` | A string message that explains why the value is invalid. Can    also be a function that takes the value as input and returns a string. |
+
+#### Returns
+
+[`Validator`](API.md#validator)
+
+A validator ready for use in a config schema
+
+#### Defined in
+
+[packages/framework/esm-config/src/validators/validator.ts:25](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/validators/validator.ts#L25)
 
 ___
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This fixes a problem where higher-level validators wouldn't receive some of the config info they need to work, because they were running on the input config rather than the filled-in config. Validators now run on the filled-in config.

It also adds a new validator, `oneOf`.
