### PR TITLE
feat:(cli) Add the ability to generate a manifest of actually assembled versions

### DIFF
--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -54,7 +54,7 @@
     "webpack-dev-server": "^4.10.1",
     "webpack-pwa-manifest": "^4.3.0",
     "workbox-webpack-plugin": "^6.4.1",
-    "yargs": "16.0.3"
+    "yargs": "^17.6.2"
   },
   "devDependencies": {
     "@types/express": "^4.11.1",

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -60,7 +60,7 @@
     "@types/express": "^4.11.1",
     "@types/glob": "^7.1.1",
     "@types/inquirer": "^6.5.0",
-    "@types/node": "12.12.2",
+    "@types/node": "^18.11.11",
     "@types/pacote": "^11.1.5",
     "@types/react": "^18.0.9",
     "@types/rimraf": "^2.0.2",

--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import * as yargs from "yargs";
+import yargs from "yargs";
 import { fork } from "child_process";
 import { resolve } from "path";
 import {
@@ -281,37 +281,44 @@ yargs.command(
   "Assembles an import map incl. all required resources.",
   (argv) =>
     argv
-      .string("target")
-      .default("target", "dist")
-      .describe(
-        "target",
-        "The target directory where the gathered artifacts will be stored."
-      )
-      .string("registry")
-      .default("registry", "https://registry.npmjs.org/")
-      .describe("registry", "The NPM registry used for getting the packages.")
-      .string("config")
-      .default("config", "spa-build-config.json")
-      .describe("config", "Path to a SPA build config JSON.")
-      .boolean("fresh")
-      .describe(
-        "fresh",
-        "Determines if the output directory should be cleaned before the run."
-      )
-      .default("fresh", false)
-      .choices("mode", ["config", "survey"])
-      .default("mode", "survey")
-      .describe(
-        "mode",
-        "The source of the frontend modules to assemble. `config` uses a configuration file specified via `--config`. `survey` starts an interactive command-line survey."
-      ),
-  (args) =>
-    runCommand("runAssemble", {
-      ...args,
-      registry: trimEnd(args.registry, "/"),
-      config: resolve(process.cwd(), args.config),
-      target: resolve(process.cwd(), args.target),
-    })
+      .option("target", {
+        default: "dist",
+        description:
+          "The target directory where the gathered artifacts will be stored.",
+        type: "string",
+        coerce: (arg) => resolve(process.cwd(), arg),
+      })
+      .option("registry", {
+        default: "https://registry.npmjs.org/",
+        description: "The NPM registry used for getting the packages.",
+        type: "string",
+        coerce: (arg) => trimEnd(arg, "/"),
+      })
+      .option("config", {
+        default: "spa-build-config.json",
+        description: "Path to a SPA build config JSON.",
+        type: "string",
+        coerce: (arg) => resolve(process.cwd(), arg),
+      })
+      .option("fresh", {
+        default: false,
+        description:
+          "Determines if the output directory should be cleaned before the run.",
+        type: "boolean",
+      })
+      .option("manifest", {
+        default: false,
+        description: "Whether to output a manifest",
+        type: "boolean",
+      })
+      .option("mode", {
+        choices: ["config", "survey"],
+        default: "survey",
+        description:
+          "The source of the frontend modules to assemble. `config` uses a configuration file specified via `--config`. `survey` starts an interactive command-line survey.",
+        type: "string",
+      }),
+  (args) => runCommand("runAssemble", args)
 );
 
 yargs.command(

--- a/packages/tooling/openmrs/src/commands/assemble.ts
+++ b/packages/tooling/openmrs/src/commands/assemble.ts
@@ -1,18 +1,11 @@
-import {
-  readFileSync,
-  writeFileSync,
-  unlinkSync,
-  existsSync,
-  mkdirSync,
-  createReadStream,
-  copyFileSync,
-} from "fs";
+import { copyFile, mkdir, readFile, unlink, writeFile } from "fs/promises";
 import { resolve, dirname, basename } from "path";
 import { prompt, Question } from "inquirer";
 import rimraf from "rimraf";
 import axios from "axios";
 import pacote from "pacote";
 import { logInfo, untar } from "../utils";
+import { createReadStream, existsSync } from "fs";
 
 export interface AssembleArgs {
   target: string;
@@ -53,7 +46,7 @@ async function readConfig(
 
       return {
         baseDir: dirname(config),
-        ...JSON.parse(readFileSync(config, "utf8")),
+        ...JSON.parse(await readFile(config, "utf8")),
       };
     case "survey":
       logInfo(`Loading available frontend modules ...`);
@@ -126,13 +119,13 @@ async function downloadPackage(
     const source = resolve(baseDir, esmVersion.substr(5));
     const file = basename(source);
     const target = resolve(cacheDir, file);
-    copyFileSync(source, target);
+    await copyFile(source, target);
     return file;
   } else if (/^https?:\/\//.test(esmVersion)) {
     const response = await axios.get<Buffer>(esmVersion);
     const content = response.data;
     const file = esmName.replace("@", "").replace(/\//g, "-") + ".tgz";
-    writeFileSync(resolve(cacheDir, file), content);
+    await writeFile(resolve(cacheDir, file), content);
     return file;
   } else {
     const packageName = `${esmName}@${esmVersion}`;
@@ -146,22 +139,22 @@ async function downloadPackage(
       .replace(/^@/, "")
       .replace(/\//, "-");
 
-    mkdirSync(cacheDir, { recursive: true });
-    writeFileSync(resolve(cacheDir, filename), tarball);
+    await mkdir(cacheDir, { recursive: true });
+    await writeFile(resolve(cacheDir, filename), tarball);
 
     return filename;
   }
 }
 
 async function extractFiles(sourceFile: string, targetDir: string) {
-  mkdirSync(targetDir, { recursive: true });
+  await mkdir(targetDir, { recursive: true });
   const packageRoot = "package";
   const rs = createReadStream(sourceFile);
   const files = await untar(rs);
   const packageJson = JSON.parse(
     files[`${packageRoot}/package.json`].toString("utf8")
   );
-  const version = packageJson.version ?? "unknown";
+  const version = packageJson.version ?? "0.0.0";
   const entryModule =
     packageJson.browser ?? packageJson.module ?? packageJson.main;
   const fileName = basename(entryModule);
@@ -170,15 +163,15 @@ async function extractFiles(sourceFile: string, targetDir: string) {
   Object.keys(files)
     .filter((m) => m.startsWith(`${packageRoot}/${sourceDir}`))
     .filter((m) => !m.endsWith(".map"))
-    .forEach((m) => {
+    .forEach(async (m) => {
       const content = files[m];
       const fileName = m.replace(`${packageRoot}/${sourceDir}/`, "");
       const targetFile = resolve(targetDir, fileName);
-      mkdirSync(dirname(targetFile), { recursive: true });
-      writeFileSync(targetFile, content);
+      await mkdir(dirname(targetFile), { recursive: true });
+      await writeFile(targetFile, content);
     });
 
-  unlinkSync(sourceFile);
+  await unlink(sourceFile);
   return [fileName, version];
 }
 
@@ -200,7 +193,7 @@ export async function runAssemble(args: AssembleArgs) {
     await new Promise((resolve) => rimraf(args.target, resolve));
   }
 
-  mkdirSync(args.target, { recursive: true });
+  await mkdir(args.target, { recursive: true });
 
   await Promise.all(
     Object.keys(frontendModules).map(async (esmName) => {
@@ -222,17 +215,17 @@ export async function runAssemble(args: AssembleArgs) {
     })
   );
 
-  writeFileSync(
+  await writeFile(
     resolve(args.target, "importmap.json"),
     JSON.stringify(importmap, undefined, 2),
     "utf8"
   );
 
   if (args.manifest) {
-    writeFileSync(
+    await writeFile(
       resolve(args.target, "spa-module-versions.json"),
       JSON.stringify(versionManifest, undefined, 2),
-      "utf-8"
+      "utf8"
     );
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6883,7 +6883,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cliui@npm:^7.0.0, cliui@npm:^7.0.2":
+"cliui@npm:^7.0.2":
   version: 7.0.4
   resolution: "cliui@npm:7.0.4"
   dependencies:
@@ -9248,7 +9248,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"escalade@npm:^3.0.2, escalade@npm:^3.1.1":
+"escalade@npm:^3.1.1":
   version: 3.1.1
   resolution: "escalade@npm:3.1.1"
   checksum: a3e2a99f07acb74b3ad4989c48ca0c3140f69f923e56d0cba0526240ee470b91010f9d39001f2a4a313841d237ede70a729e92125191ba5d21e74b106800b133
@@ -14559,7 +14559,7 @@ __metadata:
     webpack-dev-server: ^4.10.1
     webpack-pwa-manifest: ^4.3.0
     workbox-webpack-plugin: ^6.4.1
-    yargs: 16.0.3
+    yargs: ^17.6.2
   bin:
     openmrs: ./dist/cli.js
   languageName: unknown
@@ -20225,7 +20225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"y18n@npm:^5.0.1, y18n@npm:^5.0.5":
+"y18n@npm:^5.0.5":
   version: 5.0.8
   resolution: "y18n@npm:5.0.8"
   checksum: 54f0fb95621ee60898a38c572c515659e51cc9d9f787fb109cef6fde4befbe1c4602dc999d30110feee37456ad0f1660fa2edcfde6a9a740f86a290999550d30
@@ -20260,32 +20260,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^20.0.0, yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.3":
+"yargs-parser@npm:^20.2.2, yargs-parser@npm:^20.2.3":
   version: 20.2.9
   resolution: "yargs-parser@npm:20.2.9"
   checksum: 8bb69015f2b0ff9e17b2c8e6bfe224ab463dd00ca211eece72a4cd8a906224d2703fb8a326d36fdd0e68701e201b2a60ed7cf81ce0fd9b3799f9fe7745977ae3
   languageName: node
   linkType: hard
 
-"yargs-parser@npm:^21.0.0":
+"yargs-parser@npm:^21.0.0, yargs-parser@npm:^21.1.1":
   version: 21.1.1
   resolution: "yargs-parser@npm:21.1.1"
   checksum: ed2d96a616a9e3e1cc7d204c62ecc61f7aaab633dcbfab2c6df50f7f87b393993fe6640d017759fe112d0cb1e0119f2b4150a87305cc873fd90831c6a58ccf1c
-  languageName: node
-  linkType: hard
-
-"yargs@npm:16.0.3":
-  version: 16.0.3
-  resolution: "yargs@npm:16.0.3"
-  dependencies:
-    cliui: ^7.0.0
-    escalade: ^3.0.2
-    get-caller-file: ^2.0.5
-    require-directory: ^2.1.1
-    string-width: ^4.2.0
-    y18n: ^5.0.1
-    yargs-parser: ^20.0.0
-  checksum: e59676cfc84ae64c59200d066b9c9a736ef8c54bac909ea56e3578332f54aff4da64ce9ce9e595e25529cb3f4063a1902adf3bc08313ae1bf808563c8c6e348a
   languageName: node
   linkType: hard
 
@@ -20316,6 +20301,21 @@ __metadata:
     y18n: ^5.0.5
     yargs-parser: ^21.0.0
   checksum: 604bdb4a6395a870540d2f3fea083c8e28441f12da8fd05b172b1e68480f00ed73d76be4a05fac19de9bf55ec7729b41e81cf555cccaed700aa192e4fff64872
+  languageName: node
+  linkType: hard
+
+"yargs@npm:^17.6.2":
+  version: 17.6.2
+  resolution: "yargs@npm:17.6.2"
+  dependencies:
+    cliui: ^8.0.1
+    escalade: ^3.1.1
+    get-caller-file: ^2.0.5
+    require-directory: ^2.1.1
+    string-width: ^4.2.3
+    y18n: ^5.0.5
+    yargs-parser: ^21.1.1
+  checksum: 47da1b0d854fa16d45a3ded57b716b013b2179022352a5f7467409da5a04a1eef5b3b3d97a2dfc13e8bbe5f2ffc0afe3bc6a4a72f8254e60f5a4bd7947138643
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4646,17 +4646,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/node@npm:12.12.2":
-  version: 12.12.2
-  resolution: "@types/node@npm:12.12.2"
-  checksum: 0758099b5312ce0a63542663d22bf9c9cf308d8c7e000bc9c59701585680e6a08cacbac289d4e059d5afcfea00a86f64a98b81bd78155213b3c1444f47794174
-  languageName: node
-  linkType: hard
-
 "@types/node@npm:16.9.1":
   version: 16.9.1
   resolution: "@types/node@npm:16.9.1"
   checksum: 41afcf183a22d59323a0199dd7e0f46591247f45fc08a4434edb26d56dc279ae4fdb80f37989ddd7a0f45e3857c4933e6e82057ede09c5a829f77e373e680375
+  languageName: node
+  linkType: hard
+
+"@types/node@npm:^18.11.11":
+  version: 18.11.11
+  resolution: "@types/node@npm:18.11.11"
+  checksum: c4b1176a8f1714a3ee3fc2a5e1d568b0cd50209000282db5c68154b3c975952928dbb834ef3a0ce55bd7b345ae29f2cbf4a34635a070294d135a24254231386a
   languageName: node
   linkType: hard
 
@@ -14531,7 +14531,7 @@ __metadata:
     "@types/express": ^4.11.1
     "@types/glob": ^7.1.1
     "@types/inquirer": ^6.5.0
-    "@types/node": 12.12.2
+    "@types/node": ^18.11.11
     "@types/pacote": ^11.1.5
     "@types/react": ^18.0.9
     "@types/rimraf": ^2.0.2


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
The idea here is to have, as part of the assembled frontend, a manifest file which declares all of there versions in the right format to be re-consumed by the assemble command. Basically, this allows the assemble command to be repeatably run.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
