### PR TITLE
(fix) O3-2183: Location picker should not render if only one location is available

### DIFF
--- a/packages/apps/esm-login-app/src/location-picker/location-picker-main.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker-main.component.tsx
@@ -1,0 +1,64 @@
+import React, { useCallback } from "react";
+import LocationPicker from "./location-picker.component";
+import { useLoginLocations } from "../login.resource";
+import {
+  navigate,
+  setSessionLocation,
+  useConfig,
+} from "@openmrs/esm-framework";
+import { useLocation } from "react-router-dom";
+import { LoginReferrer } from "../login/login.component";
+import LoadingIcon from "../loading/loading.component";
+
+interface LocationPickerMainProps {
+  isLoginEnabled: boolean;
+}
+
+const LocationPickerMain: React.FC<LocationPickerMainProps> = ({
+  isLoginEnabled,
+}) => {
+  const { chooseLocation, links } = useConfig();
+  const { locations, isLoading } = useLoginLocations(
+    chooseLocation.useLoginLocationTag,
+    chooseLocation.locationsPerRequest
+  );
+  const { state } = useLocation() as { state: LoginReferrer };
+  const returnToUrl = new URLSearchParams(location?.search).get("returnToUrl");
+  const changeLocation = useCallback(
+    (locationUuid?: string) => {
+      const sessionDefined = locationUuid
+        ? setSessionLocation(locationUuid, new AbortController())
+        : Promise.resolve();
+
+      sessionDefined.then(() => {
+        if (
+          state?.referrer &&
+          !["/", "/login", "/login/location"].includes(state?.referrer)
+        ) {
+          navigate({ to: "${openmrsSpaBase}" + state?.referrer });
+          return;
+        }
+        if (returnToUrl && returnToUrl !== "/") {
+          navigate({ to: returnToUrl });
+        } else {
+          navigate({ to: links.loginSuccess });
+        }
+        return;
+      });
+    },
+    [state?.referrer, returnToUrl, links.loginSuccess]
+  );
+
+  if (isLoading) {
+    return <LoadingIcon />;
+  }
+
+  if (locations?.length === 1) {
+    changeLocation(locations[0]?.resource.id);
+    return;
+  }
+
+  return <LocationPicker isLoginEnabled={isLoginEnabled} />;
+};
+
+export default LocationPickerMain;

--- a/packages/apps/esm-login-app/src/root.component.tsx
+++ b/packages/apps/esm-login-app/src/root.component.tsx
@@ -3,6 +3,7 @@ import Login from "./login/login.component";
 import LocationPicker from "./location-picker/location-picker.component";
 import RedirectLogout from "./redirect-logout/redirect-logout.component";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
+import LocationPickerMain from "./location-picker/location-picker-main.component";
 
 export interface RootProps {
   isLoginEnabled: boolean;
@@ -22,7 +23,7 @@ const Root: React.FC<RootProps> = ({ isLoginEnabled }) => {
         />
         <Route
           path="/login/location"
-          element={<LocationPicker isLoginEnabled={isLoginEnabled} />}
+          element={<LocationPickerMain isLoginEnabled={isLoginEnabled} />}
         />
         <Route
           path="/logout"


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
- Updates the Location picker to not render if only one location is available

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
- https://issues.openmrs.org/browse/O3-2183

## Other
<!-- Anything not covered above -->
