### PR TITLE
(fix) O3-2152: Fixed incorrect positioning of headers and icons

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -394,11 +394,25 @@ html[dir="rtl"] {
       right: spacing.$spacing-05;
     }
   }
+
+  .cds--search-close {
+    right: unset;
+    left: 0;
+  }
+
   .cds--search--sm {
     .cds--search-magnifier {
       svg {
         left: unset;
         right: spacing.$spacing-03;
+      }
+    }
+  }
+
+  .cds--tile {
+    & > div:first-child {
+      h4 {
+        text-align: right;
       }
     }
   }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Fixed incorrect positioning of headers and the cross icon during search

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-core/assets/68945262/3b8edf90-1aee-4ec8-98c1-7e7bcbc5e0b2)
![image](https://github.com/openmrs/openmrs-esm-core/assets/68945262/0bf19627-4121-4b61-92ab-005cef337314)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
