### PR TITLE
(refactor) Refactor primary navigation

### DIFF
--- a/packages/apps/esm-primary-navigation-app/__mocks__/mock-session.ts
+++ b/packages/apps/esm-primary-navigation-app/__mocks__/mock-session.ts
@@ -1,6 +1,22 @@
-import { UserSession } from "../src/types";
-
-export const mockSession: UserSession = {
+export const mockSession = {
+  authenticated: true,
+  user: {
+    uuid: "82f18b44-6814-11e8-923f-e9a88dcb533f",
+    display: "admin",
+    username: "",
+    systemId: "admin",
+    userProperties: {
+      defaultLocale: "en",
+      loginAttempts: "0",
+    },
+    person: {
+      uuid: "5f87c042-6814-11e8-923f-e9a88dcb533f",
+      display: "Super User",
+    },
+    privileges: [],
+  },
+  locale: "en",
+  allowedLocales: ["en", "es", "fr", "km"],
   sessionLocation: {
     display: "Unknown Location",
   },

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/user-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/user-menu-panel.component.tsx
@@ -10,7 +10,7 @@ import styles from "../../root.scss";
 
 interface UserMenuPanelProps extends HeaderPanelProps {
   expanded: boolean;
-  user: LoggedInUser;
+  user: LoggedInUser | false | null;
   allowedLocales: any;
   onLogout(): void;
   session: UserSession;

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -1,11 +1,5 @@
-import React, { useCallback, useMemo, useState } from "react";
-import {
-  LoggedInUser,
-  useLayoutType,
-  ExtensionSlot,
-  ConfigurableLink,
-  useAssignedExtensions,
-} from "@openmrs/esm-framework";
+import React, { memo, useCallback, useMemo, useState } from "react";
+import { Navigate } from "react-router-dom";
 import {
   HeaderContainer,
   Header,
@@ -14,35 +8,35 @@ import {
   HeaderGlobalAction,
 } from "@carbon/react";
 import { Close, Switcher, UserAvatarFilledAlt } from "@carbon/react/icons";
-import AppMenuPanel from "../navbar-header-panels/app-menu-panel.component";
-import UserMenuPanel from "../navbar-header-panels/user-menu-panel.component";
-import NotificationsMenuPanel from "../navbar-header-panels/notifications-menu-panel.component";
-import SideMenuPanel from "../navbar-header-panels/side-menu-panel.component";
-import Logo from "../logo/logo.component";
-import OfflineBanner from "../offline-banner/offline-banner.component";
+import {
+  LoggedInUser,
+  useLayoutType,
+  ExtensionSlot,
+  ConfigurableLink,
+  useAssignedExtensions,
+  useSession,
+} from "@openmrs/esm-framework";
 import { isDesktop } from "../../utils";
-import { UserSession } from "../../types";
+import AppMenuPanel from "../navbar-header-panels/app-menu-panel.component";
+import Logo from "../logo/logo.component";
+import NotificationsMenuPanel from "../navbar-header-panels/notifications-menu-panel.component";
+import OfflineBanner from "../offline-banner/offline-banner.component";
+import UserMenuPanel from "../navbar-header-panels/user-menu-panel.component";
+import SideMenuPanel from "../navbar-header-panels/side-menu-panel.component";
 import styles from "./navbar.scss";
 
-export interface NavbarProps {
-  user: LoggedInUser;
-  allowedLocales: Array<string>;
-  onLogout(): void;
-  session: UserSession;
-}
-
-const Navbar: React.FC<NavbarProps> = ({
-  user,
-  onLogout,
-  allowedLocales,
-  session,
-}) => {
+const Navbar: React.FC = () => {
+  const session = useSession();
+  const [user, setUser] = useState<LoggedInUser | null | false>(
+    session?.user ?? null
+  );
+  const [activeHeaderPanel, setActiveHeaderPanel] = useState<string>(null);
+  const allowedLocales = session?.allowedLocales ?? null;
   const layout = useLayoutType();
   const navMenuItems = useAssignedExtensions(
     "patient-chart-dashboard-slot"
   ).map((e) => e.id);
-
-  const [activeHeaderPanel, setActiveHeaderPanel] = useState<string>(null);
+  const openmrsSpaBase = window["getOpenmrsSpaBase"]();
 
   const isActivePanel = useCallback(
     (panelName: string) => activeHeaderPanel === panelName,
@@ -57,6 +51,8 @@ const Navbar: React.FC<NavbarProps> = ({
     []
   );
 
+  const logout = useCallback(() => setUser(false), []);
+
   const hidePanel = useCallback(() => {
     setActiveHeaderPanel(null);
   }, []);
@@ -66,127 +62,131 @@ const Navbar: React.FC<NavbarProps> = ({
     [navMenuItems.length, layout]
   );
 
-  const render = useCallback(
-    () => (
-      <>
-        <OfflineBanner />
-        <Header className={styles.topNavHeader} aria-label="OpenMRS">
-          {showHamburger && (
-            <HeaderMenuButton
-              aria-label="Open menu"
-              isCollapsible
-              className={styles.headerMenuButton}
-              onClick={(event) => {
-                togglePanel("sideMenu");
-                event.stopPropagation();
-              }}
-              isActive={isActivePanel("sideMenu")}
-            />
-          )}
-          <ConfigurableLink to="${openmrsSpaBase}/home">
-            <div className={showHamburger ? "" : styles.spacedLogo}>
-              <Logo />
-            </div>
-          </ConfigurableLink>
+  const HeaderItems = () => (
+    <>
+      <OfflineBanner />
+      <Header aria-label="OpenMRS">
+        {showHamburger && (
+          <HeaderMenuButton
+            aria-label="Open menu"
+            isCollapsible
+            className={styles.headerMenuButton}
+            onClick={(event) => {
+              togglePanel("sideMenu");
+              event.stopPropagation();
+            }}
+            isActive={isActivePanel("sideMenu")}
+          />
+        )}
+        <ConfigurableLink to="${openmrsSpaBase}/home">
+          <div className={showHamburger ? "" : styles.spacedLogo}>
+            <Logo />
+          </div>
+        </ConfigurableLink>
+        <ExtensionSlot
+          className={styles.dividerOverride}
+          name="top-nav-info-slot"
+        />
+        <ExtensionSlot
+          className={styles.dividerOverride}
+          name="top-nav-info-slot"
+        />
+        <HeaderGlobalBar className={styles.headerGlobalBar}>
           <ExtensionSlot
-            className={styles.dividerOverride}
-            name="top-nav-info-slot"
+            name="top-nav-actions-slot"
+            className={styles.topNavActionsSlot}
           />
-          <HeaderGlobalBar className={styles.headerGlobalBar}>
-            <ExtensionSlot
-              name="top-nav-actions-slot"
-              className={styles.topNavActionsSlot}
-            />
-            <ExtensionSlot
-              name="notifications-menu-button-slot"
-              state={{
-                isActivePanel: isActivePanel,
-                togglePanel: togglePanel,
-              }}
-            />
-            <HeaderGlobalAction
-              aria-label="Users"
-              aria-labelledby="Users Avatar Icon"
-              className={`${
-                isActivePanel("userMenu")
-                  ? styles.headerGlobalBarButton
-                  : styles.activePanel
-              }`}
-              enterDelayMs={500}
-              name="Users"
-              isActive={isActivePanel("userMenu")}
-              onClick={(event) => {
-                togglePanel("userMenu");
-                event.stopPropagation();
-              }}
-            >
-              {isActivePanel("userMenu") ? (
-                <Close size={20} />
-              ) : (
-                <UserAvatarFilledAlt size={20} />
-              )}
-            </HeaderGlobalAction>
-            <HeaderGlobalAction
-              aria-label="App Menu"
-              aria-labelledby="App Menu"
-              enterDelayMs={500}
-              isActive={isActivePanel("appMenu")}
-              tooltipAlignment="end"
-              className={`${
-                isActivePanel("appMenu")
-                  ? styles.headerGlobalBarButton
-                  : styles.activePanel
-              }`}
-              onClick={(event) => {
-                togglePanel("appMenu");
-                event.stopPropagation();
-              }}
-            >
-              {isActivePanel("appMenu") ? (
-                <Close size={20} />
-              ) : (
-                <Switcher size={20} />
-              )}
-            </HeaderGlobalAction>
-          </HeaderGlobalBar>
-          {!isDesktop(layout) && (
-            <SideMenuPanel
-              hidePanel={hidePanel}
-              expanded={isActivePanel("sideMenu")}
-            />
-          )}
-          <AppMenuPanel
-            expanded={isActivePanel("appMenu")}
+          <ExtensionSlot
+            name="notifications-menu-button-slot"
+            state={{
+              isActivePanel: isActivePanel,
+              togglePanel: togglePanel,
+            }}
+          />
+          <HeaderGlobalAction
+            aria-label="Users"
+            aria-labelledby="Users Avatar Icon"
+            className={`${
+              isActivePanel("userMenu")
+                ? styles.headerGlobalBarButton
+                : styles.activePanel
+            }`}
+            enterDelayMs={500}
+            name="Users"
+            isActive={isActivePanel("userMenu")}
+            onClick={(event) => {
+              togglePanel("userMenu");
+              event.stopPropagation();
+            }}
+          >
+            {isActivePanel("userMenu") ? (
+              <Close size={20} />
+            ) : (
+              <UserAvatarFilledAlt size={20} />
+            )}
+          </HeaderGlobalAction>
+          <HeaderGlobalAction
+            aria-label="App Menu"
+            aria-labelledby="App Menu"
+            enterDelayMs={500}
+            isActive={isActivePanel("appMenu")}
+            tooltipAlignment="end"
+            className={`${
+              isActivePanel("appMenu")
+                ? styles.headerGlobalBarButton
+                : styles.activePanel
+            }`}
+            onClick={(event) => {
+              togglePanel("appMenu");
+              event.stopPropagation();
+            }}
+          >
+            {isActivePanel("appMenu") ? (
+              <Close size={20} />
+            ) : (
+              <Switcher size={20} />
+            )}
+          </HeaderGlobalAction>
+        </HeaderGlobalBar>
+        {!isDesktop(layout) && (
+          <SideMenuPanel
             hidePanel={hidePanel}
+            expanded={isActivePanel("sideMenu")}
           />
-          <NotificationsMenuPanel
-            expanded={isActivePanel("notificationsMenu")}
-          />
-          <UserMenuPanel
-            user={user}
-            session={session}
-            expanded={isActivePanel("userMenu")}
-            allowedLocales={allowedLocales}
-            onLogout={onLogout}
-            hidePanel={hidePanel}
-          />
-        </Header>
-      </>
-    ),
-    [
-      showHamburger,
-      session,
-      user,
-      allowedLocales,
-      isActivePanel,
-      layout,
-      hidePanel,
-      togglePanel,
-      onLogout,
-    ]
+        )}
+        <AppMenuPanel
+          expanded={isActivePanel("appMenu")}
+          hidePanel={hidePanel}
+        />
+        <NotificationsMenuPanel expanded={isActivePanel("notificationsMenu")} />
+        <UserMenuPanel
+          user={user}
+          session={session}
+          expanded={isActivePanel("userMenu")}
+          allowedLocales={allowedLocales}
+          onLogout={logout}
+          hidePanel={hidePanel}
+        />
+      </Header>
+    </>
   );
 
-  return <div>{session && <HeaderContainer render={render} />}</div>;
+  if (user) {
+    return <HeaderContainer render={memo(HeaderItems)}></HeaderContainer>;
+  }
+
+  return (
+    <Navigate
+      to={`${openmrsSpaBase}login`}
+      state={{
+        referrer: window.location.pathname.slice(
+          window.location.pathname.indexOf(openmrsSpaBase) +
+            openmrsSpaBase.length -
+            1
+        ),
+      }}
+    />
+  );
 };
 
 export default Navbar;

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -171,7 +171,7 @@ const Navbar: React.FC = () => {
     </>
   );
 
-  if (user) {
+  if (user && session) {
     return <HeaderContainer render={memo(HeaderItems)}></HeaderContainer>;
   }
 

--- a/packages/apps/esm-primary-navigation-app/src/root.component.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/root.component.test.tsx
@@ -1,6 +1,7 @@
 import React from "react";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { of } from "rxjs";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { isDesktop } from "./utils";
 import { mockUser } from "../__mocks__/mock-user";
 import { mockSession } from "../__mocks__/mock-session";
@@ -8,6 +9,7 @@ import Root from "./root.component";
 
 const mockUserObservable = of(mockUser);
 const mockSessionObservable = of({ data: mockSession });
+
 jest.mock("@openmrs/esm-framework", () => ({
   openmrsFetch: jest.fn().mockResolvedValue({}),
   useAssignedExtensions: jest.fn().mockReturnValue([]),
@@ -25,6 +27,7 @@ jest.mock("@openmrs/esm-framework", () => ({
     const { useRef } = require("react");
     return useRef();
   }),
+  useSession: jest.fn().mockReturnValue(mockSession),
   refetchCurrentUser: jest.fn(),
   subscribeConnectivity: jest.fn(),
   navigate: jest.fn(),
@@ -46,23 +49,25 @@ jest.mock("./utils", () => ({
   isDesktop: jest.fn(() => true),
 }));
 
-describe(`<Root />`, () => {
-  beforeEach(() => {
-    render(<Root />);
-  });
-
+describe("Root", () => {
   it("should display navbar with title", async () => {
-    expect(screen.getByRole("button", { name: /Users/i })).toBeInTheDocument();
+    render(<Root />);
+
+    expect(screen.getByRole("button", { name: /users/i })).toBeInTheDocument();
     expect(
-      screen.getByRole("banner", { name: /OpenMRS/i })
+      screen.getByRole("banner", { name: /openmrs/i })
     ).toBeInTheDocument();
-    expect(screen.getByText(/Mock EMR/i)).toBeInTheDocument();
+    expect(screen.getByText(/mock emr/i)).toBeInTheDocument();
   });
 
   it("should open user-menu panel", async () => {
-    const userButton = await screen.findByRole("button", { name: /Users/i });
-    fireEvent.click(userButton);
-    expect(screen.getByLabelText(/Location/i)).toBeInTheDocument();
+    const user = userEvent.setup();
+
+    render(<Root />);
+
+    const userButton = screen.getByRole("button", { name: /users/i });
+    await user.click(userButton);
+    expect(screen.getByLabelText(/location/i)).toBeInTheDocument();
   });
 
   describe("when view is desktop", () => {

--- a/packages/apps/esm-primary-navigation-app/src/root.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/root.component.tsx
@@ -1,69 +1,15 @@
-import React, { useCallback, useEffect, useState } from "react";
-import styles from "./root.scss";
+import React from "react";
+import { BrowserRouter } from "react-router-dom";
 import Navbar from "./components/navbar/navbar.component";
-import { BrowserRouter, Navigate } from "react-router-dom";
-import { LoggedInUser, createErrorHandler } from "@openmrs/esm-framework";
-import { getCurrentSession, getSynchronizedCurrentUser } from "./root.resource";
-import { UserSession } from "./types";
+import styles from "./root.scss";
 
 export interface RootProps {}
 
 const Root: React.FC<RootProps> = () => {
-  const [user, setUser] = useState<LoggedInUser | null | false>(null);
-  const [userSession, setUserSession] = useState<UserSession>(null);
-  const [allowedLocales, setAllowedLocales] = useState<Array<string> | null>();
-  const logout = useCallback(() => setUser(false), []);
-  const openmrsSpaBase = window["getOpenmrsSpaBase"]();
-
-  useEffect(() => {
-    const currentUserSub = getSynchronizedCurrentUser().subscribe(
-      (response) => {
-        setAllowedLocales(response.allowedLocales);
-
-        if (response.authenticated) {
-          setUser(response.user);
-        } else {
-          setUser(false);
-        }
-
-        createErrorHandler();
-      }
-    );
-
-    const currentSessionSub = getCurrentSession().subscribe(({ data }) =>
-      setUserSession(data)
-    );
-
-    return () => {
-      currentUserSub.unsubscribe();
-      currentSessionSub.unsubscribe();
-    };
-  }, []);
-
   return (
     <BrowserRouter>
       <div className={styles.primaryNavContainer}>
-        {user === false ? (
-          <Navigate
-            to={`${openmrsSpaBase}login`}
-            state={{
-              referrer: window.location.pathname.slice(
-                window.location.pathname.indexOf(openmrsSpaBase) +
-                  openmrsSpaBase.length -
-                  1
-              ),
-            }}
-          />
-        ) : (
-          user && (
-            <Navbar
-              allowedLocales={allowedLocales}
-              user={user}
-              onLogout={logout}
-              session={userSession}
-            />
-          )
-        )}
+        <Navbar />
       </div>
     </BrowserRouter>
   );


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR refactors the primary navigation widget with the aim of improving performance. The significant change it introduces is how the session gets loaded. Specifically, instead of using `getSynchronizedCurrentUser` to fetch the session object, we use the `useSession` hook instead. In local testing, the navbar gets loaded faster each time compared to the previous implementation. The potential downside of this change is that changes made in offline mode might not sync as well as they did when using `getSynchronizedCurrentUser`.

Additionally, this PR moves some logic from the root component into the Navbar component. These include functions that fetch the current user session and log the user out. 