### PR TITLE
O3-1129: Should be easy to differentiate slots from extensions

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
@@ -58,7 +58,7 @@ export function SlotOverlay({ slotName }) {
   return (
     <>
       <div className={styles.slotOverlay}></div>
-      <div className={styles.slotName}>{slotName}</div>
+      <div className={styles.slotName}>{"Slot: " + slotName}</div>
     </>
   );
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Slot names in the UI editor should be prefixed with `Slot: `.
@vasharma05 @hadijahkyampeire @denniskigen 

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1669" alt="Screenshot 2023-03-07 at 14 51 07" src="https://user-images.githubusercontent.com/58003327/223414333-6d13782c-8790-4e42-ac3b-d4e46cf4188f.png">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-1129

## Other
<!-- Anything not covered above -->
