### PR TITLE
(fix) Remove global left nav menu style overrides

### DIFF
--- a/packages/apps/esm-offline-tools-app/src/dashboard-link.scss
+++ b/packages/apps/esm-offline-tools-app/src/dashboard-link.scss
@@ -1,6 +1,1 @@
 @import "~@openmrs/esm-styleguide/src/vars";
-
-:global(.active-left-nav-link) .link:nth-child(1) {
-  color: $ui-05;
-  padding: 1.2rem 0 1.2rem 1.2rem;
-}

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useRef } from "react";
-import { LeftNavMenu, usePatient } from "@openmrs/esm-framework";
+import React, { useEffect, useRef } from "react";
+import { LeftNavMenu } from "@openmrs/esm-framework";
 
 interface SideMenuPanelProps {
   expanded: boolean;
@@ -23,7 +23,7 @@ const SideMenuPanel: React.FC<SideMenuPanelProps> = ({
     return () => document.removeEventListener("click", handleClickOutside);
   }, [menuRef, hidePanel]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     window.addEventListener("popstate", hidePanel);
     return window.addEventListener("popstate", hidePanel);
   }, [hidePanel]);


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Removes some style overrides that affect the appearance of the [left panel](https://zeroheight.com/23a080e38/p/796c6a-left-panel). The source of truth for styling the left panel ought to be the Left Nav menu component [stylesheet](https://github.com/openmrs/openmrs-esm-core/blob/43a4cbe41f05df9e828d4a30c9d94b88f46a18ff/packages/framework/esm-styleguide/src/left-nav/left-nav.module.scss#L1).