### PR TITLE
(docs) Update FHIR module link in docs

### DIFF
--- a/docs/main/data.md
+++ b/docs/main/data.md
@@ -2,7 +2,7 @@
 
 Frontend modules interact with the OpenMRS server via the APIs exposed
 by its modules. In general, most of the endpoints we use are provided
-by the [FHIR Module](https://wiki.openmrs.org/display/projects/OpenMRS+HL7+FHIR+Solutions).
+by the [FHIR Module](https://wiki.openmrs.org/display/projects/FHIR+101%3A+OpenMRS+Strategy%2C+Tools%2C+FHIR+API%2C+and+Help).
 Most of the rest are provided by the
 [REST Module](https://wiki.openmrs.org/display/docs/REST+Module), which is
 documented [here](https://rest.openmrs.org/).


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Fixes a dead link in our frontend developer documentation's [Retrieving and posting data guide](https://o3-dev.docs.openmrs.org/#/main/data). This is what's causing the `check documentation` CI action to fail.

The old docs page appears to have [been moved](https://wiki.openmrs.org/display/projects/OpenMRS+HL7+FHIR+Solutions)