### PR TITLE
(feat) Load scripts for non-visible modules asynchronously after starting application

### DIFF
--- a/packages/framework/esm-dynamic-loading/src/dynamic-loading.ts
+++ b/packages/framework/esm-dynamic-loading/src/dynamic-loading.ts
@@ -37,7 +37,7 @@ export async function importDynamic<T = any>(
 
   const container = window[jsPackageSlug] as unknown;
   if (!isFederatedModule(container)) {
-    const error = `The global variable ${jsPackageSlug}  does not refer to a federated module`;
+    const error = `The global variable ${jsPackageSlug} does not refer to a federated module`;
     console.error(error);
     throw new Error(error);
   }

--- a/packages/framework/esm-dynamic-loading/src/dynamic-loading.ts
+++ b/packages/framework/esm-dynamic-loading/src/dynamic-loading.ts
@@ -1,7 +1,7 @@
 /** @module @category Dynamic Loading */
 "use strict";
 // hack to make the types defined in esm-globals available here
-import type {} from "@openmrs/esm-globals";
+import type { ImportMap } from "@openmrs/esm-globals";
 
 /**
  * @internal
@@ -28,34 +28,12 @@ export function slugify(name: string) {
  */
 export async function importDynamic<T = any>(
   jsPackage: string,
-  share: string = "./start"
+  share: string = "./start",
+  options?: { importMap?: ImportMap }
 ): Promise<T> {
-  if (typeof jsPackage !== "string" || jsPackage.trim().length === 0) {
-    const error =
-      "Attempted to call importDynamic() without supplying a package to load";
-    console.error(error);
-    throw new Error(error);
-  }
+  await preloadImport(jsPackage, options?.importMap);
 
   const jsPackageSlug = slugify(jsPackage);
-
-  if (!window[jsPackageSlug]) {
-    const importMap = await window.importMapOverrides.getCurrentPageMap();
-    if (!importMap.imports.hasOwnProperty(jsPackage)) {
-      const error = `Could not find the package ${jsPackage} defined in the current importmap`;
-      console.error(error);
-      throw new Error(error);
-    }
-
-    let url = importMap.imports[jsPackage];
-    if (url.startsWith("./")) {
-      url = window.spaBase + url.substring(1);
-    }
-
-    await new Promise((resolve, reject) => {
-      loadScript(url, resolve, reject);
-    });
-  }
 
   const container = window[jsPackageSlug] as unknown;
   if (!isFederatedModule(container)) {
@@ -78,6 +56,57 @@ export async function importDynamic<T = any>(
   return module as unknown as T;
 }
 
+/**
+ * @internal
+ *
+ * This internal method is used to ensure that the script belonging
+ * to the given package is loaded and added to the head.
+ *
+ * @param jsPackage The package to load
+ * @param importMap The import map to use for loading this package.
+ *  The main reason for specifying this is to avoid needing to call
+ *  `getCurrentPageMap()` for every script when bulk loading.
+ */
+export async function preloadImport(jsPackage: string, importMap?: ImportMap) {
+  if (typeof jsPackage !== "string" || jsPackage.trim().length === 0) {
+    const error =
+      "Attempted to call importDynamic() without supplying a package to load";
+    console.error(error);
+    throw new Error(error);
+  }
+
+  const jsPackageSlug = slugify(jsPackage);
+
+  if (!window[jsPackageSlug]) {
+    const activeImportMap = importMap ?? (await getCurrentImportMap());
+    if (!activeImportMap.imports.hasOwnProperty(jsPackage)) {
+      const error = `Could not find the package ${jsPackage} defined in the current importmap`;
+      console.error(error);
+      throw new Error(error);
+    }
+
+    let url = activeImportMap.imports[jsPackage];
+    if (url.startsWith("./")) {
+      url = window.spaBase + url.substring(1);
+    }
+
+    await new Promise((resolve, reject) => {
+      loadScript(url, resolve, reject);
+    });
+  }
+}
+
+/**
+ * @internal
+ *
+ * Used to load the current import map
+ *
+ * @returns The current page map
+ */
+export async function getCurrentImportMap() {
+  return window.importMapOverrides.getCurrentPageMap();
+}
+
 interface FederatedModule {
   init: (scope: typeof __webpack_share_scopes__.default) => void;
   get: (_export: string) => Promise<() => unknown>;
@@ -97,7 +126,7 @@ function isFederatedModule(a: unknown): a is FederatedModule {
 // internals to track script loading
 // basically, if we're already loading a script, we should wait until the script is loaded
 // we use a global to track this
-const OPENMRS_SCRIPT_LOADING = "__openmrs_script_loading";
+const OPENMRS_SCRIPT_LOADING = Symbol("__openmrs_script_loading");
 
 /**
  * Appends a `<script>` to the DOM with the given URL.

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -2100,7 +2100,7 @@ ___
 
 ### importDynamic
 
-▸ **importDynamic**<`T`\>(`jsPackage`, `share?`): `Promise`<`T`\>
+▸ **importDynamic**<`T`\>(`jsPackage`, `share?`, `options?`): `Promise`<`T`\>
 
 Loads the named export from a named package. This might be used like:
 
@@ -2120,6 +2120,8 @@ const { someComponent } = importDynamic("@openmrs/esm-template-app")
 | :------ | :------ | :------ | :------ |
 | `jsPackage` | `string` | `undefined` | The package to load the export from |
 | `share` | `string` | `"./start"` | Indicates the name of the shared module; this is an advanced feature if the package you are loading   doesn't use the default OpenMRS shared module name "./start" |
+| `options?` | `Object` | `undefined` | - |
+| `options.importMap?` | [`ImportMap`](interfaces/ImportMap.md) | `undefined` |  |
 
 #### Returns
 

--- a/packages/framework/esm-react-utils/src/Extension.tsx
+++ b/packages/framework/esm-react-utils/src/Extension.tsx
@@ -90,6 +90,7 @@ export const Extension: React.FC<ExtensionProps> = ({
       return () => {
         if (parcel && parcel.current) {
           const status = parcel.current.getStatus();
+          console.log(`Unmounting ${parcel.current}; status: ${status}`);
           switch (status) {
             case "MOUNTING":
               parcel.current.mountPromise.then(parcel.current.unmount);


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This is something I was deferring to "phase 2" because it was a little hard to test without the full routes setup. The idea here is that we pre-load the script (and the initial chunk containing the contents of `index.ts`), but not call any code at this point.

Hopefully, this should make things feel more responsive.

NB It is quite trivial for this design to be less than optimal; however, further optimising this likely involves prioritising the preloading (i.e., ensure that scripts are preloaded in the order they are likely needed, but that requires some way of declaring that prioritisation). 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
