### PR TITLE
(fix)O3-2207:openmrs build script exits with exit code 0 even if there is a build failure

### DIFF
--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -30,7 +30,13 @@ function runCommand<T extends CommandNames>(
     args,
   });
 
-  ps.on("exit", (code) => process.exit(code || 0));
+  ps.on("exit", (code) => {
+    if (code === 0) {
+      process.exit(0); // Build success, exit with code 0
+    } else {
+      process.exit(1); // Build failure, exit with code 1
+    }
+  });
 }
 
 yargs.command(


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
I added a condition for the build script to exit  with code 0 when the build is successful and code 1 if there is a build failure.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://issues.openmrs.org/browse/O3-2207

## Other
<!-- Anything not covered above -->
