### PR TITLE
(fix) Offline tools should not render when online

### DIFF
--- a/packages/apps/esm-implementer-tools-app/translations/am.json
+++ b/packages/apps/esm-implementer-tools-app/translations/am.json
@@ -6,6 +6,7 @@
   "downloadConfig": "Download Config",
   "edit": "Edit",
   "editValueButtonText": "Edit",
+  "extensions": "Extensions",
   "frontendModules": "Frontend Modules",
   "installedVersion": "Installed Version",
   "itemDescriptionSourceDefaultText": "The current value is the default.",

--- a/packages/apps/esm-implementer-tools-app/translations/es.json
+++ b/packages/apps/esm-implementer-tools-app/translations/es.json
@@ -6,6 +6,7 @@
   "downloadConfig": "Descargar config",
   "edit": "Editar",
   "editValueButtonText": "Editar",
+  "extensions": "Extensions",
   "frontendModules": "Frontend Modules",
   "installedVersion": "Versión instalada",
   "itemDescriptionSourceDefaultText": "El valor coriente es lo predeterminado.",

--- a/packages/apps/esm-implementer-tools-app/translations/fr.json
+++ b/packages/apps/esm-implementer-tools-app/translations/fr.json
@@ -6,6 +6,7 @@
   "downloadConfig": "Download Config",
   "edit": "Edit",
   "editValueButtonText": "Edit",
+  "extensions": "Extensions",
   "frontendModules": "Frontend Modules",
   "installedVersion": "Installed Version",
   "itemDescriptionSourceDefaultText": "The current value is the default.",

--- a/packages/apps/esm-implementer-tools-app/translations/he.json
+++ b/packages/apps/esm-implementer-tools-app/translations/he.json
@@ -6,6 +6,7 @@
   "downloadConfig": "הורד תצורה",
   "edit": "ערוך",
   "editValueButtonText": "ערוך",
+  "extensions": "Extensions",
   "frontendModules": "מודולים בצד הלקוח",
   "installedVersion": "גרסה מותקנת",
   "itemDescriptionSourceDefaultText": "הערך הנוכחי הוא הערך המוגדר כברירת מחדל.",

--- a/packages/apps/esm-implementer-tools-app/translations/km.json
+++ b/packages/apps/esm-implementer-tools-app/translations/km.json
@@ -6,6 +6,7 @@
   "downloadConfig": "Download Config",
   "edit": "Edit",
   "editValueButtonText": "Edit",
+  "extensions": "Extensions",
   "frontendModules": "Frontend Modules",
   "installedVersion": "Installed Version",
   "itemDescriptionSourceDefaultText": "The current value is the default.",

--- a/packages/apps/esm-offline-tools-app/src/routes.json
+++ b/packages/apps/esm-offline-tools-app/src/routes.json
@@ -7,7 +7,7 @@
     {
       "component": "offlineTools",
       "route": "offline-tools",
-      "online": true,
+      "online": false,
       "offline": true
     }
   ],
@@ -16,26 +16,26 @@
       "name": "offline-tools-link",
       "slot": "app-menu-slot",
       "component": "offlineToolsLink",
-      "online": true,
+      "online": false,
       "offline": true
     },
     {
       "name": "offline-tools-nav-items",
       "component": "offlineToolsNavItems",
-      "online": true,
+      "online": false,
       "offline": true
     },
     {
       "name": "offline-tools-confirmation-modal",
       "component": "offlineToolsConfirmationModal",
-      "online": true,
+      "online": false,
       "offline": true
     },
     {
       "name": "offline-tools-dashboard-patients-card",
       "slot": "offline-tools-dashboard-cards",
       "component": "offlineToolsPatientsCard",
-      "online": true,
+      "online": false,
       "offline": true,
       "order": 0
     },
@@ -43,7 +43,7 @@
       "name": "offline-tools-dashboard-actions-card",
       "slot": "offline-tools-dashboard-cards",
       "component": "offlineToolsActionsCard",
-      "online": true,
+      "online": false,
       "offline": true,
       "order": 2
     },
@@ -55,14 +55,14 @@
         "name": "patients",
         "slot": "offline-tools-page-offline-patients-slot"
       },
-      "online": true,
+      "online": false,
       "offline": true
     },
     {
       "name": "offline-tools-page-offline-patients",
       "slot": "offline-tools-page-offline-patients-slot",
       "component": "offlineToolsPatients",
-      "online": true,
+      "online": false,
       "offline": true
     },
     {
@@ -73,14 +73,14 @@
         "name": "actions",
         "slot": "offline-tools-page-actions-slot"
       },
-      "online": true,
+      "online": false,
       "offline": true
     },
     {
       "name": "offline-tools-page-actions",
       "slot": "offline-tools-page-actions-slot",
       "component": "offlineToolsPageActions",
-      "online": true,
+      "online": false,
       "offline": true
     },
     {
@@ -98,7 +98,7 @@
       "name": "offline-tools-patient-chart-actions-dashboard",
       "slot": "patient-chart-offline-actions-dashboard-slot",
       "component": "offlineToolsPatientChartActions",
-      "online": true,
+      "online": false,
       "offline": true,
       "order": 0
     },
@@ -111,14 +111,14 @@
         "title": "Offline Actions"
       },
       "order": 12,
-      "online": true,
+      "online": false,
       "offline": true
     },
     {
       "name": "offline-tools-opt-in-offline-mode-button",
       "slot": "user-panel-slot",
       "component": "offlineToolsOptInButton",
-      "online": true,
+      "online": false,
       "offline": true,
       "order": 1
     }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR tweaks the metadata configuration for extensions in the Offline tools app, ensuring they only render when the user is offline. It also adds some orphaned translation keys and strings from a previous commit.

## Screenshots
*None*

## Related Issue
*None*

## Other
*None*

