### PR TITLE
O3-1444: Expired login session keeps the location page stuck

### DIFF
--- a/packages/apps/esm-login-app/src/login/login.component.tsx
+++ b/packages/apps/esm-login-app/src/login/login.component.tsx
@@ -9,7 +9,14 @@ import {
 } from "@carbon/react";
 import { ArrowLeft, ArrowRight } from "@carbon/react/icons";
 import { useTranslation } from "react-i18next";
-import { useConfig, interpolateUrl, useSession } from "@openmrs/esm-framework";
+import {
+  useConfig,
+  interpolateUrl,
+  useSession,
+  refetchCurrentUser,
+  clearCurrentUser,
+  getSessionStore,
+} from "@openmrs/esm-framework";
 import { performLogin } from "./login.resource";
 import styles from "./login.scss";
 
@@ -44,7 +51,14 @@ const Login: React.FC<LoginProps> = ({ isLoginEnabled }) => {
 
   useEffect(() => {
     if (user) {
-      navigate("/login/location", { state: location.state });
+      clearCurrentUser();
+      refetchCurrentUser().then(() => {
+        const authenticated =
+          getSessionStore().getState().session.authenticated;
+        if (authenticated) {
+          navigate("/login/location", { state: location.state });
+        }
+      });
     } else if (!username && location.pathname === "/login/confirm") {
       navigate("/login", { state: location.state });
     }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

The session is saved as a global store using developit/unistore (https://github.com/developit/unistore).  This session object is only updated either by clearing the session store (https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L188), or by refetching the current user (https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L163).  

However, clearing or refetching the session store depends on only timeout and if the store is loaded, but doesn't check for the availability the JSESSIONID cookie.  At the same time, this cookie is an HTTP-ONLY cookie so it ain't available via document.cookie. 

to make this work, i manually opted to verifying that the user is logged in twice.  As this is working, it might be not working wright.

cc @brandones @denniskigen @vasharma05 @ibacher @hadijahkyampeire 

## Screenshots
<!-- Required if you are making UI changes. -->

https://user-images.githubusercontent.com/58003327/206906938-c784ce8d-3223-417b-9a81-934395690ffe.mov

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-1444

## Other
<!-- Anything not covered above -->
