### PR TITLE
(feat) More useful service worker registration errors

### DIFF
--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -224,12 +224,12 @@ async function setupOffline() {
     );
     await activateOfflineCapability();
     setupOfflineStaticDependencyPrecaching();
-  } catch (e) {
-    console.error("Error while setting up offline mode.", e);
+  } catch (error) {
+    console.error("Error while setting up offline mode.", error);
     showNotification({
-      critical: true,
+      kind: "error",
       title: "Offline Setup Error",
-      description: `There was an error while initializing the website's offline mode. You can try reloading the page later.`,
+      description: error.message,
     });
   }
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Show more useful error messages when the service worker fails to get registered. The current error message isn't very helpful for users using browsers which don't support service workers.


## Screenshots
> Before

<img width="763" alt="Screenshot 2023-02-24 at 12 57 20" src="https://user-images.githubusercontent.com/8509731/221151247-9fac7edf-fb6f-4c3d-b43d-0a5fbbb6a52a.png">

> After

<img width="767" alt="Screenshot 2023-02-24 at 13 01 51" src="https://user-images.githubusercontent.com/8509731/221151284-a855fd1c-11dc-4929-8659-dce3bde4a0bf.png">
