### PR TITLE
(feat) Control clean plugin through CLI

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -38,6 +38,20 @@ const openmrsConfigUrls = (process.env.OMRS_CONFIG_URLS || "")
   .filter((url) => url.length > 0)
   .map((url) => JSON.stringify(url))
   .join(", ");
+const openmrsCleanBeforeBuild =
+  (() => {
+    try {
+      return (
+        process.env.OMRS_CLEAN_BEFORE_BUILD === undefined ||
+        (typeof process.env.OMRS_CLEAN_BEFORE_BUILD === "boolean" &&
+          process.env.OMRS_CLEAN_BEFORE_BUILD) ||
+        (typeof process.env.OMRS_CLEAN_BEFORE_BUILD === "string" &&
+          process.env.OMRS_CLEAN_BEFORE_BUILD.toLowerCase() !== "false")
+      );
+    } catch {}
+
+    return undefined;
+  })() ?? true;
 
 module.exports = (env, argv = {}) => {
   const mode = argv.mode || process.env.NODE_ENV || production;
@@ -149,7 +163,7 @@ module.exports = (env, argv = {}) => {
       },
     },
     plugins: [
-      new CleanWebpackPlugin(),
+      openmrsCleanBeforeBuild && new CleanWebpackPlugin(),
       new WebpackPwaManifest({
         name: "OpenMRS",
         short_name: "OpenMRS",

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -90,13 +90,10 @@ export async function runBuild(args: BuildArgs) {
     pageTitle: buildConfig.pageTitle || args.pageTitle,
     supportOffline: buildConfig.supportOffline ?? args.supportOffline,
     spaPath: buildConfig.spaPath || args.spaPath,
+    fresh: args.fresh ?? false,
   });
 
   logInfo(`Running build process ...`);
-
-  if (args.fresh && existsSync(args.target)) {
-    await new Promise((resolve) => rimraf(args.target, resolve));
-  }
 
   const compiler = webpack({
     ...config,

--- a/packages/tooling/openmrs/src/utils/config.ts
+++ b/packages/tooling/openmrs/src/utils/config.ts
@@ -12,6 +12,7 @@ export interface WebpackOptions {
   env?: string;
   coreAppsDir?: string;
   addCookie?: string;
+  fresh?: boolean;
 }
 
 export function loadWebpackConfig(options: WebpackOptions = {}) {
@@ -63,6 +64,10 @@ export function loadWebpackConfig(options: WebpackOptions = {}) {
 
   if (typeof options.coreAppsDir === "string") {
     variables.OMRS_ESM_CORE_APPS_DIR = options.coreAppsDir;
+  }
+
+  if (typeof options.fresh === "boolean") {
+    variables.OMRS_CLEAN_BEFORE_BUILD = options.fresh;
   }
 
   setEnvVariables(variables);


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Hopefully the last PR [related](https://github.com/openmrs/openmrs-esm-core/pull/641) [to](https://github.com/openmrs/openmrs-esm-core/pull/628) [caching](https://github.com/openmrs/openmrs-esm-core/pull/623) for a bit.

#628 attempted to fix this by defaulting the `--fresh` argument to `false`. Unfortunately, it turns out that `--fresh` wasn't the only thing clearing out the build directory, we were also using the `CleanWebpackPlugin`. The `CleanWebpackPlugin` is necessary when actually building the shell as part of the release process for this repo, but isn't useful when running the build using the CLI in conjunction with the `assemble` command, so this PR makes it possible to turn off the `CleanWebpackPlugin` and re-wires the `--fresh` option on the `build` command to control the `CleanWebpackPlugin`.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
