### PR TITLE
(fix) O3-1492: Remove dangerous global selectors from stylesheets

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -32,6 +32,16 @@
   border-right: none;
 }
 
+/* Side nav */
+.cds--side-nav {
+  z-index: 0;
+}
+
+/* Tooltip */
+.cds--tooltip--definition .cds--tooltip__trigger {
+  border-bottom: none;
+}
+
 /* Content Switcher */
 .cds--content-switcher-btn {
   background-color: $ui-02;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Sets up global overrides for the `SideNav` and `Tooltip` carbon components in the style guide. This is the canonical way to set up style overrides without polluting the global scope. 

## Related Issue
https://issues.openmrs.org/browse/O3-1492
