### PR TITLE
(refactor) Setup `esm-form-entry` to use webpack module federation

### DIFF
--- a/packages/shell/esm-app-shell/src/load-modules.ts
+++ b/packages/shell/esm-app-shell/src/load-modules.ts
@@ -44,17 +44,6 @@ export async function loadModules(modules: Record<string, string>) {
         console.warn(
           `${name} failed to be loaded into the webpack container. Perhaps it has been built using openmrs@3.x (or @openmrs/webpack-config@3.x). The current app shell version is 4.x (${window.spaVersion}), therefore frontend modules will need to be built with openmrs@4 (or @openmrs/webpack-config@4). Check the version in ${name}'s package dependencies.`
         );
-
-        try {
-          const module = await System.import(name);
-          return [name, module];
-        } catch (error) {
-          console.error(
-            `Failed to load module ${name} using either the supported mechanism or the legacy loading mechanism.`,
-            error
-          );
-          return [name, {}];
-        }
       }
 
       if (isFederatedModule(app)) {

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -336,9 +336,6 @@ export function run(configUrls: Array<string>, offline: boolean) {
   subscribeActionableNotificationShown(showActionableNotification);
   subscribeToastShown(showToast);
   subscribePrecacheStaticDependencies(precacheGlobalStaticDependencies);
-  // FIXME this is part of a hack to load esm-form-app which depends on the legacy loading for now
-  // Once esm-form-app can be upgraded to Angular 12 and Module Federation, we should be able to ditch this
-  registerModules(sharedDependencies);
   setupApiModule();
   registerCoreExtensions();
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR is required for https://github.com/openmrs/openmrs-esm-patient-chart/pull/1168 to work. It removes the legacy module loading approach, paving the way for a singular module loading strategy predicated on webpack module federation. 
