### PR TITLE
(fix) Webpack should ignore `.git` and `test-results` directories

### DIFF
--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -225,7 +225,7 @@ export default (
     },
     watchOptions: merge(
       {
-        ignored: /\.git/,
+        ignored: [".git", "test-results"],
       },
       watchConfig
     ),


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Stops webpack from [watching](https://webpack.js.org/configuration/watch/#watchoptionsignored) files in both the `.git` and `test-results` directories. Watching files in the `test-results` directory causes e2e test execution against a local dev server to get stuck in a loop in some cases due to traces getting committed to the directory by Playwright (see the video below). To reproduce:

- Run `yarn test-e2e --headed --ui`.
- A chromium window gets launched. Fire up the dev tools console.
- If the O3 login page fails to load and the page appears to keep reloading, check that the error in the video is shown in the console.  

## Video

https://github.com/openmrs/openmrs-esm-core/assets/8509731/088d26d6-3163-4678-8e7f-b68962c146e4
