### PR TITLE
(fix) Improve service-worker behaviour when running in development

### DIFF
--- a/packages/tooling/openmrs/src/commands/develop.ts
+++ b/packages/tooling/openmrs/src/commands/develop.ts
@@ -57,6 +57,13 @@ export function runDevelop(args: DevelopArgs) {
       `http://${host}:${port}${spaPath}/importmap.json`
     );
 
+  const sw = resolve(source, "service-worker.js");
+  // remove any full references to dev3.openmrs.org
+  const swContent = readFileSync(sw, "utf-8").replace(
+    /https:\/\/dev3.openmrs.org\/openmrs\/spa\//g,
+    ``
+  );
+
   const pageUrl = `http://${host}:${port}${spaPath}`;
 
   // Set up routes. Note that different middlewares have different rules
@@ -87,6 +94,11 @@ export function runDevelop(args: DevelopArgs) {
       res.contentType("application/json").send(stringifiedRoutes);
     });
   }
+
+  // Route for custom `service-worker.js` before most things
+  app.get(`${spaPath}/service-worker.js`, (_, res) => {
+    res.contentType("js").send(swContent);
+  });
 
   // Route for custom `index.html` goes above static assets
   app.get(indexHtmlPathMatcher, (_, res) =>


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Hopefully somewhat improves the SW when running in development mode. In particular:

1. service-worker.js is served from a static route, so it should be available more quickly.
2. absolute references to dev3.openmrs.org are removed, leaving us with relative paths, which should be the right handling in most use-cases

Since this is a SW update, your browser will need to update the copy of the service-worker for these changes to take effect. This _should_ happen automatically, but you can speed up the process by clicking the "Sync" button in the "Service Workers" view of the Application tab in Chrome DevTools to help it along.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
