### PR TITLE
(feat) Resolve template literals in the `src` prop of the logo config

### DIFF
--- a/packages/apps/esm-login-app/src/login/login.test.tsx
+++ b/packages/apps/esm-login-app/src/login/login.test.tsx
@@ -27,6 +27,8 @@ jest.mock("@openmrs/esm-framework", () => {
         }),
       };
     }),
+    // mock only the happy path
+    interpolateUrl: jest.fn().mockImplementation((url: string) => url),
   };
 });
 

--- a/packages/apps/esm-primary-navigation-app/src/components/logo/logo.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/logo/logo.component.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useConfig } from "@openmrs/esm-framework";
+import { interpolateUrl, useConfig } from "@openmrs/esm-framework";
 import styles from "./logo.scss";
 
 const Logo: React.FC = () => {
@@ -10,7 +10,7 @@ const Logo: React.FC = () => {
       {logo?.src ? (
         <img
           className={styles.logo}
-          src={logo.src}
+          src={interpolateUrl(logo.src)}
           alt={logo.alt}
           width={110}
           height={40}

--- a/packages/apps/esm-primary-navigation-app/src/components/logo/logo.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/logo/logo.test.tsx
@@ -7,6 +7,7 @@ const mockUseConfig = useConfig as jest.Mock;
 
 jest.mock("@openmrs/esm-framework", () => ({
   useConfig: jest.fn(),
+  interpolateUrl: jest.fn(),
 }));
 
 describe("<Logo/>", () => {

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type {} from "@openmrs/esm-globals";
 import { createStore, StoreApi } from "zustand";
-import { never, of } from "rxjs";
+import { NEVER, of } from "rxjs";
 import { interpolateUrl } from "@openmrs/esm-config";
 import { SessionStore } from "@openmrs/esm-api";
 export {
@@ -193,7 +193,7 @@ export const ConfigurableLink = jest
 export const importDynamic = jest.fn();
 
 /* esm-error-handling */
-export const createErrorHandler = () => jest.fn().mockReturnValue(never());
+export const createErrorHandler = () => jest.fn().mockReturnValue(NEVER);
 
 export const reportError = jest.fn().mockImplementation((error) => {
   throw error;


### PR DESCRIPTION
## Requirements
- [X] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Ensures that any encountered template literals within `logo.src` are resolved if supported.

