### PR TITLE
(fix) eliminate some console error messages for loading translations

### DIFF
--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -34,6 +34,8 @@ export function setupI18n() {
       read(language, namespace, callback) {
         if (namespace === "translation") {
           callback(Error("can't handle translation namespace"), null);
+        } else if (namespace === undefined || language === undefined) {
+          callback(Error(), null);
         } else {
           const app: any = window[slugify(namespace)];
 
@@ -45,18 +47,25 @@ export function setupI18n() {
                   Promise.all([
                     getImportPromise(start(), namespace, language),
                     getConfigInternal(namespace),
-                  ]).then(([json, config]) => {
-                    let translations = json ?? {};
+                  ])
+                    .then(([json, config]) => {
+                      let translations = json ?? {};
 
-                    if (config && "Translation overrides" in config) {
-                      const overrides = config["Translation overrides"];
-                      if (language in overrides) {
-                        translations = merge(translations, overrides[language]);
+                      if (config && "Translation overrides" in config) {
+                        const overrides = config["Translation overrides"];
+                        if (language in overrides) {
+                          translations = merge(
+                            translations,
+                            overrides[language]
+                          );
+                        }
                       }
-                    }
 
-                    callback(null, translations);
-                  });
+                      callback(null, translations);
+                    })
+                    .catch((err: Error) => {
+                      callback(err, null);
+                    });
                 })
                 .catch((err: Error) => {
                   callback(err, null);


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
In the current iteration of the translation loading code, there are some console error messages that are just the result of how i18next and our loading mechanism works. This PR aims to eliminate those messages by defining the correct behaviour for the case where they occur.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
