### PR TITLE
(fix) pin semver version so backend modules aren't reported as missing

### DIFF
--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -47,6 +47,6 @@
     "rxjs": "6.x"
   },
   "dependencies": {
-    "semver": "^7.3.2"
+    "semver": "7.3.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3872,7 +3872,7 @@ __metadata:
     "@types/semver": ^7.3.4
     dayjs: ^1.10.4
     rxjs: ^6.5.3
-    semver: ^7.3.2
+    semver: 7.3.2
   peerDependencies:
     dayjs: 1.x
     i18next: 19.x
@@ -16460,6 +16460,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 272c11bf8d083274ef79fe40a81c55c184dff84dd58e3c325299d0927ba48cece1f020793d138382b85f89bab5002a35a5ba59a3a68a7eebbb597eb733838778
+  languageName: node
+  linkType: hard
+
+"semver@npm:7.3.2":
+  version: 7.3.2
+  resolution: "semver@npm:7.3.2"
+  bin:
+    semver: bin/semver.js
+  checksum: 692f4900dadb43919614b0df9af23fe05743051cda0d1735b5e4d76f93c9e43a266fae73cfc928f5d1489f022c5c0e65dfd2900fcf5b1839c4e9a239729afa7b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Pins the version of semver to a version that works. The more recent version causes some sort of infinite recursive call when trying to access the LRU cache from the "lru-cache" library. I don't know exactly why that happens, but both the semver and lru-cache libraries are targetted at Node as a runtime rather than browsers, so I suspect that the libraries don't play well with ESM semantics.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
