### PR TITLE
(fix) Fix import map overrides panel

### DIFF
--- a/packages/apps/esm-devtools-app/src/devtools/import-map.component.tsx
+++ b/packages/apps/esm-devtools-app/src/devtools/import-map.component.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from "react";
 import styles from "./import-map.styles.css";
 
-export default function ImportMap(props: ImportMapProps) {
+export default function ImportMap({ toggleOverridden }: ImportMapProps) {
   const importMapListRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
@@ -16,7 +16,7 @@ export default function ImportMap(props: ImportMapProps) {
       );
 
     function handleImportMapChange(evt) {
-      props.toggleOverridden(importMapOverridden());
+      toggleOverridden(importMapOverridden());
     }
   }, [importMapListRef.current]);
 

--- a/packages/shell/esm-app-shell/src/index.ejs
+++ b/packages/shell/esm-app-shell/src/index.ejs
@@ -26,6 +26,10 @@
     >
     <script type="systemjs-importmap" src="<%= openmrsImportmapUrl %>"></script>
 <% } %>
+    <script
+    type="text/javascript"
+    src="https://cdn.jsdelivr.net/npm/import-map-overrides/dist/import-map-overrides.js"
+    ></script>
   </head>
   <body>
     <%= htmlWebpackPlugin.tags.bodyTags %>

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -1,4 +1,3 @@
-import "import-map-overrides";
 import "systemjs/dist/system";
 import "systemjs/dist/extras/amd";
 import "systemjs/dist/extras/named-exports";


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR fixes an issue where the overrides list UI in the `import-map-overrides` panel wouldn't display following the recent 4.0 upgrade. It changes how we install the `import-map-overrides` package in esm-core by switching from installing it as an npm package to the [preferred approach](https://github.com/single-spa/import-map-overrides/blob/main/docs/installation.md) - installing it via a `script` tag in our HTML file.

Many thanks to @donaldkibet for pairing on this!

## Video

https://user-images.githubusercontent.com/8509731/188953227-c1e7d93d-4317-4127-b07c-384c80d39fda.mp4




