### PR TITLE
(feat) Change ExtensionSlot's 'extensionSlotName' prop to just 'name'

### DIFF
--- a/packages/apps/esm-offline-tools-app/src/home/cards-container.component.tsx
+++ b/packages/apps/esm-offline-tools-app/src/home/cards-container.component.tsx
@@ -10,7 +10,7 @@ import styles from "./cards-container.styles.scss";
 const CardsContainer: React.FC = () => {
   return (
     <ExtensionSlot
-      extensionSlotName="offline-tools-dashboard-cards"
+      name="offline-tools-dashboard-cards"
       className={styles.overviewCardContainer}
     />
   );

--- a/packages/apps/esm-offline-tools-app/src/nav/desktop-side-nav.component.tsx
+++ b/packages/apps/esm-offline-tools-app/src/nav/desktop-side-nav.component.tsx
@@ -19,7 +19,7 @@ const DesktopSideNav: React.FC = () => {
   return (
     layout === "desktop" && (
       <SideNav expanded aria-label="Menu" className={styles.link}>
-        <ExtensionSlot extensionSlotName="nav-menu-slot" />
+        <ExtensionSlot name="nav-menu-slot" />
       </SideNav>
     )
   );

--- a/packages/apps/esm-offline-tools-app/src/nav/offline-tools-nav-menu.component.tsx
+++ b/packages/apps/esm-offline-tools-app/src/nav/offline-tools-nav-menu.component.tsx
@@ -8,7 +8,7 @@ const OfflineToolsNavMenu: React.FC = () => {
   return (
     <>
       <OfflineToolsNavLink title={t("home", "Home")} />
-      <ExtensionSlot extensionSlotName="offline-tools-page-slot" />
+      <ExtensionSlot name="offline-tools-page-slot" />
     </>
   );
 };

--- a/packages/apps/esm-offline-tools-app/src/offline-tools-page/offline-tools-page.component.tsx
+++ b/packages/apps/esm-offline-tools-app/src/offline-tools-page/offline-tools-page.component.tsx
@@ -26,10 +26,10 @@ const OfflineToolsPage: React.FC<
 
   return (
     <>
-      <ExtensionSlot extensionSlotName="breadcrumbs-slot" />
+      <ExtensionSlot name="breadcrumbs-slot" />
       <ExtensionSlot
         key={pageConfig.slot}
-        extensionSlotName={pageConfig.slot}
+        name={pageConfig.slot}
         state={{ basePath }}
       />
     </>

--- a/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.component.tsx
@@ -44,7 +44,7 @@ const ChangeLocale: React.FC<ChangeLocaleProps> = ({
       >
         {options}
       </Select>
-      <ExtensionSlot extensionSlotName="user-panel-actions-slot" />
+      <ExtensionSlot name="user-panel-actions-slot" />
     </div>
   );
 };

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/app-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/app-menu-panel.component.tsx
@@ -26,10 +26,7 @@ const AppMenuPanel: React.FC<AppMenuProps> = ({ expanded, hidePanel }) => {
       aria-label="App Menu Panel"
       expanded={expanded}
     >
-      <ExtensionSlot
-        className={styles.menuLink}
-        extensionSlotName="app-menu-slot"
-      />
+      <ExtensionSlot className={styles.menuLink} name="app-menu-slot" />
       {config?.externalRefLinks?.length > 0 && (
         <div className={`${styles.menuLink} ${styles.externalLinks}`}>
           {config?.externalRefLinks?.map((link) => (

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/notifications-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/notifications-menu-panel.component.tsx
@@ -21,10 +21,7 @@ const NotificationsMenuPanel: React.FC<NotificationsMenuPanelProps> = ({
       expanded={expanded}
     >
       <h1 className={styles.heading}>{t("notifications", "Notifications")}</h1>
-      <ExtensionSlot
-        extensionSlotName="notifications-nav-menu-slot"
-        state={state}
-      />
+      <ExtensionSlot name="notifications-nav-menu-slot" state={state} />
     </HeaderPanel>
   );
 };

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/user-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/user-menu-panel.component.tsx
@@ -35,7 +35,7 @@ const UserMenuPanel: React.FC<UserMenuPanelProps> = ({
       aria-labelledby="Location Icon"
     >
       <ExtensionSlot
-        extensionSlotName="user-panel-slot"
+        name="user-panel-slot"
         state={{
           user: user,
           allowedLocales: allowedLocales,

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -92,15 +92,15 @@ const Navbar: React.FC<NavbarProps> = ({
           </ConfigurableLink>
           <ExtensionSlot
             className={styles.dividerOverride}
-            extensionSlotName="top-nav-info-slot"
+            name="top-nav-info-slot"
           />
           <HeaderGlobalBar className={styles.headerGlobalBar}>
             <ExtensionSlot
-              extensionSlotName="top-nav-actions-slot"
+              name="top-nav-actions-slot"
               className={styles.topNavActionsSlot}
             />
             <ExtensionSlot
-              extensionSlotName="notifications-menu-button-slot"
+              name="notifications-menu-button-slot"
               state={{
                 isActivePanel: isActivePanel,
                 togglePanel: togglePanel,

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -388,11 +388,11 @@ ___
 
 ### ExtensionSlotProps
 
-Ƭ **ExtensionSlotProps**: [`ExtensionSlotBaseProps`](interfaces/ExtensionSlotBaseProps.md) & `React.HTMLAttributes`<`HTMLDivElement`\>
+Ƭ **ExtensionSlotProps**: [`OldExtensionSlotBaseProps`](interfaces/OldExtensionSlotBaseProps.md) \| [`ExtensionSlotBaseProps`](interfaces/ExtensionSlotBaseProps.md) & `React.HTMLAttributes`<`HTMLDivElement`\>
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:48](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L48)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:58](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L58)
 
 ___
 
@@ -714,7 +714,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:55](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L55)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:68](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L68)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotBaseProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotBaseProps.md
@@ -7,6 +7,7 @@
 ### Properties
 
 - [extensionSlotName](ExtensionSlotBaseProps.md#extensionslotname)
+- [name](ExtensionSlotBaseProps.md#name)
 - [state](ExtensionSlotBaseProps.md#state)
 
 ### Methods
@@ -17,7 +18,19 @@
 
 ### extensionSlotName
 
-• **extensionSlotName**: `string`
+• `Optional` **extensionSlotName**: `string`
+
+**`deprecated`** Use `name`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:45](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L45)
+
+___
+
+### name
+
+• **name**: `string`
 
 #### Defined in
 
@@ -31,7 +44,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:45](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L45)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:47](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L47)
 
 ## Methods
 
@@ -51,4 +64,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:44](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L44)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:46](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L46)

--- a/packages/framework/esm-framework/docs/interfaces/OldExtensionSlotBaseProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OldExtensionSlotBaseProps.md
@@ -1,0 +1,67 @@
+[@openmrs/esm-framework](../API.md) / OldExtensionSlotBaseProps
+
+# Interface: OldExtensionSlotBaseProps
+
+## Table of contents
+
+### Properties
+
+- [extensionSlotName](OldExtensionSlotBaseProps.md#extensionslotname)
+- [name](OldExtensionSlotBaseProps.md#name)
+- [state](OldExtensionSlotBaseProps.md#state)
+
+### Methods
+
+- [select](OldExtensionSlotBaseProps.md#select)
+
+## Properties
+
+### extensionSlotName
+
+• **extensionSlotName**: `string`
+
+**`deprecated`** Use `name`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:53](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L53)
+
+___
+
+### name
+
+• `Optional` **name**: `string`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:51](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L51)
+
+___
+
+### state
+
+• `Optional` **state**: `Record`<`string`, `any`\>
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:55](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L55)
+
+## Methods
+
+### select
+
+▸ `Optional` **select**(`extensions`): [`ConnectedExtension`](ConnectedExtension.md)[]
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `extensions` | [`ConnectedExtension`](ConnectedExtension.md)[] |
+
+#### Returns
+
+[`ConnectedExtension`](ConnectedExtension.md)[]
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:54](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L54)

--- a/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
@@ -55,7 +55,7 @@ describe("Interaction between configuration and extension systems", () => {
       moduleName: "esm-flintstone",
       featureName: "The Flintstones",
       disableTranslations: true,
-    })(() => <ExtensionSlot data-testid="slot" extensionSlotName="A slot" />);
+    })(() => <ExtensionSlot data-testid="slot" name="A slot" />);
     render(<App />);
     await waitFor(() => expect(screen.getByText("Betty")).toBeInTheDocument());
     const slot = screen.getByTestId("slot");
@@ -93,14 +93,8 @@ describe("Interaction between configuration and extension systems", () => {
       disableTranslations: true,
     })(() => (
       <>
-        <ExtensionSlot
-          data-testid="flintstone-slot"
-          extensionSlotName="Flintstone slot"
-        />
-        <ExtensionSlot
-          data-testid="future-slot"
-          extensionSlotName="Future slot"
-        />
+        <ExtensionSlot data-testid="flintstone-slot" name="Flintstone slot" />
+        <ExtensionSlot data-testid="future-slot" name="Future slot" />
       </>
     ));
     render(<App />);
@@ -140,10 +134,7 @@ describe("Interaction between configuration and extension systems", () => {
       disableTranslations: true,
     })(() => (
       <>
-        <ExtensionSlot
-          data-testid="flintstone-slot"
-          extensionSlotName="Flintstone slot"
-        />
+        <ExtensionSlot data-testid="flintstone-slot" name="Flintstone slot" />
       </>
     ));
     render(<App />);
@@ -161,7 +152,7 @@ describe("Interaction between configuration and extension systems", () => {
       moduleName: "esm-slaghoople",
       featureName: "The Slaghooples",
       disableTranslations: true,
-    })(() => <ExtensionSlot data-testid="slot" extensionSlotName="A slot" />);
+    })(() => <ExtensionSlot data-testid="slot" name="A slot" />);
     render(<App />);
     await waitFor(() => expect(screen.getByText("Pearl")).toBeInTheDocument());
     act(() => {
@@ -188,7 +179,7 @@ describe("Interaction between configuration and extension systems", () => {
       moduleName: "esm-quarry",
       featureName: "The Flintstones",
       disableTranslations: true,
-    })(() => <ExtensionSlot data-testid="slot" extensionSlotName="A slot" />);
+    })(() => <ExtensionSlot data-testid="slot" name="A slot" />);
     render(<App />);
     await waitFor(() =>
       expect(screen.getByText(/Mr. Slate/)).toBeInTheDocument()
@@ -221,7 +212,7 @@ describe("Interaction between configuration and extension systems", () => {
       const store = useExtensionStore();
       return (
         <div>
-          <ExtensionSlot data-testid="slot" extensionSlotName="A slot" />
+          <ExtensionSlot data-testid="slot" name="A slot" />
           {store.slots["A slot"].assignedExtensions.map((e) => (
             <div key={e.name}>{JSON.stringify(e.config)}</div>
           ))}

--- a/packages/framework/esm-react-utils/src/useConfig.test.tsx
+++ b/packages/framework/esm-react-utils/src/useConfig.test.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { render, cleanup, screen, waitFor } from "@testing-library/react";
+import { render, cleanup, screen, waitFor, act } from "@testing-library/react";
 import {
   defineConfigSchema,
   temporaryConfigStore,
@@ -26,7 +26,6 @@ function clearConfig() {
 
 describe(`useConfig in root context`, () => {
   afterEach(clearConfig);
-  afterEach(cleanup);
 
   it(`can return config as a react hook`, async () => {
     defineConfigSchema("foo-module", {
@@ -103,9 +102,11 @@ describe(`useConfig in root context`, () => {
       expect(screen.findByText("The first thing")).toBeTruthy()
     );
 
-    temporaryConfigStore.setState({
-      config: { "foo-module": { thing: "A new thing" } },
-    });
+    act(() =>
+      temporaryConfigStore.setState({
+        config: { "foo-module": { thing: "A new thing" } },
+      })
+    );
 
     await waitFor(() => expect(screen.findByText("A new thing")).toBeTruthy());
   });
@@ -273,7 +274,7 @@ describe(`useConfig in an extension`, () => {
     );
 
     const newConfig = { "ext-module": { thing: "A new thing" } };
-    temporaryConfigStore.setState({ config: newConfig });
+    act(() => temporaryConfigStore.setState({ config: newConfig }));
 
     await waitFor(() => expect(screen.findByText("A new thing")).toBeTruthy());
 
@@ -290,7 +291,7 @@ describe(`useConfig in an extension`, () => {
         },
       },
     };
-    temporaryConfigStore.setState({ config: newConfig2 });
+    act(() => temporaryConfigStore.setState({ config: newConfig2 }));
 
     await waitFor(() =>
       expect(screen.findByText("Yet another thing")).toBeTruthy()

--- a/packages/framework/esm-styleguide/src/left-nav/index.tsx
+++ b/packages/framework/esm-styleguide/src/left-nav/index.tsx
@@ -43,12 +43,9 @@ export const LeftNavMenu = React.forwardRef<HTMLElement, LeftNavMenuProps>(
           className={styles.leftNav}
           {...props}
         >
-          <ExtensionSlot extensionSlotName="global-nav-menu-slot" />
+          <ExtensionSlot name="global-nav-menu-slot" />
           {slotName ? (
-            <ExtensionSlot
-              extensionSlotName={slotName}
-              state={{ basePath, currentPath }}
-            />
+            <ExtensionSlot name={slotName} state={{ basePath, currentPath }} />
           ) : null}
         </SideNav>
       </BrowserRouter>


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Does what it says on the tin. Having `extensionSlot` prefixing one of the props for `ExtensionSlot` is redundant.
