### PR TITLE
O3-1594: Added the event listener to record the origin page for the patient chart

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useMemo, useState } from "react";
+import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   LoggedInUser,
   useLayoutType,
@@ -65,6 +65,43 @@ const Navbar: React.FC<NavbarProps> = ({
     () => !isDesktop(layout) && navMenuItems.length > 0,
     [navMenuItems.length, layout]
   );
+
+  // This part of code is present to record the origin page when navigating to the patient chart.
+  // This piece of code is not related to primary-navigation, but since primary-nagivation is present
+  // in all of the app, hence putting this code in here.
+  const handleRouteChange = useCallback(
+    (evt) => {
+      const prevUrl = evt?.detail?.oldUrl;
+      const newUrl = evt?.detail?.newUrl;
+
+      const patientChartURLRegex = /\/patient\/([a-zA-Z0-9\-]+)\/chart\/?/;
+
+      if (
+        !patientChartURLRegex.test(prevUrl) &&
+        patientChartURLRegex.test(newUrl)
+      ) {
+        const originPage = prevUrl.split(window.spaBase)?.[1];
+        window.localStorage.setItem("patient-chart-origin-page", originPage);
+      }
+    },
+    [origin]
+  );
+
+  useEffect(() => {
+    window.addEventListener(
+      "single-spa:before-routing-event",
+      handleRouteChange
+    );
+
+    return () => {
+      window.removeEventListener(
+        "single-spa:before-routing-event",
+        handleRouteChange
+      );
+    };
+  }, [handleRouteChange]);
+
+  // The code for recording the origin page of the patient chart ends here.
 
   const render = useCallback(
     () => (


### PR DESCRIPTION
#### P.S. This ticket was assigned to @sharleenawinja and she has done the work. I did help with distributing the work into different repositories, and hence this ticket is assigned to @sharleenawinja and hence she is the rightful owner.

## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR adds the event listener to record the origin page for the patient-chart, so whenever we exit from the patient chart, we should be directed back to the origin page from where we jumped into the patient chart.

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/O3-1594

## Other
<!-- Anything not covered above -->
