### PR TITLE
(fix) Fix an incorrectly-named variable

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/configuration/configuration.test.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/configuration.test.tsx
@@ -158,7 +158,7 @@ describe("Configuration", () => {
         { uuid: "61523693-72e2-456d-8c64-8c5293febeb6", display: "Fedora" },
       ],
       error: null,
-      isSearchingConditions: false,
+      isSearchingConcepts: false,
     }));
 
     mockUseGetConceptByUuid.mockImplementation(() => ({


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
I changed the `isSearchingConditions variable` to `isSearchingConcepts` to match the mocked implementation of the useConceptLookup function.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
