### PR TITLE
(fix) O3-2152: Fixed incorrect positioning of dropdown title

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -343,6 +343,9 @@ html[dir="rtl"] {
     & > svg {
       margin: 2px 0 0 1rem;
     }
+    p {
+      text-align: right;
+    }
   }
 
   .cds--content-switcher {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Fixed incorrect positioning of dropdown title

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-core/assets/68945262/83197a95-d689-409a-a3f7-3e89e02b0b77)

## Related Issue
https://issues.openmrs.org/browse/O3-2152

## Other
<!-- Anything not covered above -->
