### PR TITLE
(fix) Properly scope hyperlink styles for the left nav menu

### DIFF
--- a/packages/framework/esm-styleguide/src/left-nav/left-nav.module.scss
+++ b/packages/framework/esm-styleguide/src/left-nav/left-nav.module.scss
@@ -22,6 +22,14 @@
     }
 
     a {
+      :global(.omrs-breakpoint-gt-tablet) {
+        height: 2rem;
+      }
+
+      :global(.omrs-breakpoint-lt-desktop) {
+        height: 3rem;
+      }
+
       color: $ui-04;
       @include type.type-style("heading-compact-01");
       color: $text-02;
@@ -37,22 +45,6 @@
         color: $ui-05;
         border-left: var(--brand-01);
       }
-    }
-  }
-}
-
-:global(.omrs-breakpoint-gt-tablet) {
-  div {
-    a {
-      height: 2rem;
-    }
-  }
-}
-
-:global(.omrs-breakpoint-lt-desktop) {
-  div {
-    a {
-      height: 3rem;
     }
   }
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Fixes the appearance of hyperlinks in the app after I broke them by mistakenly applying [these styles globally](https://github.com/openmrs/openmrs-esm-core/blob/a98a7b15cc16b615cce4b19f9d3133faf5f2b74e/packages/framework/esm-styleguide/src/left-nav/left-nav.module.scss#L44). This has borked the display of things like breadcrumbs in the app.

This PR fixes that by properly scoping the styles affecting hyperlinks in the left nav menu under the `leftNav` class name.

## Screenshots

> Broken breadcrumbs menu due to height override

<img width="374" alt="Screenshot 2023-03-15 at 12 11 44 PM" src="https://user-images.githubusercontent.com/8509731/225261746-875213e5-9043-4dcd-946e-6913f1b5fd15.png">

