### PR TITLE
(feat) Fix extension state, improve ExtensionSlot API

### DIFF
--- a/docs/main/config.md
+++ b/docs/main/config.md
@@ -327,9 +327,9 @@ Can be used anywhere within the schema structure.
 
 #### `_elements`
 
-Only valid alongside `_type: Type.Array` or `_type: Type.Object`. A `_default`
-must also be provided at this level. Value should be an object which is
-a schema for the values contained in the array or object.
+Only valid alongside `_type: Type.Array`. A `_default`
+must also be provided at this level. Value should be a schema for the values
+contained in the array.
 
 ## API Documentation
 

--- a/docs/main/extensions.md
+++ b/docs/main/extensions.md
@@ -136,8 +136,11 @@ slots have a standard configuration interface that allows administrators
 to add, remove, and re-order extensions, as well as specific
 configuration specific to an extension within a particular slot.
 
-You can use `useConfig` as usual within an extension. An extension uses
-the config schema of the module in which it is defined.
+You can use `useConfig` as usual within an extension.
+
+The schema for an extension can be specified using `defineExtensionConfigSchema`.
+If no schema is defined specifically for your extension, the extension will inherit
+the configuration of the module that contains it.
 
 ## State
 
@@ -147,8 +150,8 @@ Most commonly, extensions that pertain to a specific patient will accept
 a `patientUuid` parameter which can be used to fetch relevant patient
 information.
 
-State is provided as a parameter to the slot, and recieved as a normal
-component parameter by the extension.
+State is provided as a parameter to the `ExtensionSlot` or `Extension`
+components, and recieved as a prop by the extension.
 
 See the [ExtensionSlot API docs](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/docs/API.md#extensionslot)
 for more.

--- a/packages/framework/esm-extensions/jest.config.js
+++ b/packages/framework/esm-extensions/jest.config.js
@@ -3,6 +3,6 @@ module.exports = {
     "^.+\\.(j|t)sx?$": ["@swc/jest"],
   },
   moduleNameMapper: {
-    "lodash-es/(.*)": "lodash/$1",
+    "lodash-es": "lodash",
   },
 };

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -2301,7 +2301,7 @@ ___
 
 ### renderExtension
 
-▸ **renderExtension**(`domElement`, `extensionSlotName`, `extensionSlotModuleName`, `extensionId`, `renderFunction?`, `additionalProps?`): `Parcel` \| ``null``
+▸ **renderExtension**(`domElement`, `extensionSlotName`, `extensionSlotModuleName`, `extensionId`, `renderFunction?`, `additionalProps?`): `Object`
 
 Mounts into a DOM node (representing an extension slot)
 a lazy-loaded component from *any* frontend module
@@ -2320,7 +2320,12 @@ that registered an extension component for this slot.
 
 #### Returns
 
-`Parcel` \| ``null``
+`Object`
+
+| Name | Type |
+| :------ | :------ |
+| `parcel` | `Parcel` \| ``null`` |
+| `unmount` | () => `void` |
 
 #### Defined in
 
@@ -3819,7 +3824,7 @@ The dispose function to force closing the modal dialog.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/modals/index.tsx:165](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-styleguide/src/modals/index.tsx#L165)
+[packages/framework/esm-styleguide/src/modals/index.tsx:164](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-styleguide/src/modals/index.tsx#L164)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -2301,7 +2301,7 @@ ___
 
 ### renderExtension
 
-▸ **renderExtension**(`domElement`, `extensionSlotName`, `extensionSlotModuleName`, `extensionId`, `renderFunction?`, `additionalProps?`): `Object`
+▸ **renderExtension**(`domElement`, `extensionSlotName`, `extensionSlotModuleName`, `extensionId`, `renderFunction?`, `additionalProps?`): `Parcel` \| ``null``
 
 Mounts into a DOM node (representing an extension slot)
 a lazy-loaded component from *any* frontend module
@@ -2320,12 +2320,7 @@ that registered an extension component for this slot.
 
 #### Returns
 
-`Object`
-
-| Name | Type |
-| :------ | :------ |
-| `parcel` | `Parcel` \| ``null`` |
-| `unmount` | () => `void` |
+`Parcel` \| ``null``
 
 #### Defined in
 
@@ -3824,7 +3819,7 @@ The dispose function to force closing the modal dialog.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/modals/index.tsx:164](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-styleguide/src/modals/index.tsx#L164)
+[packages/framework/esm-styleguide/src/modals/index.tsx:165](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-styleguide/src/modals/index.tsx#L165)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -140,6 +140,10 @@
 - [syncOfflinePatientData](API.md#syncofflinepatientdata)
 - [useConnectivity](API.md#useconnectivity)
 
+### Other Functions
+
+- [ExtensionSlot](API.md#extensionslot)
+
 ### Store Functions
 
 - [createGlobalStore](API.md#createglobalstore)
@@ -388,11 +392,11 @@ ___
 
 ### ExtensionSlotProps
 
-Ƭ **ExtensionSlotProps**: [`OldExtensionSlotBaseProps`](interfaces/OldExtensionSlotBaseProps.md) \| [`ExtensionSlotBaseProps`](interfaces/ExtensionSlotBaseProps.md) & `React.HTMLAttributes`<`HTMLDivElement`\>
+Ƭ **ExtensionSlotProps**: [`OldExtensionSlotBaseProps`](interfaces/OldExtensionSlotBaseProps.md) \| [`ExtensionSlotBaseProps`](interfaces/ExtensionSlotBaseProps.md) & `React.HTMLAttributes`<`HTMLDivElement`\> & { `children?`: `React.ReactNode` \| (`extension`: [`ConnectedExtension`](interfaces/ConnectedExtension.md)) => `React.ReactNode`  }
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:58](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L58)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:23](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L23)
 
 ___
 
@@ -704,17 +708,7 @@ and *must* only be used once within that `<ExtensionSlot>`.
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/Extension.tsx:23](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/Extension.tsx#L23)
-
-___
-
-### ExtensionSlot
-
-• **ExtensionSlot**: `React.FC`<[`ExtensionSlotProps`](API.md#extensionslotprops)\>
-
-#### Defined in
-
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:68](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L68)
+[packages/framework/esm-react-utils/src/Extension.tsx:31](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/Extension.tsx#L31)
 
 ___
 
@@ -2307,7 +2301,7 @@ ___
 
 ### renderExtension
 
-▸ **renderExtension**(`domElement`, `extensionSlotName`, `extensionSlotModuleName`, `extensionId`, `renderFunction?`, `additionalProps?`): [`CancelLoading`](interfaces/CancelLoading.md)
+▸ **renderExtension**(`domElement`, `extensionSlotName`, `extensionSlotModuleName`, `extensionId`, `renderFunction?`, `additionalProps?`): `Parcel` \| ``null``
 
 Mounts into a DOM node (representing an extension slot)
 a lazy-loaded component from *any* frontend module
@@ -2326,7 +2320,7 @@ that registered an extension component for this slot.
 
 #### Returns
 
-[`CancelLoading`](interfaces/CancelLoading.md)
+`Parcel` \| ``null``
 
 #### Defined in
 
@@ -3428,6 +3422,57 @@ ___
 
 ___
 
+## Other Functions
+
+### ExtensionSlot
+
+▸ **ExtensionSlot**(`__namedParameters`): `Element`
+
+An [extension slot](https://o3-dev.docs.openmrs.org/#/main/extensions).
+A place with a name. Extensions that get connected to that name
+will be rendered into this.
+
+**`example`**
+Passing a react node as children
+
+```tsx
+<ExtensionSlot name="Foo">
+  <div style={{ width: 10rem }}>
+    <Extension />
+  </div>
+</ExtensionSlot>
+```
+
+**`example`**
+Passing a function as children
+
+```tsx
+<ExtensionSlot name="Bar">
+  {(extension) => (
+    <h1>{extension.name}</h1>
+    <div style={{ color: extension.meta.color }}>
+      <Extension />
+    </div>
+  )}
+</ExtensionSlot>
+```
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `__namedParameters` | [`ExtensionSlotProps`](API.md#extensionslotprops) |
+
+#### Returns
+
+`Element`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:85](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L85)
+
+___
+
 ## Store Functions
 
 ### createGlobalStore
@@ -3774,7 +3819,7 @@ The dispose function to force closing the modal dialog.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/modals/index.tsx:164](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-styleguide/src/modals/index.tsx#L164)
+[packages/framework/esm-styleguide/src/modals/index.tsx:165](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-styleguide/src/modals/index.tsx#L165)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionProps.md
@@ -20,13 +20,15 @@
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/Extension.tsx:7](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/Extension.tsx#L7)
+[packages/framework/esm-react-utils/src/Extension.tsx:14](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/Extension.tsx#L14)
 
 ## Methods
 
 ### wrap
 
 ▸ `Optional` **wrap**(`slot`, `extension`): ``null`` \| `ReactElement`<`any`, `any`\>
+
+**`deprecated`** Pass a function as the child of `ExtensionSlot` instead.
 
 #### Parameters
 
@@ -41,4 +43,4 @@
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/Extension.tsx:8](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/Extension.tsx#L8)
+[packages/framework/esm-react-utils/src/Extension.tsx:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/Extension.tsx#L16)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotBaseProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotBaseProps.md
@@ -24,7 +24,7 @@
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:45](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L45)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:10](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L10)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:43](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L43)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:8](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L8)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:47](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L47)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:12](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L12)
 
 ## Methods
 
@@ -64,4 +64,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:46](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L46)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:11](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L11)

--- a/packages/framework/esm-framework/docs/interfaces/OldExtensionSlotBaseProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OldExtensionSlotBaseProps.md
@@ -24,7 +24,7 @@
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:53](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L53)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:18](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L18)
 
 ___
 
@@ -34,7 +34,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:51](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L51)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:16](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L16)
 
 ___
 
@@ -44,7 +44,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:55](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L55)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:20](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L20)
 
 ## Methods
 
@@ -64,4 +64,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:54](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L54)
+[packages/framework/esm-react-utils/src/ExtensionSlot.tsx:19](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L19)

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -249,12 +249,6 @@ export const useSession = jest.fn(() => ({
 
 export const useLayoutType = jest.fn(() => "desktop");
 
-export const useExtensionSlot = jest.fn(() => ({
-  extensionSlotModuleName: "",
-  attachedExtensionSlotName: "",
-  extensionIdsToRender: [],
-}));
-
 export const useExtensionSlotMeta = jest.fn(() => ({}));
 
 export const UserHasAccess = jest.fn().mockImplementation((props: any) => {

--- a/packages/framework/esm-react-utils/__mocks__/openmrs-esm-state.mock.ts
+++ b/packages/framework/esm-react-utils/__mocks__/openmrs-esm-state.mock.ts
@@ -64,6 +64,7 @@ export function getGlobalStore<TState = any>(
 
 function instrumentedStore<T>(name: string, store: Store<T>) {
   return {
+    action: jest.spyOn(store, "action"),
     getState: jest.spyOn(store, "getState"),
     setState: jest.spyOn(store, "setState"),
     subscribe: jest.spyOn(store, "subscribe"),

--- a/packages/framework/esm-react-utils/jest.config.js
+++ b/packages/framework/esm-react-utils/jest.config.js
@@ -1,10 +1,11 @@
 module.exports = {
   transform: {
-    "^.+\\.tsx?$": ["@swc/jest"],
+    "^.+\\.(j|t)sx?$": ["@swc/jest"],
   },
-  setupFiles: ["<rootDir>/src/setup-tests.js"],
+  setupFilesAfterEnv: ["<rootDir>/src/setup-tests.js"],
   moduleNameMapper: {
     "lodash-es": "lodash",
+    "^lodash-es/(.*)$": "lodash/$1",
     "@openmrs/esm-error-handling":
       "<rootDir>/__mocks__/openmrs-esm-error-handling.mock.ts",
     "@openmrs/esm-state": "<rootDir>/__mocks__/openmrs-esm-state.mock.ts",

--- a/packages/framework/esm-react-utils/src/Extension.tsx
+++ b/packages/framework/esm-react-utils/src/Extension.tsx
@@ -45,7 +45,7 @@ export const Extension: React.FC<ExtensionProps> = ({ state, wrap }) => {
 
   useEffect(() => {
     if (domElement != null && extension && !parcel.current) {
-      parcel.current = renderExtension(
+      const { parcel: resultParcel, unmount } = renderExtension(
         domElement,
         extension.extensionSlotName,
         extension.extensionSlotModuleName,
@@ -53,9 +53,8 @@ export const Extension: React.FC<ExtensionProps> = ({ state, wrap }) => {
         undefined,
         state
       );
-      return () => {
-        parcel.current && parcel.current.unmount();
-      };
+      parcel.current = resultParcel;
+      return unmount;
     }
   }, [
     extension?.extensionSlotName,

--- a/packages/framework/esm-react-utils/src/Extension.tsx
+++ b/packages/framework/esm-react-utils/src/Extension.tsx
@@ -45,7 +45,7 @@ export const Extension: React.FC<ExtensionProps> = ({ state, wrap }) => {
 
   useEffect(() => {
     if (domElement != null && extension && !parcel.current) {
-      const { parcel: resultParcel, unmount } = renderExtension(
+      parcel.current = renderExtension(
         domElement,
         extension.extensionSlotName,
         extension.extensionSlotModuleName,
@@ -53,8 +53,9 @@ export const Extension: React.FC<ExtensionProps> = ({ state, wrap }) => {
         undefined,
         state
       );
-      parcel.current = resultParcel;
-      return unmount;
+      return () => {
+        parcel.current && parcel.current.unmount();
+      };
     }
   }, [
     extension?.extensionSlotName,

--- a/packages/framework/esm-react-utils/src/Extension.tsx
+++ b/packages/framework/esm-react-utils/src/Extension.tsx
@@ -47,9 +47,9 @@ export const Extension: React.FC<ExtensionProps> = ({ state, wrap }) => {
     domElement,
   ]);
 
-  // The extension is rendered into the `<slot>`. It is surrounded by a
-  // `<div>` with relative positioning in order to allow the UI Editor
-  // to absolutely position elements within it.
+  // The extension is rendered into the `<div>`. The `<div>` has relative
+  // positioning in order to allow the UI Editor to absolutely position
+  // elements within it.
   const slot = (
     <div
       ref={ref}

--- a/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
+++ b/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
@@ -77,32 +77,6 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
   const name = (goodName ?? extensionSlotName) as string;
   const slotRef = useRef(null);
   const { extensions, extensionSlotModuleName } = useExtensionSlot(name);
-  const stateRef = useRef(state);
-
-  if (!isShallowEqual(stateRef.current, state)) {
-    stateRef.current = state;
-  }
-
-  const content = useMemo(
-    () =>
-      name &&
-      select(extensions).map((extension) => (
-        <ComponentContext.Provider
-          key={extension.id}
-          value={{
-            moduleName: extensionSlotModuleName, // moduleName is not used by the receiving Extension
-            extension: {
-              extensionId: extension.id,
-              extensionSlotName: name,
-              extensionSlotModuleName,
-            },
-          }}
-        >
-          {children ?? <Extension state={stateRef.current} />}
-        </ComponentContext.Provider>
-      )),
-    [select, extensions, name, stateRef.current]
-  );
 
   return (
     <div
@@ -112,7 +86,22 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
       style={{ ...style, position: "relative" }}
       {...divProps}
     >
-      {content}
+      {name &&
+        select(extensions).map((extension) => (
+          <ComponentContext.Provider
+            key={extension.id}
+            value={{
+              moduleName: extensionSlotModuleName, // moduleName is not used by the receiving Extension
+              extension: {
+                extensionId: extension.id,
+                extensionSlotName: name,
+                extensionSlotModuleName,
+              },
+            }}
+          >
+            {children ?? <Extension state={state} />}
+          </ComponentContext.Provider>
+        ))}
     </div>
   );
 };

--- a/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
+++ b/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
@@ -4,41 +4,6 @@ import { ComponentContext } from "./ComponentContext";
 import { Extension } from "./Extension";
 import { useExtensionSlot } from "./useExtensionSlot";
 
-function isShallowEqual(prevDeps: any, nextDeps: any) {
-  if (prevDeps === nextDeps) {
-    return true;
-  }
-
-  if (!prevDeps && nextDeps) {
-    return false;
-  }
-
-  if (prevDeps && !nextDeps) {
-    return false;
-  }
-
-  if (typeof prevDeps !== "object" || typeof nextDeps !== "object") {
-    return false;
-  }
-
-  const prev = Object.keys(prevDeps);
-  const next = Object.keys(nextDeps);
-
-  if (prev.length !== next.length) {
-    return false;
-  }
-
-  for (let i = 0; i < prev.length; i++) {
-    const key = prev[i];
-
-    if (!(key in nextDeps) || nextDeps[key] !== prevDeps[key]) {
-      return false;
-    }
-  }
-
-  return true;
-}
-
 export interface ExtensionSlotBaseProps {
   name: string;
   /** @deprecated Use `name` */
@@ -59,24 +24,93 @@ export type ExtensionSlotProps = (
   | OldExtensionSlotBaseProps
   | ExtensionSlotBaseProps
 ) &
-  React.HTMLAttributes<HTMLDivElement>;
+  React.HTMLAttributes<HTMLDivElement> & {
+    children?:
+      | React.ReactNode
+      | ((extension: ConnectedExtension) => React.ReactNode);
+  };
 
 function defaultSelect(extensions: Array<ConnectedExtension>) {
   return extensions;
 }
 
-export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
-  name: goodName,
-  extensionSlotName,
+/**
+ * An [extension slot](https://o3-dev.docs.openmrs.org/#/main/extensions).
+ * A place with a name. Extensions that get connected to that name
+ * will be rendered into this.
+ *
+ * @param props.name The name of the extension slot
+ * @param props.select An optional function for filtering or otherwise modifying
+ *   the list of extensions that will be rendered.
+ * @param props.state *Only works if no children are provided*. Passes data
+ *   through as props to the extensions that are mounted here. If `ExtensionSlot`
+ *   has children, you must pass the state through the `state` param of the
+ *   `Extension` component.
+ * @param props.children There are two different ways to use `ExtensionSlot`
+ *   children.
+ *  - Passing a `ReactNode`, the "normal" way. The child must contain the component
+ *     `Extension`. Whatever is passed as the child will be rendered once per extension.
+ *     See the first example below.
+ *  - Passing a function, the "render props" way. The child must be a function
+ *     which takes a [[ConnectedExtension]] as argument and returns a `ReactNode`.
+ *     the resulting react node must contain the component `Extension`. It will
+ *     be run for each extension. See the second example below.
+ *
+ * @example
+ * Passing a react node as children
+ *
+ * ```tsx
+ * <ExtensionSlot name="Foo">
+ *   <div style={{ width: 10rem }}>
+ *     <Extension />
+ *   </div>
+ * </ExtensionSlot>
+ * ```
+ *
+ * @example
+ * Passing a function as children
+ *
+ * ```tsx
+ * <ExtensionSlot name="Bar">
+ *   {(extension) => (
+ *     <h1>{extension.name}</h1>
+ *     <div style={{ color: extension.meta.color }}>
+ *       <Extension />
+ *     </div>
+ *   )}
+ * </ExtensionSlot>
+ * ```
+ *
+ */
+export function ExtensionSlot({
+  name: extensionSlotName,
+  extensionSlotName: legacyExtensionSlotName,
   select = defaultSelect,
   children,
   state,
   style,
   ...divProps
-}: ExtensionSlotProps) => {
-  const name = (goodName ?? extensionSlotName) as string;
+}: ExtensionSlotProps) {
+  if (children && state) {
+    throw new Error(
+      "Both children and state have been provided. If children are provided, the state must be passed as a prop to the `Extension` component."
+    );
+  }
+
+  const name = (extensionSlotName ?? legacyExtensionSlotName) as string;
   const slotRef = useRef(null);
   const { extensions, extensionSlotModuleName } = useExtensionSlot(name);
+
+  const extensionsToRender = useMemo(
+    () => select(extensions),
+    [select, extensions]
+  );
+
+  const extensionsFromChildrenFunction = useMemo(() => {
+    if (typeof children == "function" && !React.isValidElement(children)) {
+      return extensionsToRender.map((extension) => children(extension));
+    }
+  }, [children, extensionsToRender]);
 
   return (
     <div
@@ -87,7 +121,7 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
       {...divProps}
     >
       {name &&
-        select(extensions).map((extension) => (
+        extensionsToRender.map((extension, i) => (
           <ComponentContext.Provider
             key={extension.id}
             value={{
@@ -99,9 +133,11 @@ export const ExtensionSlot: React.FC<ExtensionSlotProps> = ({
               },
             }}
           >
-            {children ?? <Extension state={state} />}
+            {extensionsFromChildrenFunction?.[i] ?? children ?? (
+              <Extension state={state} />
+            )}
           </ComponentContext.Provider>
         ))}
     </div>
   );
-};
+}

--- a/packages/framework/esm-react-utils/src/extensions.test.tsx
+++ b/packages/framework/esm-react-utils/src/extensions.test.tsx
@@ -1,0 +1,218 @@
+import React, {
+  useCallback,
+  useReducer,
+  useMemo,
+  useRef,
+  useEffect,
+} from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import {
+  attach,
+  getExtensionNameFromId,
+  registerExtension,
+  updateInternalExtensionStore,
+} from "@openmrs/esm-extensions";
+import {
+  getSyncLifecycle,
+  Extension,
+  ExtensionSlot,
+  openmrsComponentDecorator,
+  useExtensionSlotMeta,
+  ExtensionData,
+} from ".";
+import userEvent from "@testing-library/user-event";
+
+describe("ExtensionSlot, Extension, and useExtensionSlotMeta", () => {
+  beforeEach(() => {
+    updateInternalExtensionStore(() => ({ slots: {}, extensions: {} }));
+  });
+
+  test("Extension receives state changes passed through (not using <Extension>)", async () => {
+    function EnglishExtension({ suffix }) {
+      return <div>English{suffix}</div>;
+    }
+    registerSimpleExtension("English", "esm-languages-app", EnglishExtension);
+    attach("Box", "English");
+    const App = openmrsComponentDecorator({
+      moduleName: "esm-languages-app",
+      featureName: "Languages",
+      disableTranslations: true,
+    })(() => {
+      const [suffix, toggleSuffix] = useReducer(
+        (suffix) => (suffix == "!" ? "?" : "!"),
+        "!"
+      );
+      return (
+        <div>
+          <ExtensionSlot name="Box" state={{ suffix }} />
+          <button onClick={toggleSuffix}>Toggle suffix</button>
+        </div>
+      );
+    });
+    render(<App />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/English/)).toBeInTheDocument()
+    );
+    expect(screen.getByText(/English/)).toHaveTextContent("English!");
+    userEvent.click(screen.getByText("Toggle suffix"));
+    await waitFor(() =>
+      expect(screen.getByText(/English/)).toHaveTextContent("English?")
+    );
+  });
+
+  test("Extension receives state changes (using <Extension>)", async () => {
+    function HaitianCreoleExtension({ suffix }) {
+      return <div>Haitian Creole{suffix}</div>;
+    }
+    registerSimpleExtension(
+      "Haitian",
+      "esm-languages-app",
+      HaitianCreoleExtension
+    );
+    attach("Box", "Haitian");
+    const App = openmrsComponentDecorator({
+      moduleName: "esm-languages-app",
+      featureName: "Languages",
+      disableTranslations: true,
+    })(() => {
+      const [suffix, toggleSuffix] = useReducer(
+        (suffix) => (suffix == "!" ? "?" : "!"),
+        "!"
+      );
+
+      return (
+        <div>
+          <ExtensionSlot name="Box">
+            {suffix}
+            <Extension state={{ suffix }} />
+          </ExtensionSlot>
+          <button onClick={toggleSuffix}>Toggle suffix</button>
+        </div>
+      );
+    });
+    render(<App />);
+
+    await waitFor(() =>
+      expect(screen.getByText(/Haitian/)).toBeInTheDocument()
+    );
+    expect(screen.getByText(/Haitian/)).toHaveTextContent("Haitian Creole!");
+    userEvent.click(screen.getByText("Toggle suffix"));
+    await waitFor(() =>
+      expect(screen.getByText(/Haitian/)).toHaveTextContent("Haitian Creole?")
+    );
+  });
+
+  test("Extension Slot receives meta", async () => {
+    registerSimpleExtension("Spanish", "esm-languages-app", undefined, {
+      code: "es",
+    });
+    attach("Box", "Spanish");
+    const App = openmrsComponentDecorator({
+      moduleName: "esm-languages-app",
+      featureName: "Languages",
+      disableTranslations: true,
+    })(() => {
+      const metas = useExtensionSlotMeta("Box");
+      const wrapItem = useCallback(
+        (slot: React.ReactNode, extension: ExtensionData) => {
+          return (
+            <div>
+              <h1>
+                {metas[getExtensionNameFromId(extension.extensionId)].code}
+              </h1>
+              {slot}
+            </div>
+          );
+        },
+        [metas]
+      );
+      return (
+        <div>
+          <ExtensionSlot name="Box">
+            <Extension wrap={wrapItem} />
+          </ExtensionSlot>
+        </div>
+      );
+    });
+    render(<App />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading")).toBeInTheDocument()
+    );
+    expect(screen.getByRole("heading")).toHaveTextContent("es");
+    expect(screen.getByText("Spanish")).toBeInTheDocument();
+  });
+
+  test("Both meta and state can be used at the same time", async () => {
+    function SwahiliExtension({ suffix }) {
+      return <div>Swahili{suffix}</div>;
+    }
+    registerSimpleExtension("Swahili", "esm-languages-app", SwahiliExtension, {
+      code: "sw",
+    });
+    attach("Box", "Swahili");
+    const App = openmrsComponentDecorator({
+      moduleName: "esm-languages-app",
+      featureName: "Languages",
+      disableTranslations: true,
+    })(() => {
+      const [suffix, toggleSuffix] = useReducer(
+        (suffix) => (suffix == "!" ? "?" : "!"),
+        "!"
+      );
+      const metas = useExtensionSlotMeta("Box");
+      const wrapItem = useCallback(
+        (slot: React.ReactNode, extension: ExtensionData) => {
+          return (
+            <div>
+              <h1>
+                {metas[getExtensionNameFromId(extension.extensionId)].code}
+              </h1>
+              {slot}
+            </div>
+          );
+        },
+        [metas]
+      );
+      return (
+        <div>
+          <ExtensionSlot name="Box">
+            <Extension wrap={wrapItem} state={{ suffix }} />
+          </ExtensionSlot>
+          <button onClick={toggleSuffix}>Toggle suffix</button>
+        </div>
+      );
+    });
+    render(<App />);
+
+    await waitFor(() =>
+      expect(screen.getByRole("heading")).toBeInTheDocument()
+    );
+    expect(screen.getByRole("heading")).toHaveTextContent("sw");
+    expect(screen.getByText(/Swahili/)).toHaveTextContent("Swahili!");
+    userEvent.click(screen.getByText("Toggle suffix"));
+    await waitFor(() =>
+      expect(screen.getByText(/Swahili/)).toHaveTextContent("Swahili?")
+    );
+  });
+});
+
+function registerSimpleExtension(
+  name: string,
+  moduleName: string,
+  Component?: React.ComponentType<any>,
+  meta: object = {}
+) {
+  const SimpleComponent = () => <div>{name}</div>;
+  registerExtension({
+    name,
+    moduleName,
+    load: getSyncLifecycle(Component ?? SimpleComponent, {
+      moduleName,
+      featureName: moduleName,
+      disableTranslations: true,
+    }),
+    meta,
+  });
+}

--- a/packages/framework/esm-react-utils/src/extensions.test.tsx
+++ b/packages/framework/esm-react-utils/src/extensions.test.tsx
@@ -1,10 +1,4 @@
-import React, {
-  useCallback,
-  useReducer,
-  useMemo,
-  useRef,
-  useEffect,
-} from "react";
+import React, { useCallback, useReducer } from "react";
 import { render, screen, waitFor, within } from "@testing-library/react";
 import {
   attach,
@@ -22,6 +16,14 @@ import {
   ExtensionData,
 } from ".";
 import userEvent from "@testing-library/user-event";
+
+// For some reason in the text context `isEqual` always returns true
+// when using the import substitution in jest.config.js. Here's a custom
+// mock.
+jest.mock(
+  "lodash-es/isEqual",
+  () => (a, b) => JSON.stringify(a) == JSON.stringify(b)
+);
 
 describe("ExtensionSlot, Extension, and useExtensionSlotMeta", () => {
   beforeEach(() => {

--- a/packages/framework/esm-react-utils/src/public.ts
+++ b/packages/framework/esm-react-utils/src/public.ts
@@ -12,7 +12,6 @@ export * from "./useConnectedExtensions";
 export * from "./useConnectivity";
 export * from "./usePatient";
 export * from "./useCurrentPatient";
-export * from "./useExtensionSlot";
 export * from "./useExtensionSlotMeta";
 export * from "./useExtensionStore";
 export * from "./useLayoutType";

--- a/packages/framework/esm-react-utils/src/setup-tests.js
+++ b/packages/framework/esm-react-utils/src/setup-tests.js
@@ -1,3 +1,5 @@
+import "@testing-library/jest-dom/extend-expect";
+
 window.System = {
   import: (name) => import(name),
   resolve: jest.fn().mockImplementation(() => {

--- a/packages/framework/esm-react-utils/src/useAssignedExtensionIds.ts
+++ b/packages/framework/esm-react-utils/src/useAssignedExtensionIds.ts
@@ -1,7 +1,7 @@
 /** @module @category Extension */
 import { useEffect, useState } from "react";
 import { getExtensionStore } from "@openmrs/esm-extensions";
-import { isEqual } from "lodash";
+import isEqual from "lodash-es/isEqual";
 
 /**
  * Gets the assigned extension ids for a given extension slot name.

--- a/packages/framework/esm-react-utils/src/useAssignedExtensions.ts
+++ b/packages/framework/esm-react-utils/src/useAssignedExtensions.ts
@@ -5,7 +5,7 @@ import {
   ExtensionStore,
   getExtensionStore,
 } from "@openmrs/esm-extensions";
-import { isEqual } from "lodash";
+import isEqual from "lodash/isEqual";
 
 /**
  * Gets the assigned extensions for a given extension slot name.

--- a/packages/framework/esm-styleguide/src/error-state/error-state.component.tsx
+++ b/packages/framework/esm-styleguide/src/error-state/error-state.component.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import styles from "./error-state.module.scss";
 import { Tile } from "carbon-components-react";
 import { useTranslation } from "react-i18next";
-import { useLayoutType } from "@openmrs/esm-framework";
+import { useLayoutType } from "@openmrs/esm-react-utils";
 
 export interface ErrorStateProps {
   error: any;

--- a/packages/framework/esm-styleguide/src/modals/index.tsx
+++ b/packages/framework/esm-styleguide/src/modals/index.tsx
@@ -1,6 +1,7 @@
 /** @module @category UI */
 import { renderExtension } from "@openmrs/esm-extensions";
 import { createGlobalStore } from "@openmrs/esm-state";
+import { Parcel } from "single-spa";
 
 type ModalInstanceState = "NEW" | "MOUNTED" | "TO_BE_DELETED";
 
@@ -8,7 +9,7 @@ interface ModalInstance {
   container?: HTMLElement;
   state: ModalInstanceState;
   onClose: () => void;
-  cleanup?: () => void;
+  parcel?: Parcel | null;
   extensionId: string;
   props: Record<string, any>;
 }
@@ -68,14 +69,14 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
         case "NEW":
           const { outer, contentContainer } = createModalFrame();
           instance.container = outer;
-          instance.cleanup = renderExtension(
+          instance.parcel = renderExtension(
             contentContainer,
             "",
             "",
             instance.extensionId,
             undefined,
             instance.props
-          ).unmount;
+          );
           instance.state = "MOUNTED";
           modalContainer.prepend(outer);
           outer.style.visibility = "unset";
@@ -89,7 +90,7 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
 
         case "TO_BE_DELETED":
           instance.onClose();
-          instance.cleanup?.();
+          instance.parcel?.unmount?.();
           instance.container?.remove();
           setTimeout(() => {
             modalStore.setState({

--- a/packages/framework/esm-styleguide/src/modals/index.tsx
+++ b/packages/framework/esm-styleguide/src/modals/index.tsx
@@ -1,7 +1,6 @@
 /** @module @category UI */
 import { renderExtension } from "@openmrs/esm-extensions";
 import { createGlobalStore } from "@openmrs/esm-state";
-import { Parcel } from "single-spa";
 
 type ModalInstanceState = "NEW" | "MOUNTED" | "TO_BE_DELETED";
 
@@ -9,7 +8,7 @@ interface ModalInstance {
   container?: HTMLElement;
   state: ModalInstanceState;
   onClose: () => void;
-  parcel?: Parcel | null;
+  cleanup?: () => void;
   extensionId: string;
   props: Record<string, any>;
 }
@@ -69,14 +68,14 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
         case "NEW":
           const { outer, contentContainer } = createModalFrame();
           instance.container = outer;
-          instance.parcel = renderExtension(
+          instance.cleanup = renderExtension(
             contentContainer,
             "",
             "",
             instance.extensionId,
             undefined,
             instance.props
-          );
+          ).unmount;
           instance.state = "MOUNTED";
           modalContainer.prepend(outer);
           outer.style.visibility = "unset";
@@ -90,7 +89,7 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
 
         case "TO_BE_DELETED":
           instance.onClose();
-          instance.parcel?.unmount?.();
+          instance.cleanup?.();
           instance.container?.remove();
           setTimeout(() => {
             modalStore.setState({

--- a/packages/framework/esm-styleguide/src/modals/index.tsx
+++ b/packages/framework/esm-styleguide/src/modals/index.tsx
@@ -1,6 +1,7 @@
 /** @module @category UI */
 import { renderExtension } from "@openmrs/esm-extensions";
 import { createGlobalStore } from "@openmrs/esm-state";
+import { Parcel } from "single-spa";
 
 type ModalInstanceState = "NEW" | "MOUNTED" | "TO_BE_DELETED";
 
@@ -8,7 +9,7 @@ interface ModalInstance {
   container?: HTMLElement;
   state: ModalInstanceState;
   onClose: () => void;
-  cleanup?: () => void;
+  parcel?: Parcel | null;
   extensionId: string;
   props: Record<string, any>;
 }
@@ -68,7 +69,7 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
         case "NEW":
           const { outer, contentContainer } = createModalFrame();
           instance.container = outer;
-          instance.cleanup = renderExtension(
+          instance.parcel = renderExtension(
             contentContainer,
             "",
             "",
@@ -89,7 +90,7 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
 
         case "TO_BE_DELETED":
           instance.onClose();
-          instance.cleanup?.();
+          instance.parcel?.unmount?.();
           instance.container?.remove();
           setTimeout(() => {
             modalStore.setState({


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

- Document that state provided as a prop to ExtensionSlot does not work if the ExtensionSlot has a child
- Ensure that state updates are propagated to extensions correctly
- Create a better API for wrapping extensions within extension slots

## Other

See https://issues.openmrs.org/browse/O3-1426 about modals, vaguely related.