### PR TITLE
(feat) O3-2155: Using the global system default_locale by default for the O3 

### DIFF
--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -3,7 +3,10 @@ import ICU from "i18next-icu";
 import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
 import merge from "lodash-es/merge";
-import { getConfigInternal } from "@openmrs/esm-framework/src/internal";
+import {
+  getConfigInternal,
+  openmrsFetch,
+} from "@openmrs/esm-framework/src/internal";
 import { slugify } from "./load-modules";
 declare global {
   interface Window {
@@ -15,7 +18,8 @@ export function setupI18n() {
   window.i18next = i18next.default || i18next;
 
   const languageChangeObserver = new MutationObserver(() => {
-    const reDetect: any = undefined;
+    const reDetect: any = document.documentElement.getAttribute("lang");
+    console.log("reDetect", reDetect);
     window.i18next
       .changeLanguage(reDetect)
       .catch((e) => console.error("i18next failed to re-detect language", e));
@@ -28,6 +32,12 @@ export function setupI18n() {
 
   window.i18next.on("languageChanged", () => {
     document.documentElement.setAttribute("dir", window.i18next.dir());
+  });
+
+  openmrsFetch<{ value: string }>(
+    "/ws/rest/v1/systemsetting/default_locale"
+  ).then((res) => {
+    document.documentElement.setAttribute("lang", res.data.value);
   });
 
   return window.i18next

--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -19,7 +19,6 @@ export function setupI18n() {
 
   const languageChangeObserver = new MutationObserver(() => {
     const reDetect: any = document.documentElement.getAttribute("lang");
-    console.log("reDetect", reDetect);
     window.i18next
       .changeLanguage(reDetect)
       .catch((e) => console.error("i18next failed to re-detect language", e));


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR allows using the global system's default locale for the O3 application.

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/O3-2155

## Other
<!-- Anything not covered above -->
