### PR TITLE
Remove source-maps in production builds

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -132,7 +132,7 @@ module.exports = (env, argv = {}) => {
       ],
     },
     mode,
-    devtool: isProd ? "source-map" : "inline-source-map",
+    devtool: isProd ? false : "inline-source-map",
     module: {
       rules: [
         {

--- a/packages/tooling/openmrs/src/commands/assemble.ts
+++ b/packages/tooling/openmrs/src/commands/assemble.ts
@@ -159,6 +159,7 @@ async function extractFiles(sourceFile: string, targetDir: string) {
 
   Object.keys(files)
     .filter((m) => m.startsWith(`${packageRoot}/${sourceDir}`))
+    .filter((m) => !m.endsWith(".map"))
     .forEach((m) => {
       const content = files[m];
       const fileName = m.replace(`${packageRoot}/${sourceDir}/`, "");

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -158,7 +158,7 @@ export default (
       ],
     },
     mode,
-    devtool: mode === production ? "source-map" : "inline-source-map",
+    devtool: mode === production ? false : "inline-source-map",
     devServer: {
       headers: {
         "Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This simply removes source maps from production builds. Inline sourcemaps are left in-place for non-production builds. On my machine, this change saves about 6 MB from the app shell, but about 150 MB for all applications. This will likely make problems harder to diagnose in production, but, um... that 150 MB is sourcemaps is about 150% of the size of the application.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
