### PR TITLE
(feat) allow configuration to override translations

### DIFF
--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -849,6 +849,14 @@ describe("implementer tools config", () => {
             _value: [],
           },
         },
+        "Translation overrides": {
+          _default: {},
+          _description:
+            "Per-language overrides for frontend translations should be keyed by language code and each language dictionary contains the translation key and the display value",
+          _source: "default",
+          _type: Type.Object,
+          _value: {},
+        },
       },
       "bar-module": {
         bar: { _value: "baz", _source: "my config source", _default: "quinn" },
@@ -861,6 +869,14 @@ describe("implementer tools config", () => {
             _type: Type.Array,
             _value: [],
           },
+        },
+        "Translation overrides": {
+          _default: {},
+          _description:
+            "Per-language overrides for frontend translations should be keyed by language code and each language dictionary contains the translation key and the display value",
+          _source: "default",
+          _type: Type.Object,
+          _value: {},
         },
       },
     });
@@ -1020,6 +1036,14 @@ describe("extension slot config", () => {
             _type: Type.Array,
             _value: [],
           },
+        },
+        "Translation overrides": {
+          _default: {},
+          _description:
+            "Per-language overrides for frontend translations should be keyed by language code and each language dictionary contains the translation key and the display value",
+          _source: "default",
+          _type: Type.Object,
+          _value: {},
         },
       },
     });

--- a/packages/framework/esm-config/src/module-config/state.ts
+++ b/packages/framework/esm-config/src/module-config/state.ts
@@ -208,7 +208,10 @@ export function getExtensionConfig(slotName: string, extensionId: string) {
       extensionId
     )
   );
-  extensionConfig.config = omit(["Display conditions"], extensionConfig.config);
+  extensionConfig.config = omit(
+    ["Display conditions", "Translation overrides"],
+    extensionConfig.config
+  );
   return extensionConfig;
 }
 

--- a/packages/framework/esm-config/src/types.ts
+++ b/packages/framework/esm-config/src/types.ts
@@ -28,6 +28,7 @@ export interface Config extends Object {
 export interface ConfigObject extends Object {
   [key: string]: any;
   "Display conditions"?: DisplayConditionsConfigObject;
+  "Translation overrides"?: Record<string, Record<string, string>>;
 }
 
 export interface DisplayConditionsConfigObject {

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -387,7 +387,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L37)
+[packages/framework/esm-config/src/types.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L38)
 
 ___
 
@@ -424,7 +424,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:65](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L65)
+[packages/framework/esm-config/src/types.ts:66](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L66)
 
 ___
 
@@ -468,7 +468,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L72)
+[packages/framework/esm-config/src/types.ts:73](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L73)
 
 ___
 
@@ -492,7 +492,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L70)
+[packages/framework/esm-config/src/types.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L71)
 
 ___
 
@@ -890,7 +890,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:202](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L202)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:206](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L206)
 
 ___
 
@@ -904,7 +904,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:220](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L220)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:224](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L224)
 
 ___
 
@@ -1169,7 +1169,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:229](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L229)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:233](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L233)
 
 ___
 
@@ -1557,10 +1557,6 @@ ___
 A promise-based way to access the config as soon as it is fully loaded.
 If it is already loaded, resolves the config in its present state.
 
-In general you should use the Unistore-based API provided by
-`getConfigStore`, which allows creating a subscription so that you always
-have the latest config. If using React, just use `useConfig`.
-
 This is a useful function if you need to get the config in the course
 of the execution of a function.
 
@@ -1576,7 +1572,7 @@ of the execution of a function.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:264](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L264)
+[packages/framework/esm-config/src/module-config/module-config.ts:260](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L260)
 
 ___
 
@@ -1614,6 +1610,7 @@ Use this React Hook to obtain your module's configuration.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `Display conditions?` | [`DisplayConditionsConfigObject`](interfaces/DisplayConditionsConfigObject.md) | - |
+| `Translation overrides?` | `Record`<`string`, `Record`<`string`, `string`\>\> | - |
 | `constructor` | `Function` | The initial value of Object.prototype.constructor is the standard built-in Object constructor. |
 | `hasOwnProperty` | (`v`: `PropertyKey`) => `boolean` | Determines whether an object has a property with the specified name. |
 | `isPrototypeOf` | (`v`: `Object`) => `boolean` | Determines whether an object exists in another object's prototype chain. |

--- a/packages/framework/esm-framework/docs/interfaces/ConfigObject.md
+++ b/packages/framework/esm-framework/docs/interfaces/ConfigObject.md
@@ -17,6 +17,7 @@
 ### Properties
 
 - [Display conditions](ConfigObject.md#display conditions)
+- [Translation overrides](ConfigObject.md#translation overrides)
 - [constructor](ConfigObject.md#constructor)
 
 ### Methods
@@ -37,6 +38,16 @@
 #### Defined in
 
 [packages/framework/esm-config/src/types.ts:30](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L30)
+
+___
+
+### Translation overrides
+
+• `Optional` **Translation overrides**: `Record`<`string`, `Record`<`string`, `string`\>\>
+
+#### Defined in
+
+[packages/framework/esm-config/src/types.ts:31](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L31)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/DisplayConditionsConfigObject.md
+++ b/packages/framework/esm-framework/docs/interfaces/DisplayConditionsConfigObject.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L34)
+[packages/framework/esm-config/src/types.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L35)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfig.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfig.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L46)
+[packages/framework/esm-config/src/types.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L47)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L49)
+[packages/framework/esm-config/src/types.ts:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L50)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L48)
+[packages/framework/esm-config/src/types.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L49)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L47)
+[packages/framework/esm-config/src/types.ts:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L48)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfigObject.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfigObject.md
@@ -20,7 +20,7 @@ Additional extension IDs to assign to this slot, in addition to those `attach`ed
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:58](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L58)
+[packages/framework/esm-config/src/types.ts:59](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L59)
 
 ___
 
@@ -32,7 +32,7 @@ Overrides the default ordering of extensions.
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:62](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L62)
+[packages/framework/esm-config/src/types.ts:63](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L63)
 
 ___
 
@@ -44,4 +44,4 @@ Extension IDs which were `attach`ed to the slot but which should not be assigned
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:60](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L60)
+[packages/framework/esm-config/src/types.ts:61](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L61)

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -40,7 +40,6 @@
     "dexie": "^3.0.3",
     "i18next": "^19.6.0",
     "i18next-browser-languagedetector": "^4.3.1",
-    "i18next-http-backend": "^1.0.21",
     "i18next-icu": "^1.4.2",
     "import-map-overrides": "^3.0.0",
     "lodash-es": "4.17.21",

--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -1,20 +1,14 @@
 import * as i18next from "i18next";
 import ICU from "i18next-icu";
-import HttpApi from "i18next-http-backend";
 import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
+import merge from "lodash-es/merge";
+import { getConfigInternal } from "@openmrs/esm-framework/src/internal";
 import { slugify } from "./load-modules";
-
 declare global {
   interface Window {
     i18next: i18next.i18n;
   }
-}
-
-function decodeHtmlEntity(html: string) {
-  const textArea = document.createElement("textarea");
-  textArea.innerHTML = html;
-  return textArea.value;
 }
 
 export function setupI18n() {
@@ -34,36 +28,49 @@ export function setupI18n() {
 
   return window.i18next
     .use(LanguageDetector)
-    .use(HttpApi)
+    .use({
+      type: "backend",
+      init() {},
+      read(language, namespace, callback) {
+        if (namespace === "translation") {
+          callback(Error("can't handle translation namespace"), null);
+        } else {
+          const app: any = window[slugify(namespace)];
+
+          if (app) {
+            if ("get" in app) {
+              app
+                .get("./start")
+                .then((start) => {
+                  Promise.all([
+                    getImportPromise(start(), namespace, language),
+                    getConfigInternal(namespace),
+                  ]).then(([json, config]) => {
+                    let translations = json ?? {};
+
+                    if (config && "Translation overrides" in config) {
+                      const overrides = config["Translation overrides"];
+                      if (language in overrides) {
+                        translations = merge(translations, overrides[language]);
+                      }
+                    }
+
+                    callback(null, translations);
+                  });
+                })
+                .catch((err: Error) => {
+                  callback(err, null);
+                });
+            }
+          }
+
+          callback(Error(`could not load app for ${namespace}`), null);
+        }
+      },
+    } as i18next.BackendModule)
     .use(initReactI18next)
     .use(ICU)
     .init({
-      backend: {
-        parse: (data) => data,
-        loadPath: "{{lng}}|{{ns}}",
-        async request(options, url, payload, callback) {
-          const [language, namespace] = url.split("|");
-
-          if (namespace === "translation") {
-            callback(null, { status: 404, data: null });
-          } else {
-            const app: any = window[slugify(decodeHtmlEntity(namespace))];
-
-            if (app) {
-              if ("init" in app && "get" in app) {
-                app.init(__webpack_share_scopes__.default);
-                const start = await app.get("./start");
-                const module = start();
-
-                getImportPromise(module, namespace, language).then(
-                  (json) => callback(null, { status: 200, data: json }),
-                  (err) => callback(err, { status: 404, data: null })
-                );
-              }
-            }
-          }
-        },
-      },
       detection: {
         order: ["querystring", "htmlTag", "localStorage", "navigator"],
         lookupQuerystring: "lang",
@@ -72,7 +79,13 @@ export function setupI18n() {
     });
 }
 
-function getImportPromise(module, namespace, language) {
+function getImportPromise(
+  module: {
+    importTranslation: (language: string) => Promise<Record<string, string>>;
+  },
+  namespace: string,
+  language: string
+) {
   if (typeof module.importTranslation !== "function") {
     throw Error(
       `Module ${namespace} does not export an importTranslation function`

--- a/yarn.lock
+++ b/yarn.lock
@@ -3452,7 +3452,6 @@ __metadata:
     dexie: ^3.0.3
     i18next: ^19.6.0
     i18next-browser-languagedetector: ^4.3.1
-    i18next-http-backend: ^1.0.21
     i18next-icu: ^1.4.2
     import-map-overrides: ^3.0.0
     lodash-es: 4.17.21
@@ -7283,15 +7282,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-fetch@npm:3.1.5":
-  version: 3.1.5
-  resolution: "cross-fetch@npm:3.1.5"
-  dependencies:
-    node-fetch: 2.6.7
-  checksum: f6b8c6ee3ef993ace6277fd789c71b6acf1b504fd5f5c7128df4ef2f125a429e29cd62dc8c127523f04a5f2fa4771ed80e3f3d9695617f441425045f505cf3bb
-  languageName: node
-  linkType: hard
-
 "cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
@@ -10604,15 +10594,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"i18next-http-backend@npm:^1.0.21":
-  version: 1.4.1
-  resolution: "i18next-http-backend@npm:1.4.1"
-  dependencies:
-    cross-fetch: 3.1.5
-  checksum: 1ed4c68c458cc5e7c60af3b641223b9f1b49b6e7ded0fb908cf034ddf62de401db9bb8bb0f6be0634c53ceeee0fec7e03e7171b0dea2cbebca5bbcee6da46e2f
-  languageName: node
-  linkType: hard
-
 "i18next-icu@npm:^1.4.2":
   version: 1.4.2
   resolution: "i18next-icu@npm:1.4.2"
@@ -13290,7 +13271,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-fetch@npm:2.6.7, node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
+"node-fetch@npm:^2.6.1, node-fetch@npm:^2.6.7":
   version: 2.6.7
   resolution: "node-fetch@npm:2.6.7"
   dependencies:


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Adds the ability to override translations in module configuration by providing different translations. Useful for cases where an implementation wants to use slightly different terminology.

E.g.,

```json
{
  "@openmrs/esm-patient-chart": {
    "Translation overrides": {
      "en": {
        "patient": "Client"
      }
    }
  }
}
```

A couple of notes:
1. The provided language key ("en") must exactly match the translation file, i.e., "en-GB" will not override translations where the translations are only provided in an "en.json" file, but would override those in "en-GB.json".
2. The provided translation key must match the key to be overridden.

Additionally, this drops the use of the i18next-http-backend plugin in favour of a custom i18next plugin. We were already implementing all the logic in a custom way, so it wasn't necessary and should actually make translation loading marginally more efficient.

It also fixes a couple of edge cases where translations weren't being loaded properly.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
