### PR TITLE
(feat) Added styles for overflow menus in data tables

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -232,3 +232,33 @@
 .cds--pagination-nav__page:focus {
   outline: 2px solid var(--brand-03);
 }
+
+.cds--data-table--xs .cds--overflow-menu {
+  height: spacing.$spacing-07;
+}
+
+.cds--data-table--sm .cds--overflow-menu {
+  height: spacing.$spacing-08;
+}
+
+.cds--data-table--sm .cds--overflow-menu--sm {
+  height: spacing.$spacing-07;
+}
+
+.cds--data-table--xs .cds--overflow-menu {
+  max-height: spacing.$spacing-07;
+}
+
+.cds--data-table-container {
+  padding-top: 0;
+}
+
+.cds--data-table td.cds--table-column-menu {
+  width: spacing.$spacing-08;
+  vertical-align: top;
+  padding-right: 0;
+}
+
+.cds--data-table--lg td.cds--table-column-menu {
+  width: spacing.$spacing-09;
+}


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR fixes the data-table's overflow menu stylings. Currently the overflow menu takes up space in the data table, as shown in the image below:
![image](https://user-images.githubusercontent.com/51502471/220066562-ce38c054-550a-49c0-836c-73ce497c60b8.png)

As per these fixes, the tables will have the overflow menus, at the end of the tables, taking up less space and giving the other content in the table more space to expand.

![image](https://user-images.githubusercontent.com/51502471/220068199-b318cd30-58fa-4566-9b44-2fed9f42a363.png)


![image](https://user-images.githubusercontent.com/51502471/220067864-08c4f384-3883-432d-9f5a-37235c87035a.png)


## Screenshots
Attached above

## Related Issue
*None*

## Other
<!-- Anything not covered above -->
