### PR TITLE
(chore) O3-2307 - Update the webpack watch ignore paths

### DIFF
--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -238,7 +238,7 @@ export default (
     },
     watchOptions: merge(
       {
-        ignored: [".git", "test-results"],
+        ignored: ["**/.git", "**/test-results"],
       },
       watchConfig
     ),


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currenlty there's an issue with the webpack watch mode where it watch for test output files causing the tests to fail. I updated the webpack ignore paths with the correct wildcards.

## Screenshots
<!-- Required if you are making UI changes. -->
None

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-2307

## Other
<!-- Anything not covered above -->
None