### PR TITLE
Global button for opening Implementer Tools

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/global-implementer-tools-button.test.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/global-implementer-tools-button.test.tsx
@@ -1,0 +1,13 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import React from "react";
+import "@testing-library/jest-dom";
+import GlobalImplementerToolsButton from "./global-implementer-tools.component";
+
+describe("Testing the global implementer tools button", () => {
+  afterEach(cleanup);
+  it("should render global Implementer tools", () => {
+    render(<GlobalImplementerToolsButton />);
+    const button = screen.getByTestId("globalImplementerToolsButton");
+    expect(button).toBeInTheDocument();
+  });
+});

--- a/packages/apps/esm-implementer-tools-app/src/global-implementer-tools.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/global-implementer-tools.component.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import ChevronUp from "@carbon/icons-react/es/chevron--up/16";
+import ChevronDown from "@carbon/icons-react/es/chevron--down/16";
+import { UserHasAccess, useStore } from "@openmrs/esm-framework";
+import { implementerToolsStore, togglePopup } from "./store";
+import styles from "./implementer-tools.styles.scss";
+
+const GlobalImplementerToolsButton: React.FC = () => {
+  const { t } = useTranslation();
+  const { isOpen } = useStore(implementerToolsStore);
+
+  return (
+    <UserHasAccess privilege="coreapps.systemAdministration">
+      <div
+        className={styles.chevronImplementerToolsButton}
+        data-testid="globalImplementerToolsButton"
+      >
+        <div onClick={togglePopup} role="button" tabIndex={0}>
+          {isOpen ? <ChevronUp /> : <ChevronDown />}
+        </div>
+      </div>
+    </UserHasAccess>
+  );
+};
+
+export default GlobalImplementerToolsButton;

--- a/packages/apps/esm-implementer-tools-app/src/global-implementer-tools.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/global-implementer-tools.component.tsx
@@ -17,7 +17,7 @@ const GlobalImplementerToolsButton: React.FC = () => {
         data-testid="globalImplementerToolsButton"
       >
         <div onClick={togglePopup} role="button" tabIndex={0}>
-          {isOpen ? <ChevronUp /> : <ChevronDown />}
+          {isOpen ? <ChevronDown /> : <ChevronUp />}
         </div>
       </div>
     </UserHasAccess>

--- a/packages/apps/esm-implementer-tools-app/src/implementer-tools.styles.scss
+++ b/packages/apps/esm-implementer-tools-app/src/implementer-tools.styles.scss
@@ -22,7 +22,7 @@
 
 .chevronImplementerToolsButton {
   position: fixed;
-  top: 0;
+  bottom: 0;
   left: calc(50vw - $spacing-05);
   z-index: 9999;
 

--- a/packages/apps/esm-implementer-tools-app/src/implementer-tools.styles.scss
+++ b/packages/apps/esm-implementer-tools-app/src/implementer-tools.styles.scss
@@ -17,3 +17,25 @@
 .toolStyles {
   background-color: transparent;
 }
+
+// Chevron button - implementer-tools component
+
+.chevronImplementerToolsButton {
+  position: fixed;
+  top: 0;
+  left: calc(50vw - $spacing-05);
+  z-index: 9999;
+
+  div {
+    background-color: $ui-02;
+    width: $spacing-07;
+    display: flex;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.1s ease-in-out;
+  }
+
+  div:hover {
+    padding: $spacing-03 0;
+  }
+}

--- a/packages/apps/esm-implementer-tools-app/src/index.ts
+++ b/packages/apps/esm-implementer-tools-app/src/index.ts
@@ -16,6 +16,13 @@ function setupOpenMRS() {
           options
         ),
       },
+      {
+        route: () => true,
+        load: getAsyncLifecycle(
+          () => import("./global-implementer-tools.component"),
+          options
+        ),
+      },
     ],
     extensions: [
       {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
I have made a global button for opening and closing the implementer tools in the application. Currently, we are not able to open the Implementer tools in the patient chart, due to the visit header. Seeing the designs in [here](https://app.zeplin.io/project/620a1aba48e34da85564ca12/screen/62b1f0fe10a74c1af11ed596), I have made a global button for the same.

## Screenshots
<img width="144" alt="Screenshot 2022-07-19 at 3 13 47 PM" src="https://user-images.githubusercontent.com/51502471/179720788-f00dd0e3-5898-47e5-9457-7579f17c7fd8.png">
<img width="1680" alt="Screenshot 2022-07-19 at 3 13 55 PM" src="https://user-images.githubusercontent.com/51502471/179720797-f9987631-bb87-4bfd-b07d-4442fdf0c91a.png">
<img width="1680" alt="Screenshot 2022-07-19 at 3 14 05 PM" src="https://user-images.githubusercontent.com/51502471/179720814-527df7a8-a0e8-41a4-8b2d-01293621f88c.png">
<img width="1680" alt="Screenshot 2022-07-19 at 3 14 17 PM" src="https://user-images.githubusercontent.com/51502471/179720818-b21197b5-19d3-4f03-bbf4-2333f1c8d66e.png">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
