### PR TITLE
Remove fhir.js

### DIFF
--- a/packages/framework/esm-api/package.json
+++ b/packages/framework/esm-api/package.json
@@ -36,7 +36,6 @@
     "access": "public"
   },
   "dependencies": {
-    "fhir.js": "0.0.22",
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {

--- a/packages/framework/esm-api/src/fhir.ts
+++ b/packages/framework/esm-api/src/fhir.ts
@@ -1,10 +1,9 @@
 /** @module @category API */
 import { openmrsFetch, FetchHeaders, OpenmrsFetchError } from "./openmrs-fetch";
-import type { FhirClient } from "./types/fhir";
+import type { ResourceName } from "./types/fhir";
 
 export const fhirBaseUrl = `/ws/fhir2/R4`;
 
-const makeFhir = require("fhir.js/src/fhir.js");
 const openmrsFhirAdapter = {
   http(requestObj: FHIRRequestObj) {
     return openmrsFetch(requestObj.url, {
@@ -23,7 +22,7 @@ const openmrsFhirAdapter = {
         return {
           status: err.response.status,
           headers: err.response.headers,
-          data: err.responseBody,
+          data: err.responseBody as any,
           config: requestObj,
         };
       }
@@ -32,18 +31,42 @@ const openmrsFhirAdapter = {
 };
 
 /**
- * The `fhir` object is [an instance of fhir.js](https://github.com/FHIR/fhir.js)
+ * The `fhir` object is replicates the API from [fhir.js](https://github.com/FHIR/fhir.js)
  * that can be used to call FHIR-compliant OpenMRS APIs. See
  * [the docs for fhir.js](https://github.com/FHIR/fhir.js) for more info
  * and example usage.
  *
+ * This object should be considered deprecated and may be removed from a future version
+ * of the framework.
+ *
  * @category API
+ * @deprecated
  */
-export const fhir: FhirClient = makeFhir(
-  { baseUrl: fhirBaseUrl },
-  openmrsFhirAdapter
-);
+export const fhir = {
+  read: <T>(
+    options: FHIRRequestOptions
+  ): Promise<{
+    status: number;
+    headers: Headers;
+    data: T;
+    config: FHIRRequestObj;
+  }> => {
+    return openmrsFhirAdapter.http({
+      url: `${fhirBaseUrl}/${options.type}/${options.patient}`,
+      method: "GET",
+      headers: options.headers ?? {},
+    });
+  },
+};
 
+/** @deprecated */
+export interface FHIRRequestOptions {
+  type: ResourceName;
+  patient: string;
+  headers?: FetchHeaders;
+}
+
+/** @deprecated */
 export interface FHIRRequestObj {
   url: string;
   method: string;

--- a/packages/framework/esm-api/src/openmrs-fetch.ts
+++ b/packages/framework/esm-api/src/openmrs-fetch.ts
@@ -1,12 +1,7 @@
 /** @module @category API */
 import { Observable } from "rxjs";
 import isPlainObject from "lodash-es/isPlainObject";
-import {
-  getConfig,
-  interpolateString,
-  interpolateUrl,
-  navigate,
-} from "@openmrs/esm-config";
+import { getConfig, navigate } from "@openmrs/esm-config";
 import { FetchResponse } from "./types";
 
 export const sessionEndpoint = "/ws/rest/v1/session";
@@ -315,6 +310,6 @@ interface FetchBody {
   [key: string]: any;
 }
 
-interface FetchResponseJson {
+export interface FetchResponseJson {
   [key: string]: any;
 }

--- a/packages/framework/esm-api/src/types/fhir.ts
+++ b/packages/framework/esm-api/src/types/fhir.ts
@@ -7,7 +7,7 @@ we can remove this file in favor of the one they maintain
 */
 
 type ClientFn = (...args: any[]) => Promise<{ data: any }>;
-type ResourceName =
+export type ResourceName =
   | "DomainResource"
   | "Organization"
   | "Location"

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -545,7 +545,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/UserHasAccess.tsx:9](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/UserHasAccess.tsx#L9)
+[packages/framework/esm-react-utils/src/UserHasAccess.tsx:10](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/UserHasAccess.tsx#L10)
 
 ___
 
@@ -561,16 +561,27 @@ ___
 
 ### fhir
 
-• **fhir**: `FhirClient`
+• **fhir**: `Object`
 
-The `fhir` object is [an instance of fhir.js](https://github.com/FHIR/fhir.js)
+The `fhir` object is replicates the API from [fhir.js](https://github.com/FHIR/fhir.js)
 that can be used to call FHIR-compliant OpenMRS APIs. See
 [the docs for fhir.js](https://github.com/FHIR/fhir.js) for more info
 and example usage.
 
+This object should be considered deprecated and may be removed from a future version
+of the framework.
+
+**`deprecated`**
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `read` | <T\>(`options`: [`FHIRRequestOptions`](interfaces/FHIRRequestOptions.md)) => `Promise`<{ `config`: [`FHIRRequestObj`](interfaces/FHIRRequestObj.md) ; `data`: `T` ; `headers`: `Headers` ; `status`: `number`  }\> |
+
 #### Defined in
 
-[packages/framework/esm-api/src/fhir.ts:42](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/fhir.ts#L42)
+[packages/framework/esm-api/src/fhir.ts:45](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/fhir.ts#L45)
 
 ___
 
@@ -600,7 +611,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:12](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L12)
+[packages/framework/esm-api/src/openmrs-fetch.ts:7](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L7)
 
 ___
 
@@ -752,18 +763,18 @@ ___
 
 ### fetchCurrentPatient
 
-▸ **fetchCurrentPatient**(`patientUuid`, `contentOverrides?`): `Promise`<{ `data`: `Patient`  }\> \| `Promise`<``null``\>
+▸ **fetchCurrentPatient**(`patientUuid`, `contentOverrides?`): `Promise`<{ `config`: [`FHIRRequestObj`](interfaces/FHIRRequestObj.md) ; `data`: `Patient` ; `headers`: `Headers` ; `status`: `number`  }\> \| `Promise`<``null``\>
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `patientUuid` | [`PatientUuid`](API.md#patientuuid) |
-| `contentOverrides?` | `Partial`<{ `headers?`: [`FetchHeaders`](interfaces/FetchHeaders.md) ; `id?`: `string` ; `patient?`: `string` ; `type`: `ResourceName`  }\> |
+| `contentOverrides?` | `Partial`<[`FHIRRequestOptions`](interfaces/FHIRRequestOptions.md)\> |
 
 #### Returns
 
-`Promise`<{ `data`: `Patient`  }\> \| `Promise`<``null``\>
+`Promise`<{ `config`: [`FHIRRequestObj`](interfaces/FHIRRequestObj.md) ; `data`: `Patient` ; `headers`: `Headers` ; `status`: `number`  }\> \| `Promise`<``null``\>
 
 #### Defined in
 
@@ -967,7 +978,7 @@ makeUrl('/foo/bar');
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L24)
+[packages/framework/esm-api/src/openmrs-fetch.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L19)
 
 ___
 
@@ -1034,7 +1045,7 @@ free up memory and network resources and to prevent race conditions.
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:77](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L77)
+[packages/framework/esm-api/src/openmrs-fetch.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L72)
 
 ___
 
@@ -1085,7 +1096,7 @@ To cancel the network request, simply call `subscription.unsubscribe();`
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:248](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L248)
+[packages/framework/esm-api/src/openmrs-fetch.ts:243](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L243)
 
 ___
 

--- a/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
+++ b/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
@@ -53,7 +53,7 @@ Error.constructor
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:286](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L286)
+[packages/framework/esm-api/src/openmrs-fetch.ts:281](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L281)
 
 ## API Properties
 
@@ -63,17 +63,17 @@ Error.constructor
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:299](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L299)
+[packages/framework/esm-api/src/openmrs-fetch.ts:294](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L294)
 
 ___
 
 ### responseBody
 
-• **responseBody**: ``null`` \| `string` \| `FetchResponseJson`
+• **responseBody**: ``null`` \| `string` \| [`FetchResponseJson`](../interfaces/FetchResponseJson.md)
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:300](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L300)
+[packages/framework/esm-api/src/openmrs-fetch.ts:295](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/openmrs-fetch.ts#L295)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/FHIRRequestObj.md
+++ b/packages/framework/esm-framework/docs/interfaces/FHIRRequestObj.md
@@ -2,6 +2,8 @@
 
 # Interface: FHIRRequestObj
 
+**`deprecated`**
+
 ## Table of contents
 
 ### API Properties
@@ -18,7 +20,7 @@
 
 #### Defined in
 
-[packages/framework/esm-api/src/fhir.ts:50](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/fhir.ts#L50)
+[packages/framework/esm-api/src/fhir.ts:73](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/fhir.ts#L73)
 
 ___
 
@@ -28,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/fhir.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/fhir.ts#L49)
+[packages/framework/esm-api/src/fhir.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/fhir.ts#L72)
 
 ___
 
@@ -38,4 +40,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/fhir.ts:48](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/fhir.ts#L48)
+[packages/framework/esm-api/src/fhir.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/fhir.ts#L71)

--- a/packages/framework/esm-framework/docs/interfaces/FHIRRequestOptions.md
+++ b/packages/framework/esm-framework/docs/interfaces/FHIRRequestOptions.md
@@ -1,0 +1,43 @@
+[@openmrs/esm-framework](../API.md) / FHIRRequestOptions
+
+# Interface: FHIRRequestOptions
+
+**`deprecated`**
+
+## Table of contents
+
+### API Properties
+
+- [headers](FHIRRequestOptions.md#headers)
+- [patient](FHIRRequestOptions.md#patient)
+- [type](FHIRRequestOptions.md#type)
+
+## API Properties
+
+### headers
+
+• `Optional` **headers**: [`FetchHeaders`](FetchHeaders.md)
+
+#### Defined in
+
+[packages/framework/esm-api/src/fhir.ts:66](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/fhir.ts#L66)
+
+___
+
+### patient
+
+• **patient**: `string`
+
+#### Defined in
+
+[packages/framework/esm-api/src/fhir.ts:65](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/fhir.ts#L65)
+
+___
+
+### type
+
+• **type**: `ResourceName`
+
+#### Defined in
+
+[packages/framework/esm-api/src/fhir.ts:64](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-api/src/fhir.ts#L64)

--- a/packages/framework/esm-framework/docs/interfaces/FetchResponseJson.md
+++ b/packages/framework/esm-framework/docs/interfaces/FetchResponseJson.md
@@ -1,0 +1,7 @@
+[@openmrs/esm-framework](../API.md) / FetchResponseJson
+
+# Interface: FetchResponseJson
+
+## Indexable
+
+▪ [key: `string`]: `any`

--- a/packages/framework/esm-framework/docs/interfaces/UserHasAccessProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/UserHasAccessProps.md
@@ -6,9 +6,20 @@
 
 ### API Properties
 
+- [fallback](UserHasAccessProps.md#fallback)
 - [privilege](UserHasAccessProps.md#privilege)
 
 ## API Properties
+
+### fallback
+
+• `Optional` **fallback**: `ReactNode`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/UserHasAccess.tsx:7](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/UserHasAccess.tsx#L7)
+
+___
 
 ### privilege
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3588,11 +3588,6 @@
     "@types/qs" "*"
     "@types/serve-static" "*"
 
-"@types/fhir@0.0.30":
-  version "0.0.30"
-  resolved "https://registry.yarnpkg.com/@types/fhir/-/fhir-0.0.30.tgz#a0aec3b2d7dd2a7584474dac446ede5f9a4d7a13"
-  integrity sha512-vDU62tUFeAYBVQThiWAfGd6D25TiLLDDS5pV19vim52FLpwWTBliLMvotbF4D/U+BmjxBKIuHGZgFnoh/HtV5g==
-
 "@types/fhir@0.0.31":
   version "0.0.31"
   resolved "https://registry.yarnpkg.com/@types/fhir/-/fhir-0.0.31.tgz#067392154124125dccc97e51a4297d448467c211"
@@ -4198,11 +4193,6 @@
   version "4.2.2"
   resolved "https://registry.yarnpkg.com/@xtuc/long/-/long-4.2.2.tgz#d291c6a4e97989b5c61d9acf396ae4fe133a718d"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
-
-Base64@~0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/Base64/-/Base64-0.3.0.tgz#6da261a4e80d4fa0f5c684254e5bccd16bbdce9f"
-  integrity sha1-baJhpOgNT6D1xoQlTlvM0Wu9zp8=
 
 JSONStream@^1.0.4:
   version "1.3.5"
@@ -7548,17 +7538,6 @@ fecha@^4.2.0:
   resolved "https://registry.yarnpkg.com/fecha/-/fecha-4.2.1.tgz#0a83ad8f86ef62a091e22bb5a039cd03d23eecce"
   integrity sha512-MMMQ0ludy/nBs1/o0zVOiKTpG7qMbonKUzjJgQFEuvq6INZ1OraKPRAWkBq5vlKLOUMpmNYG1JoN3oDPUQ9m3Q==
 
-fhir.js@0.0.22:
-  version "0.0.22"
-  resolved "https://registry.yarnpkg.com/fhir.js/-/fhir.js-0.0.22.tgz#5aea18d86ece91c1f590c8ba2cff79692bd1f924"
-  integrity sha512-+DUoaVMhxiDC53VTl41cBoJnp3NGaGQhQCi7HtXnGlfci5pmr8hQTYfd0axCVmKCrN5I28+/nhC8ANv2hVLFUg==
-  dependencies:
-    "@types/fhir" "0.0.30"
-    Base64 "~0.3.0"
-    merge "^1.2.1"
-    q "^1.4.1"
-    request "^2.88.0"
-
 figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -10872,11 +10851,6 @@ merge2@^1.3.0, merge2@^1.4.1:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-merge@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.1.tgz#38bebf80c3220a8a487b6fcfb3941bb11720c145"
-  integrity sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==
-
 methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
@@ -12838,7 +12812,7 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-q@^1.1.2, q@^1.4.1, q@^1.5.1:
+q@^1.1.2, q@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"
   integrity sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc=


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
The fhir.js library is basically unsupported. In any case, we're primarily accessing the FHIR API directly via `openmrsFetch()` rather than using `fhir.read()`. The one exception to this is reading the patient which occurs in a few places.

This PR removes the fhir.js library and replaces it with a minimal wrapper that supports the functionality we actually use and marks the `fhir` object as deprecated.

Hopefully, we can go through the repos and remove this usage of the `fhir` object altogether.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
