### PR TITLE
(docs) Remove documentation about freeform config objects

### DIFF
--- a/docs/main/config.md
+++ b/docs/main/config.md
@@ -206,33 +206,6 @@ Objects within arrays do not
 have to have defaults. If an object is supplied to the `robots` array that
 does not have a `name`, an error will be thrown.
 
-#### Freeform objects
-
-In unusual scenarios you might want to accept an object without
-validating its keys. To do this, you can specify the config element 
-like a normal non-object element.
-
-```js
-beepsPerRobot: {
-  _type: Type.Object
-  _default: {
-    "R2-D2": 4,
-    "C-3P0": 0
-  },
-  _elements: {  // describes the *values* of the object
-    _type: Type.Number
-    _validators: [validator(n => Number.isInteger(n), "Beeps must be integers")]
-  },
-  _description: "An object mapping robot names to number of beeps",
-  _validators: [
-    validator(o => Object.keys(o).every(n => /\d/.test(n)),
-      "Robots must have numbers in their names")
-  ]
-}
-```
-
-Note that this is the only situation in which you should ever use `Type.Object`.
-
 ### Using config values
 
 #### The generic way


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Freeform objects in config will be abolished. This removes the documentation that talks about them.
