### PR TITLE
(fix) Memoize the returned callback functions from usePagination

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -4330,14 +4330,14 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `currentPage` | `number` |
+| `goTo` | (`page`: `number`) => `void` |
+| `goToNext` | () => `void` |
+| `goToPrevious` | () => `void` |
 | `paginated` | `boolean` |
 | `results` | `T`[] |
 | `showNextButton` | `boolean` |
 | `showPreviousButton` | `boolean` |
 | `totalPages` | `number` |
-| `goTo` | (`page`: `number`) => `void` |
-| `goToNext` | () => `void` |
-| `goToPrevious` | () => `void` |
 
 #### Defined in
 

--- a/packages/framework/esm-react-utils/src/usePagination.ts
+++ b/packages/framework/esm-react-utils/src/usePagination.ts
@@ -1,5 +1,5 @@
 /** @module @category UI */
-import { useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 
 const defaultResultsPerPage = 10;
 
@@ -22,25 +22,47 @@ export function usePagination<T>(
     return data.slice(lowerBound, upperBound);
   }, [data, page, resultsPerPage]);
 
-  return {
-    results,
-    totalPages,
-    currentPage: page,
-    paginated: data.length > resultsPerPage,
-    showNextButton: page < totalPages,
-    showPreviousButton: page > 1,
-    goTo(page: number) {
+  const goTo = useCallback(
+    (page: number) => {
       setPage(Math.max(1, Math.min(totalPages, page)));
     },
-    goToNext() {
-      if (page < totalPages) {
-        setPage(page + 1);
-      }
-    },
-    goToPrevious() {
-      if (page > 1) {
-        setPage(page - 1);
-      }
-    },
-  };
+    [setPage, totalPages]
+  );
+  const goToNext = useCallback(() => {
+    if (page < totalPages) {
+      setPage(page + 1);
+    }
+  }, [page, totalPages, setPage]);
+
+  const goToPrevious = useCallback(() => {
+    if (page > 1) {
+      setPage(page - 1);
+    }
+  }, [page, setPage]);
+
+  const memoisedPaginatedData = useMemo(
+    () => ({
+      results,
+      totalPages,
+      currentPage: page,
+      paginated: data.length > resultsPerPage,
+      showNextButton: page < totalPages,
+      showPreviousButton: page > 1,
+      goTo,
+      goToNext,
+      goToPrevious,
+    }),
+    [
+      results,
+      totalPages,
+      data.length,
+      resultsPerPage,
+      page,
+      goTo,
+      goToNext,
+      goToPrevious,
+    ]
+  );
+
+  return memoisedPaginatedData;
 }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR memoize the returned callback functions from the `usePagination` hook, since the callback functions are used in multiple places as a dependency for other hooks and apparently, the callback functions such as `goTo`'s reference changes on every render, hence re-running the hook for which it is a dependency. One of the places such issue is found is in the patient search's advanced search page's pagination (hook call [here](https://github.com/openmrs/openmrs-esm-patient-management/blob/322db0b8a3c79b409eb7b47a27e962e083d513b5/packages/esm-patient-search-app/src/patient-search-page/patient-search-lg.component.tsx#L46)), which is shifting to 1st page on every pagination change.

## Screenshots
None

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
