### PR TITLE
(fix) Extension online / offline support should propagate to runtime configuration

### DIFF
--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -357,6 +357,8 @@ function getAssignedExtensionsFromSlotData(
         config: extensionConfig,
         featureFlag: extension.featureFlag,
         meta: extension.meta,
+        online: extension.online ?? true,
+        offline: extension.offline ?? false,
       });
     }
   }

--- a/packages/shell/esm-app-shell/src/apps.ts
+++ b/packages/shell/esm-app-shell/src/apps.ts
@@ -316,8 +316,8 @@ supported, so the extension will not be loaded.`
     order: extension.order,
     moduleName: appName,
     privileges: extension.privileges,
-    online: extension.online,
-    offline: extension.offline,
+    online: extension.online ?? true,
+    offline: extension.offline ?? false,
     featureFlag: extension.featureFlag,
   });
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Probably overlooked in the V5 migration, but moving to offline meant no extensions were loaded because the `offline` property from the extension registration wasn't propagated to the configuration used to actually check whether the extension should render offline. This PR fixes this so that extensions can render offline.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
