### PR TITLE
(fix) remove duplicate top-nav-info-slot

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -87,10 +87,6 @@ const Navbar: React.FC = () => {
           className={styles.dividerOverride}
           name="top-nav-info-slot"
         />
-        <ExtensionSlot
-          className={styles.dividerOverride}
-          name="top-nav-info-slot"
-        />
         <HeaderGlobalBar className={styles.headerGlobalBar}>
           <ExtensionSlot
             name="top-nav-actions-slot"


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

## Summary
This PR simply removes a duplicate `ExtensionSlot`  for `top-nav-info-slot` that might have slipped in during a rebase from this [PR](https://github.com/openmrs/openmrs-esm-core/pull/617/files#diff-cdc8cc47067b9ef3a7ae682bfdb989883c4c8915353f500044b1431a488f5455) 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
