### PR TITLE
(fix) Restore omitted `ContentSwitcher` styles

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -44,9 +44,14 @@
 
 /* Content Switcher */
 .cds--content-switcher-btn {
+  background-color: $ui-02;
   border: none;
   border-top: 1px solid colors.$blue-30;
   border-bottom: 1px solid colors.$blue-30;
+
+  &::after {
+    background-color: transparent;
+  }
 
   &:first-child {
     border-bottom-left-radius: 0.25rem;
@@ -60,13 +65,19 @@
     border-top-right-radius: 0.25rem;
   }
 
-  &:cds--content-switcher--selected {
+  &::before {
+    background-color: colors.$blue-30;
+    height: 100%;
+    z-index: 0;
+  }
+
+  &.cds--content-switcher--selected {
     border: 1px solid colors.$blue-60;
     background-color: colors.$blue-10;
     color: colors.$blue-60;
 
     &::after {
-      background: none;
+      background-color: colors.$blue-10;
     }
   }
 }


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Adds some missing styling that should've been part of #611.