### PR TITLE
(feat) O3-2145: Add "rtl" support for new languages

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -275,3 +275,34 @@
   .cds--radio-button-wrapper:not(:last-of-type) {
   margin-bottom: 0;
 }
+
+html[dir="rtl"] {
+  .cds--header-panel--expanded {
+    right: calc(100vw - var(--omrs-sidenav-width));
+  }
+
+  .active-left-nav-link {
+    border-right: 0.25rem solid var(--brand-01);
+    border-left: unset !important;
+  }
+
+  .omrs-breakpoint-gt-tablet {
+    main {
+      & > section {
+        margin-left: unset;
+        margin-right: var(--omrs-sidenav-width);
+        nav {
+          left: calc(100vw - var(--omrs-sidenav-width));
+          border-left: 1px solid #e0e0e0;
+          border-right: unset;
+        }
+      }
+    }
+  }
+
+  .omrs-breakpoint-lt-desktop {
+    .cds--side-nav {
+      left: unset !important;
+    }
+  }
+}

--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -26,6 +26,10 @@ export function setupI18n() {
     attributes: true,
   });
 
+  window.i18next.on("languageChanged", () => {
+    document.documentElement.setAttribute("dir", window.i18next.dir());
+  });
+
   return window.i18next
     .use(LanguageDetector)
     .use({


### PR DESCRIPTION

## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
I implemented initial RTL support in the application, resolving UI bugs that arose as a result. Now, when a user selects an RTL language, the application seamlessly switches to RTL view. However, it's important to note that there are remaining bugs in other modules, and additional pull requests will be made in respective repositories to address them.

## Screenshots
(Tested using English)
![image](https://github.com/openmrs/openmrs-esm-core/assets/68945262/2e0d007f-24fe-4d43-9379-2870dd24b5a4)
![image](https://github.com/openmrs/openmrs-esm-core/assets/68945262/eb1ef86e-37dc-48ed-8bc6-181a04284c77)
![image](https://github.com/openmrs/openmrs-esm-core/assets/68945262/12830e23-494e-45c7-b87c-bd8119918a7e)

## Related Issue
https://issues.openmrs.org/browse/O3-2145

## Other
<!-- Anything not covered above -->
