### PR TITLE
(docs) Get rid of "conceptual overview" video

### DIFF
--- a/docs/main/extensions.md
+++ b/docs/main/extensions.md
@@ -188,9 +188,6 @@ by modifying the `order` configuration parameter of that slot.
 
 ## Additional Resources
 
-Conceptual overview video:
-[![OpenMRS Frontend Extension System Conceptual Introduction](https://img.youtube.com/vi/F342HUY4i5U/0.jpg)](https://www.youtube.com/watch?v=F342HUY4i5U)
-
 Introductory presentation: [Quick Guide to Slots](https://docs.google.com/presentation/d/1mQxh7qAYLD-gc9sh0I58t4o_XNndPcu6hAJmTZQZ_fo/edit#slide=id.gbe34f6b087_0_34 )
 
 For a terse technical description of the extension system, see the


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Gets rid of the video from the extension page of the developer docs. It is so out of date that it is more confusing than helpful.