### PR TITLE
(fix) KH-126: Redirected to home page without selecting a location

### DIFF
--- a/packages/apps/esm-login-app/src/location-picker/location-picker.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.component.tsx
@@ -117,18 +117,6 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
     return chooseLocation.numberToShow;
   });
 
-  // Handle cases where the location picker is disabled, there is only one location, or there are no locations.
-  useEffect(() => {
-    if (!isLoading) {
-      if (!config.chooseLocation.enabled || locations?.length === 1) {
-        changeLocation(locations[0]?.resource.id);
-      }
-      if (!isLoading && !locations?.length) {
-        changeLocation();
-      }
-    }
-  }, [config.chooseLocation.enabled, isLoading, locations, changeLocation]);
-
   const search = debounce((location: string) => {
     setActiveLocation("");
     setSearchTerm(location);
@@ -196,6 +184,22 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
           <div className={styles.searchResults}>
             {isLoading ? (
               <div className={styles.loadingContainer}>
+                <RadioButtonSkeleton
+                  className={styles.radioButtonSkeleton}
+                  role="progressbar"
+                />
+                <RadioButtonSkeleton
+                  className={styles.radioButtonSkeleton}
+                  role="progressbar"
+                />
+                <RadioButtonSkeleton
+                  className={styles.radioButtonSkeleton}
+                  role="progressbar"
+                />
+                <RadioButtonSkeleton
+                  className={styles.radioButtonSkeleton}
+                  role="progressbar"
+                />
                 <RadioButtonSkeleton
                   className={styles.radioButtonSkeleton}
                   role="progressbar"

--- a/packages/apps/esm-login-app/src/location-picker/location-picker.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.component.tsx
@@ -117,6 +117,24 @@ const LocationPicker: React.FC<LocationPickerProps> = ({
     return chooseLocation.numberToShow;
   });
 
+  // Handle cases where the location picker is disabled, there is only one location, or there are no locations.
+  useEffect(() => {
+    if (!isLoading && !searchTerm) {
+      if (!config.chooseLocation.enabled || locations?.length === 1) {
+        changeLocation(locations[0]?.resource.id);
+      }
+      if (!locations?.length) {
+        changeLocation();
+      }
+    }
+  }, [
+    config.chooseLocation.enabled,
+    isLoading,
+    locations,
+    changeLocation,
+    searchTerm,
+  ]);
+
   const search = debounce((location: string) => {
     setActiveLocation("");
     setSearchTerm(location);

--- a/packages/apps/esm-login-app/src/location-picker/location-picker.scss
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.scss
@@ -52,7 +52,7 @@
 .locationResultsContainer {
   display: flex;
   overflow-y: auto;
-  padding: 0rem spacing.$spacing-01 0rem;
+  padding: spacing.$spacing-03 spacing.$spacing-01 0rem;
 }
 
 .locationRadioButton {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR fixes the issue of redirection to home page without selecting any location, mainly triggered when searching.

The cause of the issue was the below condition:
```
// Handle cases where the location picker is disabled, there is only one location, or there are no locations.
  useEffect(() => {
    if (!isLoading) {
      if (!config.chooseLocation.enabled || locations?.length === 1) {
        changeLocation(locations[0]?.resource.id);
      }
      if (!isLoading && !locations?.length) {
        changeLocation();
      }
    }
  }, [config.chooseLocation.enabled, isLoading, locations, changeLocation]);
```

Since the searching is done via backend's endpoint, cases where only 1 or no results were returned, the user was redirected to the home page without selecting any location.

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/KH-126

## Other
<!-- Anything not covered above -->
