### PR TITLE
(chore): Fix the reference to the webpack types

### DIFF
--- a/packages/shell/esm-app-shell/src/system.ts
+++ b/packages/shell/esm-app-shell/src/system.ts
@@ -1,4 +1,4 @@
-/// <reference path="../../../../node_modules/webpack/module.d.ts" />
+/// <reference types="webpack/module" />
 import "import-map-overrides";
 import "systemjs/dist/system";
 import "systemjs/dist/extras/amd";


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
In #448, I removed some conflicting type definitions. However, the way I did this resulted in a package that's dependent on a certain dependency structure, i.e., the structure of the monorepo. This breaks the ability of this code to be built outside of the monorepo. The App Shell, however, **needs** to be buildable outside of the monorepo for the `openmrs build` command to work properly, so this shifts to using proper dependency resolution for the types rather than a file path.

Marked as a _chore_ as this is a tooling fix rather than an API change.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
