### PR TITLE
(chore) Tweak `pre-release` job skip logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,9 @@ jobs:
   pre_release:
     runs-on: ubuntu-latest
     needs: build
-
+    
     if: ${{ (github.event.head_commit == null || 
-          !startsWith(github.event.head_commit.message, '(release)')) && 
+          !startsWith(github.event.head_commit.message, '(chore) Release v')) && 
           (github.event_name == 'push' || github.event_name == 'workflow_dispatch') }}
 
     steps:


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR tweaks the custom logic in the `pre-release` job of the CI workflow to accurately represent the signature of a release commit. This is so that GitHub Actions knows not to run the `pre-release` job for commits that cut releases. The current logic assumes that release PRs are prefixed with `(release)`, which is not correct. Typically, release commits in this O3 use `(chore) Release v` followed by a version number as their commit message.

## Screenshots
*None*
<!-- Required if you are making UI changes. -->

## Related Issue
*None*
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
*None*
<!-- Anything not covered above -->
