### PR TITLE
(feat) Core support for O3-2242: Separate 'active visit' and 'current visit'

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1401,9 +1401,21 @@ ___
 
 ▸ **useVisit**(`patientUuid`): [`VisitReturnType`](interfaces/VisitReturnType.md)
 
-This React hook returns a visit object. If the `patientUuid` is provided
-as a parameter, then the currentVisit, error and mutate function
-for that patient visit is returned.
+This React hook returns visit information if the patient UUID is not null. There are
+potentially two relevant visits at a time: "active" and "current".
+
+The active visit is the most recent visit without an end date. The presence of an active
+visit generally means that the patient is in the facility.
+
+The current visit is the active visit, unless a retrospective visit has been selected.
+If there is no active visit and no selected retrospective visit, then there is no
+current visit. If there is no active visit but there is a retrospective visit, then
+the retrospective visit is the current visit. `currentVisitIsRetrospective` tells you
+whether the current visit is a retrospective visit.
+
+The active visit and current visit require two separate API calls. `error` contains
+the error from either one, if there is an error. `isValidating` is true if either
+API call is in progress. `mutate` refreshes the data from both API calls.
 
 #### Parameters
 
@@ -1415,11 +1427,9 @@ for that patient visit is returned.
 
 [`VisitReturnType`](interfaces/VisitReturnType.md)
 
-Object {`error` `isValidating`, `currentVisit`, `mutate`}
-
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useVisit.ts:32](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L32)
+[packages/framework/esm-react-utils/src/useVisit.ts:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L45)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/VisitReturnType.md
+++ b/packages/framework/esm-framework/docs/interfaces/VisitReturnType.md
@@ -6,10 +6,11 @@
 
 ### API Properties
 
+- [activeVisit](VisitReturnType.md#activevisit)
 - [currentVisit](VisitReturnType.md#currentvisit)
+- [currentVisitIsRetrospective](VisitReturnType.md#currentvisitisretrospective)
 - [error](VisitReturnType.md#error)
 - [isLoading](VisitReturnType.md#isloading)
-- [isRetrospective](VisitReturnType.md#isretrospective)
 - [isValidating](VisitReturnType.md#isvalidating)
 
 ### API Methods
@@ -18,13 +19,33 @@
 
 ## API Properties
 
+### activeVisit
+
+• **activeVisit**: ``null`` \| [`Visit`](Visit.md)
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/useVisit.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L20)
+
+___
+
 ### currentVisit
 
 • **currentVisit**: ``null`` \| [`Visit`](Visit.md)
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useVisit.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L20)
+[packages/framework/esm-react-utils/src/useVisit.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L21)
+
+___
+
+### currentVisitIsRetrospective
+
+• **currentVisitIsRetrospective**: `boolean`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/useVisit.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L22)
 
 ___
 
@@ -44,17 +65,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useVisit.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L22)
-
-___
-
-### isRetrospective
-
-• **isRetrospective**: `boolean`
-
-#### Defined in
-
-[packages/framework/esm-react-utils/src/useVisit.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L21)
+[packages/framework/esm-react-utils/src/useVisit.ts:23](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L23)
 
 ___
 

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -319,6 +319,8 @@ export const useVisit = jest.fn().mockReturnValue({
   mutate: jest.fn(),
   isValidating: true,
   currentVisit: null,
+  activeVisit: null,
+  currentVisitIsRetrospective: false,
 });
 
 export const useVisitTypes = jest.fn(() => []);


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Creates separate "active visit" and "current visit" returns from `useVisit`. This will allow us to have the user go between retrospective entry and entry on an ongoing visit.

## Screenshots
![Screencast from 2023-07-25 20-09-28](https://github.com/openmrs/openmrs-esm-core/assets/1031876/8fbf7563-4bcc-4f23-a9ad-729ca2c31511)

## Related Issue
https://issues.openmrs.org/browse/O3-2242
