### PR TITLE
(feat) Add support for setting default language via html lang attribute

### DIFF
--- a/packages/shell/esm-app-shell/src/index.ejs
+++ b/packages/shell/esm-app-shell/src/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= openmrsDefaultLanguage %>">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/packages/shell/esm-app-shell/src/index.ejs
+++ b/packages/shell/esm-app-shell/src/index.ejs
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="<%= openmrsDefaultLanguage %>">
+<html lang="<%= openmrsDefaultLocale %>">
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -32,6 +32,7 @@ const openmrsPageTitle = process.env.OMRS_PAGE_TITLE || "OpenMRS";
 const openmrsFavicon =
   process.env.OMRS_FAVICON || `${openmrsPublicPath}/favicon.ico`;
 const openmrsOffline = process.env.OMRS_OFFLINE !== "disable";
+const openmrsDefaultLanguage = process.env.OMRS_ESM_DEFAULT_LANGUAGE || "en";
 const openmrsImportmapDef = process.env.OMRS_ESM_IMPORTMAP;
 const openmrsEnvironment = process.env.OMRS_ENV || process.env.NODE_ENV || "";
 const openmrsImportmapUrl =
@@ -230,6 +231,7 @@ module.exports = (env, argv = {}) => {
           openmrsPublicPath,
           openmrsFavicon,
           openmrsPageTitle,
+          openmrsDefaultLanguage,
           openmrsImportmapDef,
           openmrsImportmapUrl,
           openmrsOffline,

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -32,7 +32,7 @@ const openmrsPageTitle = process.env.OMRS_PAGE_TITLE || "OpenMRS";
 const openmrsFavicon =
   process.env.OMRS_FAVICON || `${openmrsPublicPath}/favicon.ico`;
 const openmrsOffline = process.env.OMRS_OFFLINE !== "disable";
-const openmrsDefaultLanguage = process.env.OMRS_ESM_DEFAULT_LANGUAGE || "en";
+const openmrsDefaultLocale = process.env.OMRS_ESM_DEFAULT_LOCALE || "en";
 const openmrsImportmapDef = process.env.OMRS_ESM_IMPORTMAP;
 const openmrsEnvironment = process.env.OMRS_ENV || process.env.NODE_ENV || "";
 const openmrsImportmapUrl =
@@ -231,7 +231,7 @@ module.exports = (env, argv = {}) => {
           openmrsPublicPath,
           openmrsFavicon,
           openmrsPageTitle,
-          openmrsDefaultLanguage,
+          openmrsDefaultLocale,
           openmrsImportmapDef,
           openmrsImportmapUrl,
           openmrsOffline,

--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -266,6 +266,12 @@ yargs.command(
         describe:
           "The import map to use. Can be a path to an import map to be taken literally, an URL, or a fixed JSON object.",
         type: "string",
+      })
+      .option("default-language", {
+        default: "",
+        describe:
+          "The language to use as a default for this build of the app shell. Should be a value that's valid to use in an HTML lang attribute, e.g., en or en_GB.",
+        type: "string",
       }),
   async (args) =>
     runCommand("runBuild", {

--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -267,10 +267,10 @@ yargs.command(
           "The import map to use. Can be a path to an import map to be taken literally, an URL, or a fixed JSON object.",
         type: "string",
       })
-      .option("default-language", {
+      .option("default-locale", {
         default: "",
         describe:
-          "The language to use as a default for this build of the app shell. Should be a value that's valid to use in an HTML lang attribute, e.g., en or en_GB.",
+          "The locale to use as a default for this build of the app shell. Should be a value that's valid to use in an HTML lang attribute, e.g., en or en_GB.",
         type: "string",
       }),
   async (args) =>

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -14,7 +14,7 @@ import { basename, join, parse, resolve } from "path";
 export interface BuildArgs {
   target: string;
   registry: string;
-  defaultLanguage: string;
+  defaultLocale: string;
   importmap: string;
   spaPath: string;
   fresh?: boolean;
@@ -30,7 +30,7 @@ export interface BuildConfig {
   apiUrl: string;
   configUrls: Array<string>;
   configPaths: Array<string>;
-  defaultLanguage?: string;
+  defaultLocale?: string;
   pageTitle: string;
   supportOffline?: boolean;
   importmap: string;
@@ -89,7 +89,7 @@ export async function runBuild(args: BuildArgs) {
     env: "production",
     apiUrl: buildConfig.apiUrl || args.apiUrl,
     configUrls: configUrls,
-    defaultLanguage: args.defaultLanguage || buildConfig.defaultLanguage,
+    defaultLocale: args.defaultLocale || buildConfig.defaultLocale,
     pageTitle: buildConfig.pageTitle || args.pageTitle,
     supportOffline: buildConfig.supportOffline ?? args.supportOffline,
     spaPath: buildConfig.spaPath || args.spaPath,

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -14,6 +14,7 @@ import { basename, join, parse, resolve } from "path";
 export interface BuildArgs {
   target: string;
   registry: string;
+  defaultLanguage: string;
   importmap: string;
   spaPath: string;
   fresh?: boolean;
@@ -29,6 +30,7 @@ export interface BuildConfig {
   apiUrl: string;
   configUrls: Array<string>;
   configPaths: Array<string>;
+  defaultLanguage?: string;
   pageTitle: string;
   supportOffline?: boolean;
   importmap: string;
@@ -87,6 +89,7 @@ export async function runBuild(args: BuildArgs) {
     env: "production",
     apiUrl: buildConfig.apiUrl || args.apiUrl,
     configUrls: configUrls,
+    defaultLanguage: args.defaultLanguage || buildConfig.defaultLanguage,
     pageTitle: buildConfig.pageTitle || args.pageTitle,
     supportOffline: buildConfig.supportOffline ?? args.supportOffline,
     spaPath: buildConfig.spaPath || args.spaPath,

--- a/packages/tooling/openmrs/src/utils/config.ts
+++ b/packages/tooling/openmrs/src/utils/config.ts
@@ -3,6 +3,7 @@ import { setEnvVariables } from "./variables";
 
 export interface WebpackOptions {
   backend?: string;
+  defaultLanguage?: string;
   importmap?: ImportmapDeclaration;
   apiUrl?: string;
   spaPath?: string;
@@ -49,6 +50,10 @@ export function loadWebpackConfig(options: WebpackOptions = {}) {
   if (typeof options.env === "string") {
     variables.OMRS_ENV = options.env;
     variables.NODE_ENV = options.env;
+  }
+
+  if (typeof options.defaultLanguage === "string") {
+    variables.OMRS_ESM_DEFAULT_LANGUAGE = options.defaultLanguage;
   }
 
   if (typeof options.importmap === "object") {

--- a/packages/tooling/openmrs/src/utils/config.ts
+++ b/packages/tooling/openmrs/src/utils/config.ts
@@ -3,7 +3,7 @@ import { setEnvVariables } from "./variables";
 
 export interface WebpackOptions {
   backend?: string;
-  defaultLanguage?: string;
+  defaultLocale?: string;
   importmap?: ImportmapDeclaration;
   apiUrl?: string;
   spaPath?: string;
@@ -52,8 +52,8 @@ export function loadWebpackConfig(options: WebpackOptions = {}) {
     variables.NODE_ENV = options.env;
   }
 
-  if (typeof options.defaultLanguage === "string") {
-    variables.OMRS_ESM_DEFAULT_LANGUAGE = options.defaultLanguage;
+  if (typeof options.defaultLocale === "string") {
+    variables.OMRS_ESM_DEFAULT_LOCALE = options.defaultLocale;
   }
 
   if (typeof options.importmap === "object") {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Adds support for configuring a default language via the build config or command line arguments.

While this is technically duplicative of the `default_locale` system setting from the backend, we have good reason to ensure that some kind of default language is set in the frontend in case the backend is, for whatever reason unavailable.

@vasharma05 To support Mekom's use-case, once merged, I'll add an overridable environment variable to the O3 RefApp so that this can be set on a per-instance basis.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://issues.openmrs.org/browse/O3-2155

## Other
<!-- Anything not covered above -->
