### PR TITLE
(feat) Allow useConfig() to load configuration from other modules

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1715,7 +1715,7 @@ ___
 
 ### useConfig
 
-▸ **useConfig**<`T`\>(): `T`
+▸ **useConfig**<`T`\>(`moduleName?`): `T`
 
 Use this React Hook to obtain your module's configuration.
 
@@ -1723,7 +1723,13 @@ Use this React Hook to obtain your module's configuration.
 
 | Name | Type |
 | :------ | :------ |
-| `T` | `Omit`<[`ConfigObject`](interfaces/ConfigObject.md), ``"Display conditions"`` \| ``"Translation overrides"``\> |
+| `T` | `Record`<`string`, `any`\> |
+
+#### Parameters
+
+| Name | Type | Default value |
+| :------ | :------ | :------ |
+| `moduleName` | `undefined` \| ``null`` \| `string` | `undefined` |
 
 #### Returns
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1715,7 +1715,7 @@ ___
 
 ### useConfig
 
-▸ **useConfig**<`T`\>(`moduleName?`): `T`
+▸ **useConfig**<`T`\>(`options?`): `T`
 
 Use this React Hook to obtain your module's configuration.
 
@@ -1727,9 +1727,9 @@ Use this React Hook to obtain your module's configuration.
 
 #### Parameters
 
-| Name | Type | Default value |
+| Name | Type | Description |
 | :------ | :------ | :------ |
-| `moduleName` | `undefined` \| ``null`` \| `string` | `undefined` |
+| `options?` | `UseConfigOptions` | Additional options that can be passed to useConfig() |
 
 #### Returns
 
@@ -1737,7 +1737,7 @@ Use this React Hook to obtain your module's configuration.
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useConfig.ts:163](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useConfig.ts#L163)
+[packages/framework/esm-react-utils/src/useConfig.ts:171](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useConfig.ts#L171)
 
 ___
 

--- a/packages/framework/esm-react-utils/src/useConfig.test.tsx
+++ b/packages/framework/esm-react-utils/src/useConfig.test.tsx
@@ -20,6 +20,12 @@ function RenderConfig(props) {
   return <button>{config[props.configKey]}</button>;
 }
 
+function RenderExternalConfig(props) {
+  const config = useConfig({ externalModuleName: props.externalModuleName });
+
+  return <button>{config[props.configKey]}</button>;
+}
+
 function clearConfig() {
   mockConfigInternalStore.resetMock();
 }
@@ -296,5 +302,41 @@ describe(`useConfig in an extension`, () => {
     await waitFor(() =>
       expect(screen.findByText("Yet another thing")).toBeTruthy()
     );
+  });
+
+  it("can optionally load an external module's configuration", async () => {
+    defineConfigSchema("first-module", {
+      thing: {
+        _default: "first thing",
+      },
+    });
+
+    defineConfigSchema("second-module", {
+      thing: {
+        _default: "second thing",
+      },
+    });
+
+    render(
+      <React.Suspense fallback={<div>Suspense!</div>}>
+        <ComponentContext.Provider
+          value={{
+            moduleName: "first-module",
+            extension: {
+              extensionSlotName: "fooSlot",
+              extensionSlotModuleName: "slot-mod",
+              extensionId: "fooExt#id1",
+            },
+          }}
+        >
+          <RenderExternalConfig
+            externalModuleName="second-module"
+            configKey="thing"
+          />
+        </ComponentContext.Provider>
+      </React.Suspense>
+    );
+
+    await waitFor(() => expect(screen.findByText("second thing")).toBeTruthy());
   });
 });

--- a/packages/framework/esm-react-utils/src/useConfig.ts
+++ b/packages/framework/esm-react-utils/src/useConfig.ts
@@ -157,31 +157,37 @@ function useNormalConfig(moduleName: string) {
   return state;
 }
 
+interface UseConfigOptions {
+  /** An external module to load the configuration from. This option should only be used if
+      absolutely necessary as it can end up making frontend modules coupled to one another. */
+  externalModuleName?: string;
+}
+
 /**
  * Use this React Hook to obtain your module's configuration.
+ *
+ * @param options Additional options that can be passed to useConfig()
  */
-export function useConfig<T = Record<string, any>>(
-  moduleName: string | null | undefined = undefined
-) {
+export function useConfig<T = Record<string, any>>(options?: UseConfigOptions) {
   // This hook uses the config of the MF defining the component.
   // If the component is used in an extension slot then the slot
   // may override (part of) its configuration.
   const { moduleName: contextModuleName, extension } =
     useContext(ComponentContext);
-  const finalModuleName = moduleName ?? contextModuleName;
+  const moduleName = options?.externalModuleName ?? contextModuleName;
 
-  if (!finalModuleName && !extension) {
+  if (!moduleName && !extension) {
     throw Error(errorMessage);
   }
 
-  const normalConfig = useNormalConfig(finalModuleName);
+  const normalConfig = useNormalConfig(moduleName);
   const extensionConfig = useExtensionConfig(extension);
   const config = useMemo(
     () =>
-      finalModuleName === moduleName
+      options?.externalModuleName && moduleName === options.externalModuleName
         ? { ...normalConfig }
         : { ...normalConfig, ...extensionConfig },
-    [moduleName, finalModuleName, normalConfig, extensionConfig]
+    [moduleName, options?.externalModuleName, normalConfig, extensionConfig]
   );
 
   return config as T;

--- a/packages/framework/esm-react-utils/src/useConfig.ts
+++ b/packages/framework/esm-react-utils/src/useConfig.ts
@@ -160,26 +160,28 @@ function useNormalConfig(moduleName: string) {
 /**
  * Use this React Hook to obtain your module's configuration.
  */
-export function useConfig<
-  T = Omit<ConfigObject, "Display conditions" | "Translation overrides">
->() {
+export function useConfig<T = Record<string, any>>(
+  moduleName: string | null | undefined = undefined
+) {
   // This hook uses the config of the MF defining the component.
   // If the component is used in an extension slot then the slot
   // may override (part of) its configuration.
-  const { moduleName, extension } = useContext(ComponentContext);
+  const { moduleName: contextModuleName, extension } =
+    useContext(ComponentContext);
+  const finalModuleName = moduleName ?? contextModuleName;
 
-  if (!moduleName && !extension) {
+  if (!finalModuleName && !extension) {
     throw Error(errorMessage);
   }
 
-  const normalConfig = useNormalConfig(moduleName);
+  const normalConfig = useNormalConfig(finalModuleName);
   const extensionConfig = useExtensionConfig(extension);
   const config = useMemo(
-    () => ({
-      ...normalConfig,
-      ...extensionConfig,
-    }),
-    [normalConfig, extensionConfig]
+    () =>
+      finalModuleName === moduleName
+        ? { ...normalConfig }
+        : { ...normalConfig, ...extensionConfig },
+    [moduleName, finalModuleName, normalConfig, extensionConfig]
   );
 
   return config as T;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Occasionally, we want a module to be able to load the configuration from a different module; this is possible in the underlying configuration API, but not via the `useConfig()` hook. This PR just extends the `useConfig()` hook to allow you to pass an _optional_ module name, in which case `useConfig()` will return the configuration of that module. Note that the usage of this feature is _discouraged_ as it may add unnecessary coupling between modules.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
