### PR TITLE
(fix) Revert typedoc-plugin-markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "turbo": "^1.2.1",
     "typedoc": "^0.22.15",
     "typedoc-plugin-file-tags": "^1.0.0",
-    "typedoc-plugin-markdown": "^3.11.12",
+    "typedoc-plugin-markdown": "3.11.14",
     "typedoc-plugin-no-inherit": "^1.3.1",
     "typescript": "~4.6.4",
     "webpack": "^5.74.0"

--- a/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
+++ b/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
@@ -153,6 +153,8 @@ node_modules/@types/node/globals.d.ts:142
 
 ▸ `Static` **captureStackTrace**(`targetObject`, `constructorOpt?`): `void`
 
+Create .stack property on a target object
+
 #### Parameters
 
 | Name | Type |
@@ -177,6 +179,10 @@ ___
 ### prepareStackTrace
 
 ▸ `Static` `Optional` **prepareStackTrace**(`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`see`** https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces
 
 #### Parameters
 

--- a/packages/framework/esm-framework/docs/enums/Type.md
+++ b/packages/framework/esm-framework/docs/enums/Type.md
@@ -20,7 +20,7 @@
 
 ### Array
 
-• **Array** = ``"Array"``
+• **Array**
 
 #### Defined in
 
@@ -30,7 +30,7 @@ ___
 
 ### Boolean
 
-• **Boolean** = ``"Boolean"``
+• **Boolean**
 
 #### Defined in
 
@@ -40,7 +40,7 @@ ___
 
 ### ConceptUuid
 
-• **ConceptUuid** = ``"ConceptUuid"``
+• **ConceptUuid**
 
 #### Defined in
 
@@ -50,7 +50,7 @@ ___
 
 ### Number
 
-• **Number** = ``"Number"``
+• **Number**
 
 #### Defined in
 
@@ -60,7 +60,7 @@ ___
 
 ### Object
 
-• **Object** = ``"Object"``
+• **Object**
 
 #### Defined in
 
@@ -70,7 +70,7 @@ ___
 
 ### PatientIdentifierTypeUuid
 
-• **PatientIdentifierTypeUuid** = ``"PatientIdentifierTypeUuid"``
+• **PatientIdentifierTypeUuid**
 
 #### Defined in
 
@@ -80,7 +80,7 @@ ___
 
 ### PersonAttributeTypeUuid
 
-• **PersonAttributeTypeUuid** = ``"PersonAttributeTypeUuid"``
+• **PersonAttributeTypeUuid**
 
 #### Defined in
 
@@ -90,7 +90,7 @@ ___
 
 ### String
 
-• **String** = ``"String"``
+• **String**
 
 #### Defined in
 
@@ -100,7 +100,7 @@ ___
 
 ### UUID
 
-• **UUID** = ``"UUID"``
+• **UUID**
 
 #### Defined in
 

--- a/packages/framework/esm-framework/docs/enums/VisitMode.md
+++ b/packages/framework/esm-framework/docs/enums/VisitMode.md
@@ -14,7 +14,7 @@
 
 ### EDITVISIT
 
-• **EDITVISIT** = ``"editVisit"``
+• **EDITVISIT**
 
 #### Defined in
 
@@ -24,7 +24,7 @@ ___
 
 ### LOADING
 
-• **LOADING** = ``"loadingVisit"``
+• **LOADING**
 
 #### Defined in
 
@@ -34,7 +34,7 @@ ___
 
 ### NEWVISIT
 
-• **NEWVISIT** = ``"startVisit"``
+• **NEWVISIT**
 
 #### Defined in
 

--- a/packages/framework/esm-framework/docs/enums/VisitStatus.md
+++ b/packages/framework/esm-framework/docs/enums/VisitStatus.md
@@ -13,7 +13,7 @@
 
 ### NOTSTARTED
 
-• **NOTSTARTED** = ``"notStarted"``
+• **NOTSTARTED**
 
 #### Defined in
 
@@ -23,7 +23,7 @@ ___
 
 ### ONGOING
 
-• **ONGOING** = ``"ongoing"``
+• **ONGOING**
 
 #### Defined in
 

--- a/packages/framework/esm-framework/docs/interfaces/AssignedExtension.md
+++ b/packages/framework/esm-framework/docs/interfaces/AssignedExtension.md
@@ -20,6 +20,8 @@
 
 • **config**: ``null`` \| [`ConfigObject`](ConfigObject.md)
 
+The extension's config. Note that this will be `null` until the slot is mounted.
+
 #### Defined in
 
 [packages/framework/esm-extensions/src/store.ts:80](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L80)

--- a/packages/framework/esm-framework/docs/interfaces/BreadcrumbSettings.md
+++ b/packages/framework/esm-framework/docs/interfaces/BreadcrumbSettings.md
@@ -17,6 +17,13 @@
 
 • `Optional` **matcher**: `string` \| `RegExp`
 
+A string or RegEx that determines whether the breadcrumb should be displayed.
+It is tested against the current location's path.
+
+If `matcher` is a string, it can contain route parameters. e.g. `/foo/:bar`.
+
+Can be omitted; the value of `path` is used as the default value.
+
 #### Defined in
 
 [packages/framework/esm-breadcrumbs/src/types.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-breadcrumbs/src/types.ts#L16)
@@ -26,6 +33,13 @@ ___
 ### parent
 
 • `Optional` **parent**: `string`
+
+The breadcrumb's parent breadcrumb. Supply the path of the breadcrumb here, e.g.,
+if we are currently in "/foo/bar", you could provide "/foo" to get the breadcrumb
+associated with the path "/foo".
+
+If a path is missing for some reason, the closest matching one will be taken as
+parent.
 
 #### Defined in
 
@@ -37,6 +51,8 @@ ___
 
 • **path**: `string`
 
+Gets the path of breadcrumb for navigation purposes.
+
 #### Defined in
 
 [packages/framework/esm-breadcrumbs/src/types.ts:7](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-breadcrumbs/src/types.ts#L7)
@@ -46,6 +62,8 @@ ___
 ### title
 
 • **title**: `string` \| (`params`: `any`) => `string` \| (`params`: `any`) => `Promise`<`string`\>
+
+The title of the breadcrumb.
 
 #### Defined in
 

--- a/packages/framework/esm-framework/docs/interfaces/ComponentDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/ComponentDefinition.md
@@ -30,6 +30,8 @@
 
 • **appName**: `string`
 
+The module/app that defines the component
+
 #### Defined in
 
 [packages/framework/esm-globals/src/types.ts:99](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L99)
@@ -39,6 +41,8 @@ ___
 ### offline
 
 • `Optional` **offline**: `boolean` \| `object`
+
+Defines the offline support / properties of the component.
 
 #### Defined in
 
@@ -50,6 +54,8 @@ ___
 
 • `Optional` **online**: `boolean` \| `object`
 
+Defines the online support / properties of the component.
+
 #### Defined in
 
 [packages/framework/esm-globals/src/types.ts:107](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L107)
@@ -59,6 +65,9 @@ ___
 ### privilege
 
 • `Optional` **privilege**: `string` \| `string`[]
+
+Defines the access privilege(s) required for this component, if any.
+If more than one privilege is provided, the user must have all specified permissions.
 
 #### Defined in
 
@@ -70,6 +79,8 @@ ___
 
 • `Optional` **resources**: `Record`<`string`, [`ResourceLoader`](ResourceLoader.md)<`any`\>\>
 
+Defines resources that are loaded when the component should mount.
+
 #### Defined in
 
 [packages/framework/esm-globals/src/types.ts:120](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L120)
@@ -79,6 +90,8 @@ ___
 ### load
 
 ▸ **load**(): `Promise`<`any`\>
+
+Defines a function to use for actually loading the component's lifecycle.
 
 #### Returns
 

--- a/packages/framework/esm-framework/docs/interfaces/Config.md
+++ b/packages/framework/esm-framework/docs/interfaces/Config.md
@@ -33,6 +33,8 @@
 
 • **constructor**: `Function`
 
+The initial value of Object.prototype.constructor is the standard built-in Object constructor.
+
 #### Inherited from
 
 Object.constructor
@@ -47,11 +49,13 @@ node_modules/typescript/lib/lib.es5.d.ts:124
 
 ▸ **hasOwnProperty**(`v`): `boolean`
 
+Determines whether an object has a property with the specified name.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `v` | `PropertyKey` |  |
+| `v` | `PropertyKey` | A property name. |
 
 #### Returns
 
@@ -71,11 +75,13 @@ ___
 
 ▸ **isPrototypeOf**(`v`): `boolean`
 
+Determines whether an object exists in another object's prototype chain.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `v` | `Object` |  |
+| `v` | `Object` | Another object whose prototype chain is to be checked. |
 
 #### Returns
 
@@ -95,11 +101,13 @@ ___
 
 ▸ **propertyIsEnumerable**(`v`): `boolean`
 
+Determines whether a specified property is enumerable.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `v` | `PropertyKey` |  |
+| `v` | `PropertyKey` | A property name. |
 
 #### Returns
 
@@ -119,6 +127,8 @@ ___
 
 ▸ **toLocaleString**(): `string`
 
+Returns a date converted to a string using the current locale.
+
 #### Returns
 
 `string`
@@ -137,6 +147,8 @@ ___
 
 ▸ **toString**(): `string`
 
+Returns a string representation of an object.
+
 #### Returns
 
 `string`
@@ -154,6 +166,8 @@ ___
 ### valueOf
 
 ▸ **valueOf**(): `Object`
+
+Returns the primitive value of the specified object.
 
 #### Returns
 

--- a/packages/framework/esm-framework/docs/interfaces/ConfigObject.md
+++ b/packages/framework/esm-framework/docs/interfaces/ConfigObject.md
@@ -44,6 +44,8 @@ ___
 
 • **constructor**: `Function`
 
+The initial value of Object.prototype.constructor is the standard built-in Object constructor.
+
 #### Inherited from
 
 Object.constructor
@@ -58,11 +60,13 @@ node_modules/typescript/lib/lib.es5.d.ts:124
 
 ▸ **hasOwnProperty**(`v`): `boolean`
 
+Determines whether an object has a property with the specified name.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `v` | `PropertyKey` |  |
+| `v` | `PropertyKey` | A property name. |
 
 #### Returns
 
@@ -82,11 +86,13 @@ ___
 
 ▸ **isPrototypeOf**(`v`): `boolean`
 
+Determines whether an object exists in another object's prototype chain.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `v` | `Object` |  |
+| `v` | `Object` | Another object whose prototype chain is to be checked. |
 
 #### Returns
 
@@ -106,11 +112,13 @@ ___
 
 ▸ **propertyIsEnumerable**(`v`): `boolean`
 
+Determines whether a specified property is enumerable.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `v` | `PropertyKey` |  |
+| `v` | `PropertyKey` | A property name. |
 
 #### Returns
 
@@ -130,6 +138,8 @@ ___
 
 ▸ **toLocaleString**(): `string`
 
+Returns a date converted to a string using the current locale.
+
 #### Returns
 
 `string`
@@ -148,6 +158,8 @@ ___
 
 ▸ **toString**(): `string`
 
+Returns a string representation of an object.
+
 #### Returns
 
 `string`
@@ -165,6 +177,8 @@ ___
 ### valueOf
 
 ▸ **valueOf**(): `Object`
+
+Returns the primitive value of the specified object.
 
 #### Returns
 

--- a/packages/framework/esm-framework/docs/interfaces/ConnectedExtension.md
+++ b/packages/framework/esm-framework/docs/interfaces/ConnectedExtension.md
@@ -17,6 +17,8 @@
 
 • **config**: ``null`` \| [`ConfigObject`](ConfigObject.md)
 
+The extension's config. Note that this will be `null` until the slot is mounted.
+
 #### Defined in
 
 [packages/framework/esm-extensions/src/store.ts:90](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L90)

--- a/packages/framework/esm-framework/docs/interfaces/DynamicOfflineData.md
+++ b/packages/framework/esm-framework/docs/interfaces/DynamicOfflineData.md
@@ -2,6 +2,8 @@
 
 # Interface: DynamicOfflineData
 
+Represents the registration of a single dynamic offline data entry.
+
 ## Table of contents
 
 ### Offline Properties
@@ -18,6 +20,8 @@
 
 • `Optional` **id**: `number`
 
+The internal ID of the data entry, as assigned by the IndexedDB where it is stored.
+
 #### Defined in
 
 [packages/framework/esm-offline/src/dynamic-offline-data.ts:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-offline/src/dynamic-offline-data.ts#L48)
@@ -27,6 +31,9 @@ ___
 ### identifier
 
 • **identifier**: `string`
+
+The externally provided identifier of the data entry.
+This is typically the ID of the resource as assigned by a remote API.
 
 #### Defined in
 
@@ -38,6 +45,9 @@ ___
 
 • `Optional` **syncState**: [`DynamicOfflineDataSyncState`](DynamicOfflineDataSyncState.md)
 
+If this entry has already been synced, returns the result of that last sync attempt.
+Otherwise this is `undefined`.
+
 #### Defined in
 
 [packages/framework/esm-offline/src/dynamic-offline-data.ts:67](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-offline/src/dynamic-offline-data.ts#L67)
@@ -48,6 +58,9 @@ ___
 
 • **type**: `string`
 
+The underlying type used for categorizing the data entry.
+Examples could be `"patient"` or `"form"`.
+
 #### Defined in
 
 [packages/framework/esm-offline/src/dynamic-offline-data.ts:53](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-offline/src/dynamic-offline-data.ts#L53)
@@ -57,6 +70,8 @@ ___
 ### users
 
 • **users**: `string`[]
+
+The UUIDs of the users who need this data entry available offline.
 
 #### Defined in
 

--- a/packages/framework/esm-framework/docs/interfaces/DynamicOfflineDataHandler.md
+++ b/packages/framework/esm-framework/docs/interfaces/DynamicOfflineDataHandler.md
@@ -2,6 +2,9 @@
 
 # Interface: DynamicOfflineDataHandler
 
+A handler for synchronizing dynamically declared offline data.
+Can be setup using the [setupDynamicOfflineDataHandler](../API.md#setupdynamicofflinedatahandler) function.
+
 ## Table of contents
 
 ### Offline Properties
@@ -21,6 +24,9 @@
 
 • `Optional` **displayName**: `string`
 
+A human-readable string representing the handler.
+If provided, the handler can be rendered in the UI using that string.
+
 #### Defined in
 
 [packages/framework/esm-offline/src/dynamic-offline-data.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-offline/src/dynamic-offline-data.ts#L24)
@@ -30,6 +36,8 @@ ___
 ### id
 
 • **id**: `string`
+
+A string uniquely identifying the handler.
 
 #### Defined in
 
@@ -41,6 +49,9 @@ ___
 
 • **type**: `string`
 
+The type of offline data handled by this handler.
+See [DynamicOfflineData.type](DynamicOfflineData.md#type) for details.
+
 #### Defined in
 
 [packages/framework/esm-offline/src/dynamic-offline-data.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-offline/src/dynamic-offline-data.ts#L19)
@@ -51,12 +62,16 @@ ___
 
 ▸ **isSynced**(`identifier`, `abortSignal?`): `Promise`<`boolean`\>
 
+Evaluates whether the given offline data is correctly synced at this point in time from the perspective
+of this single handler.
+If `false`, the handler would have to (re-)sync the data in order for offline mode to properly work.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `identifier` | `string` |  |
-| `abortSignal?` | `AbortSignal` |  |
+| `identifier` | `string` | The identifier of the offline data. See [DynamicOfflineData](DynamicOfflineData.md) for details. |
+| `abortSignal?` | `AbortSignal` | An {@link AbortSignal} which can be used to cancel the operation. |
 
 #### Returns
 
@@ -72,12 +87,14 @@ ___
 
 ▸ **sync**(`identifier`, `abortSignal?`): `Promise`<`void`\>
 
+Synchronizes the given offline data.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `identifier` | `string` |  |
-| `abortSignal?` | `AbortSignal` |  |
+| `identifier` | `string` | The identifier of the offline data. See [DynamicOfflineData](DynamicOfflineData.md) for details. |
+| `abortSignal?` | `AbortSignal` | An {@link AbortSignal} which can be used to cancel the operation. |
 
 #### Returns
 

--- a/packages/framework/esm-framework/docs/interfaces/DynamicOfflineDataSyncState.md
+++ b/packages/framework/esm-framework/docs/interfaces/DynamicOfflineDataSyncState.md
@@ -2,6 +2,8 @@
 
 # Interface: DynamicOfflineDataSyncState
 
+Represents the result of syncing a given [DynamicOfflineData](DynamicOfflineData.md) entry.
+
 ## Table of contents
 
 ### Offline Properties
@@ -18,6 +20,8 @@
 
 • **erroredHandlers**: `string`[]
 
+The IDs of the handlers which failed to synchronize their data.
+
 #### Defined in
 
 [packages/framework/esm-offline/src/dynamic-offline-data.ts:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-offline/src/dynamic-offline-data.ts#L89)
@@ -27,6 +31,8 @@ ___
 ### errors
 
 • **errors**: { `handlerId`: `string` ; `message`: `string`  }[]
+
+A collection of the errors caught while synchronizing, per handler.
 
 #### Defined in
 
@@ -38,6 +44,8 @@ ___
 
 • **succeededHandlers**: `string`[]
 
+The IDs of the handlers which successfully synchronized their data.
+
 #### Defined in
 
 [packages/framework/esm-offline/src/dynamic-offline-data.ts:85](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-offline/src/dynamic-offline-data.ts#L85)
@@ -48,6 +56,8 @@ ___
 
 • **syncedBy**: `string`
 
+The ID of the user who has triggered the data synchronization.
+
 #### Defined in
 
 [packages/framework/esm-offline/src/dynamic-offline-data.ts:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-offline/src/dynamic-offline-data.ts#L81)
@@ -57,6 +67,8 @@ ___
 ### syncedOn
 
 • **syncedOn**: `Date`
+
+The time when the entry has been synced the last time.
 
 #### Defined in
 

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionDefinition.md
@@ -34,6 +34,8 @@
 
 • **appName**: `string`
 
+The module/app that defines the component
+
 #### Inherited from
 
 [ComponentDefinition](ComponentDefinition.md).[appName](ComponentDefinition.md#appname)
@@ -48,6 +50,8 @@ ___
 
 • `Optional` **id**: `string`
 
+**`deprecated`** A confusing way to specify the name of the extension
+
 #### Defined in
 
 [packages/framework/esm-globals/src/types.ts:135](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L135)
@@ -57,6 +61,8 @@ ___
 ### meta
 
 • `Optional` **meta**: `Record`<`string`, `any`\>
+
+The meta data used for reflection by other components
 
 #### Defined in
 
@@ -68,6 +74,8 @@ ___
 
 • **name**: `string`
 
+The name of the extension being registered
+
 #### Defined in
 
 [packages/framework/esm-globals/src/types.ts:125](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L125)
@@ -77,6 +85,8 @@ ___
 ### offline
 
 • `Optional` **offline**: `boolean` \| `object`
+
+Defines the offline support / properties of the component.
 
 #### Inherited from
 
@@ -92,6 +102,8 @@ ___
 
 • `Optional` **online**: `boolean` \| `object`
 
+Defines the online support / properties of the component.
+
 #### Inherited from
 
 [ComponentDefinition](ComponentDefinition.md).[online](ComponentDefinition.md#online)
@@ -106,6 +118,8 @@ ___
 
 • `Optional` **order**: `number`
 
+Specifies the relative order in which the extension renders in a slot
+
 #### Defined in
 
 [packages/framework/esm-globals/src/types.ts:133](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L133)
@@ -115,6 +129,9 @@ ___
 ### privilege
 
 • `Optional` **privilege**: `string` \| `string`[]
+
+Defines the access privilege(s) required for this component, if any.
+If more than one privilege is provided, the user must have all specified permissions.
 
 #### Inherited from
 
@@ -130,6 +147,8 @@ ___
 
 • `Optional` **resources**: `Record`<`string`, [`ResourceLoader`](ResourceLoader.md)<`any`\>\>
 
+Defines resources that are loaded when the component should mount.
+
 #### Inherited from
 
 [ComponentDefinition](ComponentDefinition.md).[resources](ComponentDefinition.md#resources)
@@ -144,6 +163,8 @@ ___
 
 • `Optional` **slot**: `string`
 
+A slot to attach to
+
 #### Defined in
 
 [packages/framework/esm-globals/src/types.ts:127](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L127)
@@ -154,6 +175,8 @@ ___
 
 • `Optional` **slots**: `string`[]
 
+Slots to attach to
+
 #### Defined in
 
 [packages/framework/esm-globals/src/types.ts:129](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L129)
@@ -163,6 +186,8 @@ ___
 ### load
 
 ▸ **load**(): `Promise`<`any`\>
+
+Defines a function to use for actually loading the component's lifecycle.
 
 #### Returns
 

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotBaseProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotBaseProps.md
@@ -20,6 +20,8 @@
 
 • `Optional` **extensionSlotName**: `string`
 
+**`deprecated`** Use `name`
+
 #### Defined in
 
 [packages/framework/esm-react-utils/src/ExtensionSlot.tsx:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L10)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfigObject.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfigObject.md
@@ -16,6 +16,8 @@
 
 • `Optional` **add**: `string`[]
 
+Additional extension IDs to assign to this slot, in addition to those `attach`ed in code.
+
 #### Defined in
 
 [packages/framework/esm-config/src/types.ts:58](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L58)
@@ -26,6 +28,8 @@ ___
 
 • `Optional` **order**: `string`[]
 
+Overrides the default ordering of extensions.
+
 #### Defined in
 
 [packages/framework/esm-config/src/types.ts:62](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L62)
@@ -35,6 +39,8 @@ ___
 ### remove
 
 • `Optional` **remove**: `string`[]
+
+Extension IDs which were `attach`ed to the slot but which should not be assigned.
 
 #### Defined in
 

--- a/packages/framework/esm-framework/docs/interfaces/FHIRRequestObj.md
+++ b/packages/framework/esm-framework/docs/interfaces/FHIRRequestObj.md
@@ -2,6 +2,8 @@
 
 # Interface: FHIRRequestObj
 
+**`deprecated`**
+
 ## Table of contents
 
 ### API Properties

--- a/packages/framework/esm-framework/docs/interfaces/FHIRRequestOptions.md
+++ b/packages/framework/esm-framework/docs/interfaces/FHIRRequestOptions.md
@@ -2,6 +2,8 @@
 
 # Interface: FHIRRequestOptions
 
+**`deprecated`**
+
 ## Table of contents
 
 ### API Properties

--- a/packages/framework/esm-framework/docs/interfaces/OfflinePatientArgs.md
+++ b/packages/framework/esm-framework/docs/interfaces/OfflinePatientArgs.md
@@ -2,6 +2,8 @@
 
 # Interface: OfflinePatientArgs
 
+**`deprecated`** Will be removed once all modules have been migrated to the new dynamic offline data API.
+
 ## Table of contents
 
 ### Offline Properties

--- a/packages/framework/esm-framework/docs/interfaces/OfflinePatientDataSyncHandler.md
+++ b/packages/framework/esm-framework/docs/interfaces/OfflinePatientDataSyncHandler.md
@@ -2,6 +2,8 @@
 
 # Interface: OfflinePatientDataSyncHandler
 
+**`deprecated`** Will be removed once all modules have been migrated to the new dynamic offline data API.
+
 ## Table of contents
 
 ### Offline Properties

--- a/packages/framework/esm-framework/docs/interfaces/OfflinePatientDataSyncState.md
+++ b/packages/framework/esm-framework/docs/interfaces/OfflinePatientDataSyncState.md
@@ -2,6 +2,8 @@
 
 # Interface: OfflinePatientDataSyncState
 
+**`deprecated`** Will be removed once all modules have been migrated to the new dynamic offline data API.
+
 ## Table of contents
 
 ### Offline Properties

--- a/packages/framework/esm-framework/docs/interfaces/OfflinePatientDataSyncStore.md
+++ b/packages/framework/esm-framework/docs/interfaces/OfflinePatientDataSyncStore.md
@@ -2,6 +2,8 @@
 
 # Interface: OfflinePatientDataSyncStore
 
+**`deprecated`** Will be removed once all modules have been migrated to the new dynamic offline data API.
+
 ## Table of contents
 
 ### Offline Properties

--- a/packages/framework/esm-framework/docs/interfaces/OldExtensionSlotBaseProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OldExtensionSlotBaseProps.md
@@ -20,6 +20,8 @@
 
 • **extensionSlotName**: `string`
 
+**`deprecated`** Use `name`
+
 #### Defined in
 
 [packages/framework/esm-react-utils/src/ExtensionSlot.tsx:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ExtensionSlot.tsx#L18)

--- a/packages/framework/esm-framework/docs/interfaces/PageDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/PageDefinition.md
@@ -30,6 +30,8 @@
 
 • **appName**: `string`
 
+The module/app that defines the component
+
 #### Inherited from
 
 [ComponentDefinition](ComponentDefinition.md).[appName](ComponentDefinition.md#appname)
@@ -43,6 +45,8 @@ ___
 ### offline
 
 • `Optional` **offline**: `boolean` \| `object`
+
+Defines the offline support / properties of the component.
 
 #### Inherited from
 
@@ -58,6 +62,8 @@ ___
 
 • `Optional` **online**: `boolean` \| `object`
 
+Defines the online support / properties of the component.
+
 #### Inherited from
 
 [ComponentDefinition](ComponentDefinition.md).[online](ComponentDefinition.md#online)
@@ -72,6 +78,8 @@ ___
 
 • **order**: `number`
 
+The order in which to load the page. This determines DOM order.
+
 #### Defined in
 
 [packages/framework/esm-globals/src/types.ts:146](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L146)
@@ -81,6 +89,9 @@ ___
 ### privilege
 
 • `Optional` **privilege**: `string` \| `string`[]
+
+Defines the access privilege(s) required for this component, if any.
+If more than one privilege is provided, the user must have all specified permissions.
 
 #### Inherited from
 
@@ -96,6 +107,8 @@ ___
 
 • `Optional` **resources**: `Record`<`string`, [`ResourceLoader`](ResourceLoader.md)<`any`\>\>
 
+Defines resources that are loaded when the component should mount.
+
 #### Inherited from
 
 [ComponentDefinition](ComponentDefinition.md).[resources](ComponentDefinition.md#resources)
@@ -110,6 +123,8 @@ ___
 
 • **route**: `string`
 
+The route of the page.
+
 #### Defined in
 
 [packages/framework/esm-globals/src/types.ts:142](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L142)
@@ -119,6 +134,8 @@ ___
 ### load
 
 ▸ **load**(): `Promise`<`any`\>
+
+Defines a function to use for actually loading the component's lifecycle.
 
 #### Returns
 

--- a/packages/framework/esm-framework/docs/interfaces/QueueItemDescriptor.md
+++ b/packages/framework/esm-framework/docs/interfaces/QueueItemDescriptor.md
@@ -2,6 +2,11 @@
 
 # Interface: QueueItemDescriptor
 
+Contains information about the sync item which has been provided externally by the caller
+who added the item to the queue.
+This information is all optional, but, when provided while enqueuing the item, can be used in other
+locations to better represent the sync item, e.g. in the UI.
+
 ## Table of contents
 
 ### Offline Properties

--- a/packages/framework/esm-framework/docs/interfaces/RetryOptions.md
+++ b/packages/framework/esm-framework/docs/interfaces/RetryOptions.md
@@ -2,6 +2,8 @@
 
 # Interface: RetryOptions
 
+Options for configuring the behavior of the [retry](../API.md#retry) function.
+
 ## Table of contents
 
 ### Methods
@@ -16,11 +18,14 @@
 
 ▸ `Optional` **getDelay**(`attempt`): `number`
 
+Calculates the next delay (in milliseconds) before a retry attempt.
+Returning a value for the inital attempt (`0`) delays the initial function invocation.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `attempt` | `number` |  |
+| `attempt` | `number` | The current (zero-based) retry attempt. `0` indicates the initial attempt. |
 
 #### Returns
 
@@ -36,12 +41,15 @@ ___
 
 ▸ `Optional` **onError**(`e`, `attempt`): `void`
 
+Called when invoking the function resulted in an error.
+Allows running side-effects on errors, e.g. logging.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `e` | `any` |  |
-| `attempt` | `number` |  |
+| `e` | `any` | The error thrown by the function. |
+| `attempt` | `number` | The current (zero-based) retry attempt. `0` indicates the initial attempt. |
 
 #### Returns
 
@@ -57,11 +65,14 @@ ___
 
 ▸ `Optional` **shouldRetry**(`attempt`): `any`
 
+Determines whether the retry function should retry executing the function after it failed
+with an error on the current attempt.
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `attempt` | `number` |  |
+| `attempt` | `number` | The current (zero-based) retry attempt. `0` indicates the initial attempt. |
 
 #### Returns
 

--- a/packages/framework/esm-framework/docs/interfaces/SpaConfig.md
+++ b/packages/framework/esm-framework/docs/interfaces/SpaConfig.md
@@ -18,6 +18,8 @@
 
 • **apiUrl**: `string`
 
+The base path or URL for the OpenMRS API / endpoints.
+
 #### Defined in
 
 [packages/framework/esm-globals/src/types.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L70)
@@ -27,6 +29,8 @@ ___
 ### configUrls
 
 • `Optional` **configUrls**: `string`[]
+
+URLs of configurations to load in the system.
 
 #### Defined in
 
@@ -38,6 +42,10 @@ ___
 
 • `Optional` **env**: [`SpaEnvironment`](../API.md#spaenvironment)
 
+The environment to use.
+
+**`default`** production
+
 #### Defined in
 
 [packages/framework/esm-globals/src/types.ts:79](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L79)
@@ -48,6 +56,10 @@ ___
 
 • `Optional` **offline**: `boolean`
 
+Defines if offline should be supported by installing a service worker.
+
+**`default`** true
+
 #### Defined in
 
 [packages/framework/esm-globals/src/types.ts:88](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L88)
@@ -57,6 +69,8 @@ ___
 ### spaPath
 
 • **spaPath**: `string`
+
+The base path for the SPA root path.
 
 #### Defined in
 

--- a/packages/framework/esm-framework/docs/interfaces/SyncItem.md
+++ b/packages/framework/esm-framework/docs/interfaces/SyncItem.md
@@ -2,6 +2,10 @@
 
 # Interface: SyncItem<T\>
 
+Defines an item queued up in the offline synchronization queue.
+A `SyncItem` contains both meta information about the item in the sync queue, as well as the
+actual data to be synchronized (i.e. the item's `content`).
+
 ## Type parameters
 
 | Name | Type |

--- a/packages/framework/esm-framework/docs/interfaces/SyncProcessOptions.md
+++ b/packages/framework/esm-framework/docs/interfaces/SyncProcessOptions.md
@@ -2,6 +2,8 @@
 
 # Interface: SyncProcessOptions<T\>
 
+Additional data which can be used for synchronizing data in a {@link ProcessSyncItem} function.
+
 ## Type parameters
 
 | Name |

--- a/yarn.lock
+++ b/yarn.lock
@@ -3594,7 +3594,7 @@ __metadata:
     turbo: ^1.2.1
     typedoc: ^0.22.15
     typedoc-plugin-file-tags: ^1.0.0
-    typedoc-plugin-markdown: ^3.11.12
+    typedoc-plugin-markdown: 3.11.14
     typedoc-plugin-no-inherit: ^1.3.1
     typescript: ~4.6.4
     webpack: ^5.74.0
@@ -18099,14 +18099,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typedoc-plugin-markdown@npm:^3.11.12":
-  version: 3.13.4
-  resolution: "typedoc-plugin-markdown@npm:3.13.4"
+"typedoc-plugin-markdown@npm:3.11.14":
+  version: 3.11.14
+  resolution: "typedoc-plugin-markdown@npm:3.11.14"
   dependencies:
     handlebars: ^4.7.7
   peerDependencies:
-    typedoc: ">=0.23.0"
-  checksum: b4edc0147694b8669a05695ef67b6a1f645c10179930fa86759374347f4e8cbb6bd29b58929abce62ab6a3e165de36711ab22eaad240785b1235c06bba4574e4
+    typedoc: ">=0.22.0"
+  checksum: 7eff9e5b8b6b2457b484ea16bbae453c23313c838b4ac8826bd166c5d37a18010242dd43a21010b759965d860106951ddd321f85bd0ff39b78dcb172daa60e6e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Docstrings were accidentally removed with [this PR](https://github.com/openmrs/openmrs-esm-core/pull/500). This reverts typedoc-plugin-markdown to 3.11.14 which appears to fix the document file generation issue.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
