### PR TITLE
Fix: Remove duplicate overriding styles for the patient chart sideNav.

### DIFF
--- a/packages/framework/esm-styleguide/src/left-nav/index.tsx
+++ b/packages/framework/esm-styleguide/src/left-nav/index.tsx
@@ -1,5 +1,7 @@
 /** @module @category UI */
 import React from "react";
+import { BrowserRouter, useLocation } from "react-router-dom";
+
 import { ExtensionSlot, useStore } from "@openmrs/esm-react-utils";
 import { createGlobalStore } from "@openmrs/esm-state";
 import { SideNav, SideNavProps } from "carbon-components-react";
@@ -30,20 +32,27 @@ type LeftNavMenuProps = SideNavProps;
 export const LeftNavMenu = React.forwardRef<HTMLElement, LeftNavMenuProps>(
   (props, ref) => {
     const { slotName, basePath } = useStore(leftNavStore);
+    const location = useLocation();
+    const currentPath = location.pathname;
 
     return (
-      <SideNav
-        ref={ref}
-        expanded
-        aria-label="Left navigation"
-        className={styles.link}
-        {...props}
-      >
-        <ExtensionSlot extensionSlotName="global-nav-menu-slot" />
-        {slotName ? (
-          <ExtensionSlot extensionSlotName={slotName} state={{ basePath }} />
-        ) : null}
-      </SideNav>
+      <BrowserRouter>
+        <SideNav
+          ref={ref}
+          expanded
+          aria-label="Left navigation"
+          className={styles.leftNav}
+          {...props}
+        >
+          <ExtensionSlot extensionSlotName="global-nav-menu-slot" />
+          {slotName ? (
+            <ExtensionSlot
+              extensionSlotName={slotName}
+              state={{ basePath, currentPath }}
+            />
+          ) : null}
+        </SideNav>
+      </BrowserRouter>
     );
   }
 );

--- a/packages/framework/esm-styleguide/src/left-nav/left-nav.module.scss
+++ b/packages/framework/esm-styleguide/src/left-nav/left-nav.module.scss
@@ -2,25 +2,32 @@
 @import "carbon-components/scss/globals/scss/typography.scss";
 @import "~carbon-components/scss/globals/scss/_spacing.scss";
 
-.link > div a:nth-child(1) {
-  height: 3rem;
-  padding: 1.5rem 0 1.5rem 1.2rem;
+:global(.active-left-nav-link) {
+  background-color: $ui-03;
+  outline: none;
+  color: $ui-05;
+  border-left: 0.25rem solid var(--brand-01);
+}
+
+.leftNav > div a:nth-child(1) {
+  height: 2.5rem;
   color: $ui-04;
   border-left: 0.25rem solid transparent;
   @include carbon--type-style("productive-heading-01");
 }
 
-:global(.omrs-breakpoint-gt-tablet) .link > div {
+:global(.omrs-breakpoint-gt-tablet) .leftNav > div {
   padding-top: 1rem;
 }
 
-.link > div a:nth-child(1):hover {
+.leftNav > div a:nth-child(1):hover {
   background-color: $ui-03;
   color: $ui-05;
   border-left: var(--brand-01);
+  padding: 1.2rem 0 1.2rem 1.2rem;
 }
 
-.link > div a:nth-child(1):focus {
+.leftNav > div a:nth-child(1):focus {
   background-color: $ui-03;
   outline: none;
   color: $ui-05;

--- a/packages/framework/esm-styleguide/src/left-nav/left-nav.module.scss
+++ b/packages/framework/esm-styleguide/src/left-nav/left-nav.module.scss
@@ -14,12 +14,6 @@
   padding-top: 1rem;
 }
 
-:global(.omrs-breakpoint-gt-tablet) .link > div a:nth-child(1) {
-  height: 2rem;
-  color: $ui-04;
-  padding: 0 0 0 1rem;
-}
-
 .link > div a:nth-child(1):hover {
   background-color: $ui-03;
   color: $ui-05;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).


## Summary
- Remove overriding styles for the patient chart sideNav. This fix is needed to fix the active class styles in this [PR](https://github.com/openmrs/openmrs-esm-patient-chart/pull/721).

## Related Issue
[PR](https://github.com/openmrs/openmrs-esm-patient-chart/pull/721)
[Ticktet](https://issues.openmrs.org/browse/O3-578)


