### PR TITLE
(feat) Datatable style overrides

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1181,7 +1181,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:241](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L241)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:239](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L239)
 
 ___
 

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -147,6 +147,32 @@
   color: $text-02;
 }
 
+/* Alternate background and border colors for zebra styled table rows */
+
+// Datatables without expansion
+.cds--data-table--zebra tbody tr:not(.cds--parent-row):nth-child(odd) td {
+  background-color: $ui-02;
+  border-bottom: 1px solid $ui-03;
+}
+
+.cds--data-table--zebra tbody tr:not(.cds--parent-row):nth-child(2n) td {
+  background-color: $ui-01;
+  border-bottom: 1px solid $ui-03;
+  border-top: 1px solid $ui-03;
+}
+
+// Datatables with expansion
+.cds--data-table--zebra tbody tr[data-parent-row]:nth-child(4n + 1) td {
+  background-color: $ui-02;
+  border-bottom: 1px solid $ui-03;
+  border-top: 1px solid $ui-03;
+}
+
+.cds--data-table--zebra tbody tr[data-parent-row]:nth-child(4n + 3) td {
+  background-color: $ui-01;
+  border-bottom: 1px solid $ui-03;
+}
+
 /* Misc */
 .cds--btn--primary,
 .cds--btn--primary:active,


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Applies styling overrides to the Carbon `DataTable` component to get it in line with our [designs](https://zpl.io/Am0lJkP). Specifically, these relate to table row `background-color` and `border` properties. See the screenshots below for comparison.

## Screenshots

> Before (DataTable with expansion)

<img width="1155" alt="Screenshot 2022-11-14 at 14 41 18" src="https://user-images.githubusercontent.com/8509731/201652182-0ada80d1-30a0-46c2-88e3-6550962bc654.png">

> After 

<img width="1147" alt="Screenshot 2022-11-14 at 14 39 33" src="https://user-images.githubusercontent.com/8509731/201652311-19c49e51-923d-4063-ab0e-a571047683fa.png">


> Before (DataTable without expansion)
<img width="1150" alt="Screenshot 2022-11-14 at 14 41 08" src="https://user-images.githubusercontent.com/8509731/201652459-86587e9e-39b7-4732-b07e-395030020c1c.png">

> After

<img width="1146" alt="Screenshot 2022-11-14 at 14 39 10" src="https://user-images.githubusercontent.com/8509731/201652490-31b0d9e7-1025-4c7c-b87b-0ebfff5e1dd5.png">
