### PR TITLE
(Align) spacing between skeletons and radio items in location picker

### DIFF
--- a/packages/apps/esm-login-app/src/location-picker/location-picker.scss
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.scss
@@ -75,7 +75,7 @@
 
 .radioButtonSkeleton {
   margin-right: 0 !important;
-  margin-bottom: spacing.$spacing-05;
+  margin-bottom: spacing.$spacing-09;
 }
 
 .radioButtonSkeleton span {


### PR DESCRIPTION



## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR addresses issue O3-2069 by making changes to the style file located at packages/apps/esm-login-app/src/location-picker. Specifically, the margin-bottom property in .radioButtonSkeleton was modified to match the spacing between radio items in the location picker.  This change ensures that the spacing between the skeletons is the same as the spacing between the radio items in the location picker, as requested in the issue title "Spacing between the skeletons should be the same as to the spacing between the radio items in the location picker".

## Screenshots
<!-- Required if you are making UI changes. -->
Before 
![openmrs](https://github.com/openmrs/openmrs-esm-core/assets/95313032/d2399d74-ffef-4a65-801b-4a737386b731)

After screen 
![opemrsskeleton](https://github.com/openmrs/openmrs-esm-core/assets/95313032/2293bce2-a158-4254-bd52-2ebe2c7fac95)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[Issue Link](https://issues.openmrs.org/browse/O3-2069
)
## Other
<!-- Anything not covered above -->
