### PR TITLE
(feat) Delay display of menu item tooltips by 500ms

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/implementer-tools.button.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/implementer-tools.button.tsx
@@ -16,6 +16,7 @@ const ImplementerToolsButton: React.FC = () => {
         aria-label={t("implementerTools", "Implementer Tools")}
         aria-labelledby="Implementer Tools"
         className={styles.toolStyles}
+        enterDelayMs={500}
         name="ImplementerToolsIcon"
         onClick={togglePopup}
       >

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -66,8 +66,8 @@ const Navbar: React.FC<NavbarProps> = ({
     [navMenuItems.length, layout]
   );
 
-  const render = useCallback(() => {
-    return (
+  const render = useCallback(
+    () => (
       <>
         <OfflineBanner />
         <Header className={styles.topNavHeader} aria-label="OpenMRS">
@@ -112,6 +112,7 @@ const Navbar: React.FC<NavbarProps> = ({
                   ? styles.headerGlobalBarButton
                   : styles.activePanel
               }`}
+              enterDelayMs={500}
               name="Users"
               isActive={isActivePanel("userMenu")}
               onClick={(event) => {
@@ -127,14 +128,15 @@ const Navbar: React.FC<NavbarProps> = ({
             </HeaderGlobalAction>
             <HeaderGlobalAction
               aria-label="App Menu"
-              tooltipAlignment="end"
+              aria-labelledby="App Menu"
+              enterDelayMs={500}
               isActive={isActivePanel("appMenu")}
+              tooltipAlignment="end"
               className={`${
                 isActivePanel("appMenu")
                   ? styles.headerGlobalBarButton
                   : styles.activePanel
               }`}
-              aria-labelledby="App Menu"
               onClick={(event) => {
                 togglePanel("appMenu");
                 event.stopPropagation();
@@ -170,18 +172,19 @@ const Navbar: React.FC<NavbarProps> = ({
           />
         </Header>
       </>
-    );
-  }, [
-    showHamburger,
-    session,
-    user,
-    allowedLocales,
-    isActivePanel,
-    layout,
-    hidePanel,
-    togglePanel,
-    onLogout,
-  ]);
+    ),
+    [
+      showHamburger,
+      session,
+      user,
+      allowedLocales,
+      isActivePanel,
+      layout,
+      hidePanel,
+      togglePanel,
+      onLogout,
+    ]
+  );
 
   return <div>{session && <HeaderContainer render={render} />}</div>;
 };


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Ups the `HeaderGlobalAction` component's `enterDelayMs` prop value from 100ms to 500ms. This delay is sufficient for the tooltips not to overlap when a user hovers over menu items in the navigation bar.

## Related Issue

https://issues.openmrs.org/browse/O3-1585

Related PR: https://github.com/openmrs/openmrs-esm-patient-management/pull/466
