### PR TITLE
(fix) Remove full export of @carbon/react from app-shell

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "typedoc-plugin-markdown": "3.11.14",
     "typedoc-plugin-no-inherit": "^1.3.1",
     "typescript": "~4.6.4",
-    "webpack": "^5.74.0"
+    "webpack": "^5.75.0"
   },
   "resolutions": {
     "minipass": "3.3.5",

--- a/packages/shell/esm-app-shell/dependencies.json
+++ b/packages/shell/esm-app-shell/dependencies.json
@@ -5,9 +5,7 @@
   "react-dom",
   "react-router-dom",
   "react-i18next",
-  "single-spa",
   "@openmrs/esm-framework",
   "@openmrs/esm-framework/src/internal",
-  "@carbon/react",
   "rxjs"
 ]

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -51,7 +51,7 @@
     "rimraf": "^3.0.2",
     "tar": "^6.0.5",
     "typescript": "~4.5.2",
-    "webpack": "^5.74.0",
+    "webpack": "^5.75.0",
     "webpack-cli": "^4.10.0",
     "webpack-dev-server": "^4.10.1",
     "webpack-pwa-manifest": "^4.3.0",

--- a/packages/tooling/webpack-config/package.json
+++ b/packages/tooling/webpack-config/package.json
@@ -43,7 +43,7 @@
     "style-loader": "^3.3.1",
     "swc-loader": "^0.1.15",
     "systemjs-webpack-interop": "^2.3.7",
-    "webpack": "^5.74.0",
+    "webpack": "^5.75.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-stats-plugin": "^1.0.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3609,7 +3609,7 @@ __metadata:
     typedoc-plugin-markdown: 3.11.14
     typedoc-plugin-no-inherit: ^1.3.1
     typescript: ~4.6.4
-    webpack: ^5.74.0
+    webpack: ^5.75.0
   languageName: unknown
   linkType: soft
 
@@ -3916,7 +3916,7 @@ __metadata:
     swc-loader: ^0.1.15
     systemjs-webpack-interop: ^2.3.7
     typescript: ~4.5.2
-    webpack: ^5.74.0
+    webpack: ^5.75.0
     webpack-bundle-analyzer: ^4.5.0
     webpack-stats-plugin: ^1.0.3
   peerDependencies:
@@ -14668,7 +14668,7 @@ __metadata:
     rimraf: ^3.0.2
     tar: ^6.0.5
     typescript: ~4.5.2
-    webpack: ^5.74.0
+    webpack: ^5.75.0
     webpack-cli: ^4.10.0
     webpack-dev-server: ^4.10.1
     webpack-pwa-manifest: ^4.3.0
@@ -19791,46 +19791,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"webpack@npm:^5.74.0":
-  version: 5.74.0
-  resolution: "webpack@npm:5.74.0"
-  dependencies:
-    "@types/eslint-scope": ^3.7.3
-    "@types/estree": ^0.0.51
-    "@webassemblyjs/ast": 1.11.1
-    "@webassemblyjs/wasm-edit": 1.11.1
-    "@webassemblyjs/wasm-parser": 1.11.1
-    acorn: ^8.7.1
-    acorn-import-assertions: ^1.7.6
-    browserslist: ^4.14.5
-    chrome-trace-event: ^1.0.2
-    enhanced-resolve: ^5.10.0
-    es-module-lexer: ^0.9.0
-    eslint-scope: 5.1.1
-    events: ^3.2.0
-    glob-to-regexp: ^0.4.1
-    graceful-fs: ^4.2.9
-    json-parse-even-better-errors: ^2.3.1
-    loader-runner: ^4.2.0
-    mime-types: ^2.1.27
-    neo-async: ^2.6.2
-    schema-utils: ^3.1.0
-    tapable: ^2.1.1
-    terser-webpack-plugin: ^5.1.3
-    watchpack: ^2.4.0
-    webpack-sources: ^3.2.3
-  peerDependenciesMeta:
-    webpack-cli:
-      optional: true
-  bin:
-    webpack: bin/webpack.js
-  checksum: 320c41369a75051b19e18c63f408b3dcc481852e992f83d311771c5ec0f05f2946385e8ebef62030cf3587f0a3d2f12779ffdb191569a966847289ba7313f946
-  languageName: node
-  linkType: hard
-
 "webpack@npm:^5.75.0":
-  version: 5.75.0
-  resolution: "webpack@npm:5.75.0"
+  version: 5.77.0
+  resolution: "webpack@npm:5.77.0"
   dependencies:
     "@types/eslint-scope": ^3.7.3
     "@types/estree": ^0.0.51
@@ -19861,7 +19824,7 @@ __metadata:
       optional: true
   bin:
     webpack: bin/webpack.js
-  checksum: 2bcc5f3c195f375944e8af2f00bf2feea39cb9fda5f763b0d1b00077f1c51783db25c94d3fae96a07dead9fa085e6ae7474417e5ab31719c9776ea5969ceb83a
+  checksum: 21341bb72cbbf61dfb3af91eabe9290a6c05139f268eff3c419e5339deb6c79f2f36de55d9abf017d3ccbad290a535c02325001b2816acc393f3c022e67ac17c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently, we have `@carbon/react` marked as a shared module in the app shell's Module Federation configuration. This essentially means that we're bundling the whole of `@carbon/react` in the app shell. Since, AFAICT, none of our MFs depend on a shared version of `@carbon/react`, this means we're shipping unnecessary code. This PR just removes `@carbon/react` as a shared module.

