### PR TITLE
(feat): Add version numbers for apps and display them in the implementer tools

### DIFF
--- a/packages/apps/esm-devtools-app/src/index.ts
+++ b/packages/apps/esm-devtools-app/src/index.ts
@@ -1,5 +1,8 @@
 import { getAsyncLifecycle } from "@openmrs/esm-framework";
 
+declare var __VERSION__: string;
+const version = __VERSION__;
+
 const importTranslation = () => Promise.resolve();
 
 function setupOpenMRS() {
@@ -19,4 +22,4 @@ function setupOpenMRS() {
   };
 }
 
-export { setupOpenMRS, importTranslation };
+export { setupOpenMRS, importTranslation, version };

--- a/packages/apps/esm-devtools-app/src/index.ts
+++ b/packages/apps/esm-devtools-app/src/index.ts
@@ -1,6 +1,7 @@
 import { getAsyncLifecycle } from "@openmrs/esm-framework";
 
 declare var __VERSION__: string;
+// __VERSION__ is replaced by Webpack with the version from package.json
 const version = __VERSION__;
 
 const importTranslation = () => Promise.resolve();

--- a/packages/apps/esm-implementer-tools-app/src/backend-dependencies/backend-dependencies.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/backend-dependencies/backend-dependencies.component.tsx
@@ -10,10 +10,10 @@ import {
   TableCell,
   TableContainer,
 } from "carbon-components-react";
-import { FrontendModule } from "./openmrs-backend-dependencies";
+import { ResolvedDependenciesModule } from "./openmrs-backend-dependencies";
 
 export interface ModuleDiagnosticsProps {
-  frontendModules: Array<FrontendModule>;
+  frontendModules: Array<ResolvedDependenciesModule>;
 }
 
 export const ModuleDiagnostics: React.FC<ModuleDiagnosticsProps> = ({

--- a/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
+++ b/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
@@ -13,6 +13,7 @@ export interface ResolvedBackendModule {
 export interface FrontendModule {
   name: string;
   dependencies: Array<ResolvedBackendModule>;
+  version?: string;
 }
 
 interface Module {

--- a/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
+++ b/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
@@ -10,10 +10,9 @@ export interface ResolvedBackendModule {
   type: ResolvedBackendModuleType;
 }
 
-export interface FrontendModule {
+export interface ResolvedDependenciesModule {
   name: string;
   dependencies: Array<ResolvedBackendModule>;
-  version?: string;
 }
 
 interface Module {
@@ -26,7 +25,7 @@ interface BackendModule {
   version: string;
 }
 
-let cachedFrontendModules: Array<FrontendModule>;
+let cachedFrontendModules: Array<ResolvedDependenciesModule>;
 
 async function initInstalledBackendModules(): Promise<Array<BackendModule>> {
   try {
@@ -42,7 +41,7 @@ async function initInstalledBackendModules(): Promise<Array<BackendModule>> {
 function checkIfModulesAreInstalled(
   module: Module,
   installedBackendModules: Array<BackendModule>
-): FrontendModule {
+): ResolvedDependenciesModule {
   const dependencies: Array<ResolvedBackendModule> = [];
 
   const missingBackendModule = getMissingBackendModules(
@@ -142,7 +141,9 @@ function getResolvedModuleType(
   return "okay";
 }
 
-export async function checkModules(): Promise<Array<FrontendModule>> {
+export async function checkModules(): Promise<
+  Array<ResolvedDependenciesModule>
+> {
   if (!cachedFrontendModules) {
     const modules = (window.installedModules ?? [])
       .filter((module) => module[1].backendDependencies)
@@ -160,7 +161,9 @@ export async function checkModules(): Promise<Array<FrontendModule>> {
   return cachedFrontendModules;
 }
 
-export function hasInvalidDependencies(frontendModules: Array<FrontendModule>) {
+export function hasInvalidDependencies(
+  frontendModules: Array<ResolvedDependenciesModule>
+) {
   return frontendModules.some((m) =>
     m.dependencies.some((n) => n.type !== "okay")
   );

--- a/packages/apps/esm-implementer-tools-app/src/backend-dependencies/useBackendDependencies.ts
+++ b/packages/apps/esm-implementer-tools-app/src/backend-dependencies/useBackendDependencies.ts
@@ -1,11 +1,14 @@
 import { useEffect, useState } from "react";
-import { checkModules, FrontendModule } from "./openmrs-backend-dependencies";
+import {
+  checkModules,
+  ResolvedDependenciesModule,
+} from "./openmrs-backend-dependencies";
 
 export function useBackendDependencies() {
   const [
     modulesWithMissingBackendModules,
     setModulesWithMissingBackendModules,
-  ] = useState<Array<FrontendModule>>([]);
+  ] = useState<Array<ResolvedDependenciesModule>>([]);
 
   useEffect(() => {
     // loading missing modules

--- a/packages/apps/esm-implementer-tools-app/src/frontend-modules/frontend-modules.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/frontend-modules/frontend-modules.component.tsx
@@ -1,0 +1,69 @@
+import React, { useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import {
+  DataTable,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "carbon-components-react";
+import type { FrontendModule } from "../backend-dependencies/openmrs-backend-dependencies";
+
+export interface FrontendModulesProps {
+  frontendModules: Array<FrontendModule>;
+}
+
+export const FrontendModules: React.FC<FrontendModulesProps> = ({
+  frontendModules,
+}) => {
+  const { t } = useTranslation();
+
+  const headers = useMemo(
+    () => [
+      {
+        key: "name",
+        header: t("moduleName", "Module Name"),
+      },
+      {
+        key: "installedVersion",
+        header: t("installedVersion", "Installed Version"),
+      },
+    ],
+    [t]
+  );
+
+  return (
+    <div style={{ height: "50vh", overflowY: "auto" }}>
+      <DataTable rows={[]} headers={headers}>
+        {({ headers, getTableProps, getHeaderProps }) => (
+          <TableContainer title="">
+            <Table {...getTableProps()}>
+              <TableHead>
+                <TableRow>
+                  {headers.map((header) => (
+                    <TableHeader {...getHeaderProps({ header })}>
+                      {header.header}
+                    </TableHeader>
+                  ))}
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {frontendModules.map((esm) => (
+                  <TableRow key={esm.name}>
+                    <TableCell>{esm.name}</TableCell>
+                    <TableCell>
+                      {esm.version ?? t("unknownVersion", "unknown")}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </TableContainer>
+        )}
+      </DataTable>
+    </div>
+  );
+};

--- a/packages/apps/esm-implementer-tools-app/src/frontend-modules/frontend-modules.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/frontend-modules/frontend-modules.component.tsx
@@ -10,7 +10,11 @@ import {
   TableHeader,
   TableRow,
 } from "carbon-components-react";
-import type { FrontendModule } from "../backend-dependencies/openmrs-backend-dependencies";
+
+export interface FrontendModule {
+  name: string;
+  version?: string;
+}
 
 export interface FrontendModulesProps {
   frontendModules: Array<FrontendModule>;

--- a/packages/apps/esm-implementer-tools-app/src/frontend-modules/useFrontendModules.ts
+++ b/packages/apps/esm-implementer-tools-app/src/frontend-modules/useFrontendModules.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from "react";
+import { FrontendModule } from "../backend-dependencies/openmrs-backend-dependencies";
+
+let cachedFrontendModules: Array<FrontendModule>;
+
+export function getModules(): Array<FrontendModule> {
+  if (!cachedFrontendModules) {
+    cachedFrontendModules = (window.installedModules ?? [])
+      .filter((module) => Boolean(module) && Boolean(module[1]))
+      .map((module) => ({
+        dependencies: [],
+        version: module[1].version,
+        name: module[0],
+      }));
+  }
+
+  return cachedFrontendModules;
+}
+
+export function useFrontendModules() {
+  return getModules();
+}

--- a/packages/apps/esm-implementer-tools-app/src/frontend-modules/useFrontendModules.ts
+++ b/packages/apps/esm-implementer-tools-app/src/frontend-modules/useFrontendModules.ts
@@ -1,5 +1,4 @@
-import { useEffect, useState } from "react";
-import { FrontendModule } from "../backend-dependencies/openmrs-backend-dependencies";
+import { FrontendModule } from "./frontend-modules.component";
 
 let cachedFrontendModules: Array<FrontendModule>;
 

--- a/packages/apps/esm-implementer-tools-app/src/frontend-modules/useFrontendModules.ts
+++ b/packages/apps/esm-implementer-tools-app/src/frontend-modules/useFrontendModules.ts
@@ -1,21 +1,13 @@
+import { useMemo } from "react";
 import { FrontendModule } from "./frontend-modules.component";
 
-let cachedFrontendModules: Array<FrontendModule>;
-
-export function getModules(): Array<FrontendModule> {
-  if (!cachedFrontendModules) {
-    cachedFrontendModules = (window.installedModules ?? [])
+export function useFrontendModules() {
+  return useMemo<Array<FrontendModule>>(() => {
+    return (window.installedModules ?? [])
       .filter((module) => Boolean(module) && Boolean(module[1]))
       .map((module) => ({
-        dependencies: [],
         version: module[1].version,
         name: module[0],
       }));
-  }
-
-  return cachedFrontendModules;
-}
-
-export function useFrontendModules() {
-  return getModules();
+  }, [window.installedModules]);
 }

--- a/packages/apps/esm-implementer-tools-app/src/implementer-tools.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/implementer-tools.component.tsx
@@ -14,21 +14,23 @@ import {
 import { useBackendDependencies } from "./backend-dependencies/useBackendDependencies";
 import { hasInvalidDependencies } from "./backend-dependencies/openmrs-backend-dependencies";
 import { useTranslation } from "react-i18next";
+import { useFrontendModules } from "./frontend-modules/useFrontendModules";
 
 const Popup = React.lazy(() => import("./popup/popup.component"));
 const UiEditor = React.lazy(() => import("./ui-editor/ui-editor"));
 
 function PopupHandler() {
-  const frontendModules = useBackendDependencies();
+  const frontendModules = useFrontendModules();
+  const backendDependencies = useBackendDependencies();
   const [shouldShowNotification, setShouldShowNotification] = useState(false);
   const { t } = useTranslation();
   useEffect(() => {
     // displaying toast if modules are missing
     setShouldShowNotification(
       (alreadyShowing) =>
-        alreadyShowing || hasInvalidDependencies(frontendModules)
+        alreadyShowing || hasInvalidDependencies(backendDependencies)
     );
-  }, [frontendModules]);
+  }, [backendDependencies]);
 
   useEffect(() => {
     // only show notification max. 1 time
@@ -54,6 +56,7 @@ function PopupHandler() {
         <Popup
           close={togglePopup}
           frontendModules={frontendModules}
+          backendDependencies={backendDependencies}
           visibleTabIndex={openTabIndex}
         />
       ) : null}

--- a/packages/apps/esm-implementer-tools-app/src/index.ts
+++ b/packages/apps/esm-implementer-tools-app/src/index.ts
@@ -1,5 +1,8 @@
 import { getAsyncLifecycle } from "@openmrs/esm-framework";
 
+declare var __VERSION__: string;
+const version = __VERSION__;
+
 function setupOpenMRS() {
   const moduleName = "@openmrs/esm-implementer-tools-app";
   const options = {
@@ -44,6 +47,5 @@ const importTranslation = require.context(
   "lazy"
 );
 
-export { setupOpenMRS, importTranslation };
-
+export { setupOpenMRS, importTranslation, version };
 export { default as ConfigEditButton } from "./config-edit-button/config-edit-button.component";

--- a/packages/apps/esm-implementer-tools-app/src/index.ts
+++ b/packages/apps/esm-implementer-tools-app/src/index.ts
@@ -1,6 +1,7 @@
 import { getAsyncLifecycle } from "@openmrs/esm-framework";
 
 declare var __VERSION__: string;
+// __VERSION__ is replaced by Webpack with the version from package.json
 const version = __VERSION__;
 
 function setupOpenMRS() {

--- a/packages/apps/esm-implementer-tools-app/src/popup/popup.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/popup/popup.component.tsx
@@ -4,14 +4,17 @@ import styles from "./popup.styles.scss";
 import { Button, ContentSwitcher, Switch } from "carbon-components-react";
 import { useTranslation } from "react-i18next";
 import { Configuration } from "../configuration/configuration.component";
-import { FrontendModules } from "../frontend-modules/frontend-modules.component";
+import {
+  FrontendModule,
+  FrontendModules,
+} from "../frontend-modules/frontend-modules.component";
 import { ModuleDiagnostics } from "../backend-dependencies/backend-dependencies.component";
-import type { FrontendModule } from "../backend-dependencies/openmrs-backend-dependencies";
+import type { ResolvedDependenciesModule } from "../backend-dependencies/openmrs-backend-dependencies";
 
 interface DevToolsPopupProps {
   close(): void;
   frontendModules: Array<FrontendModule>;
-  backendDependencies: Array<FrontendModule>;
+  backendDependencies: Array<ResolvedDependenciesModule>;
   visibleTabIndex?: number;
 }
 

--- a/packages/apps/esm-implementer-tools-app/src/popup/popup.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/popup/popup.component.tsx
@@ -1,21 +1,36 @@
-import React, { useState } from "react";
+import React, { useMemo, useState } from "react";
 import Close16 from "@carbon/icons-react/es/close/16";
 import styles from "./popup.styles.scss";
 import { Button, ContentSwitcher, Switch } from "carbon-components-react";
 import { useTranslation } from "react-i18next";
 import { Configuration } from "../configuration/configuration.component";
+import { FrontendModules } from "../frontend-modules/frontend-modules.component";
 import { ModuleDiagnostics } from "../backend-dependencies/backend-dependencies.component";
-import { FrontendModule } from "../backend-dependencies/openmrs-backend-dependencies";
+import type { FrontendModule } from "../backend-dependencies/openmrs-backend-dependencies";
 
 interface DevToolsPopupProps {
   close(): void;
   frontendModules: Array<FrontendModule>;
+  backendDependencies: Array<FrontendModule>;
   visibleTabIndex?: number;
 }
 
-export default function Popup({ close, frontendModules }: DevToolsPopupProps) {
+export default function Popup({
+  close,
+  frontendModules,
+  backendDependencies,
+}: DevToolsPopupProps) {
   const { t } = useTranslation();
   const [activeTab, setActiveTab] = useState(0);
+  const tabContent = useMemo(() => {
+    if (activeTab == 0) {
+      return <Configuration />;
+    } else if (activeTab == 1) {
+      return <FrontendModules frontendModules={frontendModules} />;
+    } else {
+      return <ModuleDiagnostics frontendModules={backendDependencies} />;
+    }
+  }, [activeTab]);
 
   return (
     <div className={styles.popup}>
@@ -29,6 +44,10 @@ export default function Popup({ close, frontendModules }: DevToolsPopupProps) {
             <Switch
               name="configuration-tab"
               text={t("configuration", "Configuration")}
+            />
+            <Switch
+              name="frontend-modules-tab"
+              text={t("frontendModules", "Frontend Modules")}
             />
             <Switch
               name="backend-modules-tab"
@@ -46,13 +65,7 @@ export default function Popup({ close, frontendModules }: DevToolsPopupProps) {
           />
         </div>
       </div>
-      <div className={styles.content}>
-        {activeTab == 0 ? (
-          <Configuration />
-        ) : (
-          <ModuleDiagnostics frontendModules={frontendModules} />
-        )}
-      </div>
+      <div className={styles.content}>{tabContent}</div>
     </div>
   );
 }

--- a/packages/apps/esm-implementer-tools-app/translations/en.json
+++ b/packages/apps/esm-implementer-tools-app/translations/en.json
@@ -7,6 +7,7 @@
   "downloadConfig": "Download Config",
   "edit": "Edit",
   "editValueButtonText": "Edit",
+  "frontendModules": "Frontend Modules",
   "installedVersion": "Installed Version",
   "itemDescriptionSourceDefaultText": "The current value is the default.",
   "jsonEditor": "JSON Editor",
@@ -15,6 +16,7 @@
   "requiredVersion": "Required Version",
   "resetToDefaultValueButtonText": "Reset to default",
   "uiEditor": "UI Editor",
+  "unknownVersion": "unknown",
   "value": "Value",
   "view": "View"
 }

--- a/packages/apps/esm-login-app/src/index.ts
+++ b/packages/apps/esm-login-app/src/index.ts
@@ -1,6 +1,9 @@
 import { getAsyncLifecycle, defineConfigSchema } from "@openmrs/esm-framework";
 import { configSchema } from "./config-schema";
 
+declare var __VERSION__: string;
+const version = __VERSION__;
+
 const importTranslation = require.context(
   "../translations",
   false,
@@ -78,4 +81,4 @@ function setupOpenMRS() {
   };
 }
 
-export { setupOpenMRS, importTranslation, backendDependencies };
+export { setupOpenMRS, importTranslation, backendDependencies, version };

--- a/packages/apps/esm-login-app/src/index.ts
+++ b/packages/apps/esm-login-app/src/index.ts
@@ -2,6 +2,7 @@ import { getAsyncLifecycle, defineConfigSchema } from "@openmrs/esm-framework";
 import { configSchema } from "./config-schema";
 
 declare var __VERSION__: string;
+// __VERSION__ is replaced by Webpack with the version from package.json
 const version = __VERSION__;
 
 const importTranslation = require.context(

--- a/packages/apps/esm-offline-tools-app/src/index.ts
+++ b/packages/apps/esm-offline-tools-app/src/index.ts
@@ -11,6 +11,7 @@ import { setupOffline } from "./offline";
 import { setupSynchronizingOfflineActionsNotifications } from "./offline-actions/synchronizing-notification";
 
 declare var __VERSION__: string;
+// __VERSION__ is replaced by Webpack with the version from package.json
 const version = __VERSION__;
 
 const importTranslation = require.context(

--- a/packages/apps/esm-offline-tools-app/src/index.ts
+++ b/packages/apps/esm-offline-tools-app/src/index.ts
@@ -10,6 +10,9 @@ import OfflineToolsNavLink from "./nav/offline-tools-nav-link.component";
 import { setupOffline } from "./offline";
 import { setupSynchronizingOfflineActionsNotifications } from "./offline-actions/synchronizing-notification";
 
+declare var __VERSION__: string;
+const version = __VERSION__;
+
 const importTranslation = require.context(
   "../translations",
   false,
@@ -229,4 +232,4 @@ function setupOpenMRS() {
   };
 }
 
-export { setupOpenMRS, importTranslation, backendDependencies };
+export { setupOpenMRS, importTranslation, backendDependencies, version };

--- a/packages/apps/esm-primary-navigation-app/src/index.ts
+++ b/packages/apps/esm-primary-navigation-app/src/index.ts
@@ -15,6 +15,7 @@ import { navigateToUrl } from "single-spa";
 import { genericLinkConfigSchema } from "./components/generic-link/generic-link.component";
 
 declare var __VERSION__: string;
+// __VERSION__ is replaced by Webpack with the version from package.json
 const version = __VERSION__;
 
 const importTranslation = require.context(

--- a/packages/apps/esm-primary-navigation-app/src/index.ts
+++ b/packages/apps/esm-primary-navigation-app/src/index.ts
@@ -14,6 +14,9 @@ import { syncUserLanguagePreference } from "./offline";
 import { navigateToUrl } from "single-spa";
 import { genericLinkConfigSchema } from "./components/generic-link/generic-link.component";
 
+declare var __VERSION__: string;
+const version = __VERSION__;
+
 const importTranslation = require.context(
   "../translations",
   false,
@@ -102,4 +105,4 @@ function setupOpenMRS() {
   };
 }
 
-export { setupOpenMRS, importTranslation, backendDependencies };
+export { setupOpenMRS, importTranslation, backendDependencies, version };

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -7,6 +7,7 @@ import { StatsWriterPlugin } from "webpack-stats-plugin";
 // eslint-disable-next-line no-restricted-imports
 import { merge, mergeWith, isArray } from "lodash";
 import { postProcessFile } from "./optimize";
+import { inc } from "semver";
 
 const production = "production";
 const { ModuleFederationPlugin } = container;
@@ -181,7 +182,10 @@ export default (
         analyzerMode: env && env.analyze ? "server" : "disabled",
       }),
       new DefinePlugin({
-        __VERSION__: JSON.stringify(version),
+        __VERSION__:
+          mode === production
+            ? JSON.stringify(version)
+            : JSON.stringify(inc(version, "prerelease", "local")),
         "process.env.FRAMEWORK_VERSION": JSON.stringify(frameworkVersion),
       }),
       new ModuleFederationPlugin({

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -85,10 +85,14 @@ export default (
   argv: Record<string, string> = {}
 ) => {
   const root = process.cwd();
-  const { name, peerDependencies, browser, main, types } = require(resolve(
-    root,
-    "package.json"
-  ));
+  const {
+    name,
+    version,
+    peerDependencies,
+    browser,
+    main,
+    types,
+  } = require(resolve(root, "package.json"));
   const mode = argv.mode || process.env.NODE_ENV || "development";
   const filename = basename(browser || main);
   const outDir = dirname(browser || main);
@@ -177,6 +181,7 @@ export default (
         analyzerMode: env && env.analyze ? "server" : "disabled",
       }),
       new DefinePlugin({
+        __VERSION__: JSON.stringify(version),
         "process.env.FRAMEWORK_VERSION": JSON.stringify(frameworkVersion),
       }),
       new ModuleFederationPlugin({


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This adds a constant, `__VERSION__` to our webpack build configuration which can be added to any module to get its current version. This also adds the convention that the `index.ts` of an app exports a `version` field to identify the version of the frontend module. Finally, I've added a tab to the implementer tools to give you an overview of the versions of modules running.

This requires modifications to existing apps that's something like this:

```ts
declare var __VERSION__: string;  // keep TS happy
const version = __VERSION__;  // __VERSION__ is replaced by Webpack with the version from package.json

// ...

export { /* existing stuff */, version };  // add the version to the exports
```

As shown, for modules that do not declare a version the string "unknown" is shown.

## Screenshots
<!-- Required if you are making UI changes. -->

![Screenshot of implementer tools showing the version number view](https://user-images.githubusercontent.com/52504170/182412165-7f9fd4d4-3534-40ec-befb-c93b9d80fcd3.png)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
