### PR TITLE
(fix) Fix loading config from relative URLs

### DIFF
--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -168,21 +168,11 @@ function clearDevOverrides() {
   location.reload();
 }
 
-function isAbsoluteUrl(url: string): boolean {
-  const absoluteUrlPattern = /^https?:\/\//i;
-  return absoluteUrlPattern.test(url);
-}
-
 function createConfigLoader(configUrls: Array<string>) {
   const loadingConfigs = Promise.all(
     configUrls.map((configUrl) => {
-      const interpolatedUrl = `${interpolateUrl(
-        `\${openmrsSpaBase}${configUrl}`
-      )}`;
-      const url = isAbsoluteUrl(configUrl)
-        ? configUrl
-        : `${window.location.origin}${interpolatedUrl}`;
-      return fetch(url)
+      const interpolatedUrl = interpolateUrl(configUrl);
+      return fetch(interpolatedUrl)
         .then((res) => res.json())
         .then((config) => ({
           name: configUrl,


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
#674, in trying to allow absolute and relative URLs, adds a regression, specifically, by always injecting the `openmrsSpaBase` variable while resolving the URL. This adjust things to continue to use `interpolateUrl` here (so you can use `${openmrsSpaBase}` in the config string, but by not automatically pre-pending it.

Because #674 introduced a breaking change, this PR is likely breaking for anyone relying on that change.

In the future, we need to carefully ensure that (feat) PRs do not change core semantics or if they do, we appropriately mark them as BREAKING.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
