### PR TITLE
(fix) Add a missing `order` property to the offline tools routes

### DIFF
--- a/packages/apps/esm-offline-tools-app/src/routes.json
+++ b/packages/apps/esm-offline-tools-app/src/routes.json
@@ -99,6 +99,7 @@
         "columns": 1,
         "title": "Offline Actions"
       },
+      "order": 12,
       "online": true,
       "offline": true
     },


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Adds a missing `order` property to the offline tools routes.
