### PR TITLE
(fix) The 3.x UI should never prompt the user for Basic auth

### DIFF
--- a/packages/framework/esm-api/src/openmrs-fetch.test.ts
+++ b/packages/framework/esm-api/src/openmrs-fetch.test.ts
@@ -55,7 +55,10 @@ describe("openmrsFetch", () => {
     window.fetch.mockReturnValue(new Promise(() => {}));
     openmrsFetch("/ws/rest/v1/session");
     expect(window.fetch).toHaveBeenCalledWith("/openmrs/ws/rest/v1/session", {
-      headers: { Accept: "application/json" },
+      headers: {
+        Accept: "application/json",
+        "Disable-WWW-Authenticate": "true",
+      },
     });
   });
 
@@ -68,7 +71,10 @@ describe("openmrsFetch", () => {
       body: requestBody,
     });
     expect(window.fetch).toHaveBeenCalledWith("/openmrs/ws/rest/v1/session", {
-      headers: { Accept: "application/json" },
+      headers: {
+        Accept: "application/json",
+        "Disable-WWW-Authenticate": "true",
+      },
       body: JSON.stringify(requestBody),
       method: "POST",
     });
@@ -84,7 +90,10 @@ describe("openmrsFetch", () => {
       },
     });
     expect(window.fetch).toHaveBeenCalledWith("/openmrs/ws/rest/v1/session", {
-      headers: { Accept: "application/xml" },
+      headers: {
+        Accept: "application/xml",
+        "Disable-WWW-Authenticate": "true",
+      },
     });
   });
 
@@ -98,7 +107,9 @@ describe("openmrsFetch", () => {
       },
     });
     expect(window.fetch).toHaveBeenCalledWith("/openmrs/ws/rest/v1/session", {
-      headers: {},
+      headers: {
+        "Disable-WWW-Authenticate": "true",
+      },
     });
   });
 

--- a/packages/framework/esm-api/src/openmrs-fetch.ts
+++ b/packages/framework/esm-api/src/openmrs-fetch.ts
@@ -122,6 +122,14 @@ export function openmrsFetch<T = any>(
     delete fetchInit.headers.Accept;
   }
 
+  /* This tells the OpenMRS REST API not to return a WWW-Authenticate
+   * header. Returning that header is useful when using the API, but
+   * not from a UI.
+   */
+  if (typeof fetchInit.headers["Disable-WWW-Authenticate"] === "undefined") {
+    fetchInit.headers["Disable-WWW-Authenticate"] = "true";
+  }
+
   /* We capture the stacktrace before making the request, so that if an error occurs we can
    * log a full stacktrace that includes the code that made the request and handled the response
    * Otherwise, we could run into situations where the stacktrace doesn't even show which code

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1113,7 +1113,7 @@ To cancel the network request, simply call `subscription.unsubscribe();`
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:243](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L243)
+[packages/framework/esm-api/src/openmrs-fetch.ts:251](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L251)
 
 ___
 

--- a/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
+++ b/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
@@ -25,12 +25,12 @@
 - [message](OpenmrsFetchError.md#message)
 - [name](OpenmrsFetchError.md#name)
 - [stack](OpenmrsFetchError.md#stack)
+- [prepareStackTrace](OpenmrsFetchError.md#preparestacktrace)
 - [stackTraceLimit](OpenmrsFetchError.md#stacktracelimit)
 
 ### Methods
 
 - [captureStackTrace](OpenmrsFetchError.md#capturestacktrace)
-- [prepareStackTrace](OpenmrsFetchError.md#preparestacktrace)
 
 ## API Constructors
 
@@ -53,7 +53,7 @@ Error.constructor
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:281](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L281)
+[packages/framework/esm-api/src/openmrs-fetch.ts:289](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L289)
 
 ## API Properties
 
@@ -63,7 +63,7 @@ Error.constructor
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:294](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L294)
+[packages/framework/esm-api/src/openmrs-fetch.ts:302](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L302)
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:295](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L295)
+[packages/framework/esm-api/src/openmrs-fetch.ts:303](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L303)
 
 ___
 
@@ -135,6 +135,39 @@ node_modules/typescript/lib/lib.es5.d.ts:1024
 
 ___
 
+### prepareStackTrace
+
+▪ `Static` `Optional` **prepareStackTrace**: (`err`: `Error`, `stackTraces`: `CallSite`[]) => `any`
+
+#### Type declaration
+
+▸ (`err`, `stackTraces`): `any`
+
+Optional override for formatting stack traces
+
+**`see`** https://v8.dev/docs/stack-trace-api#customizing-stack-traces
+
+##### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `err` | `Error` |
+| `stackTraces` | `CallSite`[] |
+
+##### Returns
+
+`any`
+
+#### Inherited from
+
+Error.prepareStackTrace
+
+#### Defined in
+
+packages/framework/esm-framework/node_modules/@types/node/ts4.8/globals.d.ts:11
+
+___
+
 ### stackTraceLimit
 
 ▪ `Static` **stackTraceLimit**: `number`
@@ -145,7 +178,7 @@ Error.stackTraceLimit
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:142
+packages/framework/esm-framework/node_modules/@types/node/ts4.8/globals.d.ts:13
 
 ## Methods
 
@@ -159,7 +192,7 @@ Create .stack property on a target object
 
 | Name | Type |
 | :------ | :------ |
-| `targetObject` | `Object` |
+| `targetObject` | `object` |
 | `constructorOpt?` | `Function` |
 
 #### Returns
@@ -172,33 +205,4 @@ Error.captureStackTrace
 
 #### Defined in
 
-node_modules/@types/node/globals.d.ts:133
-
-___
-
-### prepareStackTrace
-
-▸ `Static` `Optional` **prepareStackTrace**(`err`, `stackTraces`): `any`
-
-Optional override for formatting stack traces
-
-**`see`** https://github.com/v8/v8/wiki/Stack%20Trace%20API#customizing-stack-traces
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `err` | `Error` |
-| `stackTraces` | `CallSite`[] |
-
-#### Returns
-
-`any`
-
-#### Inherited from
-
-Error.prepareStackTrace
-
-#### Defined in
-
-node_modules/@types/node/globals.d.ts:140
+packages/framework/esm-framework/node_modules/@types/node/ts4.8/globals.d.ts:4


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This works around [this check](https://github.com/openmrs/openmrs-module-webservices.rest/blob/2227f456686b8acf5005cad952bb5e0a8cae9f74/omod-common/src/main/java/org/openmrs/module/webservices/rest/web/v1_0/controller/BaseRestController.java#L68), which should remove the last instance of the Basic auth prompt that sometimes shows up...

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
