### PR TITLE
(feat) O3-2306: Add formatDate option to disable special 'today' handling

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -285,7 +285,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:140](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L140)
+[packages/framework/esm-utils/src/omrs-dates.ts:141](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L141)
 
 ___
 
@@ -299,12 +299,13 @@ ___
 | :------ | :------ | :------ |
 | `day` | `boolean` | Whether to include the day number |
 | `mode` | [`FormatDateMode`](API.md#formatdatemode) | - `standard`: "03 Feb 2022" - `wide`:     "03 — Feb — 2022" |
+| `noToday` | `boolean` | Disables the special handling of dates that are today. If false (the default), then dates that are today will be formatted as "Today" in the locale language. If true, then dates that are today will be formatted the same as all other dates. |
 | `time` | `boolean` \| ``"for today"`` | Whether the time should be included in the output always (`true`), never (`false`), or only when the input date is today (`for today`). |
 | `year` | `boolean` | Whether to include the year |
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:142](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L142)
+[packages/framework/esm-utils/src/omrs-dates.ts:143](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L143)
 
 ___
 
@@ -1846,8 +1847,10 @@ Default options:
  - time: "for today",
  - day: true,
  - year: true
+ - noToday: false
 
 If the date is today then "Today" is produced (in the locale language).
+This behavior can be disabled with `noToday: true`.
 
 When time is included, it is appended with a comma and a space. This
 agrees with the output of `Date.prototype.toLocaleString` for *most*
@@ -1868,7 +1871,7 @@ TODO: Shouldn't throw on null input
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:184](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L184)
+[packages/framework/esm-utils/src/omrs-dates.ts:195](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L195)
 
 ___
 
@@ -1897,7 +1900,7 @@ output of `Date.prototype.toLocaleString` for *most* locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:251](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L251)
+[packages/framework/esm-utils/src/omrs-dates.ts:262](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L262)
 
 ___
 
@@ -1920,7 +1923,7 @@ Formats the input as a time, according to the current locale.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:235](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L235)
+[packages/framework/esm-utils/src/omrs-dates.ts:246](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L246)
 
 ___
 
@@ -1928,7 +1931,7 @@ ___
 
 ▸ **isOmrsDateStrict**(`omrsPayloadString`): `boolean`
 
-This function is STRICT on checking whether a date string is the openmrs format.
+This function checks whether a date string is the OpenMRS ISO format.
 The format should be YYYY-MM-DDTHH:mm:ss.SSSZZ
 
 #### Parameters
@@ -1986,7 +1989,7 @@ Uses `dayjs(dateString)`.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:136](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L136)
+[packages/framework/esm-utils/src/omrs-dates.ts:137](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L137)
 
 ___
 
@@ -1994,7 +1997,8 @@ ___
 
 ▸ **toDateObjectStrict**(`omrsDateString`): `Date` \| ``null``
 
-Converts the object to a date object if it is a valid ISO date time string.
+Converts the object to a date object if it is an OpenMRS ISO date time string.
+Otherwise returns null.
 
 #### Parameters
 
@@ -2008,7 +2012,7 @@ Converts the object to a date object if it is a valid ISO date time string.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L71)
+[packages/framework/esm-utils/src/omrs-dates.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L72)
 
 ___
 
@@ -2032,7 +2036,7 @@ Formats the input as a date string. By default the format "YYYY-MMM-DD" is used.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:128](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L128)
+[packages/framework/esm-utils/src/omrs-dates.ts:129](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L129)
 
 ___
 
@@ -2055,7 +2059,7 @@ Formats the input as a date string using the format "DD - MMM - YYYY".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:112](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L112)
+[packages/framework/esm-utils/src/omrs-dates.ts:113](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L113)
 
 ___
 
@@ -2063,7 +2067,7 @@ ___
 
 ▸ **toOmrsIsoString**(`date`, `toUTC?`): `string`
 
-Formats the input as a date time string using the format "YYYY-MM-DDTHH:mm:ss.SSSZZ".
+Formats the input to OpenMRS ISO format: "YYYY-MM-DDTHH:mm:ss.SSSZZ".
 
 #### Parameters
 
@@ -2078,7 +2082,7 @@ Formats the input as a date time string using the format "YYYY-MM-DDTHH:mm:ss.SS
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:82](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L82)
+[packages/framework/esm-utils/src/omrs-dates.ts:83](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L83)
 
 ___
 
@@ -2101,7 +2105,7 @@ Formats the input as a time string using the format "HH:mm A".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:104](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L104)
+[packages/framework/esm-utils/src/omrs-dates.ts:105](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L105)
 
 ___
 
@@ -2124,7 +2128,7 @@ Formats the input as a time string using the format "HH:mm".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:96](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L96)
+[packages/framework/esm-utils/src/omrs-dates.ts:97](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L97)
 
 ___
 
@@ -2147,7 +2151,7 @@ Formats the input as a date string using the format "DD-MMM".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:120](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L120)
+[packages/framework/esm-utils/src/omrs-dates.ts:121](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L121)
 
 ___
 

--- a/packages/framework/esm-utils/src/omrs-dates.test.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.test.ts
@@ -131,4 +131,20 @@ describe("Openmrs Dates", () => {
     expect(formatDatetime(testDate)).toEqual("09 févr. 2022, 13:15");
     expect(formatDatetime(todayDate)).toEqual("Aujourd’hui, 15:20");
   });
+
+  it("does not handle today specially when `noToday` is passed", () => {
+    const testDate = new Date();
+    testDate.setHours(15);
+    testDate.setMinutes(22);
+    window.i18next.language = "en";
+    const expected =
+      testDate
+        .toLocaleDateString("en-GB", {
+          year: "numeric",
+          month: "short",
+          day: "2-digit",
+        })
+        .replace(/ /g, "-") + ", 03:22 PM";
+    expect(formatDate(testDate, { noToday: true })).toEqual(expected);
+  });
 });

--- a/packages/framework/esm-utils/src/omrs-dates.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.ts
@@ -21,7 +21,7 @@ export type DateInput = string | number | Date;
 const isoFormat = "YYYY-MM-DDTHH:mm:ss.SSSZZ";
 
 /**
- * This function is STRICT on checking whether a date string is the openmrs format.
+ * This function checks whether a date string is the OpenMRS ISO format.
  * The format should be YYYY-MM-DDTHH:mm:ss.SSSZZ
  */
 export function isOmrsDateStrict(omrsPayloadString: string): boolean {
@@ -66,7 +66,8 @@ export function isOmrsDateToday(date: DateInput) {
 }
 
 /**
- * Converts the object to a date object if it is a valid ISO date time string.
+ * Converts the object to a date object if it is an OpenMRS ISO date time string.
+ * Otherwise returns null.
  */
 export function toDateObjectStrict(omrsDateString: string): Date | null {
   if (!isOmrsDateStrict(omrsDateString)) {
@@ -77,7 +78,7 @@ export function toDateObjectStrict(omrsDateString: string): Date | null {
 }
 
 /**
- * Formats the input as a date time string using the format "YYYY-MM-DDTHH:mm:ss.SSSZZ".
+ * Formats the input to OpenMRS ISO format: "YYYY-MM-DDTHH:mm:ss.SSSZZ".
  */
 export function toOmrsIsoString(date: DateInput, toUTC = false): string {
   let d = dayjs(date);
@@ -154,6 +155,13 @@ export type FormatDateOptions = {
   day: boolean;
   /** Whether to include the year */
   year: boolean;
+  /**
+   * Disables the special handling of dates that are today. If false
+   * (the default), then dates that are today will be formatted as "Today"
+   * in the locale language. If true, then dates that are today will be
+   * formatted the same as all other dates.
+   */
+  noToday: boolean;
 };
 
 const defaultOptions: FormatDateOptions = {
@@ -161,6 +169,7 @@ const defaultOptions: FormatDateOptions = {
   time: "for today",
   day: true,
   year: true,
+  noToday: false,
 };
 
 /**
@@ -172,8 +181,10 @@ const defaultOptions: FormatDateOptions = {
  *  - time: "for today",
  *  - day: true,
  *  - year: true
+ *  - noToday: false
  *
  * If the date is today then "Today" is produced (in the locale language).
+ * This behavior can be disabled with `noToday: true`.
  *
  * When time is included, it is appended with a comma and a space. This
  * agrees with the output of `Date.prototype.toLocaleString` for *most*
@@ -182,7 +193,7 @@ const defaultOptions: FormatDateOptions = {
  * TODO: Shouldn't throw on null input
  */
 export function formatDate(date: Date, options?: Partial<FormatDateOptions>) {
-  const { mode, time, day, year }: FormatDateOptions = {
+  const { mode, time, day, year, noToday }: FormatDateOptions = {
     ...defaultOptions,
     ...options,
   };
@@ -194,7 +205,7 @@ export function formatDate(date: Date, options?: Partial<FormatDateOptions>) {
   let locale = getLocale();
   let localeString: string;
   const isToday = dayjs(date).isToday();
-  if (isToday) {
+  if (isToday && !noToday) {
     // This produces the word "Today" in the language of `locale`
     const rtf = new Intl.RelativeTimeFormat(locale, { numeric: "auto" });
     localeString = rtf.format(0, "day");


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Adds an option that makes the date formatter not handle today specially.


## Related Issue
https://issues.openmrs.org/browse/O3-2306

## Other

CC @nanfuka 