### PR TITLE
(feat) Add support for reading configuration from .npmrc

### DIFF
--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -32,6 +32,7 @@
   "dependencies": {
     "@openmrs/esm-app-shell": "4.1.0",
     "@openmrs/webpack-config": "4.1.0",
+    "@pnpm/npm-conf": "^2.1.0",
     "autoprefixer": "^10.4.2",
     "axios": "^0.21.1",
     "browserslist-config-openmrs": "^1.0.1",
@@ -43,6 +44,7 @@
     "html-webpack-plugin": "^5.5.0",
     "inquirer": "^7.3.3",
     "mini-css-extract-plugin": "^2.4.5",
+    "npm-registry-fetch": "^14.0.3",
     "pacote": "^15.0.0",
     "postcss": "^8.4.6",
     "postcss-loader": "^6.2.1",

--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -257,12 +257,6 @@ yargs.command(
       .describe(
         "importmap",
         "The import map to use. Can be a path to an import map to be taken literally, an URL, or a fixed JSON object."
-      )
-      .boolean("download-coreapps")
-      .default("download-coreapps", false)
-      .describe(
-        "download-coreapps",
-        "Downloads and bundles the core apps. For cases where the core apps are not in the import map."
       ),
   async (args) =>
     runCommand("runBuild", {
@@ -289,7 +283,8 @@ yargs.command(
         coerce: (arg) => resolve(process.cwd(), arg),
       })
       .option("registry", {
-        default: "https://registry.npmjs.org/",
+        alias: "reg",
+        default: "",
         description: "The NPM registry used for getting the packages.",
         type: "string",
         coerce: (arg) => trimEnd(arg, "/"),

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -1,18 +1,7 @@
-import {
-  copyFileSync,
-  createReadStream,
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  readFileSync,
-  statSync,
-  unlinkSync,
-  writeFileSync,
-} from "fs";
-import { getImportmap, loadWebpackConfig, logInfo, untar } from "../utils";
+import { copyFileSync, existsSync, readFileSync } from "fs";
+import { getImportmap, loadWebpackConfig, logInfo } from "../utils";
 import rimraf from "rimraf";
-import { basename, resolve } from "path";
-import { execSync } from "child_process";
+import { basename, join, resolve } from "path";
 
 /* eslint-disable no-console */
 
@@ -25,7 +14,6 @@ export interface BuildArgs {
   apiUrl: string;
   pageTitle: string;
   supportOffline?: boolean;
-  downloadCoreapps: boolean;
   configUrls: Array<string>;
   configPaths: Array<string>;
   buildConfig?: string;
@@ -49,103 +37,13 @@ function loadBuildConfig(buildConfigPath?: string): BuildConfig {
   }
 }
 
-async function extractFiles(sourceFile: string, targetDir: string) {
-  const packageRoot = "package/";
-  const rs = createReadStream(sourceFile);
-  const files = await untar(rs);
-  const packageJson = JSON.parse(
-    files[`${packageRoot}package.json`].toString("utf8")
-  );
-  const entryModule =
-    packageJson.browser ?? packageJson.module ?? packageJson.main;
-
-  Object.keys(files)
-    .filter(
-      (f) =>
-        f === "package/package.json" ||
-        f.substr(packageRoot.length) === entryModule
-    )
-    .forEach((f) => {
-      const content = files[f];
-      const fileName = f.replace(packageRoot, "");
-      const targetFile = resolve(targetDir, fileName);
-      writeFileSync(targetFile, content);
-    });
-
-  unlinkSync(sourceFile);
-}
-
-function loadCoreApps(registry: string) {
-  /*
-   * if the user specified a OMRS_ESM_CORE_APPS_DIR, we assume this has
-   * the necessary coreapps; otherwise, we check if there are any coreapps
-   * available in the places the webpack configuration will check; if there
-   * aren't, we download the apps specified in the app-shell devDependencies
-   */
-  const appsPath =
-    process.env.OMRS_ESM_CORE_APPS_DIR ??
-    resolve(require.resolve("@openmrs/esm-app-shell"), "..", "..", "apps");
-
-  let hasApp = false;
-  if (existsSync(appsPath) && statSync(appsPath).isDirectory()) {
-    hasApp = readdirSync(appsPath).some((entry) => {
-      if (statSync(entry).isDirectory()) {
-        const packageJson = resolve(entry, "package.json");
-        if (existsSync(packageJson) && statSync(packageJson).isFile()) {
-          return require(packageJson).name?.endsWith("-app");
-        }
-      }
-    });
-  }
-
-  if (!hasApp) {
-    logInfo("Fetching core apps...");
-    const devDependencies: Record<string, string> =
-      require("@openmrs/esm-app-shell/package.json").devDependencies;
-
-    const apps = Object.keys(devDependencies)
-      .filter((dep) => dep.endsWith("-app"))
-      .map((dep) => [dep, devDependencies[dep]]);
-
-    if (apps.length > 0) {
-      const cacheDir = resolve(process.cwd(), ".cache");
-      if (!existsSync(cacheDir)) {
-        mkdirSync(cacheDir, { recursive: true });
-      }
-      const coreAppsDir =
-        process.env.OMRS_ESM_CORE_APPS_DIR ??
-        resolve(process.cwd(), ".cache", "apps");
-      rimraf.sync(coreAppsDir);
-      mkdirSync(coreAppsDir, { recursive: true });
-
-      apps.forEach(async ([name, version]) => {
-        const packageName = `${name}@${version}`;
-        const command = `npm pack ${packageName} --registry ${registry}`;
-        const result = execSync(command, {
-          cwd: cacheDir,
-        });
-
-        const tgzFile =
-          result.toString("utf8").split("\n").filter(Boolean).pop() ?? "";
-        const appDirName = tgzFile.replace(".tgz", "");
-        await extractFiles(
-          resolve(cacheDir, tgzFile),
-          resolve(coreAppsDir, appDirName)
-        );
-      });
-
-      return coreAppsDir;
-    }
-  }
-}
-
 function addConfigFilesFromPaths(
   configPaths: Array<string>,
   targetDir: string
 ) {
   for (let configPath of configPaths) {
     const realPath = resolve(configPath);
-    copyFileSync(realPath, targetDir + "/" + basename(configPath));
+    copyFileSync(realPath, join(targetDir, basename(configPath)));
   }
 }
 
@@ -156,9 +54,7 @@ export async function runBuild(args: BuildArgs) {
   for (let configPath of buildConfig.configPaths || args.configPaths) {
     configUrls.push(basename(configPath));
   }
-  const coreAppsDir = args.downloadCoreapps
-    ? loadCoreApps(args.registry)
-    : undefined;
+
   const config = loadWebpackConfig({
     importmap: await getImportmap(buildConfig.importmap || args.importmap),
     env: "production",
@@ -167,7 +63,6 @@ export async function runBuild(args: BuildArgs) {
     pageTitle: buildConfig.pageTitle || args.pageTitle,
     supportOffline: buildConfig.supportOffline ?? args.supportOffline,
     spaPath: buildConfig.spaPath || args.spaPath,
-    coreAppsDir,
   });
 
   logInfo(`Running build process ...`);

--- a/packages/tooling/openmrs/src/commands/debug.ts
+++ b/packages/tooling/openmrs/src/commands/debug.ts
@@ -54,5 +54,5 @@ export function runDebug(args: DebugArgs) {
     }
   });
 
-  return new Promise(() => {});
+  return new Promise<void>(() => {});
 }

--- a/packages/tooling/openmrs/src/commands/develop.ts
+++ b/packages/tooling/openmrs/src/commands/develop.ts
@@ -129,5 +129,5 @@ export function runDevelop(args: DevelopArgs) {
     }
   });
 
-  return new Promise(() => {});
+  return new Promise<void>(() => {});
 }

--- a/packages/tooling/openmrs/src/commands/start.ts
+++ b/packages/tooling/openmrs/src/commands/start.ts
@@ -57,5 +57,5 @@ export function runStart(args: StartArgs) {
     }
   });
 
-  return new Promise(() => {});
+  return new Promise<void>(() => {});
 }

--- a/packages/tooling/openmrs/src/runner.ts
+++ b/packages/tooling/openmrs/src/runner.ts
@@ -1,16 +1,26 @@
 import * as commands from "./commands";
 import { logFail } from "./utils";
 
-process.on("message", async ({ type, args }) => {
-  const command = commands[type];
+type Commands = typeof commands;
+type CommandNames = keyof Commands;
+interface HandleMessageArgs<T extends CommandNames> {
+  type: T;
+  args: Parameters<Commands[T]>[0];
+}
 
-  if (typeof command === "function") {
-    try {
-      await command(args);
-      process.exit(0);
-    } catch (err) {
-      logFail(err.message);
-      process.exit(1);
+process.on(
+  "message",
+  async <T extends CommandNames>({ type, args }: HandleMessageArgs<T>) => {
+    const command: (a: typeof args) => Promise<unknown> = commands[type];
+
+    if (typeof command === "function") {
+      try {
+        await command(args);
+        process.exit(0);
+      } catch (err) {
+        logFail(err.message);
+        process.exit(1);
+      }
     }
   }
-});
+);

--- a/packages/tooling/openmrs/src/utils/npmConfig.ts
+++ b/packages/tooling/openmrs/src/utils/npmConfig.ts
@@ -1,0 +1,57 @@
+import npmRegistryFetch from "npm-registry-fetch";
+import npmConfig from "@pnpm/npm-conf";
+
+/**
+ * Utility function to load the appropriate configuration for npmRegistryFetch
+ * from the .npmrc configuration chain. Essentially, this allows us to use .npmrc
+ * files to configure reading from the NPM registry, which is useful when using
+ * a custom registry, especially for private packages.
+ *
+ * This uses the @pnpm/npm-conf library for reading .npmrc files as its both
+ * maintained and sane to work with.
+ *
+ * @param registry The NPM registry to use, if any
+ */
+export function getNpmRegistryConfiguration(
+  registry?: string | null | undefined
+): npmRegistryFetch.Options {
+  const conf = npmConfig();
+
+  if (!conf) {
+    return {};
+  }
+
+  if (conf.warnings.length >= 1) {
+    throw new Error(
+      `Warnings while loading .npmrc:\n  ${conf.warnings.join("\n  ")}`
+    );
+  }
+
+  if (!conf.config) {
+    return {};
+  }
+
+  // the returned config object uses getters with no list of keys
+  // so to convert this to a "normal" object, we combine all the settings
+  // found; note this relies on the internal structure of the config
+  // object and may not be stable
+  const configuration: npmRegistryFetch.Options = Object.assign(
+    {},
+    ...(conf.config.list.slice().reverse() ?? [])
+  );
+
+  if (configuration.__source__) {
+    delete configuration.__source__;
+  }
+
+  if ("strict-ssl" in configuration) {
+    configuration.strictSSL = configuration["strict-ssl"];
+    delete configuration["strict-ssl"];
+  }
+
+  if (registry) {
+    configuration.registry = registry;
+  }
+
+  return configuration;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3924,6 +3924,33 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@pnpm/config.env-replace@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@pnpm/config.env-replace@npm:1.0.0"
+  checksum: 0142dca1c4838af833ac1babeb293236047cb3199f509b5dbcb68ea4d21ffc3ab8f7d3fe8653e4caef11771c56ab2410d6b930c162ed8eb6714a8cab51a95ceb
+  languageName: node
+  linkType: hard
+
+"@pnpm/network.ca-file@npm:^1.0.1":
+  version: 1.0.2
+  resolution: "@pnpm/network.ca-file@npm:1.0.2"
+  dependencies:
+    graceful-fs: 4.2.10
+  checksum: d8d0884646500576bd5390464d13db1bb9a62e32a1069293e5bddb2ad8354b354b7e2d2a35e12850025651e795e6a80ce9e601c66312504667b7e3ee7b52becc
+  languageName: node
+  linkType: hard
+
+"@pnpm/npm-conf@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "@pnpm/npm-conf@npm:2.1.0"
+  dependencies:
+    "@pnpm/config.env-replace": ^1.0.0
+    "@pnpm/network.ca-file": ^1.0.1
+    config-chain: ^1.1.11
+  checksum: b4b19d2d2b22d6ee9d41c6499ac1c55277cdaddc150fb3a549e7460bcf7a377adbd70788c2c8c4167081b76b343d4869505c852cea2ad46060f4de632611eb30
+  languageName: node
+  linkType: hard
+
 "@polka/url@npm:^1.0.0-next.20":
   version: 1.0.0-next.21
   resolution: "@polka/url@npm:1.0.0-next.21"
@@ -7200,7 +7227,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"config-chain@npm:^1.1.12":
+"config-chain@npm:^1.1.11, config-chain@npm:^1.1.12":
   version: 1.1.13
   resolution: "config-chain@npm:1.1.13"
   dependencies:
@@ -10589,7 +10616,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"graceful-fs@npm:^4.0.0, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.3, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
+"graceful-fs@npm:4.2.10, graceful-fs@npm:^4.0.0, graceful-fs@npm:^4.1.11, graceful-fs@npm:^4.1.15, graceful-fs@npm:^4.1.2, graceful-fs@npm:^4.1.6, graceful-fs@npm:^4.2.0, graceful-fs@npm:^4.2.2, graceful-fs@npm:^4.2.3, graceful-fs@npm:^4.2.4, graceful-fs@npm:^4.2.6, graceful-fs@npm:^4.2.9":
   version: 4.2.10
   resolution: "graceful-fs@npm:4.2.10"
   checksum: 3f109d70ae123951905d85032ebeae3c2a5a7a997430df00ea30df0e3a6c60cf6689b109654d6fdacd28810a053348c4d14642da1d075049e6be1ba5216218da
@@ -10812,6 +10839,15 @@ __metadata:
   dependencies:
     lru-cache: ^7.5.1
   checksum: 22abbc6a7418344c883e2df6e791e94b38192b2a61256b19c955999d878b8d5365ea51683fd1f0cc8f217e9bd121db88d5aaa7cf0407c4b7ff287b79aabacbd3
+  languageName: node
+  linkType: hard
+
+"hosted-git-info@npm:^6.0.0":
+  version: 6.1.1
+  resolution: "hosted-git-info@npm:6.1.1"
+  dependencies:
+    lru-cache: ^7.5.1
+  checksum: fcd3ca2eaa05f3201425ccbb8aa47f88cdda4a3a6d79453f8e269f7171356278bd1db08f059d8439eb5eaa91c6a8a20800fc49cca6e9e4e899b202a332d5ba6b
   languageName: node
   linkType: hard
 
@@ -13319,6 +13355,30 @@ __metadata:
   languageName: node
   linkType: hard
 
+"make-fetch-happen@npm:^11.0.0":
+  version: 11.0.2
+  resolution: "make-fetch-happen@npm:11.0.2"
+  dependencies:
+    agentkeepalive: ^4.2.1
+    cacache: ^17.0.0
+    http-cache-semantics: ^4.1.0
+    http-proxy-agent: ^5.0.0
+    https-proxy-agent: ^5.0.0
+    is-lambda: ^1.0.1
+    lru-cache: ^7.7.1
+    minipass: ^4.0.0
+    minipass-collect: ^1.0.2
+    minipass-fetch: ^3.0.0
+    minipass-flush: ^1.0.5
+    minipass-pipeline: ^1.2.4
+    negotiator: ^0.6.3
+    promise-retry: ^2.0.1
+    socks-proxy-agent: ^7.0.0
+    ssri: ^10.0.0
+  checksum: b843ef2e42bc17c37c7636dbe82867caceaa36b3f2591f20918abc190ca85cf37e5e142148b730dab7d94e9d2f0c80947a703f8dadebae993cd93ad929dba103
+  languageName: node
+  linkType: hard
+
 "make-fetch-happen@npm:^8.0.9":
   version: 8.0.14
   resolution: "make-fetch-happen@npm:8.0.14"
@@ -13658,6 +13718,21 @@ __metadata:
     encoding:
       optional: true
   checksum: 3f216be79164e915fc91210cea1850e488793c740534985da017a4cbc7a5ff50506956d0f73bb0cb60e4fe91be08b6b61ef35101706d3ef5da2c8709b5f08f91
+  languageName: node
+  linkType: hard
+
+"minipass-fetch@npm:^3.0.0":
+  version: 3.0.1
+  resolution: "minipass-fetch@npm:3.0.1"
+  dependencies:
+    encoding: ^0.1.13
+    minipass: ^4.0.0
+    minipass-sized: ^1.0.3
+    minizlib: ^2.1.2
+  dependenciesMeta:
+    encoding:
+      optional: true
+  checksum: b5eecf462ab8409891e4b8a786260e411304b958e45e10820b0a5d31f7841ccbce5f85e49934a34fdb94501206c273bde1988b9c0ad1625bdfb9883d90285420
   languageName: node
   linkType: hard
 
@@ -14205,6 +14280,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"npm-package-arg@npm:^10.0.0":
+  version: 10.1.0
+  resolution: "npm-package-arg@npm:10.1.0"
+  dependencies:
+    hosted-git-info: ^6.0.0
+    proc-log: ^3.0.0
+    semver: ^7.3.5
+    validate-npm-package-name: ^5.0.0
+  checksum: 8fe4b6a742502345e4836ed42fdf26c544c9f75563c476c67044a481ada6e81f71b55462489c7e1899d516e4347150e58028036a90fa11d47e320bcc9365fd30
+  languageName: node
+  linkType: hard
+
 "npm-package-arg@npm:^8.0.0, npm-package-arg@npm:^8.0.1, npm-package-arg@npm:^8.1.0, npm-package-arg@npm:^8.1.2, npm-package-arg@npm:^8.1.5":
   version: 8.1.5
   resolution: "npm-package-arg@npm:8.1.5"
@@ -14301,6 +14388,21 @@ __metadata:
     npm-package-arg: ^9.0.1
     proc-log: ^2.0.0
   checksum: 5a941c2c799568e0dbccfc15f280444da398dadf2eede1b1921f08ddd5cb5f32c7cb4d16be96401f95a33073aeec13a3fd928c753790d3c412c2e64e7f7c6ee4
+  languageName: node
+  linkType: hard
+
+"npm-registry-fetch@npm:^14.0.3":
+  version: 14.0.3
+  resolution: "npm-registry-fetch@npm:14.0.3"
+  dependencies:
+    make-fetch-happen: ^11.0.0
+    minipass: ^4.0.0
+    minipass-fetch: ^3.0.0
+    minipass-json-stream: ^1.0.1
+    minizlib: ^2.1.2
+    npm-package-arg: ^10.0.0
+    proc-log: ^3.0.0
+  checksum: 451224e7272c8418000f6a0e27fb01d7eb5231bcd98dbd42acac3f275f0b5317590c152860cc84afa706427121b59f9422939e00af5690442b70e64cfa39de0a
   languageName: node
   linkType: hard
 
@@ -14538,6 +14640,7 @@ __metadata:
   dependencies:
     "@openmrs/esm-app-shell": 4.1.0
     "@openmrs/webpack-config": 4.1.0
+    "@pnpm/npm-conf": ^2.1.0
     "@types/express": ^4.11.1
     "@types/glob": ^7.1.1
     "@types/inquirer": ^6.5.0
@@ -14558,6 +14661,7 @@ __metadata:
     html-webpack-plugin: ^5.5.0
     inquirer: ^7.3.3
     mini-css-extract-plugin: ^2.4.5
+    npm-registry-fetch: ^14.0.3
     pacote: ^15.0.0
     postcss: ^8.4.6
     postcss-loader: ^6.2.1
@@ -16009,6 +16113,13 @@ __metadata:
   version: 2.0.1
   resolution: "proc-log@npm:2.0.1"
   checksum: f6f23564ff759097db37443e6e2765af84979a703d2c52c1b9df506ee9f87caa101ba49d8fdc115c1a313ec78e37e8134704e9069e6a870f3499d98bb24c436f
+  languageName: node
+  linkType: hard
+
+"proc-log@npm:^3.0.0":
+  version: 3.0.0
+  resolution: "proc-log@npm:3.0.0"
+  checksum: 02b64e1b3919e63df06f836b98d3af002b5cd92655cab18b5746e37374bfb73e03b84fe305454614b34c25b485cc687a9eebdccf0242cda8fda2475dd2c97e02
   languageName: node
   linkType: hard
 
@@ -17726,6 +17837,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"ssri@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "ssri@npm:10.0.1"
+  dependencies:
+    minipass: ^4.0.0
+  checksum: f35b147e5e16a3e1c8e3f71a4aaf5b1f7a9eb5559acbba21213c8171827921cecf56d3570118da7ade124776d25ed17d5e4c80eccbb2a083b17ce36dd24c3e5e
+  languageName: node
+  linkType: hard
+
 "ssri@npm:^8.0.0, ssri@npm:^8.0.1":
   version: 8.0.1
   resolution: "ssri@npm:8.0.1"
@@ -19258,6 +19378,15 @@ __metadata:
   dependencies:
     builtins: ^5.0.0
   checksum: a32fd537bad17fcb59cfd58ae95a414d443866020d448ec3b22e8d40550cb585026582a57efbe1f132b882eea4da8ac38ee35f7be0dd72988a3cb55d305a20c1
+  languageName: node
+  linkType: hard
+
+"validate-npm-package-name@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "validate-npm-package-name@npm:5.0.0"
+  dependencies:
+    builtins: ^5.0.0
+  checksum: 5342a994986199b3c28e53a8452a14b2bb5085727691ea7aa0d284a6606b127c371e0925ae99b3f1ef7cc7d2c9de75f52eb61a3d1cc45e39bca1e3a9444cbb4e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
No UI changes. Adds support for parsing credentials and registry information from .npmrc when running the `assemble` command.

Important caveat to this: the `assemble` command does not work correctly in `survey` mode for NPM registries hosted by Azure. This is because Azure's NPM registry does not implement the standard NPM registry API.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
