### PR TITLE
(fix) Prevent offline patients appearing twice in offline patient table

### DIFF
--- a/packages/apps/esm-offline-tools-app/src/hooks/offline-patient-data-hooks.ts
+++ b/packages/apps/esm-offline-tools-app/src/hooks/offline-patient-data-hooks.ts
@@ -1,18 +1,24 @@
 import {
   fetchCurrentPatient,
   getSynchronizationItems,
-  useStore,
   getDynamicOfflineDataEntries,
 } from "@openmrs/esm-framework";
 import useSWR from "swr";
 
 export function useOfflineRegisteredPatients() {
   return useSWR("offlineTools/offlineRegisteredPatients", async () => {
+    const offlinePatients = await getDynamicOfflineDataEntries("patient");
     const syncItems = await getSynchronizationItems<{
       fhirPatient?: fhir.Patient;
     }>("patient-registration");
     return syncItems
-      .filter((item) => item.fhirPatient)
+      .filter(
+        (item) =>
+          item.fhirPatient &&
+          !offlinePatients.find(
+            (entry) => entry.identifier === item.fhirPatient.id
+          )
+      )
       .map((item) => item.fhirPatient);
   });
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
The offline patient table displays an offline patient added to the offline patient list twice if that patient has been edited while offline. This PR fixes this issue by adding an additional filter to the patient data to be rendered.
