### PR TITLE
(fix) Restore createUseStore mock for framework

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -505,7 +505,7 @@ ___
 
 ### Actions
 
-Ƭ **Actions**: `Function` \| { `[key: string]`: `Function`;  }
+Ƭ **Actions**: `Function` \| `Record`<`string`, `Function`\>
 
 #### Defined in
 

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -272,20 +272,27 @@ export const useExtensionInternalStore = createGlobalStore(
 export const useExtensionStore = getExtensionStore();
 
 const defaultSelect = (x) => x;
-export const useStore = (
-  store: StoreApi<any>,
+export function useStore<T = any>(
+  store: StoreApi<T>,
   select = defaultSelect,
   actions = {}
-) => {
+) {
   const state = select(store.getState());
   return { ...state, ...actions };
-};
+}
 
 export function useStoreWithActions<T>(
   store: StoreApi<T>,
   actions: Function | { [key: string]: Function }
 ): T & { [key: string]: (...args: any[]) => void } {
   return useStore(store, defaultSelect, actions);
+}
+
+export function createUseStore<T = any>(store: StoreApi<T>) {
+  return (actions: Function | Record<string, Function>) => {
+    const state = store.getState();
+    return { ...state, ...actions };
+  };
 }
 
 export const usePagination = jest.fn().mockImplementation(() => ({

--- a/packages/framework/esm-react-utils/src/createUseStore.ts
+++ b/packages/framework/esm-react-utils/src/createUseStore.ts
@@ -2,7 +2,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { StoreApi } from "zustand";
 
-export type Actions = Function | { [key: string]: Function };
+export type Actions = Function | Record<string, Function>;
 export type BoundActions = { [key: string]: (...args: any[]) => void };
 
 function bindActions<T>(store: StoreApi<T>, actions: Actions): BoundActions {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Apparently, we rather extensively use this in patient chart tests

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
