### PR TITLE
(docs) Link to extension videos in docs

### DIFF
--- a/docs/main/extensions.md
+++ b/docs/main/extensions.md
@@ -191,6 +191,10 @@ by modifying the `order` configuration parameter of that slot.
 
 ## Additional Resources
 
+Short introductory videos:
+- [OpenMRS Frontend 3 Extension System 1 - Basics](https://youtu.be/Teq3FwKofSc)
+- [OpenMRS Frontend 3 Extension System 2 - State and Meta](https://youtu.be/8514ebpAEWI)
+
 Introductory presentation: [Quick Guide to Slots](https://docs.google.com/presentation/d/1mQxh7qAYLD-gc9sh0I58t4o_XNndPcu6hAJmTZQZ_fo/edit#slide=id.gbe34f6b087_0_34 )
 
 For a terse technical description of the extension system, see the


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/master/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

I've put a couple new educational videos on YouTube. This adds links to them to the docs.
