### PR TITLE
(fix) Warning text for useSession

### DIFF
--- a/packages/framework/esm-react-utils/src/useSession.tsx
+++ b/packages/framework/esm-react-utils/src/useSession.tsx
@@ -98,11 +98,11 @@ export function useSession(): Session {
   if (!result) {
     if (promise) {
       console.warn(
-        "useSessionUser is in an unexpected state. Attempting to recover."
+        "useSession is in an unexpected state. Attempting to recover."
       );
       throw promise;
     } else {
-      throw Error("useSessionUser is in an invalid state.");
+      throw Error("useSession is in an invalid state.");
     }
   }
   return result;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Update the warning text for `useSession`, which still refers to a function that no longer exists.