### PR TITLE
(fix): make app shell dependencies more self-contained

### DIFF
--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -13,7 +13,7 @@
     "analyze": "webpack --mode=production --env analyze=true",
     "watch": "webpack serve --mode development",
     "lint": "eslint src --ext ts,tsx",
-    "version": "yarn add @openmrs/esm-framework@$npm_package_version --exact"
+    "version": "yarn add @openmrs/esm-framework@$npm_package_version --exact @openmrs/esm-styleguide@$npm_package_version --exact"
   },
   "keywords": [
     "openmrs",
@@ -36,6 +36,7 @@
   "dependencies": {
     "@carbon/react": "^1.12.0",
     "@openmrs/esm-framework": "4.0.2",
+    "@openmrs/esm-styleguide": "4.0.2",
     "dayjs": "^1.10.4",
     "dexie": "^3.0.3",
     "i18next": "^19.6.0",
@@ -56,12 +57,9 @@
     "workbox-window": "^6.1.5"
   },
   "devDependencies": {
-    "@openmrs/esm-devtools-app": "^4.0.2",
-    "@openmrs/esm-implementer-tools-app": "^4.0.2",
-    "@openmrs/esm-login-app": "^4.0.2",
-    "@openmrs/esm-offline-tools-app": "^4.0.2",
-    "@openmrs/esm-primary-navigation-app": "^4.0.2",
+    "cross-env": "^7.0.3",
     "esbuild-loader": "^2.20.0",
+    "webpack": "^5.75.0",
     "webpack-pwa-manifest": "^4.3.0",
     "workbox-webpack-plugin": "^6.1.2"
   }

--- a/packages/shell/esm-app-shell/src/declarations.d.ts
+++ b/packages/shell/esm-app-shell/src/declarations.d.ts
@@ -1,0 +1,9 @@
+declare module "*.css";
+declare module "*.scss";
+declare const __webpack_share_scopes__: Record<
+  string,
+  Record<
+    string,
+    { loaded?: 1; get: () => Promise<unknown>; from: string; eager: boolean }
+  >
+>;

--- a/packages/shell/esm-app-shell/src/declarations.d.tsx
+++ b/packages/shell/esm-app-shell/src/declarations.d.tsx
@@ -1,3 +1,0 @@
-declare module "*.css";
-declare module "*.scss";
-declare const __webpack_share_scopes__;

--- a/packages/shell/esm-app-shell/src/helpers.ts
+++ b/packages/shell/esm-app-shell/src/helpers.ts
@@ -1,4 +1,4 @@
-import { getLoggedInUser, userHasAccess } from "@openmrs/esm-api";
+import { getLoggedInUser, userHasAccess } from "@openmrs/esm-framework";
 
 const emptyLifecycle = {
   bootstrap() {

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -226,7 +226,7 @@ module.exports = (env, argv = {}) => {
         "process.env.NODE_ENV": JSON.stringify(mode),
       }),
       new BundleAnalyzerPlugin({
-        analyzerMode: env && env.analyze ? "static" : "disabled",
+        analyzerMode: env?.analyze ? "static" : "disabled",
       }),
       openmrsOffline &&
         new InjectManifest({

--- a/yarn.lock
+++ b/yarn.lock
@@ -3506,12 +3506,9 @@ __metadata:
   resolution: "@openmrs/esm-app-shell@workspace:packages/shell/esm-app-shell"
   dependencies:
     "@carbon/react": ^1.12.0
-    "@openmrs/esm-devtools-app": ^4.0.2
     "@openmrs/esm-framework": 4.0.2
-    "@openmrs/esm-implementer-tools-app": ^4.0.2
-    "@openmrs/esm-login-app": ^4.0.2
-    "@openmrs/esm-offline-tools-app": ^4.0.2
-    "@openmrs/esm-primary-navigation-app": ^4.0.2
+    "@openmrs/esm-styleguide": 4.0.2
+    cross-env: ^7.0.3
     dayjs: ^1.10.4
     dexie: ^3.0.3
     esbuild-loader: ^2.20.0
@@ -3527,6 +3524,7 @@ __metadata:
     rxjs: ^6.5.3
     single-spa: ^5.9.2
     systemjs: ^6.8.3
+    webpack: ^5.75.0
     webpack-pwa-manifest: ^4.3.0
     workbox-core: ^6.1.5
     workbox-routing: ^6.1.5
@@ -3615,7 +3613,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-devtools-app@^4.0.2, @openmrs/esm-devtools-app@workspace:packages/apps/esm-devtools-app":
+"@openmrs/esm-devtools-app@workspace:packages/apps/esm-devtools-app":
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-devtools-app@workspace:packages/apps/esm-devtools-app"
   dependencies:
@@ -3691,7 +3689,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-implementer-tools-app@^4.0.2, @openmrs/esm-implementer-tools-app@workspace:packages/apps/esm-implementer-tools-app":
+"@openmrs/esm-implementer-tools-app@workspace:packages/apps/esm-implementer-tools-app":
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-implementer-tools-app@workspace:packages/apps/esm-implementer-tools-app"
   dependencies:
@@ -3715,7 +3713,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-login-app@^4.0.2, @openmrs/esm-login-app@workspace:packages/apps/esm-login-app":
+"@openmrs/esm-login-app@workspace:packages/apps/esm-login-app":
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-login-app@workspace:packages/apps/esm-login-app"
   dependencies:
@@ -3740,7 +3738,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-offline-tools-app@^4.0.2, @openmrs/esm-offline-tools-app@workspace:packages/apps/esm-offline-tools-app":
+"@openmrs/esm-offline-tools-app@workspace:packages/apps/esm-offline-tools-app":
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-offline-tools-app@workspace:packages/apps/esm-offline-tools-app"
   dependencies:
@@ -3787,7 +3785,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-primary-navigation-app@^4.0.2, @openmrs/esm-primary-navigation-app@workspace:packages/apps/esm-primary-navigation-app":
+"@openmrs/esm-primary-navigation-app@workspace:packages/apps/esm-primary-navigation-app":
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-primary-navigation-app@workspace:packages/apps/esm-primary-navigation-app"
   dependencies:
@@ -3855,7 +3853,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@openmrs/esm-styleguide@^4.0.2, @openmrs/esm-styleguide@workspace:packages/framework/esm-styleguide":
+"@openmrs/esm-styleguide@4.0.2, @openmrs/esm-styleguide@^4.0.2, @openmrs/esm-styleguide@workspace:packages/framework/esm-styleguide":
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-styleguide@workspace:packages/framework/esm-styleguide"
   dependencies:
@@ -7483,6 +7481,18 @@ __metadata:
     cross-env: src/bin/cross-env.js
     cross-env-shell: src/bin/cross-env-shell.js
   checksum: dcfb07e279ca83abfe2205199a38d719bd9e1ba1dd4eed0878b12bb9b45132df0e7aea4a2fcf310b6845d232d2991488fafb30059261bb4c822fd12f71fe5e28
+  languageName: node
+  linkType: hard
+
+"cross-env@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "cross-env@npm:7.0.3"
+  dependencies:
+    cross-spawn: ^7.0.1
+  bin:
+    cross-env: src/bin/cross-env.js
+    cross-env-shell: src/bin/cross-env-shell.js
+  checksum: 26f2f3ea2ab32617f57effb70d329c2070d2f5630adc800985d8b30b56e8bf7f5f439dd3a0358b79cee6f930afc23cf8e23515f17ccfb30092c6b62c6b630a79
   languageName: node
   linkType: hard
 
@@ -19675,6 +19685,43 @@ __metadata:
   bin:
     webpack: bin/webpack.js
   checksum: 320c41369a75051b19e18c63f408b3dcc481852e992f83d311771c5ec0f05f2946385e8ebef62030cf3587f0a3d2f12779ffdb191569a966847289ba7313f946
+  languageName: node
+  linkType: hard
+
+"webpack@npm:^5.75.0":
+  version: 5.75.0
+  resolution: "webpack@npm:5.75.0"
+  dependencies:
+    "@types/eslint-scope": ^3.7.3
+    "@types/estree": ^0.0.51
+    "@webassemblyjs/ast": 1.11.1
+    "@webassemblyjs/wasm-edit": 1.11.1
+    "@webassemblyjs/wasm-parser": 1.11.1
+    acorn: ^8.7.1
+    acorn-import-assertions: ^1.7.6
+    browserslist: ^4.14.5
+    chrome-trace-event: ^1.0.2
+    enhanced-resolve: ^5.10.0
+    es-module-lexer: ^0.9.0
+    eslint-scope: 5.1.1
+    events: ^3.2.0
+    glob-to-regexp: ^0.4.1
+    graceful-fs: ^4.2.9
+    json-parse-even-better-errors: ^2.3.1
+    loader-runner: ^4.2.0
+    mime-types: ^2.1.27
+    neo-async: ^2.6.2
+    schema-utils: ^3.1.0
+    tapable: ^2.1.1
+    terser-webpack-plugin: ^5.1.3
+    watchpack: ^2.4.0
+    webpack-sources: ^3.2.3
+  peerDependenciesMeta:
+    webpack-cli:
+      optional: true
+  bin:
+    webpack: bin/webpack.js
+  checksum: 2bcc5f3c195f375944e8af2f00bf2feea39cb9fda5f763b0d1b00077f1c51783db25c94d3fae96a07dead9fa085e6ae7474417e5ab31719c9776ea5969ceb83a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Really, this is about making the app shell dependencies more explicit. Basically, we should be importing things from esm-framework rather than via it's component packages, except the CSS from esm-styleguide which doesn't appear to be directly exported...

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
