### PR TITLE
(fix) remove dependency of app-shell on esm-offline

### DIFF
--- a/packages/shell/esm-app-shell/src/service-worker/constants.ts
+++ b/packages/shell/esm-app-shell/src/service-worker/constants.ts
@@ -1,5 +1,13 @@
 import uniq from "lodash-es/uniq";
 
+// note that these constants are also defined in @openmrs/esm-offline
+export const omrsOfflineResponseBodyHttpHeaderName =
+  "x-omrs-offline-response-body";
+export const omrsOfflineResponseStatusHttpHeaderName =
+  "x-omrs-offline-response-status";
+export const omrsOfflineCachingStrategyHttpHeaderName =
+  "x-omrs-offline-caching-strategy";
+
 export const omrsCachePrefix = "omrs";
 export const omrsCacheName = `${omrsCachePrefix}-spa-cache-v1`;
 

--- a/packages/shell/esm-app-shell/src/service-worker/http-header-utils.ts
+++ b/packages/shell/esm-app-shell/src/service-worker/http-header-utils.ts
@@ -1,9 +1,11 @@
-import {
+import type {
   OmrsOfflineHttpHeaderNames,
   OmrsOfflineHttpHeaders,
+} from "@openmrs/esm-offline";
+import {
   omrsOfflineResponseBodyHttpHeaderName,
   omrsOfflineResponseStatusHttpHeaderName,
-} from "@openmrs/esm-offline/src/service-worker-http-headers";
+} from "./constants";
 
 export function parseOmrsOfflineResponseBodyHeader(headers: Headers) {
   // The ?? undefined here is important as getOmrsHeader returns null by default when the header

--- a/packages/shell/esm-app-shell/src/service-worker/routing.ts
+++ b/packages/shell/esm-app-shell/src/service-worker/routing.ts
@@ -3,17 +3,18 @@ import { registerRoute } from "workbox-routing";
 import { getOrCreateDefaultRouter } from "workbox-routing/utils/getOrCreateDefaultRouter";
 import { validMethods } from "workbox-routing/utils/constants";
 import { CacheOnly, NetworkFirst, NetworkOnly } from "workbox-strategies";
-import { indexUrl, omrsCacheName } from "./constants";
+import {
+  indexUrl,
+  omrsCacheName,
+  omrsOfflineCachingStrategyHttpHeaderName,
+} from "./constants";
 import { ServiceWorkerDb } from "./storage";
 import {
   getOmrsHeader,
   parseOmrsOfflineResponseBodyHeader,
   parseOmrsOfflineResponseStatusHeader,
 } from "./http-header-utils";
-import {
-  OmrsOfflineCachingStrategy,
-  omrsOfflineCachingStrategyHttpHeaderName,
-} from "@openmrs/esm-offline/src/service-worker-http-headers";
+import type { OmrsOfflineCachingStrategy } from "@openmrs/esm-offline";
 import uniq from "lodash-es/uniq";
 
 const networkOnly = new NetworkOnly();


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This removes the dependency on the @openmrs/esm-offline repository when building the app-shell from the generated JS files.

The above is a little confusing, so let me spell it out a bit more:

The app shell is built using a local configuration when running `openmrs build` using our CLI tool. Prior to this commit, we had a hard dependency on loading some constants from the @openmrs/esm-offline package. Since this package wasn't declared a dependency of the app shell, it was generally unavailable when the `openmrs build` was invoked.

There are three obvious solutions to this:

1. Change the dependency from @openmrs/esm-offline to @openmrs/esm-framework. The framework is both a declared dependency of the app shell and should re-export those constants. However, this doesn't seem to work (I can't remember why).
2. Make @openmrs/esm-offline an explicit dependency of the app shell. This is probably the most straightforward, but seems to suggest that we should refactor @openmrs/esm-offline out of the framework which is a larger lift.
3. Move the constants we need into the correct portion of the app shell. This results in the constants being duplicated in two files (one in @openmrs/esm-offline and one in the app shell).

This PR implements option 3, as a small amount of repetition for highly stable constant values seemed pretty harmless. With that change, the app shell now only depends on @openmrs/esm-offline for type-checking. This should eliminate the [issue reported](https://openmrs.slack.com/archives/CHP5QAE5R/p1675176052406429).

I've tested this as well as I can, but I'm not sure I can fully manage to verify this until we actually release a new version of this repo.

