### PR TITLE
(chore) Disable manual workflow triggering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,6 @@
 name: OpenMRS CI
 
 on:
-  workflow_dispatch: # temporary, for debugging
   push:
     branches: [main]
   pull_request:


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

## Summary

Removes the `workflow_dispatch` event from the workflow triggers event list. This was previously only set for debugging purposes.
