### PR TITLE
(fix) Add support for hashed routes

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -293,7 +293,8 @@ module.exports = (env, argv = {}) => {
           openmrsConfigUrls,
           openmrsCoreImportmap:
             appPatterns.length > 0 && JSON.stringify(coreImportmap),
-          openmrsCoreRoutes: coreRoutes && JSON.stringify(coreRoutes),
+          openmrsCoreRoutes:
+            Object.keys(coreRoutes).length > 0 && JSON.stringify(coreRoutes),
         },
       }),
       new CopyWebpackPlugin({

--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -260,9 +260,15 @@ yargs.command(
         type: "array",
       })
       .option("importmap", {
-        default: "importmap.json",
+        default: undefined,
         describe:
           "The import map to use. Can be a path to an import map to be taken literally, an URL, or a fixed JSON object.",
+        type: "string",
+      })
+      .option("routes", {
+        default: undefined,
+        describe:
+          "The routes registry to use. Can be a path to an routes registry to be taken literally, an URL, or a fixed JSON object.",
         type: "string",
       })
       .option("default-locale", {

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -5,7 +5,14 @@ import {
   readFileSync,
   statSync,
 } from "fs";
-import { getImportMap, loadWebpackConfig, logInfo } from "../utils";
+import {
+  checkImportmapJson,
+  checkRoutesJson,
+  getImportMap,
+  getRoutes,
+  loadWebpackConfig,
+  logInfo,
+} from "../utils";
 import { basename, join, parse, resolve } from "path";
 import type { webpack } from "webpack";
 
@@ -17,7 +24,8 @@ export interface BuildArgs {
   target: string;
   registry: string;
   defaultLocale: string;
-  importmap: string;
+  importmap?: string;
+  routes?: string;
   spaPath: string;
   fresh?: boolean;
   apiUrl: string;
@@ -28,16 +36,17 @@ export interface BuildArgs {
   buildConfig?: string;
 }
 
-export interface BuildConfig {
+export type BuildConfig = Partial<{
   apiUrl: string;
   configUrls: Array<string>;
   configPaths: Array<string>;
-  defaultLocale?: string;
+  defaultLocale: string;
   pageTitle: string;
-  supportOffline?: boolean;
+  supportOffline: boolean;
   importmap: string;
+  routes: string;
   spaPath: string;
-}
+}>;
 
 function loadBuildConfig(buildConfigPath?: string): BuildConfig {
   if (buildConfigPath) {
@@ -65,7 +74,9 @@ export async function runBuild(args: BuildArgs) {
     configUrls.push(basename(configPath));
   }
 
-  const importMap = await getImportMap(buildConfig.importmap || args.importmap);
+  const importMap = await getImportMap(
+    args.importmap || buildConfig.importmap || "importmap.json"
+  );
   // if we're supplying a URL importmap and the dist folder exists and the raw importmap file doesn't exist
   // we use the nearest thing. Basically, this is added to support the --hash-importmap assemble option.
   if (importMap.type === "url") {
@@ -79,7 +90,10 @@ export async function runBuild(args: BuildArgs) {
         (entry) =>
           entry.startsWith(fileName) &&
           entry.endsWith(extension) &&
-          statSync(resolve(args.target, entry)).isFile()
+          statSync(resolve(args.target, entry)).isFile() &&
+          checkImportmapJson(
+            readFileSync(resolve(args.target, entry)).toString()
+          )
       );
 
       if (paths) {
@@ -87,8 +101,41 @@ export async function runBuild(args: BuildArgs) {
       }
     }
   }
+
+  const routes = await getRoutes(
+    args.routes || buildConfig.routes || "routes.registry.json"
+  );
+  console.log(routes);
+  // As above, check for a hashed routes.registry.json if --hash-importmap assmeble option was used
+  if (routes.type === "url") {
+    if (
+      !/^https?:\/\//.test(routes.value) &&
+      existsSync(args.target) &&
+      !existsSync(resolve(args.target, routes.value))
+    ) {
+      const { name: fileName, ext: extension } = parse(routes.value);
+      const paths = readdirSync(args.target).filter(
+        (entry) =>
+          entry.startsWith(fileName) &&
+          entry.endsWith(extension) &&
+          statSync(resolve(args.target, entry)).isFile() &&
+          checkRoutesJson(readFileSync(resolve(args.target, entry)).toString())
+      );
+
+      if (paths) {
+        routes.value = routes.value.replace(
+          /routes\.registry\.json/i,
+          paths[0]
+        );
+      }
+    }
+  }
+
+  console.log(routes);
+
   const config = loadWebpackConfig({
     importmap: importMap,
+    routes,
     env: "production",
     apiUrl: buildConfig.apiUrl || args.apiUrl,
     configUrls: configUrls,

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -105,7 +105,6 @@ export async function runBuild(args: BuildArgs) {
   const routes = await getRoutes(
     args.routes || buildConfig.routes || "routes.registry.json"
   );
-  console.log(routes);
   // As above, check for a hashed routes.registry.json if --hash-importmap assmeble option was used
   if (routes.type === "url") {
     if (
@@ -130,8 +129,6 @@ export async function runBuild(args: BuildArgs) {
       }
     }
   }
-
-  console.log(routes);
 
   const config = loadWebpackConfig({
     importmap: importMap,

--- a/packages/tooling/openmrs/src/utils/config.ts
+++ b/packages/tooling/openmrs/src/utils/config.ts
@@ -1,4 +1,4 @@
-import { ImportmapDeclaration } from "./importmap";
+import type { ImportmapDeclaration, RoutesDeclaration } from "./importmap";
 import { setEnvVariables } from "./variables";
 import type { Configuration as WebpackConfig } from "webpack";
 
@@ -6,6 +6,7 @@ export interface WebpackOptions {
   backend?: string;
   defaultLocale?: string;
   importmap?: ImportmapDeclaration;
+  routes?: RoutesDeclaration;
   apiUrl?: string;
   spaPath?: string;
   pageTitle?: string;
@@ -64,6 +65,17 @@ export function loadWebpackConfig(options: WebpackOptions = {}) {
         break;
       case "url":
         variables.OMRS_ESM_IMPORTMAP_URL = options.importmap.value;
+        break;
+    }
+  }
+
+  if (typeof options.routes === "object") {
+    switch (options.routes.type) {
+      case "inline":
+        variables.OMRS_ROUTES = options.routes.value;
+        break;
+      case "url":
+        variables.OMRS_ROUTES_URL = options.routes.value;
         break;
     }
   }

--- a/packages/tooling/openmrs/src/utils/importmap.ts
+++ b/packages/tooling/openmrs/src/utils/importmap.ts
@@ -312,7 +312,7 @@ export async function getImportmapAndRoutes(
 export async function getImportMap(
   importMapPath: string,
   basePort?: number
-): Promise<ImportmapAndRoutes["importMap"]> {
+): Promise<ImportmapDeclaration> {
   if (importMapPath === "@" && basePort) {
     logWarn(
       'Using the "@" import map is deprecated. Switch to use the "--run-project" flag.'
@@ -359,7 +359,7 @@ export async function getImportMap(
 
 export async function getRoutes(
   routesPath: string
-): Promise<ImportmapAndRoutes["routes"]> {
+): Promise<RoutesDeclaration> {
   if (!/https?:\/\//.test(routesPath)) {
     const path = resolve(process.cwd(), routesPath);
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

If the `--hash-importmap` flag is used in the assemble command, we also hash the `routes.registry.json`, since these are basically generated as linked artefacts. However, I did not update the build command to find the hashed `routes.regsitry.json` file the same way it finds the hashed `importmap.json`. This PR fixes that oversight so that the `--hash-importmap` option will work as expected.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
