### PR TITLE
(fix) User should be redirected to location picker if no location is found in session

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -171,8 +171,10 @@ const Navbar: React.FC = () => {
     </>
   );
 
-  if (user && session && !session.sessionLocation) {
-    return (
+  if (user && session) {
+    return session.sessionLocation ? (
+      <HeaderContainer render={memo(HeaderItems)}></HeaderContainer>
+    ) : (
       <Navigate
         to={`${openmrsSpaBase}login/location`}
         state={{
@@ -184,10 +186,6 @@ const Navbar: React.FC = () => {
         }}
       />
     );
-  }
-
-  if (user && session) {
-    return <HeaderContainer render={memo(HeaderItems)}></HeaderContainer>;
   }
 
   return (

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -171,6 +171,21 @@ const Navbar: React.FC = () => {
     </>
   );
 
+  if (user && session && !session.sessionLocation) {
+    return (
+      <Navigate
+        to={`${openmrsSpaBase}login/location`}
+        state={{
+          referrer: window.location.pathname.slice(
+            window.location.pathname.indexOf(openmrsSpaBase) +
+              openmrsSpaBase.length -
+              1
+          ),
+        }}
+      />
+    );
+  }
+
   if (user && session) {
     return <HeaderContainer render={memo(HeaderItems)}></HeaderContainer>;
   }

--- a/packages/framework/esm-api/src/shared-api-objects/current-user.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/current-user.ts
@@ -160,8 +160,8 @@ function isSuperUser(user: { roles: Array<Role> }) {
  * refetchCurrentUser()
  * ```
  */
-export async function refetchCurrentUser() {
-  return await new Promise((resolve, reject) => {
+export function refetchCurrentUser() {
+  return new Promise((resolve, reject) => {
     lastFetchTimeMillis = Date.now();
     openmrsFetch(sessionEndpoint)
       .then((res) => {

--- a/packages/framework/esm-api/src/shared-api-objects/current-user.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/current-user.ts
@@ -160,8 +160,8 @@ function isSuperUser(user: { roles: Array<Role> }) {
  * refetchCurrentUser()
  * ```
  */
-export function refetchCurrentUser() {
-  return new Promise((resolve, reject) => {
+export async function refetchCurrentUser() {
+  return await new Promise((resolve, reject) => {
     lastFetchTimeMillis = Date.now();
     openmrsFetch(sessionEndpoint)
       .then((res) => {
@@ -249,5 +249,5 @@ export async function setSessionLocation(
     signal: abortController.signal,
   });
 
-  refetchCurrentUser();
+  await refetchCurrentUser();
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Currently, if the user by any chance skip the location picker and comes directly to the home page after login, there are many places where various APIs fails due to `undefined` location.

This fix will redirect the user to the location picker, if there's no location found in the session object.

SIde effect: The time to set location and moving to the home page increases due to the wait for updating the session object before moving ahead in the app.

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/KH-125

## Other
<!-- Anything not covered above -->
