### PR TITLE
O3-1565: Locale switcher sets backend locale

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.component.tsx
@@ -2,19 +2,24 @@ import React, { useEffect, useState } from "react";
 import styles from "./change-locale.scss";
 import { Select, SelectItem } from "@carbon/react";
 import { ExtensionSlot, LoggedInUser } from "@openmrs/esm-framework";
-import { PostUserProperties } from "./change-locale.resource";
+import {
+  PostSessionLocale,
+  PostUserProperties,
+} from "./change-locale.resource";
 import { useTranslation } from "react-i18next";
 
 export interface ChangeLocaleProps {
   allowedLocales: Array<string>;
   user: LoggedInUser;
   postUserProperties: PostUserProperties;
+  postSessionLocale: PostSessionLocale;
 }
 
 const ChangeLocale: React.FC<ChangeLocaleProps> = ({
   allowedLocales,
   user,
   postUserProperties,
+  postSessionLocale,
 }) => {
   const { t } = useTranslation();
   const [userProps, setUserProps] = useState(user.userProperties);
@@ -26,6 +31,7 @@ const ChangeLocale: React.FC<ChangeLocaleProps> = ({
     if (user.userProperties.defaultLocale !== userProps.defaultLocale) {
       const ac = new AbortController();
       postUserProperties(user.uuid, userProps, ac);
+      postSessionLocale(userProps.defaultLocale, ac);
       return () => ac.abort();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.component.tsx
@@ -35,7 +35,7 @@ const ChangeLocale: React.FC<ChangeLocaleProps> = ({
       return () => ac.abort();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [userProps]);
+  }, [userProps, postUserProperties, postSessionLocale]);
 
   return (
     <div className={`omrs-margin-12 ${styles.switcherContainer}`}>

--- a/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.resource.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.resource.tsx
@@ -32,6 +32,23 @@ export async function postUserPropertiesOnline(
   }
 }
 
+export type PostSessionLocale = (
+  locale: string,
+  abortController: AbortController
+) => Promise<any>;
+
+export async function postSessionLocaleOnline(
+  locale: string,
+  abortController: AbortController
+): Promise<any> {
+  await openmrsFetch(`/ws/rest/v1/session`, {
+    method: "POST",
+    body: { locale },
+    headers: { "Content-Type": "application/json" },
+    signal: abortController.signal,
+  });
+}
+
 export function postUserPropertiesOffline(
   userUuid: string,
   userProperties: any

--- a/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/choose-locale/change-locale.test.tsx
@@ -12,14 +12,18 @@ const user: any = {
 
 describe(`<ChangeLocale />`, () => {
   let postUserPropertiesMock = jest.fn(() => Promise.resolve({}));
+  let postSessionLocaleMock = jest.fn(() => Promise.resolve({}));
 
   beforeEach(() => {
     postUserPropertiesMock = jest.fn(() => Promise.resolve({}));
+    postSessionLocaleMock = jest.fn(() => Promise.resolve({}));
+
     render(
       <ChangeLocale
         allowedLocales={allowedLocales}
         user={user}
         postUserProperties={postUserPropertiesMock}
+        postSessionLocale={postSessionLocaleMock}
       />
     );
   });
@@ -32,12 +36,16 @@ describe(`<ChangeLocale />`, () => {
     fireEvent.change(screen.getByLabelText(/Select locale/i), {
       target: { value: "en" },
     });
-    await waitFor(() =>
+    await waitFor(() => {
       expect(postUserPropertiesMock).toHaveBeenCalledWith(
         user.uuid,
         { defaultLocale: "en" },
         expect.anything()
-      )
-    );
+      );
+      expect(postSessionLocaleMock).toHaveBeenCalledWith(
+        "en",
+        expect.anything()
+      );
+    });
   });
 });

--- a/packages/apps/esm-primary-navigation-app/src/index.ts
+++ b/packages/apps/esm-primary-navigation-app/src/index.ts
@@ -7,6 +7,7 @@ import {
 import {
   postUserPropertiesOnline,
   postUserPropertiesOffline,
+  postSessionLocaleOnline,
 } from "./components/choose-locale/change-locale.resource";
 import { configSchema } from "./config-schema";
 import { moduleName, userPropertyChange } from "./constants";
@@ -87,9 +88,11 @@ function setupOpenMRS() {
         ),
         online: {
           postUserProperties: postUserPropertiesOnline,
+          postSessionLocale: postSessionLocaleOnline,
         },
         offline: {
           postUserProperties: postUserPropertiesOffline,
+          postSessionLocale: () => Promise.resolve({}),
         },
       },
       {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
When changing locale, the locale is updated for both the user's properties and the current session.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://issues.openmrs.org/browse/O3-1565

## Other
<!-- Anything not covered above -->
