### PR TITLE
(feat): Add implicit conditions to configuration schema

### DIFF
--- a/packages/framework/esm-api/src/shared-api-objects/current-user.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/current-user.ts
@@ -132,7 +132,6 @@ function userHasPrivilege(
     );
   } else if (Array.isArray(requiredPrivilege)) {
     return (
-      requiredPrivilege.length &&
       requiredPrivilege.every(
         (rp) => !isUndefined(user.privileges.find((p) => rp === p.display))
       )

--- a/packages/framework/esm-api/src/shared-api-objects/current-user.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/current-user.ts
@@ -131,10 +131,8 @@ function userHasPrivilege(
       user.privileges.find((p) => requiredPrivilege === p.display)
     );
   } else if (Array.isArray(requiredPrivilege)) {
-    return (
-      requiredPrivilege.every(
-        (rp) => !isUndefined(user.privileges.find((p) => rp === p.display))
-      )
+    return requiredPrivilege.every(
+      (rp) => !isUndefined(user.privileges.find((p) => rp === p.display))
     );
   } else {
     console.error(`Could not understand privileges "${requiredPrivilege}"`);

--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -1055,11 +1055,7 @@ describe("extension config", () => {
     updateConfigExtensionStore();
     Config.provide(moduleLevelConfig);
     const result = getExtensionConfig("barSlot", "fooExt").config;
-    expect(result).toStrictEqual({
-      bar: "qux",
-      baz: "bazzy",
-      "Display conditions": { privileges: [] },
-    });
+    expect(result).toStrictEqual({ bar: "qux", baz: "bazzy" });
     expect(console.error).not.toHaveBeenCalled();
   });
 
@@ -1077,11 +1073,7 @@ describe("extension config", () => {
     };
     Config.provide(configureConfig);
     const result = getExtensionConfig("barSlot", "fooExt#id0").config;
-    expect(result).toStrictEqual({
-      bar: "qux",
-      baz: "quiz",
-      "Display conditions": { privileges: [] },
-    });
+    expect(result).toStrictEqual({ bar: "qux", baz: "quiz" });
     expect(console.error).not.toHaveBeenCalled();
   });
 
@@ -1111,10 +1103,7 @@ describe("extension config", () => {
     const extensionAtBaseConfig = { fooExt: { qux: "quxolotl" } };
     Config.provide(extensionAtBaseConfig);
     const result = getExtensionConfig("barSlot", "fooExt").config;
-    expect(result).toStrictEqual({
-      qux: "quxolotl",
-      "Display conditions": { privileges: [] },
-    });
+    expect(result).toStrictEqual({ qux: "quxolotl" });
     expect(console.error).not.toHaveBeenCalled();
   });
 
@@ -1135,10 +1124,7 @@ describe("extension config", () => {
     };
     Config.provide(configureConfig);
     const result = getExtensionConfig("barSlot", "fooExt#id2").config;
-    expect(result).toStrictEqual({
-      qux: "quxotic",
-      "Display conditions": { privileges: [] },
-    });
+    expect(result).toStrictEqual({ qux: "quxotic" });
   });
 
   it("validates the extension configure config, with extension config schema", () => {

--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -320,7 +320,6 @@ describe("getConfig", () => {
         c: 2,
         diff: 2,
       },
-      "Display conditions": { privileges: [] },
     });
   });
 
@@ -511,7 +510,6 @@ describe("getConfig", () => {
     const config = await Config.getConfig("object-def");
     expect(config).toStrictEqual({
       furi: { kake: { gohan: "ok" } },
-      "Display conditions": { privileges: [] },
     });
   });
 
@@ -542,7 +540,6 @@ describe("getConfig", () => {
         gyudon: { gohan: "no", nori: true },
         sake: { gohan: "maybe", nori: false },
       },
-      "Display conditions": { privileges: [] },
     });
   });
 
@@ -886,10 +883,7 @@ describe("temporary config", () => {
       "foo-module": { foo: 3 },
     });
     let config = await Config.getConfig("foo-module");
-    expect(config).toStrictEqual({
-      foo: 3,
-      "Display conditions": { privileges: [] },
-    });
+    expect(config).toStrictEqual({ foo: 3 });
     temporaryConfigStore.setState({
       config: unset(temporaryConfigStore.getState(), [
         "foo-module",
@@ -897,10 +891,7 @@ describe("temporary config", () => {
       ]) as any,
     });
     config = await Config.getConfig("foo-module");
-    expect(config).toStrictEqual({
-      foo: "baz",
-      "Display conditions": { privileges: [] },
-    });
+    expect(config).toStrictEqual({ foo: "baz" });
   });
 
   it("can be gotten and cleared", async () => {
@@ -912,10 +903,7 @@ describe("temporary config", () => {
     temporaryConfigStore.setState({ config: {} });
     expect(temporaryConfigStore.getState()).toStrictEqual({ config: {} });
     const config = await Config.getConfig("foo-module");
-    expect(config).toStrictEqual({
-      foo: "qux",
-      "Display conditions": { privileges: [] },
-    });
+    expect(config).toStrictEqual({ foo: "qux" });
   });
 
   it("is not mutated by getConfig", async () => {
@@ -986,10 +974,7 @@ describe("extension slot config", () => {
       },
     });
     const config = await Config.getConfig("foo-module");
-    expect(config).toStrictEqual({
-      foo: 0,
-      "Display conditions": { privileges: [] },
-    });
+    expect(config).toStrictEqual({ foo: 0 });
     expect(console.error).not.toHaveBeenCalled();
   });
 

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -1,5 +1,5 @@
 /** @module @category Config */
-import { clone, reduce, mergeDeepRight, equals } from "ramda";
+import { clone, reduce, mergeDeepRight, equals, omit } from "ramda";
 import {
   Config,
   ConfigObject,
@@ -266,7 +266,8 @@ export function getConfig(moduleName: string): Promise<Config> {
     const store = getConfigStore(moduleName);
     function update(state: ConfigStore) {
       if (state.loaded && state.config) {
-        resolve(state.config);
+        const config = omit(["Display conditions"], state.config);
+        resolve(config);
         unsubscribe && unsubscribe();
       }
     }

--- a/packages/framework/esm-config/src/module-config/state.ts
+++ b/packages/framework/esm-config/src/module-config/state.ts
@@ -1,5 +1,6 @@
 /** @module @category Config */
 import { createGlobalStore, getGlobalStore } from "@openmrs/esm-state";
+import { omit } from "ramda";
 import {
   Config,
   ConfigObject,
@@ -199,11 +200,16 @@ export function getExtensionsConfigStore() {
 
 /** @internal */
 export function getExtensionConfig(slotName: string, extensionId: string) {
-  return getExtensionConfigFromStore(
-    getExtensionsConfigStore().getState(),
-    slotName,
-    extensionId
+  const extensionConfig = Object.assign(
+    {},
+    getExtensionConfigFromStore(
+      getExtensionsConfigStore().getState(),
+      slotName,
+      extensionId
+    )
   );
+  extensionConfig.config = omit(["Display conditions"], extensionConfig.config);
+  return extensionConfig;
 }
 
 /** @internal */

--- a/packages/framework/esm-config/src/types.ts
+++ b/packages/framework/esm-config/src/types.ts
@@ -27,6 +27,11 @@ export interface Config extends Object {
 
 export interface ConfigObject extends Object {
   [key: string]: any;
+  "Display conditions"?: DisplayConditionsConfigObject;
+}
+
+export interface DisplayConditionsConfigObject {
+  privileges?: string[];
 }
 
 export type ConfigValue =

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -1,4 +1,14 @@
+import { createGlobalStore } from "@openmrs/esm-state";
 import { attach, registerExtensionSlot } from "./extensions";
+
+const mockSessionStore = createGlobalStore("mock-session-store", {
+  loaded: false,
+  session: null,
+});
+
+jest.mock("@openmrs/esm-api", () => ({
+  getSessionStore: jest.fn(() => mockSessionStore),
+}));
 
 describe("extensions system", () => {
   it("shouldn't crash when a slot is registered before the extensions that go in it", () => {

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -315,10 +315,14 @@ function getAssignedExtensionsFromSlotData(
     const extension = internalState.extensions[name];
     // if the extension has not been registered yet, do not include it
     if (extension) {
-      const requiredPermissions =
-        extensionConfig?.["Display conditions"]?.privileges;
-
-      if (requiredPermissions && requiredPermissions.length) {
+      const requiredPrivileges =
+        extensionConfig?.["Display conditions"]?.privileges ??
+        extension.privileges;
+      if (
+        requiredPrivileges &&
+        (typeof requiredPrivileges === "string" ||
+          (Array.isArray(requiredPrivileges) && requiredPrivileges.length > 0))
+      ) {
         if (isUndefined(user)) {
           user = getSessionStore().getState().session?.user;
         }
@@ -327,7 +331,7 @@ function getAssignedExtensionsFromSlotData(
           continue;
         }
 
-        if (!userHasAccess(requiredPermissions, user)) {
+        if (!userHasAccess(requiredPrivileges, user)) {
           continue;
         }
       }

--- a/packages/framework/esm-extensions/src/store.ts
+++ b/packages/framework/esm-extensions/src/store.ts
@@ -20,6 +20,7 @@ export interface ExtensionRegistration {
   order?: number;
   online?: boolean | object;
   offline?: boolean | object;
+  privileges?: string | string[];
 }
 
 export interface ExtensionInfo extends ExtensionRegistration {

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -198,7 +198,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L16)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L17)
 
 ___
 
@@ -228,7 +228,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L14)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L15)
 
 ___
 
@@ -245,7 +245,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L21)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L22)
 
 ___
 
@@ -382,7 +382,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:32](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L32)
+[packages/framework/esm-config/src/types.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L37)
 
 ___
 
@@ -409,7 +409,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:60](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L60)
+[packages/framework/esm-config/src/types.ts:65](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L65)
 
 ___
 
@@ -453,7 +453,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:67](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L67)
+[packages/framework/esm-config/src/types.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L72)
 
 ___
 
@@ -477,7 +477,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:65](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L65)
+[packages/framework/esm-config/src/types.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L70)
 
 ___
 
@@ -736,7 +736,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:174](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L174)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:191](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L191)
 
 ___
 
@@ -802,7 +802,7 @@ leak and source of bugs.
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L70)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L71)
 
 ▸ **getCurrentUser**(`opts`): `Observable`<[`Session`](interfaces/Session.md)\>
 
@@ -819,7 +819,7 @@ leak and source of bugs.
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L71)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L72)
 
 ▸ **getCurrentUser**(`opts`): `Observable`<[`LoggedInUser`](interfaces/LoggedInUser.md)\>
 
@@ -836,7 +836,7 @@ leak and source of bugs.
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L72)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:73](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L73)
 
 ___
 
@@ -864,7 +864,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:188](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L188)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:205](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L205)
 
 ___
 
@@ -878,7 +878,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:206](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L206)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:223](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L223)
 
 ___
 
@@ -892,7 +892,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:104](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L104)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:105](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L105)
 
 ___
 
@@ -1101,7 +1101,7 @@ refetchCurrentUser()
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:149](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L149)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:166](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L166)
 
 ___
 
@@ -1143,7 +1143,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:215](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L215)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:232](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L232)
 
 ___
 
@@ -1344,24 +1344,24 @@ ___
 
 ### userHasAccess
 
-▸ **userHasAccess**(`requiredPrivilege`, `user`): `undefined` \| [`Privilege`](interfaces/Privilege.md)
+▸ **userHasAccess**(`requiredPrivilege`, `user`): `boolean`
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `requiredPrivilege` | `string` |
+| `requiredPrivilege` | `string` \| `string`[] |
 | `user` | `Object` |
 | `user.privileges` | [`Privilege`](interfaces/Privilege.md)[] |
 | `user.roles` | [`Role`](interfaces/Role.md)[] |
 
 #### Returns
 
-`undefined` \| [`Privilege`](interfaces/Privilege.md)
+`boolean`
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:181](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L181)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:198](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L198)
 
 ___
 
@@ -1488,7 +1488,7 @@ for more information about defining a config schema.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:193](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L193)
+[packages/framework/esm-config/src/module-config/module-config.ts:192](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L192)
 
 ___
 
@@ -1520,7 +1520,7 @@ for more information about defining a config schema.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:218](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L218)
+[packages/framework/esm-config/src/module-config/module-config.ts:222](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L222)
 
 ___
 
@@ -1550,7 +1550,7 @@ of the execution of a function.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:254](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L254)
+[packages/framework/esm-config/src/module-config/module-config.ts:264](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L264)
 
 ___
 
@@ -1571,7 +1571,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:234](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L234)
+[packages/framework/esm-config/src/module-config/module-config.ts:244](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/module-config/module-config.ts#L244)
 
 ___
 
@@ -1587,6 +1587,7 @@ Use this React Hook to obtain your module's configuration.
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
+| `Display conditions?` | [`DisplayConditionsConfigObject`](interfaces/DisplayConditionsConfigObject.md) | - |
 | `constructor` | `Function` | The initial value of Object.prototype.constructor is the standard built-in Object constructor. |
 | `hasOwnProperty` | (`v`: `PropertyKey`) => `boolean` | Determines whether an object has a property with the specified name. |
 | `isPrototypeOf` | (`v`: `Object`) => `boolean` | Determines whether an object exists in another object's prototype chain. |
@@ -2134,7 +2135,7 @@ writing a module for a specific implementation.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:172](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L172)
+[packages/framework/esm-extensions/src/extensions.ts:174](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L174)
 
 ___
 
@@ -2157,7 +2158,7 @@ Avoid using this. Extension attachments should be considered declarative.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:203](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L203)
+[packages/framework/esm-extensions/src/extensions.ts:205](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L205)
 
 ___
 
@@ -2179,7 +2180,7 @@ Avoid using this. Extension attachments should be considered declarative.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:227](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L227)
+[packages/framework/esm-extensions/src/extensions.ts:229](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L229)
 
 ___
 
@@ -2187,19 +2188,23 @@ ___
 
 ▸ **getAssignedExtensions**(`slotName`): [`AssignedExtension`](interfaces/AssignedExtension.md)[]
 
+Gets the list of extensions assigned to a given slot
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `slotName` | `string` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `slotName` | `string` | The slot to load the assigned extensions for |
 
 #### Returns
 
 [`AssignedExtension`](interfaces/AssignedExtension.md)[]
 
+An array of extensions assigned to the named slot
+
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:328](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L328)
+[packages/framework/esm-extensions/src/extensions.ts:355](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L355)
 
 ___
 
@@ -2225,7 +2230,7 @@ A list of extensions that should be rendered
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:285](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L285)
+[packages/framework/esm-extensions/src/extensions.ts:287](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L287)
 
 ___
 
@@ -2257,7 +2262,7 @@ getExtensionNameFromId("baz")
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:116](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L116)
+[packages/framework/esm-extensions/src/extensions.ts:118](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L118)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -545,7 +545,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/UserHasAccess.tsx:9](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/UserHasAccess.tsx#L9)
+[packages/framework/esm-react-utils/src/UserHasAccess.tsx:10](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/UserHasAccess.tsx#L10)
 
 ___
 
@@ -746,7 +746,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:191](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L191)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:188](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L188)
 
 ___
 
@@ -874,7 +874,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:205](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L205)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:202](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L202)
 
 ___
 
@@ -888,7 +888,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:223](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L223)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:220](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L220)
 
 ___
 
@@ -1111,7 +1111,7 @@ refetchCurrentUser()
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:166](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L166)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:163](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L163)
 
 ___
 
@@ -1153,7 +1153,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:232](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L232)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:229](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L229)
 
 ___
 
@@ -1371,7 +1371,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:198](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L198)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:195](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L195)
 
 ___
 
@@ -2214,7 +2214,7 @@ An array of extensions assigned to the named slot
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:355](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L355)
+[packages/framework/esm-extensions/src/extensions.ts:359](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/extensions.ts#L359)
 
 ___
 
@@ -2290,7 +2290,7 @@ extension system.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:129](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L129)
+[packages/framework/esm-extensions/src/store.ts:130](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L130)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/AssignedExtension.md
+++ b/packages/framework/esm-framework/docs/interfaces/AssignedExtension.md
@@ -24,7 +24,7 @@ The extension's config. Note that this will be `null` until the slot is mounted.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:79](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L79)
+[packages/framework/esm-extensions/src/store.ts:80](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L80)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:74](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L74)
+[packages/framework/esm-extensions/src/store.ts:75](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L75)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:77](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L77)
+[packages/framework/esm-extensions/src/store.ts:78](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L78)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:76](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L76)
+[packages/framework/esm-extensions/src/store.ts:77](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L77)
 
 ___
 
@@ -64,7 +64,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:75](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L75)
+[packages/framework/esm-extensions/src/store.ts:76](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L76)
 
 ___
 
@@ -74,7 +74,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:81](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L81)
+[packages/framework/esm-extensions/src/store.ts:82](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L82)
 
 ___
 
@@ -84,4 +84,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:80](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L80)
+[packages/framework/esm-extensions/src/store.ts:81](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L81)

--- a/packages/framework/esm-framework/docs/interfaces/ComponentDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/ComponentDefinition.md
@@ -64,13 +64,14 @@ ___
 
 ### privilege
 
-• `Optional` **privilege**: `string`
+• `Optional` **privilege**: `string` \| `string`[]
 
-Defines the access privilege required for this component, if any.
+Defines the access privilege(s) required for this component, if any.
+If more than one privilege is provided, the user must have all specified permissions.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:115](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L115)
+[packages/framework/esm-globals/src/types.ts:116](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L116)
 
 ___
 
@@ -82,7 +83,7 @@ Defines resources that are loaded when the component should mount.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:119](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L119)
+[packages/framework/esm-globals/src/types.ts:120](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L120)
 
 ## Methods
 

--- a/packages/framework/esm-framework/docs/interfaces/ConfigObject.md
+++ b/packages/framework/esm-framework/docs/interfaces/ConfigObject.md
@@ -16,6 +16,7 @@
 
 ### Properties
 
+- [Display conditions](ConfigObject.md#display conditions)
 - [constructor](ConfigObject.md#constructor)
 
 ### Methods
@@ -28,6 +29,16 @@
 - [valueOf](ConfigObject.md#valueof)
 
 ## Properties
+
+### Display conditions
+
+• `Optional` **Display conditions**: [`DisplayConditionsConfigObject`](DisplayConditionsConfigObject.md)
+
+#### Defined in
+
+[packages/framework/esm-config/src/types.ts:30](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L30)
+
+___
 
 ### constructor
 

--- a/packages/framework/esm-framework/docs/interfaces/ConnectedExtension.md
+++ b/packages/framework/esm-framework/docs/interfaces/ConnectedExtension.md
@@ -21,7 +21,7 @@ The extension's config. Note that this will be `null` until the slot is mounted.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:89](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L89)
+[packages/framework/esm-extensions/src/store.ts:90](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L90)
 
 ___
 
@@ -31,7 +31,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:85](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L85)
+[packages/framework/esm-extensions/src/store.ts:86](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L86)
 
 ___
 
@@ -41,7 +41,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L87)
+[packages/framework/esm-extensions/src/store.ts:88](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L88)
 
 ___
 
@@ -51,4 +51,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:86](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L86)
+[packages/framework/esm-extensions/src/store.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L87)

--- a/packages/framework/esm-framework/docs/interfaces/DisplayConditionsConfigObject.md
+++ b/packages/framework/esm-framework/docs/interfaces/DisplayConditionsConfigObject.md
@@ -1,0 +1,19 @@
+[@openmrs/esm-framework](../API.md) / DisplayConditionsConfigObject
+
+# Interface: DisplayConditionsConfigObject
+
+## Table of contents
+
+### Properties
+
+- [privileges](DisplayConditionsConfigObject.md#privileges)
+
+## Properties
+
+### privileges
+
+• `Optional` **privileges**: `string`[]
+
+#### Defined in
+
+[packages/framework/esm-config/src/types.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L34)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionDefinition.md
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:134](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L134)
+[packages/framework/esm-globals/src/types.ts:135](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L135)
 
 ___
 
@@ -66,7 +66,7 @@ The meta data used for reflection by other components
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:130](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L130)
+[packages/framework/esm-globals/src/types.ts:131](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L131)
 
 ___
 
@@ -78,7 +78,7 @@ The name of the extension being registered
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:124](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L124)
+[packages/framework/esm-globals/src/types.ts:125](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L125)
 
 ___
 
@@ -122,15 +122,16 @@ Specifies the relative order in which the extension renders in a slot
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:132](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L132)
+[packages/framework/esm-globals/src/types.ts:133](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L133)
 
 ___
 
 ### privilege
 
-• `Optional` **privilege**: `string`
+• `Optional` **privilege**: `string` \| `string`[]
 
-Defines the access privilege required for this component, if any.
+Defines the access privilege(s) required for this component, if any.
+If more than one privilege is provided, the user must have all specified permissions.
 
 #### Inherited from
 
@@ -138,7 +139,7 @@ Defines the access privilege required for this component, if any.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:115](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L115)
+[packages/framework/esm-globals/src/types.ts:116](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L116)
 
 ___
 
@@ -154,7 +155,7 @@ Defines resources that are loaded when the component should mount.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:119](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L119)
+[packages/framework/esm-globals/src/types.ts:120](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L120)
 
 ___
 
@@ -166,7 +167,7 @@ A slot to attach to
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:126](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L126)
+[packages/framework/esm-globals/src/types.ts:127](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L127)
 
 ___
 
@@ -178,7 +179,7 @@ Slots to attach to
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:128](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L128)
+[packages/framework/esm-globals/src/types.ts:129](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L129)
 
 ## Methods
 

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionRegistration.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionRegistration.md
@@ -12,6 +12,7 @@
 - [offline](ExtensionRegistration.md#offline)
 - [online](ExtensionRegistration.md#online)
 - [order](ExtensionRegistration.md#order)
+- [privileges](ExtensionRegistration.md#privileges)
 
 ### Methods
 
@@ -76,6 +77,16 @@ ___
 #### Defined in
 
 [packages/framework/esm-extensions/src/store.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L20)
+
+___
+
+### privileges
+
+• `Optional` **privileges**: `string` \| `string`[]
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/store.ts:23](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L23)
 
 ## Methods
 

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfig.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfig.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:41](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L41)
+[packages/framework/esm-config/src/types.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L46)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L44)
+[packages/framework/esm-config/src/types.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L49)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:43](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L43)
+[packages/framework/esm-config/src/types.ts:48](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L48)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:42](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L42)
+[packages/framework/esm-config/src/types.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L47)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfigObject.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfigObject.md
@@ -20,7 +20,7 @@ Additional extension IDs to assign to this slot, in addition to those `attach`ed
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:53](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L53)
+[packages/framework/esm-config/src/types.ts:58](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L58)
 
 ___
 
@@ -32,7 +32,7 @@ Overrides the default ordering of extensions.
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:57](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L57)
+[packages/framework/esm-config/src/types.ts:62](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L62)
 
 ___
 
@@ -44,4 +44,4 @@ Extension IDs which were `attach`ed to the slot but which should not be assigned
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:55](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L55)
+[packages/framework/esm-config/src/types.ts:60](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-config/src/types.ts#L60)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotState.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotState.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L70)
+[packages/framework/esm-extensions/src/store.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L71)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:69](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L69)
+[packages/framework/esm-extensions/src/store.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L70)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionStore.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionStore.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/store.ts:65](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L65)
+[packages/framework/esm-extensions/src/store.ts:66](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-extensions/src/store.ts#L66)

--- a/packages/framework/esm-framework/docs/interfaces/PageDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/PageDefinition.md
@@ -82,15 +82,16 @@ The order in which to load the page. This determines DOM order.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:145](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L145)
+[packages/framework/esm-globals/src/types.ts:146](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L146)
 
 ___
 
 ### privilege
 
-• `Optional` **privilege**: `string`
+• `Optional` **privilege**: `string` \| `string`[]
 
-Defines the access privilege required for this component, if any.
+Defines the access privilege(s) required for this component, if any.
+If more than one privilege is provided, the user must have all specified permissions.
 
 #### Inherited from
 
@@ -98,7 +99,7 @@ Defines the access privilege required for this component, if any.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:115](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L115)
+[packages/framework/esm-globals/src/types.ts:116](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L116)
 
 ___
 
@@ -114,7 +115,7 @@ Defines resources that are loaded when the component should mount.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:119](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L119)
+[packages/framework/esm-globals/src/types.ts:120](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L120)
 
 ___
 
@@ -126,7 +127,7 @@ The route of the page.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:141](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L141)
+[packages/framework/esm-globals/src/types.ts:142](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-globals/src/types.ts#L142)
 
 ## Methods
 

--- a/packages/framework/esm-framework/docs/interfaces/UserHasAccessProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/UserHasAccessProps.md
@@ -12,7 +12,7 @@
 
 ### privilege
 
-• **privilege**: `string`
+• **privilege**: `string` \| `string`[]
 
 #### Defined in
 

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -3,6 +3,7 @@ import type {} from "@openmrs/esm-globals";
 import createStore, { Store } from "unistore";
 import { never, of } from "rxjs";
 import { interpolateUrl } from "@openmrs/esm-config";
+import { SessionStore } from "@openmrs/esm-api";
 export {
   parseDate,
   formatDate,
@@ -50,7 +51,7 @@ export function getCurrentUser() {
   return of({ authenticated: false });
 }
 
-export const mockSessionStore = createGlobalStore("mock-session-store", {
+export const mockSessionStore = createGlobalStore<SessionStore>("mock-session-store", {
   loaded: false,
   session: null,
 });

--- a/packages/framework/esm-globals/src/types.ts
+++ b/packages/framework/esm-globals/src/types.ts
@@ -110,9 +110,10 @@ export interface ComponentDefinition {
    */
   offline?: boolean | object;
   /**
-   * Defines the access privilege required for this component, if any.
+   * Defines the access privilege(s) required for this component, if any.
+   * If more than one privilege is provided, the user must have all specified permissions.
    */
-  privilege?: string;
+  privilege?: string | string[];
   /**
    * Defines resources that are loaded when the component should mount.
    */

--- a/packages/framework/esm-react-utils/src/UserHasAccess.tsx
+++ b/packages/framework/esm-react-utils/src/UserHasAccess.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from "react";
 import { getCurrentUser, userHasAccess, LoggedInUser } from "@openmrs/esm-api";
 
 export interface UserHasAccessProps {
-  privilege: string;
+  privilege: string | string[];
 }
 
 export const UserHasAccess: React.FC<UserHasAccessProps> = ({

--- a/packages/shell/esm-app-shell/src/apps.ts
+++ b/packages/shell/esm-app-shell/src/apps.ts
@@ -207,6 +207,7 @@ To fix this, ensure that you define a "load" function inside the extension defin
     moduleName,
     offline: extension.offline,
     online: extension.online,
+    privileges: extension.privilege,
   });
 
   for (const slot of slots) {

--- a/packages/shell/esm-app-shell/src/apps.ts
+++ b/packages/shell/esm-app-shell/src/apps.ts
@@ -47,10 +47,10 @@ function trySetup(appName: string, setup: () => any): any {
 function getLoader(
   load: () => Promise<Lifecycle>,
   resources?: Record<string, ResourceLoader>,
-  privilege?: string
+  privileges?: string | string[]
 ): () => Promise<Lifecycle> {
-  if (typeof privilege === "string") {
-    load = wrapLifecycle(load, privilege);
+  if (typeof privileges === "string" || Array.isArray(privileges)) {
+    load = wrapLifecycle(load, privileges);
   }
 
   if (typeof resources === "object") {

--- a/packages/shell/esm-app-shell/src/helpers.ts
+++ b/packages/shell/esm-app-shell/src/helpers.ts
@@ -25,14 +25,12 @@ export function routeRegex(regex: RegExp, location: Location) {
 
 export function wrapLifecycle(
   load: () => Promise<any>,
-  requiredPrivilege: string
+  requiredPrivileges: string | Array<string>
 ): () => Promise<any> {
   return async () => {
     const user = await getLoggedInUser();
-    if (user && userHasAccess(requiredPrivilege, user)) {
-      return load();
-    }
-
-    return emptyLifecycle;
+    return user && userHasAccess(requiredPrivileges, user)
+      ? load()
+      : emptyLifecycle;
   };
 }

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -21,7 +21,6 @@ import {
   dispatchPrecacheStaticDependencies,
   activateOfflineCapability,
   subscribePrecacheStaticDependencies,
-  openmrsFetch,
 } from "@openmrs/esm-framework/src/internal";
 import {
   finishRegisteringAllApps,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13604,16 +13604,6 @@ ts-loader@^9.2.6:
     micromatch "^4.0.0"
     semver "^7.3.4"
 
-ts-loader@^9.3.0:
-  version "9.3.0"
-  resolved "https://registry.yarnpkg.com/ts-loader/-/ts-loader-9.3.0.tgz#980f4dbfb60e517179e15e10ed98e454b132159f"
-  integrity sha512-2kLLAdAD+FCKijvGKi9sS0OzoqxLCF3CxHpok7rVgCZ5UldRzH0TkbwG9XECKjBzHsAewntC5oDaI/FwKzEUog==
-  dependencies:
-    chalk "^4.1.0"
-    enhanced-resolve "^5.0.0"
-    micromatch "^4.0.0"
-    semver "^7.3.4"
-
 ts-toolbelt@^6.3.3:
   version "6.15.5"
   resolved "https://registry.yarnpkg.com/ts-toolbelt/-/ts-toolbelt-6.15.5.tgz#cb3b43ed725cb63644782c64fbcad7d8f28c0a83"


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This adds an implicit configuration section to every configuration schema called `"Display conditions"`[^1]. Currently, `"Display conditions"` has only one possible setting: `privileges` which is an array of one or more privileges that the user must have to be able to see any extension configured with that configuration schema. It defaults to not restricting. The `"Display conditions"` section is settable from anywhere in the configuration system (e.g., slot-specific configuration, extension-in-slot configuration). Note that this also means that no configuration scheme can have a top-level key named `"Display conditions"`. The validator does check for this and will log an error if an app tries to create a config schema with a `"Display conditions"` keys.

Usage:

```json
{
	"@openmrs/esm-patient-biometrics-app": {
		"Display conditions": {
			"privileges": ["View Obs"]
		}
	}
}
```

There are two important limitations here:
1. The configuration option does *not* override the `privilege` setting that can be returned as part of a page or extension definition. I'm open to discussing changing this.
2. Although this is added to all configuration schemas, the `"Display conditions"` section only has any effect on extensions.

Will ensure that extensions declared in `@openmrs/esm-patient-biometrics-app` only appear if the user has the "View Obs" privilege.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
This PR also contains one technically breaking change; namely `userHasAccess()` now always returns a boolean. I checked the various repos including OHRI and did not find any uses of `userHasAccess()` that depended on it's previous return value (which was either the string of the permission checked or `undefined`).

There are a couple of additional, backwards compatible API enhancements:
* `userHasAccess()` can now take either a string for a single permission or an array of multiple permissions. If multiple permissions are specified, the user must have all of those permissions.[^2]
* The `privilege` that can be returned for pages and extensions in `setupOpenMRS()` can now likewise be an array as can the `privilege` property on the `UserHasAccess` component.

[^1]: O3-1207 suggested calling this section just `"conditions"`. However, `"conditions"` seemed ambiguous—especially since a "condition" has a very different meaning in the context of clinical practice.
[^2]: This decision seems like it might need some justification since it's may not be unreasonable to want to specify multiple privileges and show something if the user has *any* of the specified privileges. My thinking here is that the most common use-case for privileges in the frontend is to enable hiding widgets from users where the backend will reject the request anyways and permissions on the backend are always additive in this way.