### PR TITLE
(fix) Ignore single-spa error 32 firing if a parcel has been unmounted

### DIFF
--- a/packages/framework/esm-react-utils/src/extensions.test.tsx
+++ b/packages/framework/esm-react-utils/src/extensions.test.tsx
@@ -181,11 +181,14 @@ describe("ExtensionSlot, Extension, and useExtensionSlotMeta", () => {
       );
       const metas = useExtensionSlotMeta("Box");
       const wrapItem = useCallback(
-        (slot: React.ReactNode, extension: ExtensionData) => {
+        (slot: React.ReactNode, extension?: ExtensionData) => {
           return (
             <div>
               <h1>
-                {metas[getExtensionNameFromId(extension.extensionId)].code}
+                {
+                  metas[getExtensionNameFromId(extension?.extensionId ?? "")]
+                    .code
+                }
               </h1>
               {slot}
             </div>
@@ -196,7 +199,7 @@ describe("ExtensionSlot, Extension, and useExtensionSlotMeta", () => {
       return (
         <div>
           <ExtensionSlot name="Box">
-            <Extension wrap={wrapItem} state={{ suffix }} />
+            <Extension state={{ suffix }}>{wrapItem}</Extension>
           </ExtensionSlot>
           <button onClick={toggleSuffix}>Toggle suffix</button>
         </div>


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
I suspect that there's a better way to handle state updates to a single-spa Parcel inside a React component than this, but this is the simplest hack around the current issue. It seems that `update()` is getting called in these instances _after_ the component is unmounted and so it fails. This just tries to ignore that exact error condition.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
