### PR TITLE
O3-1641: Extend `getVisitsForPatient` request to fetch visit attribute types

### DIFF
--- a/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts
@@ -14,8 +14,9 @@ export const defaultVisitCustomRepresentation =
   "form:(uuid,name),location:ref," +
   "encounterType:ref,encounterProviders:(uuid,display," +
   "provider:(uuid,display))),patient:(uuid,uuid)," +
-  "visitType:(uuid,name,display),attributes:(uuid,display,value),location:(uuid,name,display),startDatetime," +
-  "stopDatetime)";
+  "visitType:(uuid,name,display)," +
+  "attributes:(uuid,display,attributeType:(name,datatypeClassname,uuid),value)," +
+  "location:(uuid,name,display),startDatetime,stopDatetime)";
 
 export function getVisitsForPatient(
   patientUuid: string,


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Changed the default custom representation to accommodate necessary visitAttribute properties in the visit response body.

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/O3-1641

## Other
<!-- Anything not covered above -->
