### PR TITLE
(chore) upgrade to single-spa-react 5

### DIFF
--- a/packages/framework/esm-react-utils/package.json
+++ b/packages/framework/esm-react-utils/package.json
@@ -39,7 +39,7 @@
   },
   "dependencies": {
     "lodash-es": "^4.17.21",
-    "single-spa-react": "^4.6.1",
+    "single-spa-react": "^5.0.0",
     "swr": "^1.2.2"
   },
   "peerDependencies": {

--- a/packages/framework/esm-react-utils/src/getLifecycle.ts
+++ b/packages/framework/esm-react-utils/src/getLifecycle.ts
@@ -1,6 +1,6 @@
 /** @module @category Framework */
 import React from "react";
-import ReactDOM from "react-dom";
+import ReactDOMClient from "react-dom/client";
 import singleSpaReact from "single-spa-react";
 import {
   openmrsComponentDecorator,
@@ -13,7 +13,7 @@ export function getLifecycle<T>(
 ) {
   return singleSpaReact({
     React,
-    ReactDOM,
+    ReactDOMClient,
     rootComponent: openmrsComponentDecorator(options)(Component),
   });
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3823,7 +3823,7 @@ __metadata:
     react-dom: ^18.1.0
     react-i18next: ^11.16.9
     rxjs: ^6.5.3
-    single-spa-react: ^4.6.1
+    single-spa-react: ^5.0.0
     swr: ^1.2.2
     unistore: ^3.5.2
   peerDependencies:
@@ -16656,16 +16656,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"single-spa-react@npm:^4.6.1":
-  version: 4.6.1
-  resolution: "single-spa-react@npm:4.6.1"
+"single-spa-react@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "single-spa-react@npm:5.0.0"
   dependencies:
     browserslist-config-single-spa: ^1.0.1
   peerDependencies:
     "@types/react": "*"
     "@types/react-dom": "*"
     react: "*"
-  checksum: 12383d3b1dfc328efb7386f1094cbd255cf7e4785685416cd854ff3e1ba5da7828a2edaada94859593c8bc0405c5982c9655d1f51b5b67a2a94a6c1908983428
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 6b3d0c69720eaef494964f36a5c41fc601d80fcb1fead87bd73c9a7c2db53155ac70111626eec7d75260452f2a867c9139c88269900a2e5cb718264db4863ec7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This supports React 18 using `createRoot()` instead of `ReactDOM.render()`, basically allowing us to take advantage of React 18's new features.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
