### PR TITLE
(fix) O3-2152: Fixed incorrect padding of pagination page number

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -348,6 +348,12 @@ html[dir="rtl"] {
     }
   }
 
+  .cds--select__page-number {
+    .cds--select-input {
+      padding: 0 spacing.$spacing-05 0 2.25rem;
+    }
+  }
+
   .cds--content-switcher {
     & > :last-child {
       border-bottom-left-radius: 0.25rem;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Fixed incorrect padding of pagination page number.

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-core/assets/68945262/7c761728-f74a-42cb-a93f-e43a67c53eb5)

## Related Issue
https://issues.openmrs.org/browse/O3-2152

## Other
<!-- Anything not covered above -->
