### PR TITLE
(fix) Fix spacing of results in the location picker container

### DIFF
--- a/packages/apps/esm-login-app/src/location-picker/location-picker.scss
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.scss
@@ -52,18 +52,15 @@
 .locationResultsContainer {
   display: flex;
   overflow-y: auto;
-  margin-top: spacing.$spacing-01;
+  margin-top: spacing.$spacing-05;
   padding: 0rem spacing.$spacing-01 0rem;
 }
 
 .locationRadioButton {
   display: flex;
-  justify-content: flex-start;
-  align-items: flex-start;
+  height: spacing.$spacing-09;
+  align-items: center;
   @extend .bodyShort01;
-  padding: spacing.$spacing-01 0rem;
-  text-align: left;
-  width: 18rem;
 }
 
 .locationNotFound {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Fixes the spacing of entries in the location picker container.

## Screenshots

> Before

<img width="377" alt="Screenshot 2022-09-23 at 19 40 26" src="https://user-images.githubusercontent.com/8509731/192010385-8f8edd84-b661-4856-a70a-85f9750a6926.png">

> After

<img width="380" alt="image" src="https://user-images.githubusercontent.com/8509731/192010216-3aadae2e-029c-4b22-a7e2-e3956710019f.png">
