### PR TITLE
Adds @types/fhir as a dependency of esm-api

### DIFF
--- a/packages/framework/esm-api/package.json
+++ b/packages/framework/esm-api/package.json
@@ -36,6 +36,7 @@
     "access": "public"
   },
   "dependencies": {
+    "@types/fhir": "0.0.31",
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
@@ -46,7 +47,6 @@
     "@openmrs/esm-config": "^3.4.0",
     "@openmrs/esm-error-handling": "^3.4.0",
     "@openmrs/esm-state": "^3.4.0",
-    "@types/fhir": "0.0.31",
     "rxjs": "^6.5.3"
   }
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
See: https://github.com/openmrs/openmrs-esm-core/pull/477#issuecomment-1184206826 for motivation. This moves `@types/fhir` to a dependency of `@openmrs/esm-api` which hopefully should propagate this dependency properly.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
