### PR TITLE
(fix) Define behaviour for translations from esm-app-shell

### DIFF
--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -42,6 +42,23 @@ export function setupI18n() {
           callback(Error("can't handle translation namespace"), null);
         } else if (namespace === undefined || language === undefined) {
           callback(Error(), null);
+        } else if (namespace === "@openmrs/esm-app-shell") {
+          // currently, we don't have translations in the app shell
+          getConfigInternal(namespace)
+            .then((config) => {
+              let translations = {};
+              if (config && "Translation overrides" in config) {
+                const overrides = config["Translation overrides"];
+                if (language in overrides) {
+                  translations = overrides[language];
+                }
+              }
+
+              callback(null, translations);
+            })
+            .catch((err: Error) => {
+              callback(err, null);
+            });
         } else {
           importDynamic(namespace)
             .then((module) =>


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Some of our extensions are loaded from @openmrs/esm-app-shell; however, because the app-shell is loaded very differently from other modules, it will need it's own code path to handle translations. Currently, we don't have any translated strings in the app shell, but I have added the logic to support translation overrides anyways.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
