### PR TITLE
(fix) Webpack should not watch .git directory

### DIFF
--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -123,6 +123,13 @@ export const scssRuleConfig = {};
  */
 export const assetRuleConfig = {};
 
+/**
+ * This object will be merged into the webpack rule governing
+ * the watch options.
+ * Make sure to modify this object and not reassign it.
+ */
+export const watchConfig = {};
+
 export default (
   env: Record<string, string>,
   argv: Record<string, string> = {}
@@ -216,6 +223,12 @@ export default (
       },
       static: [resolve(root, outDir)],
     },
+    watchOptions: merge(
+      {
+        ignored: /\.git/,
+      },
+      watchConfig
+    ),
     performance: {
       hints: mode === production && "warning",
     },


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Stops webpack from watching files in `.git`. Also enables overriding the watchOptions via a watchConfig object.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
