### PR TITLE
feat: O3-512: clicking a slot name focuses the corresponding module config

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/config-tree.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/config-tree.component.tsx
@@ -2,12 +2,18 @@ import React from "react";
 import styles from "./config-tree.styles.scss";
 import { Accordion, AccordionItem } from "@carbon/react";
 import { ConfigTreeForModule } from "./config-tree-for-module.component";
+import { implementerToolsStore } from "../../store";
+import isEqual from "lodash-es/isEqual";
 
 export interface ConfigTreeProps {
   config: Record<string, any>;
 }
 
 export function ConfigTree({ config }: ConfigTreeProps) {
+  const shouldFocus = (moduleName) => {
+    const state = implementerToolsStore.getState();
+    return isEqual(state.activeItemDescription?.path[0], moduleName);
+  };
   return (
     <Accordion align="start">
       {config &&
@@ -17,6 +23,7 @@ export function ConfigTree({ config }: ConfigTreeProps) {
             const moduleConfig = config[moduleName];
             return Object.keys(moduleConfig).length ? (
               <AccordionItem
+                focus={shouldFocus(moduleName)}
                 title={<h6>{moduleName}</h6>}
                 className={styles.fullWidthAccordion}
                 key={`accordion-${moduleName}`}

--- a/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import styles from "./styles.css";
 import {
   getExtensionInternalStore,
+  useAssignedExtensions,
   useStore,
   useStoreWithActions,
 } from "@openmrs/esm-framework/src/internal";
@@ -26,7 +27,10 @@ export default function UiEditor() {
                 `*[data-extension-slot-name="${slotName}"][data-extension-slot-module-name="${slotInfo.moduleName}"]`
               )}
             >
-              <SlotOverlay slotName={slotName} />
+              <SlotOverlay
+                slotName={slotName}
+                moduleName={slotInfo.moduleName}
+              />
             </Portal>
           ))
         : null}
@@ -54,11 +58,33 @@ export default function UiEditor() {
   );
 }
 
-export function SlotOverlay({ slotName }) {
+export function SlotOverlay({ slotName, moduleName }) {
+  const assignedExtensions = useAssignedExtensions(slotName);
+
+  const setActiveExtensionSlot = (mdName, slotName) => {
+    if (!implementerToolsStore.getState().configPathBeingEdited) {
+      implementerToolsStore.setState({
+        activeItemDescription: {
+          path: [mdName, slotName],
+          value: assignedExtensions.map((e) => e.id),
+        },
+      });
+    }
+  };
   return (
     <>
       <div className={styles.slotOverlay}></div>
-      <div className={styles.slotName}>{slotName}</div>
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={(event) => {
+          event.preventDefault();
+          setActiveExtensionSlot(slotName, moduleName);
+        }}
+        className={styles.slotName}
+      >
+        {slotName}
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
For now, the rendered portal is not clickable its harder to verify that the logic is working right 
in the long run, we shall open the accordion and the corresponding slot config 

cc @vasharma05 @hadijahkyampeire @denniskigen 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
