### PR TITLE
(chore) Leverage remote caching in bundle size workflow

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -1,4 +1,3 @@
-
 name: Report bundle size
 
 on:
@@ -9,10 +8,23 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      TURBO_API: 'http://127.0.0.1:9080'
+      TURBO_TOKEN: ${{ secrets.TURBO_SERVER_TOKEN }}
+      TURBO_TEAM: ${{ github.repository_owner }}
 
     steps:
       - uses: actions/checkout@v3
-      - uses: preactjs/compressed-size-action@v2
+
+      - name: Setup a local cache server for Turborepo
+        uses: felixmosh/turborepo-gh-artifacts@v1
         with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: ${{ secrets.TURBO_SERVER_TOKEN }}
+
+      - name: Compute bundle size report
+        uses: preactjs/compressed-size-action@v2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          minimum-change-threshold: 10000 # 10 KB
           build-script: "turbo run build --color"
-          minimum-change-threshold: 500 # bytes


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Attempts to leverage remote caching in the bundle size workflow to speed up builds.
