### PR TITLE
(feat)Add interstitial Page(System Admin) which links to other app instances.

### DIFF
--- a/packages/apps/esm-system-admin-app/README.md
+++ b/packages/apps/esm-system-admin-app/README.md
@@ -1,0 +1,19 @@
+# openmrs-esm-system-administration
+
+openmrs-esm-system-administration is a page with card views to external applications that we want to extend from the core OpenMRS.
+
+## Purpose
+
+This app has an interstitial page that will hold a number of card views pointing to different pages or applications outside the OpenMRS main.
+
+Usage is documented both below and in the
+[Import Map Overrides](http://o3-dev.docs.openmrs.org/#/getting_started/setup?id=import-map-overrides)
+section of the developer documentation.
+
+## Implementation notes
+
+openmrs-esm-devtools is using
+[import-map-overrides](https://github.com/joeldenning/import-map-overrides) 
+to accomplish this behavior. 
+If you prefer using the browser console instead of a UI to manage module 
+overrides, check out the documentation in that github project.

--- a/packages/apps/esm-system-admin-app/jest.config.js
+++ b/packages/apps/esm-system-admin-app/jest.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  transform: {
+    "\\.tsx?$": ["@swc/jest"],
+  },
+  setupFiles: ["<rootDir>/src/setup-tests.tsx"],
+  moduleNameMapper: {
+    "\\.(css)$": "identity-obj-proxy",
+    "@openmrs/esm-framework": "@openmrs/esm-framework/mock.tsx",
+    "react-i18next": "<rootDir>/__mocks__/react-i18next.mock.js",
+  },
+  globals: {
+    System: {
+      Node: null,
+    },
+  },
+  testEnvironment: "jsdom",
+  testEnvironmentOptions: {
+    url: "http://localhost/",
+  },
+};

--- a/packages/apps/esm-system-admin-app/package.json
+++ b/packages/apps/esm-system-admin-app/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@openmrs/esm-system-admin-app",
+  "version": "4.4.1",
+  "license": "MPL-2.0",
+  "description": "System Admin page for OpenMRS",
+  "browser": "dist/openmrs-esm-system-admin-app.js",
+  "main": "src/index.ts",
+  "source": true,
+  "scripts": {
+    "start": "openmrs develop",
+    "serve": "webpack serve --mode=development",
+    "debug": "npm run serve",
+    "test": "jest --config jest.config.js --passWithNoTests",
+    "build": "webpack --mode=production",
+    "build:development": "webpack --mode=development",
+    "analyze": "webpack --mode=production --env analyze=true",
+    "typescript": "tsc",
+    "lint": "eslint src --ext ts,tsx",
+    "extract-translations": "i18next 'src/**/*.component.tsx'"
+  },
+  "keywords": [
+    "openmrs",
+    "microfrontends"
+  ],
+  "browserslist": [
+    "extends browserslist-config-openmrs"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openmrs/openmrs-esm-core.git"
+  },
+  "bugs": {
+    "url": "https://github.com/openmrs/openmrs-esm-core/issues"
+  },
+  "homepage": "https://github.com/openmrs/openmrs-esm-core#readme",
+  "publishConfig": {
+    "access": "public"
+  },
+  "peerDependencies": {
+    "@openmrs/esm-framework": "*",
+    "react": "18.x",
+    "react-dom": "18.x",
+    "rxjs": "6.x"
+  },
+  "devDependencies": {
+    "@openmrs/esm-framework": "^4.4.1",
+    "@openmrs/webpack-config": "^4.4.1",
+    "react": "^18.1.0",
+    "react-dom": "^18.1.0",
+    "rxjs": "6.x"
+  },
+  "dependencies": {
+    "@carbon/react": "^1.12.0",
+    "lodash-es": "^4.17.21",
+    "react-i18next": "^12.3.1"
+  }
+}

--- a/packages/apps/esm-system-admin-app/src/config-schema.ts
+++ b/packages/apps/esm-system-admin-app/src/config-schema.ts
@@ -1,0 +1,9 @@
+import { Type } from "@openmrs/esm-framework";
+
+export const configSchema = {
+  oclLink: {
+    _type: Type.String,
+    _description: "Provides link to OCL",
+    _default: "http",
+  },
+};

--- a/packages/apps/esm-system-admin-app/src/constants.ts
+++ b/packages/apps/esm-system-admin-app/src/constants.ts
@@ -1,0 +1,3 @@
+export const spaRoot = window["getOpenmrsSpaBase"];
+export const basePath = "/system-administration";
+export const spaBasePath = `${window.spaBase}${basePath}`;

--- a/packages/apps/esm-system-admin-app/src/dashboard/card.component.tsx
+++ b/packages/apps/esm-system-admin-app/src/dashboard/card.component.tsx
@@ -1,0 +1,38 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { Layer, Tile, TileProps, Button } from "@carbon/react";
+import { ArrowRight } from "@carbon/react/icons";
+import styles from "./card.scss";
+
+export interface LinkCardProps extends TileProps {
+  header: string;
+  viewLink: string;
+  children?: React.ReactNode;
+}
+
+export const LinkCard: React.FC<LinkCardProps> = ({
+  header,
+  viewLink,
+  children,
+}) => {
+  const { t } = useTranslation();
+
+  return (
+    <Layer>
+      <Tile className={styles.overviewCard}>
+        <div className={styles.heading}>{header}</div>
+        <Button
+          className={styles.viewButton}
+          kind="ghost"
+          renderIcon={(props) => <ArrowRight size={16} {...props} />}
+          size="sm"
+          href={viewLink}
+          target="_blank"
+          rel="no-refferer"
+        >
+          {t("homeOverviewCardView", "View")}
+        </Button>
+      </Tile>
+    </Layer>
+  );
+};

--- a/packages/apps/esm-system-admin-app/src/dashboard/card.component.tsx
+++ b/packages/apps/esm-system-admin-app/src/dashboard/card.component.tsx
@@ -10,11 +10,7 @@ export interface LinkCardProps extends TileProps {
   children?: React.ReactNode;
 }
 
-export const LinkCard: React.FC<LinkCardProps> = ({
-  header,
-  viewLink,
-  children,
-}) => {
+export const LinkCard: React.FC<LinkCardProps> = ({ header, viewLink }) => {
   const { t } = useTranslation();
 
   return (
@@ -30,7 +26,7 @@ export const LinkCard: React.FC<LinkCardProps> = ({
           target="_blank"
           rel="no-refferer"
         >
-          {t("homeOverviewCardView", "View")}
+          {t("systemAdminCardView", "View")}
         </Button>
       </Tile>
     </Layer>

--- a/packages/apps/esm-system-admin-app/src/dashboard/card.scss
+++ b/packages/apps/esm-system-admin-app/src/dashboard/card.scss
@@ -1,0 +1,30 @@
+@use "@carbon/styles/scss/spacing";
+@use "@carbon/styles/scss/type";
+@import "~@openmrs/esm-styleguide/src/vars";
+
+.productiveHeading01 {
+  @include type.type-style("heading-compact-01");
+}
+.overviewCard {
+  display: flex;
+  justify-content: space-between;
+  margin-right: 1rem;
+  width: 20rem;
+  align-items: center;
+
+  .heading {
+    @extend .productiveHeading01;
+    color: $text-02;
+    font-weight: 700;
+  }
+
+  .viewButton {
+    margin-top: -(spacing.$spacing-02);
+    margin-right: -(spacing.$spacing-05);
+
+    .heading {
+      color: $color-gray-70;
+      font-weight: 600;
+    }
+  }
+}

--- a/packages/apps/esm-system-admin-app/src/dashboard/index.scss
+++ b/packages/apps/esm-system-admin-app/src/dashboard/index.scss
@@ -1,0 +1,20 @@
+@use "@carbon/styles/scss/spacing";
+@use "@carbon/styles/scss/type";
+@import "~@openmrs/esm-styleguide/src/vars";
+
+.systemAdminPage {
+  background-color: $ui-02;
+  height: 100vh;
+  .breadCrumbsContainer {
+    nav {
+      background-color: $ui-01;
+    }
+  }
+
+  .cardsView {
+    display: flex;
+    background-color: $ui-01;
+    padding: 2rem 1rem;
+    margin-top: 2rem;
+  }
+}

--- a/packages/apps/esm-system-admin-app/src/dashboard/index.tsx
+++ b/packages/apps/esm-system-admin-app/src/dashboard/index.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import { useTranslation } from "react-i18next";
+import { ExtensionSlot } from "@openmrs/esm-framework";
+import { LinkCard } from "./card.component";
+
+import styles from "./index.scss";
+
+export const SystemAdministrationDashbord = () => {
+  const { t } = useTranslation();
+
+  return (
+    <div className={styles.systemAdminPage}>
+      <div className={styles.breadcrumbsContainer}>
+        <ExtensionSlot extensionSlotName="breadcrumbs-slot" />
+      </div>
+      <div className={styles.cardsView}>
+        <LinkCard
+          header={t("systemAdmin", "System Administration")}
+          viewLink={`/openmrs/admin`}
+        />
+        <LinkCard
+          header={t("openConceptLab", "Open Concept Lab")}
+          viewLink={`${window.spaBase}/ocl`}
+        />
+      </div>
+    </div>
+  );
+};

--- a/packages/apps/esm-system-admin-app/src/declarations.d.tsx
+++ b/packages/apps/esm-system-admin-app/src/declarations.d.tsx
@@ -1,0 +1,15 @@
+declare namespace JSX {
+  interface IntrinsicElements {
+    "import-map-overrides-list": any;
+  }
+}
+
+declare module "*.css" {
+  const styles: any;
+  export default styles;
+}
+
+declare module "*.scss" {
+  const styles: any;
+  export default styles;
+}

--- a/packages/apps/esm-system-admin-app/src/index.ts
+++ b/packages/apps/esm-system-admin-app/src/index.ts
@@ -1,0 +1,61 @@
+import {
+  getAsyncLifecycle,
+  defineConfigSchema,
+  registerBreadcrumbs,
+} from "@openmrs/esm-framework";
+
+import { configSchema } from "./config-schema";
+
+const importTranslation = require.context(
+  "../translations",
+  false,
+  /.json$/,
+  "lazy"
+);
+
+const backendDependencies = {
+  fhir2: "^1.2.0",
+  "webservices.rest": "^2.2.0",
+};
+
+function setupOpenMRS() {
+  const moduleName = "@openmrs/esm-system-admin-app";
+
+  const options = {
+    featureName: "system-administration",
+    moduleName,
+  };
+
+  defineConfigSchema(moduleName, configSchema);
+
+  registerBreadcrumbs([
+    {
+      path: `${window.spaBase}/system-administration`,
+      title: "System Admninistration",
+      parent: `${window.spaBase}/home`,
+    },
+  ]);
+
+  return {
+    pages: [
+      {
+        load: getAsyncLifecycle(() => import("./root.component"), options),
+        route: "system-administration",
+      },
+    ],
+    extensions: [
+      {
+        id: "system-administration-app-menu-link",
+        slot: "app-menu-slot",
+        load: getAsyncLifecycle(
+          () => import("./system-admin-app-menu-link.component"),
+          options
+        ),
+        online: true,
+        offline: true,
+      },
+    ],
+  };
+}
+
+export { backendDependencies, importTranslation, setupOpenMRS };

--- a/packages/apps/esm-system-admin-app/src/root.component.tsx
+++ b/packages/apps/esm-system-admin-app/src/root.component.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import { BrowserRouter, Route, Routes } from "react-router-dom";
+
+import { SystemAdministrationDashbord } from "./dashboard";
+
+const RootComponent: React.FC = () => {
+  return (
+    <BrowserRouter basename={`${window.spaBase}/system-administration`}>
+      <Routes>
+        <Route path="/" element={<SystemAdministrationDashbord />} />
+      </Routes>
+    </BrowserRouter>
+  );
+};
+
+export default RootComponent;

--- a/packages/apps/esm-system-admin-app/src/setup-tests.tsx
+++ b/packages/apps/esm-system-admin-app/src/setup-tests.tsx
@@ -1,0 +1,3 @@
+(window as any).importMapOverrides = {
+  getOverrideMap: jest.fn().mockReturnValue({ imports: {} }),
+};

--- a/packages/apps/esm-system-admin-app/src/system-admin-app-menu-link.component.tsx
+++ b/packages/apps/esm-system-admin-app/src/system-admin-app-menu-link.component.tsx
@@ -1,0 +1,13 @@
+import React from "react";
+import { ConfigurableLink } from "@openmrs/esm-framework";
+import { useTranslation } from "react-i18next";
+import { spaBasePath } from "./constants";
+
+export default function SystemAdminAppMenuLink() {
+  const { t } = useTranslation();
+  return (
+    <ConfigurableLink to={spaBasePath}>
+      {t("systemAdmin", "System Administration")}
+    </ConfigurableLink>
+  );
+}

--- a/packages/apps/esm-system-admin-app/translations/en.json
+++ b/packages/apps/esm-system-admin-app/translations/en.json
@@ -1,4 +1,4 @@
 {
-  "systemAdminCardView": "View",
-  "systemAdmin": "System Administration"
+  "systemAdmin": "System Administration",
+  "systemAdminCardView": "View"
 }

--- a/packages/apps/esm-system-admin-app/translations/en.json
+++ b/packages/apps/esm-system-admin-app/translations/en.json
@@ -1,0 +1,4 @@
+{
+  "systemOverviewCardView": "View",
+  "systemAdmin": "System Administration"
+}

--- a/packages/apps/esm-system-admin-app/translations/en.json
+++ b/packages/apps/esm-system-admin-app/translations/en.json
@@ -1,4 +1,4 @@
 {
-  "systemOverviewCardView": "View",
+  "systemAdminCardView": "View",
   "systemAdmin": "System Administration"
 }

--- a/packages/apps/esm-system-admin-app/tsconfig.json
+++ b/packages/apps/esm-system-admin-app/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "module": "esnext",
+    "target": "es2015",
+    "allowSyntheticDefaultImports": true,
+    "jsx": "react",
+    "skipLibCheck": true,
+    "moduleResolution": "node",
+    "lib": [
+      "dom",
+      "es5",
+      "scripthost",
+      "es2015",
+      "es2015.promise",
+      "es2016.array.include",
+      "es2018",
+      "ESNext"
+    ],
+    "noEmit": true
+  },
+  "include": ["src/**/*"]
+}

--- a/packages/apps/esm-system-admin-app/webpack.config.js
+++ b/packages/apps/esm-system-admin-app/webpack.config.js
@@ -1,0 +1,1 @@
+module.exports = require("openmrs/default-webpack-config");

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,6 +1286,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@babel/runtime@npm:^7.20.6":
+  version: 7.22.3
+  resolution: "@babel/runtime@npm:7.22.3"
+  dependencies:
+    regenerator-runtime: ^0.13.11
+  checksum: 8fc50785ca4cba749fed90bffca7e6fd52d4709755654e95b8d2a945fc034b56fb8c2e8a0183fea7c4abb86bf5fa77678c0ea35163b6920649833d180c34c234
+  languageName: node
+  linkType: hard
+
 "@babel/template@npm:^7.18.10, @babel/template@npm:^7.3.3":
   version: 7.18.10
   resolution: "@babel/template@npm:7.18.10"
@@ -3872,6 +3881,26 @@ __metadata:
     "@openmrs/esm-extensions": 4.x
     "@openmrs/esm-react-utils": 4.x
     "@openmrs/esm-state": 4.x
+    react: 18.x
+    react-dom: 18.x
+    rxjs: 6.x
+  languageName: unknown
+  linkType: soft
+
+"@openmrs/esm-system-admin-app@workspace:packages/apps/esm-system-admin-app":
+  version: 0.0.0-use.local
+  resolution: "@openmrs/esm-system-admin-app@workspace:packages/apps/esm-system-admin-app"
+  dependencies:
+    "@carbon/react": ^1.12.0
+    "@openmrs/esm-framework": ^4.4.1
+    "@openmrs/webpack-config": ^4.4.1
+    lodash-es: ^4.17.21
+    react: ^18.1.0
+    react-dom: ^18.1.0
+    react-i18next: ^12.3.1
+    rxjs: 6.x
+  peerDependencies:
+    "@openmrs/esm-framework": "*"
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x
@@ -16170,6 +16199,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-i18next@npm:^12.3.1":
+  version: 12.3.1
+  resolution: "react-i18next@npm:12.3.1"
+  dependencies:
+    "@babel/runtime": ^7.20.6
+    html-parse-stringify: ^3.0.1
+  peerDependencies:
+    i18next: ">= 19.0.0"
+    react: ">= 16.8.0"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+    react-native:
+      optional: true
+  checksum: fe3f360e5184bc63861734e94bf625a09b9ec0d28fab41779a68758af258fd1737dde25ff7a88ddb66c1571a3e3de5b3403825a91b4949bf9832a00615acb87a
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1, react-is@npm:^16.6.0, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -16489,6 +16536,13 @@ __metadata:
   version: 1.4.2
   resolution: "regenerate@npm:1.4.2"
   checksum: 3317a09b2f802da8db09aa276e469b57a6c0dd818347e05b8862959c6193408242f150db5de83c12c3fa99091ad95fb42a6db2c3329bfaa12a0ea4cbbeb30cb0
+  languageName: node
+  linkType: hard
+
+"regenerator-runtime@npm:^0.13.11":
+  version: 0.13.11
+  resolution: "regenerator-runtime@npm:0.13.11"
+  checksum: 27481628d22a1c4e3ff551096a683b424242a216fee44685467307f14d58020af1e19660bf2e26064de946bad7eff28950eae9f8209d55723e2d9351e632bbb4
   languageName: node
   linkType: hard
 
@@ -16894,7 +16948,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"rxjs@npm:^6.4.0, rxjs@npm:^6.5.3, rxjs@npm:^6.6.0":
+"rxjs@npm:6.x, rxjs@npm:^6.4.0, rxjs@npm:^6.5.3, rxjs@npm:^6.6.0":
   version: 6.6.7
   resolution: "rxjs@npm:6.6.7"
   dependencies:


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
- This PR adds an `esm-system-admin-app` which has a `dashboard` that acts as an interstitial page that holds links to external modules.
- It also adds new navigation to the App Menu `System Administration` which redirects to the interstitial page.

## Screenshots
<img width="1440" alt="Screenshot 2023-05-30 at 00 51 29" src="https://github.com/openmrs/openmrs-esm-core/assets/30952856/38acec0b-fa66-4478-bfe0-9b793b68fc4c">

- Loom recording
https://www.loom.com/share/f72fc1fd239e40dea890d7b05439014f


## Related Issue
- https://issues.openmrs.org/browse/O3-2126

