### PR TITLE
(fix) ensure we only load JS on the import map

### DIFF
--- a/packages/shell/esm-app-shell/src/load-modules.ts
+++ b/packages/shell/esm-app-shell/src/load-modules.ts
@@ -21,6 +21,10 @@
 export async function loadModules(modules: Record<string, string>) {
   return Promise.all(
     Object.entries(modules).map(async ([name, url]) => {
+      if (!url || !url.match(/\.js$/)) {
+        return [name, {}];
+      }
+
       try {
         await new Promise((resolve, reject) => {
           loadScript(name, url, resolve, reject);
@@ -28,7 +32,7 @@ export async function loadModules(modules: Record<string, string>) {
       } catch {
         // on an error, loadScript will log an appropriate message
         // we bail here so we don't break the application
-        return [name, []];
+        return [name, {}];
       }
 
       const app: any = window[slugify(name)];


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Since we now directly create a `script` tag from the module URL, we should ignore anything on the importmap that isn't likely to resolve to JS file.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
