### PR TITLE
(fix) Login app should load locations with a case-insensitive db

### DIFF
--- a/packages/apps/esm-login-app/src/login.resource.ts
+++ b/packages/apps/esm-login-app/src/login.resource.ts
@@ -55,25 +55,27 @@ export function useLoginLocations(
       return null;
     }
 
-    let url = `${fhirBaseUrl}/Location?_summary=data`;
+    let url = `${fhirBaseUrl}/Location?`;
+    let urlSearchParameters = new URLSearchParams();
+    urlSearchParameters.append("_summary", "data");
 
     if (count) {
-      url += `&_count=${count}`;
+      urlSearchParameters.append("_count", "" + count);
     }
 
     if (page) {
-      url += `&_getpagesoffset=${page * count}`;
+      urlSearchParameters.append("_getpagesoffset", "" + page * count);
     }
 
     if (useLoginLocationTag) {
-      url += "&_tag=login location";
+      urlSearchParameters.append("_tag", "Login Location");
     }
 
     if (typeof searchQuery === "string" && searchQuery != "") {
-      url += `&name:contains=${searchQuery}`;
+      urlSearchParameters.append("name:contains", searchQuery);
     }
 
-    return url;
+    return url + urlSearchParameters.toString();
   }
 
   const { data, isLoading, isValidating, setSize, error } = useSwrInfinite<


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
With case-sensitive DBs, `login location` does not match the `Login Location` tag.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
