### PR TITLE
(feat) Show more useful global errors

### DIFF
--- a/packages/framework/esm-error-handling/src/index.ts
+++ b/packages/framework/esm-error-handling/src/index.ts
@@ -4,17 +4,18 @@ import { dispatchNotificationShown } from "@openmrs/esm-globals";
 window.onerror = function (error) {
   console.error("Unexpected error: ", error);
   dispatchNotificationShown({
-    description: error,
+    description: error ?? "Oops! An unexpected error occurred.",
     kind: "error",
     title: "Error",
   });
   return false;
 };
 
-window.onunhandledrejection = function (error) {
-  console.error("Unhandled rejection: ", error);
+window.onunhandledrejection = function (event) {
+  console.error("Unhandled rejection: ", event.reason);
   dispatchNotificationShown({
-    description: error?.message,
+    description:
+      event.reason ?? "Oops! An unhandled promise rejection occurred.",
     kind: "error",
     title: "Error",
   });

--- a/packages/framework/esm-error-handling/src/index.ts
+++ b/packages/framework/esm-error-handling/src/index.ts
@@ -1,16 +1,22 @@
 /** @module @category Error Handling */
 import { dispatchNotificationShown } from "@openmrs/esm-globals";
 
-window.onerror = function () {
+window.onerror = function (error) {
+  console.error("Unexpected error: ", error);
   dispatchNotificationShown({
-    description: "Oops! An unexpected error occurred.",
+    description: error,
+    kind: "error",
+    title: "Error",
   });
   return false;
 };
 
-window.onunhandledrejection = function () {
+window.onunhandledrejection = function (error) {
+  console.error("Unhandled rejection: ", error);
   dispatchNotificationShown({
-    description: "Oops! An unexpected error occurred.",
+    description: error?.message,
+    kind: "error",
+    title: "Error",
   });
 };
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -2114,7 +2114,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-error-handling/src/index.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-error-handling/src/index.ts#L24)
+[packages/framework/esm-error-handling/src/index.ts:30](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-error-handling/src/index.ts#L30)
 
 ___
 
@@ -2134,7 +2134,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-error-handling/src/index.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-error-handling/src/index.ts#L17)
+[packages/framework/esm-error-handling/src/index.ts:23](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-error-handling/src/index.ts#L23)
 
 ___
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR amends the global error handling logic so that it displays the actual error messages instead of the uninformative `Oops! An unexpected error occurred` line. For context, both screenshots below relate to a situation where the app couldn't get a session object from the backend. 

## Screenshots

> Before

<img width="909" alt="Screenshot 2023-03-03 at 16 03 56" src="https://user-images.githubusercontent.com/8509731/222727269-d6202846-32bb-4b27-b061-c1acfd727671.png">


> After
<img width="910" alt="Screenshot 2023-03-03 at 15 57 39" src="https://user-images.githubusercontent.com/8509731/222727278-4ec05253-6a82-47ee-9908-7016bb4294da.png">



