### PR TITLE
(feat) Simplify the openmrsComponentDecorator

### DIFF
--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -7,11 +7,6 @@ import {
   getConfigInternal,
   importDynamic,
 } from "@openmrs/esm-framework/src/internal";
-declare global {
-  interface Window {
-    i18next: i18next.i18n;
-  }
-}
 
 export function setupI18n() {
   window.i18next = i18next.default || i18next;
@@ -34,7 +29,7 @@ export function setupI18n() {
 
   return window.i18next
     .use(LanguageDetector)
-    .use({
+    .use<i18next.BackendModule>({
       type: "backend",
       init() {},
       read(language, namespace, callback) {
@@ -84,7 +79,7 @@ export function setupI18n() {
             });
         }
       },
-    } as i18next.BackendModule)
+    })
     .use(initReactI18next)
     .use(ICU)
     .init({


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This removes the React `Suspense` component that attempts to preload translations, which seems to be non-functional.

I'm not 100% certain of the consequences of this, but it seems to work?

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
