### PR TITLE
(fix) Properly merge routes using routes.registry.json from backend

### DIFF
--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -100,14 +100,17 @@ yargs.command(
       .describe(
         "importmap",
         "The import map to use. Can be a path to a valid import map to be taken literally, an URL, or a fixed JSON object."
-      ),
+      )
+      .string("routes")
+      .default("routes", "routes.registry.json")
+      .describe("routes", "The routes.registry.json file to use."),
   async (args) =>
     runCommand("runDebug", {
       configUrls: args["config-url"],
       ...args,
       ...proxyImportmapAndRoutes(
         await mergeImportmapAndRoutes(
-          await getImportmapAndRoutes(args.importmap, args.port),
+          await getImportmapAndRoutes(args.importmap, args.routes, args.port),
           (args["run-project"] || (args.runProject as boolean)) &&
             (await runProject(args.port, args.sources))
         ),
@@ -170,14 +173,17 @@ yargs.command(
       .describe(
         "importmap",
         "The import map to use. Can be a path to a valid import map to be taken literally, an URL, or a fixed JSON object."
-      ),
+      )
+      .string("routes")
+      .default("routes", "routes.registry.json")
+      .describe("routes", "The routes.registry.json file to use."),
   async (args) =>
     runCommand("runDevelop", {
       configUrls: args["config-url"],
       ...args,
       ...proxyImportmapAndRoutes(
         await mergeImportmapAndRoutes(
-          await getImportmapAndRoutes(args.importmap, args.port),
+          await getImportmapAndRoutes(args.importmap, args.routes, args.port),
           (args.sources[0] as string | boolean) !== false &&
             (await runProject(args.port, args.sources)),
           args.backend,

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -5,7 +5,7 @@ import {
   readFileSync,
   statSync,
 } from "fs";
-import { getImportmapAndRoutes, loadWebpackConfig, logInfo } from "../utils";
+import { getImportMap, loadWebpackConfig, logInfo } from "../utils";
 import { basename, join, parse, resolve } from "path";
 import type { webpack } from "webpack";
 
@@ -65,9 +65,7 @@ export async function runBuild(args: BuildArgs) {
     configUrls.push(basename(configPath));
   }
 
-  const { importMap } = await getImportmapAndRoutes(
-    buildConfig.importmap || args.importmap
-  );
+  const importMap = await getImportMap(buildConfig.importmap || args.importmap);
   // if we're supplying a URL importmap and the dist folder exists and the raw importmap file doesn't exist
   // we use the nearest thing. Basically, this is added to support the --hash-importmap assemble option.
   if (importMap.type === "url") {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
As part of #671, I accidentally left a stub in place for loading routes.registry.json from the backend, which meant that when running `openmrs develop` the `routes.registry.json` file would _only_ contain the routes from the local packages and not dynamically layer them over the base routes. This PR adds proper loading of the backend `routes.registry.json`, so the devtools should hopefully work.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
