### PR TITLE
(chore) Don't trigger prerelease on release commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
 
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (github.event.head_commit == null || 
+          !startsWith(github.event.head_commit.message, "(release)")) && 
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
 
     steps:
       - uses: actions/checkout@v3
@@ -141,7 +143,9 @@ jobs:
 
     needs: pre_release
 
-    if: ${{ github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
+    if: ${{ (github.event.head_commit == null || 
+          !startsWith(github.event.head_commit.message, "(release)")) && 
+          (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
 
     steps:
       - name: Trigger RefApp Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,7 @@ jobs:
     needs: build
 
     if: ${{ (github.event.head_commit == null || 
-          !startsWith(github.event.head_commit.message, "(release)")) && 
+          !startsWith(github.event.head_commit.message, '(release)')) && 
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
 
     steps:
@@ -144,7 +144,7 @@ jobs:
     needs: pre_release
 
     if: ${{ (github.event.head_commit == null || 
-          !startsWith(github.event.head_commit.message, "(release)")) && 
+          !startsWith(github.event.head_commit.message, '(release)')) && 
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
 
     steps:


### PR DESCRIPTION
Release commits are intended to bump the version numbers only and should start with the string "(release)".

## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Not 100% certain this will work... Would appreciate a sanity-check.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
