### PR TITLE
(fix) Override stacking context for tooltips

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -42,6 +42,11 @@
   border-bottom: none;
 }
 
+/* Tooltips presently have a higher stacking context than modals, which leads to tooltip buttons rendering above modal content */
+.cds--body--with-modal-open .cds--tooltip {
+  z-index: 0;
+}
+
 /* Content Switcher */
 .cds--content-switcher-btn {
   background-color: $ui-02;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Relates to [various](https://github.com/openmrs/openmrs-form-engine-lib/pull/60).

This PR fixes an issue where the stacking context of tooltips is higher than that of a modal. This leads to a situation where tooltip items get rendered over modal content. This PR applies a style override to the `.cds--body--with-modal-open .cds--tooltip` Carbon class, dialling its z-index value all the way to 0. This guarantees that the tooltip content will not get rendered over the modal container. 

## Screenshots

> Screenshot showing tooltip content getting rendered above of the modal container

<img width="784" alt="Screenshot 2023-05-09 at 2 30 42 PM" src="https://github.com/openmrs/openmrs-esm-core/assets/8509731/f22db11b-ab4d-4608-9858-86053fce2e14">
