### PR TITLE
(fix) O3-2150: Add missing translations to side menu

### DIFF
--- a/packages/framework/esm-react-utils/src/ConfigurableLink.tsx
+++ b/packages/framework/esm-react-utils/src/ConfigurableLink.tsx
@@ -5,6 +5,7 @@ import React, {
   PropsWithChildren,
 } from "react";
 import { navigate, interpolateUrl, TemplateParams } from "@openmrs/esm-config";
+import { useTranslation } from "react-i18next";
 
 function handleClick(
   event: MouseEvent,
@@ -20,6 +21,13 @@ function handleClick(
     event.preventDefault();
     navigate({ to, templateParams });
   }
+}
+
+function camelize(str) {
+  const camelCaseString = str.replace(/\W+(.)/g, function (match, chr) {
+    return chr.toUpperCase();
+  });
+  return camelCaseString.charAt(0).toLowerCase() + camelCaseString.slice(1);
 }
 
 /**
@@ -45,13 +53,17 @@ export function ConfigurableLink({
   children,
   ...otherProps
 }: PropsWithChildren<ConfigurableLinkProps>) {
+  const { t } = useTranslation();
+
   return (
     <a
       onClick={(event) => handleClick(event, to, templateParams)}
       href={interpolateUrl(to, templateParams)}
       {...otherProps}
     >
-      {children}
+      {typeof children === "string"
+        ? t(camelize(children), children)
+        : children}
     </a>
   );
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Added the translation feature to the application's side menu

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://issues.openmrs.org/browse/O3-2150

## Other
<!-- Anything not covered above -->
