### PR TITLE
(fix) Importmap replacement should only override importmap.json part of importmap URL

### DIFF
--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -72,7 +72,7 @@ export async function runBuild(args: BuildArgs) {
     if (
       !/^https?:\/\//.test(importMap.value) &&
       existsSync(args.target) &&
-      !existsSync(resolve(args.target, importMap.value))
+      !existsSync(resolve(args.target, basename(importMap.value)))
     ) {
       const { name: fileName, ext: extension } = parse(importMap.value);
       const paths = readdirSync(args.target).filter(
@@ -81,8 +81,9 @@ export async function runBuild(args: BuildArgs) {
           entry.endsWith(extension) &&
           statSync(resolve(args.target, entry)).isFile()
       );
+
       if (paths) {
-        importMap.value = paths[0];
+        importMap.value = importMap.value.replace(/importmap\.json/i, paths[0]);
       }
     }
   }


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Fixes an issue caused by #641 where the importmap.json was being replaced with just the base path, meaning that, for the development server, when the value _should've_ been `$SPA_PATH/importmap.json` (transformed to `$SPA_PATH/importmap.xxxx.json`), it was getting overridden to `importmap.json`. With this fix, paths will be transformed as expected.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
