### PR TITLE
(feat) Add support for caching the importmap

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -52,6 +52,7 @@ module.exports = (env, argv = {}) => {
       chunkFilename: "[chunkhash].js",
       path: resolve(__dirname, outDir),
       publicPath: "",
+      hashFunction: "xxhash64",
     },
     target: "web",
     devServer: {

--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -300,6 +300,12 @@ yargs.command(
         type: "string",
         coerce: (arg) => resolve(process.cwd(), arg),
       })
+      .option("hash-importmap", {
+        default: false,
+        description:
+          "Determines whether to include a content-specific hash for the generated importmap. This is useful if you want to be able to cache the importmap.",
+        type: "boolean",
+      })
       .option("fresh", {
         default: false,
         description:

--- a/packages/tooling/openmrs/src/commands/assemble.ts
+++ b/packages/tooling/openmrs/src/commands/assemble.ts
@@ -5,7 +5,7 @@ import rimraf from "rimraf";
 import axios from "axios";
 import npmRegistryFetch from "npm-registry-fetch";
 import pacote from "pacote";
-import { logInfo, untar } from "../utils";
+import { contentHash, logInfo, untar } from "../utils";
 import { createReadStream, existsSync } from "fs";
 import { getNpmRegistryConfiguration } from "../utils/npmConfig";
 
@@ -16,6 +16,7 @@ export interface AssembleArgs {
   mode: string;
   config: string;
   registry?: string;
+  hashImportmap: boolean;
   fresh: boolean;
   manifest: boolean;
 }
@@ -234,7 +235,10 @@ export async function runAssemble(args: AssembleArgs) {
   );
 
   await writeFile(
-    resolve(args.target, "importmap.json"),
+    resolve(
+      args.target,
+      `importmap${args.hashImportmap ? "." + contentHash(importmap) : ""}.json`
+    ),
     JSON.stringify(importmap, undefined, 2),
     "utf8"
   );

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -1,7 +1,13 @@
-import { copyFileSync, existsSync, readFileSync } from "fs";
+import {
+  copyFileSync,
+  existsSync,
+  readdirSync,
+  readFileSync,
+  statSync,
+} from "fs";
 import { getImportmap, loadWebpackConfig, logInfo } from "../utils";
 import rimraf from "rimraf";
-import { basename, join, resolve } from "path";
+import { basename, join, parse, resolve } from "path";
 
 /* eslint-disable no-console */
 
@@ -55,8 +61,28 @@ export async function runBuild(args: BuildArgs) {
     configUrls.push(basename(configPath));
   }
 
+  const importMap = await getImportmap(buildConfig.importmap || args.importmap);
+  // if we're supplying a URL importmap and the dist folder exists and the raw importmap file doesn't exist
+  // we use the nearest thing. Basically, this is added to support the --hash-importmap assemble option.
+  if (importMap.type === "url") {
+    if (
+      existsSync(args.target) &&
+      !existsSync(resolve(args.target, importMap.value))
+    ) {
+      const { name: fileName, ext: extension } = parse(importMap.value);
+      const paths = readdirSync(args.target).filter(
+        (entry) =>
+          entry.startsWith(fileName) &&
+          entry.endsWith(extension) &&
+          statSync(resolve(args.target, entry)).isFile()
+      );
+      if (paths) {
+        importMap.value = paths[0];
+      }
+    }
+  }
   const config = loadWebpackConfig({
-    importmap: await getImportmap(buildConfig.importmap || args.importmap),
+    importmap: importMap,
     env: "production",
     apiUrl: buildConfig.apiUrl || args.apiUrl,
     configUrls: configUrls,

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -66,6 +66,7 @@ export async function runBuild(args: BuildArgs) {
   // we use the nearest thing. Basically, this is added to support the --hash-importmap assemble option.
   if (importMap.type === "url") {
     if (
+      !/^https?:\/\//.test(importMap.value) &&
       existsSync(args.target) &&
       !existsSync(resolve(args.target, importMap.value))
     ) {

--- a/packages/tooling/openmrs/src/utils/helpers.ts
+++ b/packages/tooling/openmrs/src/utils/helpers.ts
@@ -1,3 +1,5 @@
+import { util } from "webpack";
+
 export function trimEnd(text: string, chr: string) {
   while (text.endsWith(chr)) {
     text = text.substr(0, text.length - chr.length);
@@ -9,4 +11,10 @@ export function trimEnd(text: string, chr: string) {
 export function removeTrailingSlash(path: string) {
   const i = path.length - 1;
   return path[i] === "/" ? removeTrailingSlash(path.substr(0, i)) : path;
+}
+
+export function contentHash(obj: object) {
+  const hash = util.createHash("xxhash64");
+  hash.update(JSON.stringify(obj), "UTF-8");
+  return hash.digest().toString("hex");
 }

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -158,9 +158,9 @@ export default (
     // only one container context--i.e., if we had an entry point per module,
     // WMF could get confused and not resolve shared dependencies correctly.
     output: {
-      // Use default `libraryTarget`, which is jsonp
       publicPath: "auto",
       path: resolve(root, outDir),
+      hashFunction: "xxhash64",
     },
     module: {
       rules: [


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ] My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Allows us to generate content hashes for importmaps so they can be cached.

Previously, we've relied on the pattern of running:
  openmrs build
  openmrs assemble

In that order. Since the build step needs to know the importmap URL, to take advantage of this you need to run:
  openmrs assemble --hash-importmap
  openmrs build

The build step should automatically detect the importmap (based on name).

This PR also changes our default hash function to xxhash64, which is slated to be the default hash function for Webpack 6 and should allow us to avoid having to use `--legacy-ssl-provider` when running the build and assemble steps (this is required because Webpack's default hash is MD4, which is very fast, but very broken; xxhash64 is intentionally **not** a cryptographic algorithm).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-1938

## Other
<!-- Anything not covered above -->
