### PR TITLE
03-1630: Fix bug preventing editing of boolean config properties

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/value-editor-field.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/value-editor-field.tsx
@@ -44,7 +44,7 @@ export function ValueEditorField({
       checked={value}
       hideLabel
       labelText=""
-      onChange={onChange}
+      onChange={(event, { checked, id }) => onChange(checked)}
     ></Checkbox>
   ) : valueType === Type.ConceptUuid ? (
     <ConceptSearchBox


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR fixes a bug where users cannot edit boolean config properties using the implementer tools panel. This regression occurred following the migration to Carbon v11. Specifically, this was due to [changes](http://localhost:7002/openmrs-esm-patient-vitals-app.js) to the Checkbox component's `onChange` handler signature. 

## Screenshots

![Kapture 2022-11-18 at 12 24 17](https://user-images.githubusercontent.com/28008754/202673041-e243bd1f-47e9-42ee-b92f-7a2f26617356.gif)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
