### PR TITLE
Revert "(fix) Fix import map overrides panel (#523)"

### DIFF
--- a/packages/apps/esm-devtools-app/src/devtools/import-map.component.tsx
+++ b/packages/apps/esm-devtools-app/src/devtools/import-map.component.tsx
@@ -1,7 +1,7 @@
 import React, { useRef, useEffect } from "react";
 import styles from "./import-map.styles.css";
 
-export default function ImportMap({ toggleOverridden }: ImportMapProps) {
+export default function ImportMap(props: ImportMapProps) {
   const importMapListRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
@@ -16,7 +16,7 @@ export default function ImportMap({ toggleOverridden }: ImportMapProps) {
       );
 
     function handleImportMapChange(evt) {
-      toggleOverridden(importMapOverridden());
+      props.toggleOverridden(importMapOverridden());
     }
   }, [importMapListRef.current]);
 

--- a/packages/shell/esm-app-shell/src/index.ejs
+++ b/packages/shell/esm-app-shell/src/index.ejs
@@ -26,10 +26,6 @@
     >
     <script type="systemjs-importmap" src="<%= openmrsImportmapUrl %>"></script>
 <% } %>
-    <script
-    type="text/javascript"
-    src="https://cdn.jsdelivr.net/npm/import-map-overrides/dist/import-map-overrides.js"
-    ></script>
   </head>
   <body>
     <%= htmlWebpackPlugin.tags.bodyTags %>

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -1,3 +1,4 @@
+import "import-map-overrides";
 import "systemjs/dist/system";
 import "systemjs/dist/extras/amd";
 import "systemjs/dist/extras/named-exports";


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This reverts commit c69f1d7a6efea6fb36a02c53ba553ea10aab74d8. Loading the import map overrides script from a CDN violates dev3's CSP policy leading to problems loading the app. We're now shelving this approach and looking for a more viable solution.