### PR TITLE
Use swc-loader instead of ts-loader for building the App Shell

### DIFF
--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -63,7 +63,6 @@
     "@openmrs/esm-login-app": "^3.4.0",
     "@openmrs/esm-offline-tools-app": "^3.4.0",
     "@openmrs/esm-primary-navigation-app": "^3.4.0",
-    "ts-loader": "^9.3.0",
     "webpack-pwa-manifest": "^4.3.0",
     "workbox-webpack-plugin": "^6.1.2"
   }

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -157,21 +157,10 @@ module.exports = (env, argv = {}) => {
           type: "asset/source",
         },
         {
-          test: /\.(js|jsx)$/,
+          test: /\.(j|t)sx?$/,
           use: [
             {
               loader: require.resolve("swc-loader"),
-            },
-          ],
-        },
-        {
-          test: /\.(ts|tsx)?$/,
-          use: [
-            {
-              loader: require.resolve("ts-loader"),
-              options: {
-                allowTsInNodeModules: true,
-              },
             },
           ],
         },


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Not sure why I didn't previously do this when moving to SWC, but this replaces `ts-loader` in the App Shell build with `swc-loader`.

The motivation here is just to avoid needing to do strict type-checking when running the `openmrs build` step.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
