### PR TITLE
Fix versions

### DIFF
--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -13,7 +13,7 @@
     "analyze": "webpack --mode=production --env analyze=true",
     "watch": "webpack serve --mode development",
     "lint": "eslint src --ext ts,tsx",
-    "postversion": "yarn add @openmrs/esm-framework@$npm_package_version --exact"
+    "version": "yarn add @openmrs/esm-framework@$npm_package_version --exact"
   },
   "keywords": [
     "openmrs",
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@openmrs/esm-framework": "^3.4.0",
+    "@openmrs/esm-framework": "3.4.0",
     "carbon-components": "10.31.0",
     "carbon-icons": "7.0.7",
     "dayjs": "^1.10.4",

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -15,7 +15,7 @@
     "test": "jest --passWithNoTests",
     "build": "tsc",
     "lint": "eslint src --ext ts,tsx",
-    "postversion": "yarn add @openmrs/esm-app-shell@$npm_package_version @openmrs/esm-webpack-config@$npm_package_version --exact"
+    "version": "yarn add @openmrs/esm-app-shell@$npm_package_version @openmrs/webpack-config@$npm_package_version --exact"
   },
   "repository": {
     "type": "git",
@@ -33,8 +33,8 @@
   "homepage": "https://github.com/openmrs/openmrs-esm-core#readme",
   "dependencies": {
     "@babel/preset-typescript": "^7.16.7",
-    "@openmrs/esm-app-shell": "^3.4.0",
-    "@openmrs/webpack-config": "^3.4.0",
+    "@openmrs/esm-app-shell": "3.4.0",
+    "@openmrs/webpack-config": "3.4.0",
     "@types/react": "^16.9.46",
     "@types/systemjs": "^6.1.0",
     "autoprefixer": "^10.4.2",


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
In order to keep builds actually consistent, the tooling needs to refer to consistent versions in a few places. These were added a while ago, but moved to the `postversion` instead of `version` script, which doesn't seem to work with the version of Lerna we are using for w/e reason, so this moves them back to the `version` script which seems to be triggered correctly.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
