### PR TITLE
(fix) O3-2176: Actions overflow items should be 3rem in tablet

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -310,3 +310,9 @@ html[dir="rtl"] {
     }
   }
 }
+
+.omrs-breakpoint-lt-desktop {
+  .cds--overflow-menu-options__option {
+    height: spacing.$spacing-09;
+  }
+}


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Overrides actions overflow menu items to 48px in tablet

## Screencast

[Screencast from 2023-06-09 12-38-19.webm](https://github.com/openmrs/openmrs-esm-core/assets/104269786/f4321eb3-e0ce-43e6-b031-a7ef30d0e98d)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
- https://issues.openmrs.org/browse/O3-2176

## Other
<!-- Anything not covered above -->
