### PR TITLE
(fix) Fix issues with single-spa caused by naming extensions

### DIFF
--- a/packages/apps/esm-implementer-tools-app/translations/am.json
+++ b/packages/apps/esm-implementer-tools-app/translations/am.json
@@ -6,6 +6,7 @@
   "downloadConfig": "Download Config",
   "edit": "Edit",
   "editValueButtonText": "Edit",
+  "extensions": "Extensions",
   "frontendModules": "Frontend Modules",
   "installedVersion": "Installed Version",
   "itemDescriptionSourceDefaultText": "The current value is the default.",

--- a/packages/apps/esm-implementer-tools-app/translations/es.json
+++ b/packages/apps/esm-implementer-tools-app/translations/es.json
@@ -6,6 +6,7 @@
   "downloadConfig": "Descargar config",
   "edit": "Editar",
   "editValueButtonText": "Editar",
+  "extensions": "Extensions",
   "frontendModules": "Frontend Modules",
   "installedVersion": "Versión instalada",
   "itemDescriptionSourceDefaultText": "El valor coriente es lo predeterminado.",

--- a/packages/apps/esm-implementer-tools-app/translations/fr.json
+++ b/packages/apps/esm-implementer-tools-app/translations/fr.json
@@ -6,6 +6,7 @@
   "downloadConfig": "Download Config",
   "edit": "Edit",
   "editValueButtonText": "Edit",
+  "extensions": "Extensions",
   "frontendModules": "Frontend Modules",
   "installedVersion": "Installed Version",
   "itemDescriptionSourceDefaultText": "The current value is the default.",

--- a/packages/apps/esm-implementer-tools-app/translations/he.json
+++ b/packages/apps/esm-implementer-tools-app/translations/he.json
@@ -6,6 +6,7 @@
   "downloadConfig": "הורד תצורה",
   "edit": "ערוך",
   "editValueButtonText": "ערוך",
+  "extensions": "Extensions",
   "frontendModules": "מודולים בצד הלקוח",
   "installedVersion": "גרסה מותקנת",
   "itemDescriptionSourceDefaultText": "הערך הנוכחי הוא הערך המוגדר כברירת מחדל.",

--- a/packages/apps/esm-implementer-tools-app/translations/km.json
+++ b/packages/apps/esm-implementer-tools-app/translations/km.json
@@ -6,6 +6,7 @@
   "downloadConfig": "Download Config",
   "edit": "Edit",
   "editValueButtonText": "Edit",
+  "extensions": "Extensions",
   "frontendModules": "Frontend Modules",
   "installedVersion": "Installed Version",
   "itemDescriptionSourceDefaultText": "The current value is the default.",

--- a/packages/framework/esm-extensions/src/render.ts
+++ b/packages/framework/esm-extensions/src/render.ts
@@ -8,6 +8,8 @@ export interface CancelLoading {
   (): void;
 }
 
+let parcelCount = 0;
+
 /**
  * Mounts into a DOM node (representing an extension slot)
  * a lazy-loaded component from *any* frontend module
@@ -58,10 +60,11 @@ export async function renderExtension(
       });
 
       const { default: result, ...lifecycle } = await load();
+      const id = parcelCount++;
       parcel = mountRootParcel(
         renderFunction({
           ...(result ?? lifecycle),
-          name: `${extensionName} in ${extensionSlotName}`,
+          name: `${extensionSlotName}/${extensionName}-${id}`,
         }),
         {
           ...additionalProps,

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -2386,7 +2386,7 @@ that registered an extension component for this slot.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/render.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L16)
+[packages/framework/esm-extensions/src/render.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L18)
 
 ___
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

#708 accidentally broke our use of single-spa. Specifically, single-spa uses parcel names in order to track the parcel internally. However, we support rendering each extension basically any number of times. With the new names, this meant that if the same extension was loaded more than once (which happens relatively frequently, likely due to re-renders), this caused single-spa to improperly track the parcel's state resulting in a number of single-spa errors.

This shifts us to using the convention: `${slotName}/${extensionName}-${uniqueNumber}`, which avoids these errors.

As future work, we should look into better memoisation of rendered extensions and extension-slots to reduce the number of parcels we are generating.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
