### PR TITLE
(feat) Even more left nav UI tweaks

### DIFF
--- a/packages/framework/esm-styleguide/src/left-nav/left-nav.module.scss
+++ b/packages/framework/esm-styleguide/src/left-nav/left-nav.module.scss
@@ -3,48 +3,39 @@
 
 .leftNav {
   border-right: 1px solid $ui-03;
-  margin-top: 1rem;
+  padding-top: 1rem;
 
-  :global(.active-left-nav-link) {
-    background-color: $ui-03;
-    outline: none;
-    border-left: 0.25rem solid var(--brand-01);
+  // Left nav menu item
+  :global(.cds--side-nav__link) {
+    color: $text-02;
+    @include type.type-style("heading-compact-01");
 
-    > :global(.cds--side-nav__link) {
-      padding: 0 0.75rem;
+    &:focus,
+    &:hover {
+      background-color: $ui-01;
+    }
+
+    // Active menu item
+    &:global(.active-left-nav-link) {
       color: $ui-05;
+      border-left: 0.25rem solid var(--brand-01);
+      background-color: $ui-03;
+      outline: none;
+      padding: 0 0.75rem;
     }
   }
+}
 
-  div {
-    &:global(.omrs-breakpoint-gt-tablet) {
-      padding-top: 1rem;
-    }
+/* Desktop */
+:global(.omrs-breakpoint-gt-tablet) {
+  :global(.cds--side-nav__link) {
+    height: 2rem;
+  }
+}
 
-    a {
-      :global(.omrs-breakpoint-gt-tablet) {
-        height: 2rem;
-      }
-
-      :global(.omrs-breakpoint-lt-desktop) {
-        height: 3rem;
-      }
-
-      color: $ui-04;
-      @include type.type-style("heading-compact-01");
-      color: $text-02;
-
-      &:hover {
-        background-color: $ui-03;
-        color: $ui-05;
-        border-left: var(--brand-01);
-      }
-
-      &:focus {
-        background-color: $ui-03;
-        color: $ui-05;
-        border-left: var(--brand-01);
-      }
-    }
+/* Tablet */
+:global(.omrs-breakpoint-lt-desktop) {
+  :global(.cds--side-nav__link) {
+    height: 3rem;
   }
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Annoying that we're here again, but I cannot for the life of me figure out why local changes to the styleguide don't get propagated to my dev server after rebuilding the styleguide when running `yarn run:shell`. Regardless, here we are. The basic premise here is that these changes:

- Ensure that the right border of the left nav menu begins at the very top of the nav. This is achieved by using padding at the top of the menu instead of some margin.
- We're setting the background color of nav menu items to a light gray (`#f4f4f4`) on focus and hover.
- We're ensuring that the active menu item has a text color of `#161616`, whereas inactive items have a text color of `#525252`.
- We're using a more specific selector combination to ensure that menu items are `3rem` tall on a tablet, and `2rem` tall on a desktop.

## Other

[This](https://zeroheight.com/23a080e38/p/796c6a-left-panel) is the desired outcome.