### PR TITLE
(fix) Fix module loading error in the translations systems

### DIFF
--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -49,15 +49,17 @@ export function setupI18n() {
           } else {
             const app: any = window[slugify(decodeHtmlEntity(namespace))];
 
-            if ("init" in app && "get" in app) {
-              app.init(__webpack_share_scopes__.default);
-              const start = await app.get("./start");
-              const module = start();
+            if (app) {
+              if ("init" in app && "get" in app) {
+                app.init(__webpack_share_scopes__.default);
+                const start = await app.get("./start");
+                const module = start();
 
-              getImportPromise(module, namespace, language).then(
-                (json) => callback(null, { status: 200, data: json }),
-                (err) => callback(err, { status: 404, data: null })
-              );
+                getImportPromise(module, namespace, language).then(
+                  (json) => callback(null, { status: 200, data: json }),
+                  (err) => callback(err, { status: 404, data: null })
+                );
+              }
             }
           }
         },


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR adds a check to the code in our translation system that loads modules. The check ensures that the loaded module exists (that it is not `undefined`) before running the rest of the code. This fixes an error that currently appears in the dev tools console (see screenshot below).

## Screenshot

<img width="1136" alt="Screenshot 2022-08-31 at 15 19 06" src="https://user-images.githubusercontent.com/8509731/187676713-c245d788-1a06-49de-bf86-17f33e659690.png">
