### PR TITLE
(docs) Fix dead link in setup docs

### DIFF
--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -3,7 +3,7 @@
 ## Prerequisities
 
 You must have git, node, npm, and yarn installed. The versions required are
-- The Node [Active LTS version](https://nodejs.org/en/download/)
+- The Node [Active LTS version](https://github.com/nodejs/release#release-schedule)
 - The latest stable version of NPM
 - The latest stable version of Yarn
 

--- a/docs/getting_started/setup.md
+++ b/docs/getting_started/setup.md
@@ -3,7 +3,7 @@
 ## Prerequisities
 
 You must have git, node, npm, and yarn installed. The versions required are
-- The Node [Active LTS version](https://nodejs.org/en/about/releases/)
+- The Node [Active LTS version](https://nodejs.org/en/download/)
 - The latest stable version of NPM
 - The latest stable version of Yarn
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Fixes the [check-documentation](https://github.com/openmrs/openmrs-esm-core/actions/workflows/docs.yml) CI job by amending a [broken link](https://nodejs.org/en/about/releases/) to the Node.js LTS version webpage.

## Screenshot

<img width="467" alt="Screenshot 2022-09-17 at 23 27 13" src="https://user-images.githubusercontent.com/8509731/190875356-4471c65e-7c13-4688-857e-cf6fbfa6f425.png">
