### PR TITLE
feat:(extension) child function should be equivalent to wrap

### DIFF
--- a/packages/framework/esm-react-utils/src/Extension.tsx
+++ b/packages/framework/esm-react-utils/src/Extension.tsx
@@ -20,7 +20,7 @@ export type ExtensionProps = {
 } & Omit<React.HTMLAttributes<HTMLDivElement>, "children"> & {
     children?:
       | React.ReactNode
-      | ((extension: React.ReactNode) => React.ReactNode);
+      | ((slot: React.ReactNode, extension?: ExtensionData) => React.ReactNode);
   };
 
 /**
@@ -54,7 +54,7 @@ export const Extension: React.FC<ExtensionProps> = ({
       );
     }
     // we only warn when component mounts
-    // eslint-disable-next-line eslintreact-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   const ref = useCallback(
@@ -105,7 +105,7 @@ export const Extension: React.FC<ExtensionProps> = ({
 
     // we intentionally do not re-run this hook if state gets updated
     // state updates are handled in the next useEffect hook
-    // eslint-disable-next-line eslintreact-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     extension?.extensionSlotName,
     extension?.extensionId,
@@ -129,7 +129,7 @@ export const Extension: React.FC<ExtensionProps> = ({
     return () => {
       updatePromise.current = null;
     };
-  }, [parcel.current, state]);
+  }, [state]);
 
   // The extension is rendered into the `<div>`. The `<div>` has relative
   // positioning in order to allow the UI Editor to absolutely position
@@ -144,7 +144,7 @@ export const Extension: React.FC<ExtensionProps> = ({
   );
 
   if (typeof children == "function" && !React.isValidElement(children)) {
-    return <>{children(slot)}</>;
+    return <>{children(slot, extension)}</>;
   }
 
   return extension && wrap ? wrap(slot, extension) : slot;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This ensures that the child function for `<Extension />` is equivalent to `wrap()`, allowing us to replace `wrap` with this. Tbh, I'm not 100% certain we want to maintain the functionality this is used for, but the goal here is removing some warning messages.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
