### PR TITLE
(feat) Clear SWR cache on logout

### DIFF
--- a/packages/apps/esm-login-app/src/redirect-logout/logout.resource.ts
+++ b/packages/apps/esm-login-app/src/redirect-logout/logout.resource.ts
@@ -3,11 +3,17 @@ import {
   openmrsFetch,
   refetchCurrentUser,
 } from "@openmrs/esm-framework";
+import { mutate } from "swr";
 
 export async function performLogout() {
   await openmrsFetch("/ws/rest/v1/session", {
     method: "DELETE",
   });
+
+  // clear the SWR cache on logout, do not revalidate
+  // taken from the SWR docs
+  mutate(() => true, undefined, { revalidate: false });
+
   clearCurrentUser();
   await refetchCurrentUser();
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Does what it says, that is, clears the SWR cache when the user clicks the logout button. This hopefully prevents the user from seeing stale data that they shouldn't in the case where:

1. A more privileged user (e.g., System Developer) logs in and then logs out
2. Then, without reloading the page, a less privileged user logs in to the app

Without this change, the SWR cache is storing the results from session 1 as the "stale" data, which means both that the less privileged user in session 2 will see this stale data "flash".

Related Slack conversation: https://openmrs.slack.com/archives/CHP5QAE5R/p1678956705607029

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
