### PR TITLE
(fix) O3-1632: Search fields in the application should have an orange outline

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -233,7 +233,7 @@
   outline: 2px solid var(--brand-03);
 }
 
-// Search fields
-.cds--search-input {
-  outline: 2px solid $color-orange-40; // specify your desired outline color and thickness here
+/* Search inputs */
+.cds--search-input:focus {
+  outline: 2px solid colors.$orange-40;
 }

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -232,3 +232,8 @@
 .cds--pagination-nav__page:focus {
   outline: 2px solid var(--brand-03);
 }
+
+// Search fields
+.#{$prefix}--search-input {
+  outline: 2px solid #fdab3d; // specify your desired outline color and thickness here
+}

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -234,6 +234,6 @@
 }
 
 // Search fields
-.#{$prefix}--search-input {
-  outline: 2px solid #fdab3d; // specify your desired outline color and thickness here
+.cds--search-input {
+  outline: 2px solid $color-orange-40; // specify your desired outline color and thickness here
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
As per the designs in the Zeplin, we have an orange outline for search fields. By default, the search shows the default Carbon outline for the Search fields. We can add CSS overrides in the @openmrs/esm-styleguide.
<!-- Please describe what problems your PR addresses. -->

## Screenshots
![Screenshot from 2023-02-10 02-39-02](https://user-images.githubusercontent.com/78595738/217963298-58fe18ee-2a44-4066-b5a3-dbebba7cfee5.png)
![Screenshot from 2023-02-10 02-38-47](https://user-images.githubusercontent.com/78595738/217963312-81d6bd31-5b9a-4f18-8dab-ad50390a9225.png)
![Screenshot from 2023-02-10 02-40-04](https://user-images.githubusercontent.com/78595738/217963391-549e0113-be31-435b-b9fe-f7c1fd4fbfb1.png)

<!-- Required if you are making UI changes. -->

## Related Issue
https://issues.openmrs.org/browse/O3-1632
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
