### PR TITLE
(fix) O3-2152: Fix UI bugs in forms, form tabs

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -427,4 +427,31 @@ html[dir="rtl"] {
       left: unset !important;
     }
   }
+
+  .form-container {
+    .tab-container {
+      .tab {
+        & > button {
+          text-align: right;
+        }
+        .active {
+          border-left: unset !important;
+          border-right: 0.5rem solid #009d9a;
+        }
+        .enabled {
+          border-left: unset !important;
+          border-right: 0.5rem solid #9ef0f0;
+        }
+      }
+    }
+    .tab-content {
+      margin-left: unset;
+      margin-right: 10rem;
+
+      .pane {
+        padding-left: unset;
+        padding-right: 1rem;
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
There were several bugs here that occurred in forms when RTL was enabled. Before these changes, the tab column was overlapping with the form elements, making it impossible to fill out.

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-core/assets/68945262/753b22cf-d4c3-4721-bb0c-9d52735e4eff)

## Related Issue
https://issues.openmrs.org/browse/O3-2152

## Other
<!-- Anything not covered above -->
