### PR TITLE
(fix) support use-cases where response is not JSON

### DIFF
--- a/packages/framework/esm-api/src/openmrs-fetch.test.ts
+++ b/packages/framework/esm-api/src/openmrs-fetch.test.ts
@@ -119,7 +119,9 @@ describe("openmrsFetch", () => {
       Promise.resolve({
         ok: true,
         status: 200,
-        text: () => Promise.resolve('{ "value": "hi" }'),
+        clone: () => ({
+          text: () => Promise.resolve('{ "value": "hi" }'),
+        }),
       })
     );
 
@@ -152,12 +154,14 @@ describe("openmrsFetch", () => {
         ok: false,
         status: 500,
         statusText: "Internal Server Error",
-        text: () =>
-          Promise.resolve(
-            JSON.stringify({
-              error: "The server is dead",
-            })
-          ),
+        clone: () => ({
+          text: () =>
+            Promise.resolve(
+              JSON.stringify({
+                error: "The server is dead",
+              })
+            ),
+        }),
       })
     );
 
@@ -182,7 +186,9 @@ describe("openmrsFetch", () => {
         ok: false,
         status: 400,
         statusText: "You goofed up",
-        text: () => Promise.resolve("a string response body"),
+        clone: () => ({
+          text: () => Promise.resolve("a string response body"),
+        }),
       })
     );
 
@@ -242,7 +248,9 @@ describe("openmrsObservableFetch", () => {
       Promise.resolve({
         ok: true,
         status: 200,
-        text: () => Promise.resolve('{"value": "hi"}'),
+        clone: () => ({
+          text: () => Promise.resolve('{"value": "hi"}'),
+        }),
       })
     );
 
@@ -255,7 +263,7 @@ describe("openmrsObservableFetch", () => {
         done();
       },
       (err) => {
-        fail(err);
+        done.fail(err);
       }
     );
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1097,7 +1097,7 @@ To cancel the network request, simply call `subscription.unsubscribe();`
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:270](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L270)
+[packages/framework/esm-api/src/openmrs-fetch.ts:281](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L281)
 
 ___
 

--- a/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
+++ b/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
@@ -53,7 +53,7 @@ Error.constructor
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:308](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L308)
+[packages/framework/esm-api/src/openmrs-fetch.ts:319](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L319)
 
 ## API Properties
 
@@ -63,7 +63,7 @@ Error.constructor
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:321](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L321)
+[packages/framework/esm-api/src/openmrs-fetch.ts:332](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L332)
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:322](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L322)
+[packages/framework/esm-api/src/openmrs-fetch.ts:333](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L333)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/FetchConfig.md
+++ b/packages/framework/esm-framework/docs/interfaces/FetchConfig.md
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:327](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L327)
+[packages/framework/esm-api/src/openmrs-fetch.ts:338](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L338)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:326](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L326)
+[packages/framework/esm-api/src/openmrs-fetch.ts:337](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L337)
 
 ___
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

`openmrsFetch()` makes a hard assumption that the data returned will be JSON, and uses this to populate the `response.data` field. The problem is that in the handful of cases where the response is not JSON, the response text is lost. This is because in `openmrsFetch()` we're using a call to `text()` to consume the body of the response, but if the body cannot be parsed as JSON, we throw it out and the `bodyUsed` property will be set to `true` making it impossible to make a new call to `text()` to get the response content.

The Fetch API provides a `clone()` method that duplicates the response, essentially to handle exactly this case (be able to re-use the response body), so this method changes things so that `openmrsFetch()` operates on a clone of the response, adding the `data` property to the original response if the body can be parsed as JSON, but always returning a response with a body that the client can consume however they like.

The hope here is that the impact of the cloning on performance is minimal. Most uses of `openmrsFetch()` should be unaffected, but in the few cases where we need to deal with non-JSON responses, we should still be able to use `openmrsFetch()` to take advantage of it's other features, like session verification, URL interpolation, etc.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

This PR is motivated by three commits to openmrs-esm-form-builder:

* [15e9cfe](https://github.com/openmrs/openmrs-esm-form-builder/commit/15e9cfee073f0ded1865c0fb8a01d9a63472579b)
* [2e6e277](https://github.com/openmrs/openmrs-esm-form-builder/commit/2e6e277127e2d27f2ff2ded951fc46513a47ad54)
* [534ebb5](https://github.com/openmrs/openmrs-esm-form-builder/commit/534ebb58643987472362fb853ddc6dbb6f642bd6)

The underlying issue for the follow-up commits is that we were relying on some poorly-defined Axios magic to make things work, particularly with the API actually just returning a string rather than a valid JSON object.