### PR TITLE
(fix) Support for loading relative URLs

### DIFF
--- a/packages/shell/esm-app-shell/src/load-modules.ts
+++ b/packages/shell/esm-app-shell/src/load-modules.ts
@@ -25,6 +25,10 @@ export async function loadModules(modules: Record<string, string>) {
         return [name, {}];
       }
 
+      if (url.startsWith("./")) {
+        url = window.spaBase + url.substring(1);
+      }
+
       try {
         await new Promise((resolve, reject) => {
           loadScript(name, url, resolve, reject);

--- a/packages/shell/esm-app-shell/tools/helpers.js
+++ b/packages/shell/esm-app-shell/tools/helpers.js
@@ -1,3 +1,9 @@
+/**
+ * Removes the trailing slash from a path
+ *
+ * @param {string} path - The path to remove the trailing slash from
+ * @returns {string} The path without a trailing slash
+ */
 exports.removeTrailingSlash = (path) => {
   const i = path.length - 1;
   return path[i] === "/"
@@ -5,13 +11,19 @@ exports.removeTrailingSlash = (path) => {
     : path;
 };
 
-exports.doubleDigit = (num) => {
+/**
+ * Left-pads a number to ensure it is exactly two characters
+ *
+ * @param {string | number} num - The number to pad
+ * @returns {string} The number as a string, padded to two places
+ */
+const padToTwoDigits = (num) => {
   return num.toString().padStart(2, "0");
 };
 
 exports.getTimestamp = () => {
   const today = new Date();
-  const dd = exports.doubleDigit;
+  const dd = padToTwoDigits;
   return `${today.getFullYear()}${dd(today.getMonth() + 1)}${dd(
     today.getDate()
   )}`;

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -27,7 +27,8 @@ const openmrsPublicPath = removeTrailingSlash(
 const openmrsProxyTarget =
   process.env.OMRS_PROXY_TARGET || "https://dev3.openmrs.org/";
 const openmrsPageTitle = process.env.OMRS_PAGE_TITLE || "OpenMRS";
-const openmrsFavicon = process.env.OMRS_FAVICON || "favicon.ico";
+const openmrsFavicon =
+  process.env.OMRS_FAVICON || `${openmrsPublicPath}/favicon.ico`;
 const openmrsOffline = process.env.OMRS_OFFLINE !== "disable";
 const openmrsImportmapDef = process.env.OMRS_ESM_IMPORTMAP;
 const openmrsEnvironment = process.env.OMRS_ENV || process.env.NODE_ENV || "";


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

The default URLs used are resolved relative to the current URL. When the SPA starts on `/openmrs/spa/` these resolve correctly, but when refreshing on, e.g., `/openmrs/spa/login` they no longer resolve correctly, so this tries to fix both the favicon and scripts that are loaded.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
