### PR TITLE
(fix) Render extensions based on connectivity

### DIFF
--- a/packages/shell/esm-app-shell/src/apps.ts
+++ b/packages/shell/esm-app-shell/src/apps.ts
@@ -316,6 +316,8 @@ supported, so the extension will not be loaded.`
     order: extension.order,
     moduleName: appName,
     privileges: extension.privileges,
+    online: extension.online,
+    offline: extension.offline,
   });
 
   for (const slot of slots) {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR makes it so that [registerExtension](https://github.com/openmrs/openmrs-esm-core/blob/756956c481a7fb1a178743755a3b7c961ff7e115/packages/shell/esm-app-shell/src/apps.ts#L312) takes into account the `offline` and `online` boolean properties specified in an extension's configuration as defined in a frontend module's `routes.json` file. These boolean properties are then used to determine whether or not to render the extension.

## Screenshots
*None*

## Related Issue
*None*

## Other
*None*
