### PR TITLE
(fix) properly load importmap from backend when using develop command

### DIFF
--- a/packages/tooling/openmrs/src/commands/develop.ts
+++ b/packages/tooling/openmrs/src/commands/develop.ts
@@ -50,9 +50,13 @@ export function runDevelop(args: DevelopArgs) {
   `
     )
     .replace(/href="\/openmrs\/spa/g, `href="${spaPath}`)
-    .replace(/src="\/openmrs\/spa/g, `src="${spaPath}`);
+    .replace(/src="\/openmrs\/spa/g, `src="${spaPath}`)
+    .replace(
+      /https:\/\/dev3.openmrs.org\/openmrs\/spa\/importmap\.json/g,
+      `http://${host}:${port}${spaPath}/importmap.json`
+    );
 
-  const pageUrl = `http://${host}:${port}${spaPath}/`;
+  const pageUrl = `http://${host}:${port}${spaPath}`;
 
   // Set up routes. Note that different middlewares have different rules
   // about route precedence.
@@ -70,13 +74,11 @@ export function runDevelop(args: DevelopArgs) {
   );
 
   // Route for custom `importmap.json` goes above static assets
-  app.get(`${spaPath}/importmap.json`, (_, res) => {
-    if (importmap.type === "inline") {
+  if (importmap.type === "inline") {
+    app.get(`${spaPath}/importmap.json`, (_, res) => {
       res.contentType("application/json").send(importmap.value);
-    } else {
-      res.redirect(importmap.value);
-    }
-  });
+    });
+  }
 
   // Route for custom `index.html` goes above static assets
   app.get(indexHtmlPathMatcher, (_, res) =>

--- a/packages/tooling/openmrs/src/utils/importmap.ts
+++ b/packages/tooling/openmrs/src/utils/importmap.ts
@@ -15,9 +15,7 @@ async function readImportmap(path: string, backend?: string, spaPath?: string) {
   } else if (path === "importmap.json") {
     if (backend && spaPath) {
       try {
-        return await fetchRemoteImportmap(
-          `${backend}/${spaPath}/importmap.json`
-        );
+        return await fetchRemoteImportmap(`${backend}${spaPath}importmap.json`);
       } catch {}
     }
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This should fix the CORS errors when running `openmrs develop` (the command behind `yarn start`).

TBH, I'm not exactly sure what bit is serving the importmap, but it's correctly served from the same end-point as the app shell, so it should bypass the CORS errors.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
