### PR TITLE
(fix) O3-2015: User can’t click on any button while the toasts are up

### DIFF
--- a/packages/framework/esm-styleguide/src/toasts/_toasts.scss
+++ b/packages/framework/esm-styleguide/src/toasts/_toasts.scss
@@ -1,8 +1,8 @@
 .omrs-toasts-container {
   z-index: 100000;
   position: fixed;
-  width: 100%;
   top: 3rem;
+  right: 0;
   display: flex;
   flex-direction: column;
   align-items: flex-end;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
 - The toasts container was taking up the whole width which blocked elements like buttons that were in the same horizontal line with the toasts once they are up.

## Screenshots
<!-- Required if you are making UI changes. -->
### Before
![image](https://user-images.githubusercontent.com/104269786/230596791-42409934-4e11-4d23-a5d6-3549b3b84ff8.png)

### After
[Screencast from 2023-04-07 13-24-09.webm](https://user-images.githubusercontent.com/104269786/230596867-24f7b6a0-c518-41fe-bb74-829817c6b04f.webm)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
 - https://issues.openmrs.org/browse/O3-2015

## Other
<!-- Anything not covered above -->

