### PR TITLE
(fix) Display offline patient updates in offline tools

### DIFF
--- a/packages/apps/esm-offline-tools-app/src/hooks/offline-patient-data-hooks.ts
+++ b/packages/apps/esm-offline-tools-app/src/hooks/offline-patient-data-hooks.ts
@@ -132,5 +132,9 @@ function useMergedSwr<T>(
       isValidating,
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [merge, ...swrResponses]);
+  }, [
+    merge,
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    ...swrResponses.flatMap((res) => [res.data, res.error, res.isValidating]),
+  ]);
 }

--- a/packages/apps/esm-offline-tools-app/src/hooks/offline-patient-data-hooks.ts
+++ b/packages/apps/esm-offline-tools-app/src/hooks/offline-patient-data-hooks.ts
@@ -77,8 +77,6 @@ export function useOfflinePatientsWithEntries() {
         ...offlineUpdates
       ) as fhir.Patient;
 
-      console.log("final", fhirPatientsSwr.data);
-
       return {
         patient: finalPatient,
         entry: offlinePatientEntry,

--- a/packages/apps/esm-offline-tools-app/src/hooks/offline-patient-data-hooks.ts
+++ b/packages/apps/esm-offline-tools-app/src/hooks/offline-patient-data-hooks.ts
@@ -3,39 +3,101 @@ import {
   getSynchronizationItems,
   getDynamicOfflineDataEntries,
 } from "@openmrs/esm-framework";
-import useSWR from "swr";
+import merge from "lodash-es/merge";
+import { useMemo } from "react";
+import useSWR, { SWRResponse } from "swr";
+
+function useDynamicOfflineDataEntries(type: string) {
+  return useSWR(`dynamicOfflineData/entries/${type}`, () =>
+    getDynamicOfflineDataEntries(type)
+  );
+}
+
+function useSynchronizationItems<T>(type: string) {
+  return useSWR(`syncQueue/items/${type}`, () =>
+    getSynchronizationItems<T>(type)
+  );
+}
+
+function useFhirPatients(ids: Array<string>) {
+  const stableIds = useMemo(() => [...ids].sort(), [ids]);
+  return useSWR(["fhirPatients", stableIds], () =>
+    Promise.all(
+      stableIds.map((patientId) =>
+        fetchCurrentPatient(patientId).then((res) => res.data)
+      )
+    )
+  );
+}
 
 export function useOfflineRegisteredPatients() {
-  return useSWR("offlineTools/offlineRegisteredPatients", async () => {
-    const offlinePatients = await getDynamicOfflineDataEntries("patient");
-    const syncItems = await getSynchronizationItems<{
-      fhirPatient?: fhir.Patient;
-    }>("patient-registration");
-    return syncItems
-      .filter(
-        (item) =>
-          item.fhirPatient &&
-          !offlinePatients.find(
-            (entry) => entry.identifier === item.fhirPatient.id
-          )
-      )
+  const offlinePatientsSwr = useDynamicOfflineDataEntries("patient");
+  const patientSyncItemsSwr = useSynchronizationItems<{
+    fhirPatient?: fhir.Patient;
+  }>("patient-registration");
+
+  return useMergedSwr(() => {
+    return patientSyncItemsSwr.data
+      .filter((patientRegistrationItem) => {
+        const isNewlyRegistered =
+          patientRegistrationItem.fhirPatient &&
+          !offlinePatientsSwr.data.find(
+            (offlinePatientEntry) =>
+              offlinePatientEntry.identifier ===
+              patientRegistrationItem.fhirPatient.id
+          );
+        return isNewlyRegistered;
+      })
       .map((item) => item.fhirPatient);
-  });
+  }, [offlinePatientsSwr, patientSyncItemsSwr]);
 }
 
 export function useOfflinePatientsWithEntries() {
-  return useSWR("offlineTools/offlinePatients", async () => {
-    const offlinePatientEntries = await getDynamicOfflineDataEntries("patient");
+  const offlinePatientsSwr = useDynamicOfflineDataEntries("patient");
+  const patientSyncItemsSwr = useSynchronizationItems<{
+    fhirPatient?: fhir.Patient;
+  }>("patient-registration");
+  const fhirPatientsSwr = useFhirPatients(
+    offlinePatientsSwr.data?.map((entry) => entry.identifier) ?? []
+  );
 
-    const result = await Promise.all(
-      offlinePatientEntries.map(async (entry) => ({
-        patient: (await fetchCurrentPatient(entry.identifier))?.data,
-        entry,
-      }))
-    );
+  return useMergedSwr(() => {
+    return offlinePatientsSwr.data.map((offlinePatientEntry) => {
+      const matchingFhirPatient = fhirPatientsSwr.data.find(
+        (patient) => patient.id === offlinePatientEntry.identifier
+      );
+      const offlineUpdates = patientSyncItemsSwr.data
+        .filter(
+          (syncItem) =>
+            syncItem.fhirPatient.id === offlinePatientEntry.identifier
+        )
+        .map((item) => item.fhirPatient);
+      const finalPatient = merge(
+        matchingFhirPatient,
+        ...offlineUpdates
+      ) as fhir.Patient;
 
-    return result.filter((x) => x.patient);
-  });
+      console.log("final", fhirPatientsSwr.data);
+
+      return {
+        patient: finalPatient,
+        entry: offlinePatientEntry,
+      };
+    });
+  }, [offlinePatientsSwr, patientSyncItemsSwr, fhirPatientsSwr]);
+}
+
+export function useOfflinePatientStats() {
+  const offlinePatientsSwr = useDynamicOfflineDataEntries("patient");
+  const offlineRegisteredPatientsSwr = useOfflineRegisteredPatients();
+
+  return useMergedSwr(
+    () => ({
+      downloadedCount: offlinePatientsSwr.data.length,
+      registeredCount: offlineRegisteredPatientsSwr.data.length,
+    }),
+    [offlinePatientsSwr, offlineRegisteredPatientsSwr]
+  );
 }
 
 export function useLastSyncStateOfPatient(patientUuid: string) {
@@ -51,4 +113,26 @@ export function useLastSyncStateOfPatient(patientUuid: string) {
       return patientEntry?.syncState;
     }
   );
+}
+
+function useMergedSwr<T>(
+  merge: () => T,
+  swrResponses: Array<SWRResponse>
+): SWRResponse<T> {
+  return useMemo(() => {
+    const areAllLoaded = swrResponses.every((res) => !!res.data);
+    const data = areAllLoaded ? merge() : null;
+    const error = swrResponses.find((res) => res.error);
+    const mutate = () =>
+      Promise.all(swrResponses.map((res) => res.mutate())).then(merge);
+    const isValidating = swrResponses.some((res) => res.isValidating);
+
+    return {
+      data,
+      error,
+      mutate,
+      isValidating,
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [merge, ...swrResponses]);
 }

--- a/packages/apps/esm-offline-tools-app/src/offline-patients/patient-name-table-cell.component.tsx
+++ b/packages/apps/esm-offline-tools-app/src/offline-patients/patient-name-table-cell.component.tsx
@@ -14,7 +14,9 @@ const PatientNameTableCell: React.FC<PatientNameTableCellProps> = ({
   isNewlyRegistered = false,
 }) => {
   const { t } = useTranslation();
-  const name = `${patient.name[0].given.join(" ")} ${patient.name[0].family}`;
+  const name = `${[patient.name?.[0]?.given, patient.name?.[0]?.family]
+    .filter(Boolean)
+    .join(" ")}`;
 
   return (
     <div className={styles.cellContainer}>

--- a/packages/apps/esm-offline-tools-app/src/offline-patients/patients-overview-card.component.tsx
+++ b/packages/apps/esm-offline-tools-app/src/offline-patients/patients-overview-card.component.tsx
@@ -3,15 +3,11 @@ import { useTranslation } from "react-i18next";
 import HeaderedQuickInfo from "../components/headered-quick-info.component";
 import OverviewCard from "../components/overview-card.component";
 import { routes } from "../constants";
-import useSWR from "swr";
-import {
-  getDynamicOfflineDataEntries,
-  getSynchronizationItems,
-} from "@openmrs/esm-framework";
+import { useOfflinePatientStats } from "../hooks/offline-patient-data-hooks";
 
 const PatientsOverviewCard: React.FC = () => {
   const { t } = useTranslation();
-  const { data } = useDownloadedOfflinePatients();
+  const { data } = useOfflinePatientStats();
 
   return (
     <OverviewCard
@@ -34,23 +30,5 @@ const PatientsOverviewCard: React.FC = () => {
     </OverviewCard>
   );
 };
-
-function useDownloadedOfflinePatients() {
-  return useSWR(["offlineTools/offlinePatientsTotalCount"], async () => {
-    const patientDataEntries = await getDynamicOfflineDataEntries("patient");
-    const patientRegistrationSyncItems = await getSynchronizationItems(
-      "patient-registration"
-    );
-    const registeredCount = patientRegistrationSyncItems.length;
-    const downloadedCount = patientDataEntries.filter(
-      (entry) => entry.syncState && entry.syncState.erroredHandlers.length === 0
-    ).length;
-
-    return {
-      downloadedCount,
-      registeredCount,
-    };
-  });
-}
 
 export default PatientsOverviewCard;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Fixes the issue that offline tools were not display offline updates made to patients. The following flow did, for example, not display the name change update in the offline tool's patient table:

1. Add a patient to the offline list.
2. Go offline.
3. Make an update to that patient's name (e.g. Lisa -> Lisa Two).
4. Go to the offline tools. They still displayed the old name pre-update.

In addition, this PR also contains some other niceties, somewhat related to the above issue:
* SWRs are now used more efficiently for fetching resources required by the offline tools. Should lead to better performance in the offline tools.
* The overview card for offline patients displayed wrong numbers when a patient was updated. This is now fixed.