### PR TITLE
Docs: Add link to template app page

### DIFF
--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -49,6 +49,10 @@ This command will run a "script" from the `package.json`
 file. Take a look at the `scripts` section of that file to find out what
 the command actually does.
 
+Once the frontend server starts up, you should be able to access the template
+app at http://localhost:8080/openmrs/spa/hello. You might be redirected to
+the log in page to log in first.
+
 > :bulb: You run almost any command with `--help` to learn more about it.
 > This includes `yarn start --help`.
 

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -50,8 +50,8 @@ file. Take a look at the `scripts` section of that file to find out what
 the command actually does.
 
 Once the frontend server starts up, you should be able to access the template
-app at http://localhost:8080/openmrs/spa/hello. You might be redirected to
-the log in page to log in first.
+app at http://localhost:8080/openmrs/spa/hello. <!-- markdown-link-check-disable-line -->
+You might be redirected to the log in page to log in first.
 
 > :bulb: You run almost any command with `--help` to learn more about it.
 > This includes `yarn start --help`.


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Adds a link to the page that is created by the template app when it is run. At present it is unclear where to go after running `yarn start`.
