### PR TITLE
(fix) Tweak spacing in the location picker loading skeleton

### DIFF
--- a/packages/apps/esm-login-app/src/location-picker/location-picker.scss
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.scss
@@ -75,7 +75,7 @@
 
 .radioButtonSkeleton {
   margin-right: 0 !important;
-  margin-bottom: spacing.$spacing-09;
+  margin-bottom: spacing.$spacing-07;
 }
 
 .radioButtonSkeleton span {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
The spacing between skeletons in the  location picker have been more than expected, therefore  they have been reduced to desired spacing
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->
![Desired-spacing](https://github.com/openmrs/openmrs-esm-core/assets/95313032/841dae5e-dbc7-49a9-ba18-89353c1672a1)

![Undesired-spacing](https://github.com/openmrs/openmrs-esm-core/assets/95313032/e591ce95-9d15-4233-bbc4-97554762708f)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
[03-2069](https://issues.openmrs.org/browse/O3-2069
)<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
