### PR TITLE
(feat) Make core JS and CSS cacheable

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -8,7 +8,6 @@ const WebpackPwaManifest = require("webpack-pwa-manifest");
 const { InjectManifest } = require("workbox-webpack-plugin");
 const { DefinePlugin, container } = require("webpack");
 const { resolve } = require("path");
-const { readdirSync, statSync } = require("fs");
 const { removeTrailingSlash, getTimestamp } = require("./tools/helpers");
 const { name, version, dependencies } = require("./package.json");
 const sharedDependencies = require("./dependencies.json");
@@ -40,27 +39,6 @@ const openmrsConfigUrls = (process.env.OMRS_CONFIG_URLS || "")
   .map((url) => JSON.stringify(url))
   .join(", ");
 
-function checkDirectoryExists(dirName) {
-  if (dirName) {
-    try {
-      return statSync(dirName).isDirectory();
-    } catch {
-      return false;
-    }
-  }
-
-  return false;
-}
-
-function checkDirectoryHasContents(dirName) {
-  if (checkDirectoryExists(dirName)) {
-    const contents = readdirSync(dirName);
-    return contents.length > 0;
-  } else {
-    return false;
-  }
-}
-
 module.exports = (env, argv = {}) => {
   const mode = argv.mode || process.env.NODE_ENV || production;
   const outDir = mode === production ? "dist" : "lib";
@@ -70,7 +48,7 @@ module.exports = (env, argv = {}) => {
   return {
     entry: resolve(__dirname, "src/index.ts"),
     output: {
-      filename: "openmrs.js",
+      filename: isProd ? "openmrs.[contenthash].js" : "openmrs.js",
       chunkFilename: "[chunkhash].js",
       path: resolve(__dirname, outDir),
       publicPath: "",
@@ -221,7 +199,7 @@ module.exports = (env, argv = {}) => {
       }),
       isProd &&
         new MiniCssExtractPlugin({
-          filename: "openmrs.css",
+          filename: "openmrs.[contenthash].css",
         }),
       new DefinePlugin({
         "process.env.BUILD_VERSION": JSON.stringify(`${version}-${timestamp}`),


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Basically, this just renames `openmrs.js` and `openmrs.css` in production builds to include the contenthash. This allows us to also aggressively cache these files.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
