### PR TITLE
(chore) Restore limited sourcemaps for production

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -88,7 +88,7 @@ module.exports = (env, argv = {}) => {
       ],
     },
     mode,
-    devtool: isProd ? false : "inline-source-map",
+    devtool: isProd ? "hidden-nosources-source-map" : "eval-source-map",
     module: {
       rules: [
         {

--- a/packages/tooling/openmrs/src/commands/assemble.ts
+++ b/packages/tooling/openmrs/src/commands/assemble.ts
@@ -175,7 +175,6 @@ async function extractFiles(sourceFile: string, targetDir: string) {
 
   Object.keys(files)
     .filter((m) => m.startsWith(`${packageRoot}/${sourceDir}`))
-    .filter((m) => !m.endsWith(".map"))
     .forEach(async (m) => {
       const content = files[m];
       const fileName = m.replace(`${packageRoot}/${sourceDir}/`, "");

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -162,7 +162,6 @@ export default (
       publicPath: "auto",
       path: resolve(root, outDir),
     },
-    target: "web",
     module: {
       rules: [
         merge(
@@ -206,7 +205,8 @@ export default (
       ],
     },
     mode,
-    devtool: mode === production ? false : "inline-source-map",
+    devtool:
+      mode === production ? "hidden-nosources-source-map" : "eval-source-map",
     devServer: {
       headers: {
         "Access-Control-Allow-Origin": "*",


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Re-adds sourcemaps to production builds, but uses hidden-nosources maps, which should ensure that the maps are as small as possible and only really useful for stack traces, but hopefully this will help clarify the undiagnosable error messages we have.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
