### PR TITLE
(fix) Tabs should have the max-width of their content

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -479,3 +479,8 @@ html[dir="rtl"] {
     }
   }
 }
+
+// Tabs should expand to the width of their content
+.cds--tabs .cds--tabs__nav-link {
+  max-width: max-content;
+}


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
The tabs have a max-width of 10rem, but it should be expanded to their max-content

## Screenshots
### Before
![image](https://github.com/openmrs/openmrs-esm-core/assets/51502471/7610998a-0d5c-4c71-8c83-da39c0c88f54)

### After
![image](https://github.com/openmrs/openmrs-esm-core/assets/51502471/a85d7798-9801-426c-8a58-f4c3423b446f)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
