### PR TITLE
O3-1277: Extend FHIRResource type to cover more properties

### DIFF
--- a/packages/framework/esm-api/src/types/fhir-resource.ts
+++ b/packages/framework/esm-api/src/types/fhir-resource.ts
@@ -20,8 +20,8 @@ export interface FHIRResource {
     valueQuantity: {
       value: number;
     };
-    valueString?: string;
-    valueCodeableConcept?: { coding: Array<FHIRCode> };
+    valueString: string;
+    valueCodeableConcept: { coding: Array<FHIRCode> };
   };
 }
 

--- a/packages/framework/esm-api/src/types/fhir-resource.ts
+++ b/packages/framework/esm-api/src/types/fhir-resource.ts
@@ -20,10 +20,13 @@ export interface FHIRResource {
     valueQuantity: {
       value: number;
     };
+    valueString?: string;
+    valueCodeableConcept?: { coding: Array<FHIRCode> };
   };
 }
 
 export interface FHIRCode {
   code: string;
   system: string;
+  display?: string;
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Changes to the FHIRResource and FHIRCode so we can have texted and coded content types in O3

## Related Issue
[O3-1277 obs-by-encounter-widget should support more concept types](https://issues.openmrs.org/browse/O3-1277)

