### PR TITLE
(fix) Offline patients are not being listed in the table

### DIFF
--- a/packages/apps/esm-offline-tools-app/src/offline-patients/offline-patient-table.component.tsx
+++ b/packages/apps/esm-offline-tools-app/src/offline-patients/offline-patient-table.component.tsx
@@ -114,7 +114,7 @@ const OfflinePatientTable: React.FC<OfflinePatientTableProps> = ({
   }
 
   if (
-    offlinePatientsSwr?.data?.length === 0 ||
+    offlinePatientsSwr?.data?.length === 0 &&
     offlineRegisteredPatientsSwr?.data?.length === 0
   ) {
     return (


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
The current implementation of the offline patients list displays a misleading message when there are no offline patients. It shows a component indicating that there are no offline patients, which is incorrect. This issue occurs due to a logic error in handling the empty state display. This pull request addresses this problem and corrects the logic to display the appropriate content when dealing with offline patients.

**Bug Fix:** Modified the logic for displaying the offline patients list to accurately reflect the presence or absence of offline patients. Now, the empty state component is shown only when both the `offlinePatientsSwr` and `offlineRegisteredPatientsSwr` lists are empty.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![image](https://github.com/openmrs/openmrs-esm-core/assets/94977371/2c5d270c-9f51-48ee-8b02-144f27a6edda)

After:
![image](https://github.com/openmrs/openmrs-esm-core/assets/94977371/c65c434a-fb39-488c-9b73-1bcc5d7fdd55)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
CC: @ibacher @vasharma05 