### PR TITLE
(fix) Fix height of DataTables by removing a style override

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -145,7 +145,6 @@
 .cds--data-table td,
 .cds--data-table--sort th,
 .cds--data-table--sort th .cds--table-sort__flex {
-  height: spacing.$spacing-07;
   min-height: unset;
   color: $text-02;
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR fixes the responsiveness of DataTables in the patient chart to match the designs [here](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/6203ed8fa8eb0cbe469915a2) by removing a style override that set the height of DataTables to a specific value.

## Screencast

[Screencast from 2023-05-31 09-14-44.webm](https://github.com/openmrs/openmrs-esm-core/assets/104269786/d908d6d7-6687-4287-8840-e3c1bd3033e1)
