### PR TITLE
(fix) Resolve some errors that appear when an app has empty routes

### DIFF
--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -142,7 +142,8 @@ async function preloadScripts() {
   ]);
 
   window.installedModules.map(async ([module]) => {
-    importDynamic(module, undefined, { importMap });
+    // we simply swallow the error here since this is only a preload
+    importDynamic(module, undefined, { importMap }).catch();
   });
 }
 

--- a/packages/tooling/openmrs/src/commands/assemble.ts
+++ b/packages/tooling/openmrs/src/commands/assemble.ts
@@ -250,7 +250,10 @@ export async function runAssemble(args: AssembleArgs) {
         logWarn(
           `Routes file ${appRoutes} does not exist. We expect that routes file to be defined by ${esmName}. Note that this means that no pages or extensions for ${esmName} will be available.`
         );
-        routes[esmName] = {};
+
+        if (routes.hasOwnProperty(esmName)) {
+          delete routes[esmName];
+        }
       }
 
       importmap.imports[esmName] = `${publicUrl}/${dirName}/${fileName}`;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
In one of the recent releases, the form builder would fail to load because a `publish` step wasn't properly defined, causing an empty entry in the `route.registry.json`. This PR at least prevents that specific set of circumstances from happening by ensuring that:

1. The record only appears in the `routes.registry.json` file if the `routes.json` file exists
2. If we get an error while trying to preload a module, we swallow the error.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
