### PR TITLE
(feat) Running shell with run:shell shouldn't use the CSP

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -7,7 +7,7 @@ const BundleAnalyzerPlugin =
 const WebpackPwaManifest = require("webpack-pwa-manifest");
 const { InjectManifest } = require("workbox-webpack-plugin");
 const { DefinePlugin, container } = require("webpack");
-const { resolve, dirname, basename } = require("path");
+const { resolve } = require("path");
 const { readdirSync, statSync } = require("fs");
 const { removeTrailingSlash, getTimestamp } = require("./tools/helpers");
 const { name, version, dependencies } = require("./package.json");
@@ -16,7 +16,6 @@ const frameworkVersion = require("@openmrs/esm-framework/package.json").version;
 
 const timestamp = getTimestamp();
 const production = "production";
-const allowedSuffixes = ["-app", "-widgets"];
 const { ModuleFederationPlugin } = container;
 
 const openmrsAddCookie = process.env.OMRS_ADD_COOKIE;
@@ -102,6 +101,10 @@ module.exports = (env, argv = {}) => {
               const newCookie = `${origCookie};${openmrsAddCookie}`;
               proxyReq.setHeader("cookie", newCookie);
             }
+          },
+          onProxyRes(proxyRes) {
+            proxyRes.headers &&
+              delete proxyRes.headers["content-security-policy"];
           },
         },
       ],


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Just removes the CSP header if it exists from the response, meaning that if you use `run:shell`, the CSP is ignored.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
