### PR TITLE
(fix) define behavior for userHasAccess when user or privilege aren't set

### DIFF
--- a/packages/framework/esm-api/src/shared-api-objects/current-user.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/current-user.ts
@@ -196,6 +196,16 @@ export function userHasAccess(
   requiredPrivilege: string | string[],
   user: { privileges: Array<Privilege>; roles: Array<Role> }
 ) {
+  if (user === undefined) {
+    // if the user hasn't been loaded, then return false iff there is a required privilege
+    return Boolean(requiredPrivilege);
+  }
+
+  if (!Boolean(requiredPrivilege)) {
+    // if user exists but no requiredPrivilege is defined
+    return true;
+  }
+
   return userHasPrivilege(requiredPrivilege, user) || isSuperUser(user);
 }
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -890,7 +890,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:206](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L206)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:212](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L212)
 
 ___
 
@@ -904,7 +904,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:224](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L224)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:230](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L230)
 
 ___
 
@@ -1169,7 +1169,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:233](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L233)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:239](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L239)
 
 ___
 


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Since it's possible (but discouraged) to pass `undefined` to the `userHasAccess` arguments, and actually happens, I figured we should have defined behavior for it.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
