### PR TITLE
(fix) Don't process openmrs-esm-styleguide.css files the Sass loader

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -216,7 +216,16 @@ module.exports = (env, argv = {}) => {
     module: {
       rules: [
         {
-          test: /\.s?css$/,
+          test: /\.css$/,
+          use: [
+            isProd
+              ? { loader: require.resolve(MiniCssExtractPlugin.loader) }
+              : { loader: require.resolve("style-loader") },
+            { loader: require.resolve("css-loader") },
+          ],
+        },
+        {
+          test: /\.scss$/,
           use: [
             isProd
               ? { loader: require.resolve(MiniCssExtractPlugin.loader) }

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -216,7 +216,7 @@ module.exports = (env, argv = {}) => {
     module: {
       rules: [
         {
-          test: /\.css$/,
+          test: /openmrs-esm-styleguide\.css$/,
           use: [
             isProd
               ? { loader: require.resolve(MiniCssExtractPlugin.loader) }
@@ -225,7 +225,8 @@ module.exports = (env, argv = {}) => {
           ],
         },
         {
-          test: /\.scss$/,
+          test: /\.s?css$/,
+          exclude: [/openmrs-esm-styleguide\.css$/],
           use: [
             isProd
               ? { loader: require.resolve(MiniCssExtractPlugin.loader) }


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Something about Sass processing this file is currently broken (see [this build failure](https://ci.openmrs.org/browse/REFAPP-D3X-F2-1522/log)—yes, it looks like it succeeded; that's a separate issue); since Sass doesn't need to process this file, we just hand it off to the MiniCssExtractPlugin and css-loader.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
