### PR TITLE
(fix) Update a bunch of peer dependencies from 4.x to 5.x

### DIFF
--- a/packages/framework/esm-api/package.json
+++ b/packages/framework/esm-api/package.json
@@ -41,9 +41,9 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-config": "4.x",
-    "@openmrs/esm-error-handling": "4.x",
-    "@openmrs/esm-offline": "4.x"
+    "@openmrs/esm-config": "5.x",
+    "@openmrs/esm-error-handling": "5.x",
+    "@openmrs/esm-offline": "5.x"
   },
   "devDependencies": {
     "@openmrs/esm-config": "^5.0.2",

--- a/packages/framework/esm-breadcrumbs/package.json
+++ b/packages/framework/esm-breadcrumbs/package.json
@@ -40,7 +40,7 @@
     "path-to-regexp": "6.1.0"
   },
   "peerDependencies": {
-    "@openmrs/esm-state": "4.x"
+    "@openmrs/esm-state": "5.x"
   },
   "devDependencies": {
     "@openmrs/esm-state": "^5.0.2"

--- a/packages/framework/esm-config/package.json
+++ b/packages/framework/esm-config/package.json
@@ -40,8 +40,8 @@
     "ramda": "^0.26.1"
   },
   "peerDependencies": {
-    "@openmrs/esm-globals": "4.x",
-    "@openmrs/esm-state": "4.x",
+    "@openmrs/esm-globals": "5.x",
+    "@openmrs/esm-state": "5.x",
     "single-spa": "5.x"
   },
   "devDependencies": {

--- a/packages/framework/esm-dynamic-loading/package.json
+++ b/packages/framework/esm-dynamic-loading/package.json
@@ -41,6 +41,6 @@
     "@openmrs/esm-globals": "^5.0.2"
   },
   "peerDependencies": {
-    "@openmrs/esm-globals": "4.x"
+    "@openmrs/esm-globals": "5.x"
   }
 }

--- a/packages/framework/esm-error-handling/package.json
+++ b/packages/framework/esm-error-handling/package.json
@@ -37,7 +37,7 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@openmrs/esm-globals": "4.x"
+    "@openmrs/esm-globals": "5.x"
   },
   "devDependencies": {
     "@openmrs/esm-globals": "^5.0.2"

--- a/packages/framework/esm-extensions/package.json
+++ b/packages/framework/esm-extensions/package.json
@@ -37,9 +37,9 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@openmrs/esm-api": "4.x",
-    "@openmrs/esm-config": "4.x",
-    "@openmrs/esm-state": "4.x",
+    "@openmrs/esm-api": "5.x",
+    "@openmrs/esm-config": "5.x",
+    "@openmrs/esm-state": "5.x",
     "single-spa": "5.x"
   },
   "devDependencies": {

--- a/packages/framework/esm-offline/package.json
+++ b/packages/framework/esm-offline/package.json
@@ -45,10 +45,10 @@
     "rxjs": "^6.5.3"
   },
   "peerDependencies": {
-    "@openmrs/esm-api": "4.x",
-    "@openmrs/esm-globals": "4.x",
-    "@openmrs/esm-state": "4.x",
-    "@openmrs/esm-styleguide": "4.x",
+    "@openmrs/esm-api": "5.x",
+    "@openmrs/esm-globals": "5.x",
+    "@openmrs/esm-state": "5.x",
+    "@openmrs/esm-styleguide": "5.x",
     "rxjs": "6.x"
   },
   "dependencies": {

--- a/packages/framework/esm-react-utils/package.json
+++ b/packages/framework/esm-react-utils/package.json
@@ -44,11 +44,11 @@
     "swr": "^2.0.1"
   },
   "peerDependencies": {
-    "@openmrs/esm-api": "4.x",
-    "@openmrs/esm-config": "4.x",
-    "@openmrs/esm-error-handling": "4.x",
-    "@openmrs/esm-extensions": "4.x",
-    "@openmrs/esm-globals": "4.x",
+    "@openmrs/esm-api": "5.x",
+    "@openmrs/esm-config": "5.x",
+    "@openmrs/esm-error-handling": "5.x",
+    "@openmrs/esm-extensions": "5.x",
+    "@openmrs/esm-globals": "5.x",
     "dayjs": "1.x",
     "i18next": "19.x",
     "react": "18.x",

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -45,7 +45,7 @@
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {
-    "@openmrs/esm-framework": "4.x",
+    "@openmrs/esm-framework": "5.x",
     "react": "18.x",
     "react-dom": "18.x",
     "rxjs": "6.x"

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -56,7 +56,7 @@ function getFrameworkVersion() {
     const { version } = require("@openmrs/esm-framework/package.json");
     return `^${version}`;
   } catch {
-    return "4.x";
+    return "5.x";
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3503,9 +3503,9 @@ __metadata:
     rxjs: ^6.5.3
     webpack: ^5.88.0
   peerDependencies:
-    "@openmrs/esm-config": 4.x
-    "@openmrs/esm-error-handling": 4.x
-    "@openmrs/esm-offline": 4.x
+    "@openmrs/esm-config": 5.x
+    "@openmrs/esm-error-handling": 5.x
+    "@openmrs/esm-offline": 5.x
   languageName: unknown
   linkType: soft
 
@@ -3550,7 +3550,7 @@ __metadata:
     "@openmrs/esm-state": ^5.0.2
     path-to-regexp: 6.1.0
   peerDependencies:
-    "@openmrs/esm-state": 4.x
+    "@openmrs/esm-state": 5.x
   languageName: unknown
   linkType: soft
 
@@ -3565,8 +3565,8 @@ __metadata:
     ramda: ^0.26.1
     single-spa: ^5.9.2
   peerDependencies:
-    "@openmrs/esm-globals": 4.x
-    "@openmrs/esm-state": 4.x
+    "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-state": 5.x
     single-spa: 5.x
   languageName: unknown
   linkType: soft
@@ -3644,7 +3644,7 @@ __metadata:
   dependencies:
     "@openmrs/esm-globals": ^5.0.2
   peerDependencies:
-    "@openmrs/esm-globals": 4.x
+    "@openmrs/esm-globals": 5.x
   languageName: unknown
   linkType: soft
 
@@ -3654,7 +3654,7 @@ __metadata:
   dependencies:
     "@openmrs/esm-globals": ^5.0.2
   peerDependencies:
-    "@openmrs/esm-globals": 4.x
+    "@openmrs/esm-globals": 5.x
   languageName: unknown
   linkType: soft
 
@@ -3668,9 +3668,9 @@ __metadata:
     lodash-es: ^4.17.21
     single-spa: ^5.9.2
   peerDependencies:
-    "@openmrs/esm-api": 4.x
-    "@openmrs/esm-config": 4.x
-    "@openmrs/esm-state": 4.x
+    "@openmrs/esm-api": 5.x
+    "@openmrs/esm-config": 5.x
+    "@openmrs/esm-state": 5.x
     single-spa: 5.x
   languageName: unknown
   linkType: soft
@@ -3809,10 +3809,10 @@ __metadata:
     uuid: ^9.0.0
     workbox-window: ^6.1.5
   peerDependencies:
-    "@openmrs/esm-api": 4.x
-    "@openmrs/esm-globals": 4.x
-    "@openmrs/esm-state": 4.x
-    "@openmrs/esm-styleguide": 4.x
+    "@openmrs/esm-api": 5.x
+    "@openmrs/esm-globals": 5.x
+    "@openmrs/esm-state": 5.x
+    "@openmrs/esm-styleguide": 5.x
     rxjs: 6.x
   languageName: unknown
   linkType: soft
@@ -3863,11 +3863,11 @@ __metadata:
     swr: ^2.0.1
     webpack: ^5.88.0
   peerDependencies:
-    "@openmrs/esm-api": 4.x
-    "@openmrs/esm-config": 4.x
-    "@openmrs/esm-error-handling": 4.x
-    "@openmrs/esm-extensions": 4.x
-    "@openmrs/esm-globals": 4.x
+    "@openmrs/esm-api": 5.x
+    "@openmrs/esm-config": 5.x
+    "@openmrs/esm-error-handling": 5.x
+    "@openmrs/esm-extensions": 5.x
+    "@openmrs/esm-globals": 5.x
     dayjs: 1.x
     i18next: 19.x
     react: 18.x
@@ -3905,7 +3905,7 @@ __metadata:
     react-dom: ^18.1.0
     rxjs: ^6.5.3
   peerDependencies:
-    "@openmrs/esm-framework": 4.x
+    "@openmrs/esm-framework": 5.x
     react: 18.x
     react-dom: 18.x
     rxjs: 6.x


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
A bunch of framework lib peer dependencies still said 4.x.
