### PR TITLE
(chore) Bump @carbon/react and @carbon/charts

### DIFF
--- a/packages/apps/esm-devtools-app/package.json
+++ b/packages/apps/esm-devtools-app/package.json
@@ -50,6 +50,6 @@
     "webpack": "^5.88.0"
   },
   "dependencies": {
-    "@carbon/react": "^1.12.0"
+    "@carbon/react": "^1.37.0"
   }
 }

--- a/packages/apps/esm-devtools-app/src/declarations.d.ts
+++ b/packages/apps/esm-devtools-app/src/declarations.d.ts
@@ -1,3 +1,5 @@
+declare module "@carbon/react";
+
 declare namespace JSX {
   interface IntrinsicElements {
     "import-map-overrides-list": any;
@@ -13,3 +15,5 @@ declare module "*.scss" {
   const styles: any;
   export default styles;
 }
+
+declare type SideNavProps = {};

--- a/packages/apps/esm-implementer-tools-app/package.json
+++ b/packages/apps/esm-implementer-tools-app/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@carbon/react": "^1.12.0",
+    "@carbon/react": "^1.37.0",
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {

--- a/packages/apps/esm-implementer-tools-app/src/declarations.d.ts
+++ b/packages/apps/esm-implementer-tools-app/src/declarations.d.ts
@@ -1,2 +1,3 @@
 declare module "*.css";
 declare module "*.scss";
+declare module "@carbon/react";

--- a/packages/apps/esm-login-app/package.json
+++ b/packages/apps/esm-login-app/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@carbon/react": "^1.12.0",
+    "@carbon/react": "^1.37.0",
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {

--- a/packages/apps/esm-login-app/src/declarations.d.ts
+++ b/packages/apps/esm-login-app/src/declarations.d.ts
@@ -4,3 +4,5 @@ declare type Observable<T> = import("rxjs").Observable<T>;
 
 declare module "*.css";
 declare module "*.scss";
+declare module "@carbon/react";
+declare type SideNavProps = {};

--- a/packages/apps/esm-offline-tools-app/package.json
+++ b/packages/apps/esm-offline-tools-app/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@carbon/react": "^1.12.0",
+    "@carbon/react": "^1.37.0",
     "lodash-es": "^4.17.21",
     "swr": "^2.0.1"
   },

--- a/packages/apps/esm-offline-tools-app/src/declarations.d.ts
+++ b/packages/apps/esm-offline-tools-app/src/declarations.d.ts
@@ -1,3 +1,7 @@
 declare module "*.svg";
 declare module "*.css";
 declare module "*.scss";
+
+declare module "@carbon/react";
+declare type SideNavProps = {};
+declare type TileProps = {};

--- a/packages/apps/esm-offline-tools-app/src/offline-actions/offline-actions-table.component.tsx
+++ b/packages/apps/esm-offline-tools-app/src/offline-actions/offline-actions-table.component.tsx
@@ -3,9 +3,7 @@ import { useTranslation } from "react-i18next";
 import {
   Button,
   DataTable,
-  DataTableHeader,
   DataTableSkeleton,
-  FilterRowsData,
   Layer,
   Link,
   Pagination,
@@ -38,11 +36,7 @@ export interface SyncItemWithPatient {
   patient?: fhir.Patient;
 }
 
-export type OfflineActionsTableHeaders =
-  | "createdOn"
-  | "patient"
-  | "action"
-  | "error";
+type OfflineActionsTableHeaders = "createdOn" | "patient" | "action" | "error";
 
 export interface OfflineActionsTableProps {
   data?: Array<SyncItemWithPatient>;
@@ -65,8 +59,13 @@ const OfflineActionsTable: React.FC<OfflineActionsTableProps> = ({
   const [pageSize, setPageSize] = useState(10);
   const { results, currentPage, goTo } = usePagination(data);
   const layout = useLayoutType();
+
   const toolbarItemSize = isDesktop(layout) ? "sm" : undefined;
-  const defaultHeaders: Array<DataTableHeader<OfflineActionsTableHeaders>> = [
+
+  const defaultHeaders: Array<{
+    key: OfflineActionsTableHeaders;
+    header: string;
+  }> = [
     {
       key: "createdOn",
       header: t("offlineActionsTableCreatedOn", "Date & Time"),
@@ -280,7 +279,7 @@ function filterTableRows({
   inputValue,
   // @ts-ignore `getCellId` is not in the types, but present in Carbon.
   getCellId,
-}: FilterRowsData) {
+}) {
   return rowIds.filter((rowId) =>
     headers.some(({ key }) => {
       const cellId = getCellId(rowId, key);

--- a/packages/apps/esm-offline-tools-app/src/offline-patients/offline-patient-table.component.tsx
+++ b/packages/apps/esm-offline-tools-app/src/offline-patients/offline-patient-table.component.tsx
@@ -2,10 +2,7 @@ import React, { useMemo, useState } from "react";
 import {
   Button,
   DataTable,
-  DataTableCustomRenderProps,
   DataTableSkeleton,
-  DenormalizedRow,
-  FilterRowsData,
   Layer,
   Search,
   SearchSkeleton,
@@ -53,6 +50,7 @@ const OfflinePatientTable: React.FC<OfflinePatientTableProps> = ({
   isInteractive,
   showHeader,
 }) => {
+  // TODO: Restore @carbon/react type annotations
   const { t } = useTranslation();
   const layout = useLayoutType();
   const offlinePatientsSwr = useOfflinePatientsWithEntries();
@@ -64,9 +62,7 @@ const OfflinePatientTable: React.FC<OfflinePatientTableProps> = ({
   const headers = useOfflinePatientTableHeaders();
   const rows = useOfflinePatientTableRows(syncingPatientUuids);
 
-  const handleUpdateSelectedPatientsClick = async (
-    selectedRows: ReadonlyArray<DenormalizedRow>
-  ) => {
+  const handleUpdateSelectedPatientsClick = async (selectedRows) => {
     const selectedPatientUuids = selectedRows.map((row) => row.id);
     setSyncingPatientUuids(selectedPatientUuids);
     await syncSelectedOfflinePatients(selectedPatientUuids).finally(() =>
@@ -77,9 +73,7 @@ const OfflinePatientTable: React.FC<OfflinePatientTableProps> = ({
     offlineRegisteredPatientsSwr.mutate();
   };
 
-  const handleRemovePatientsFromOfflineListClick = async (
-    selectedRows: ReadonlyArray<DenormalizedRow>
-  ) => {
+  const handleRemovePatientsFromOfflineListClick = async (selectedRows) => {
     const closeModal = showModal("offline-tools-confirmation-modal", {
       title: t(
         "offlinePatientsTableDeleteConfirmationModalTitle",
@@ -138,7 +132,7 @@ const OfflinePatientTable: React.FC<OfflinePatientTableProps> = ({
           getSelectionProps,
           onInputChange,
           selectedRows,
-        }: DataTableCustomRenderProps) => (
+        }) => (
           <TableContainer
             className={styles.tableContainer}
             {...getTableContainerProps()}
@@ -254,7 +248,7 @@ function filterTableRows({
   inputValue,
   // @ts-ignore `getCellId` is not in the types, but present in Carbon.
   getCellId,
-}: FilterRowsData) {
+}) {
   return rowIds.filter((rowId) =>
     headers.some(({ key }) => {
       const cellId = getCellId(rowId, key);

--- a/packages/apps/esm-primary-navigation-app/package.json
+++ b/packages/apps/esm-primary-navigation-app/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@carbon/react": "^1.12.0",
+    "@carbon/react": "^1.37.0",
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {

--- a/packages/apps/esm-primary-navigation-app/src/declarations.d.ts
+++ b/packages/apps/esm-primary-navigation-app/src/declarations.d.ts
@@ -1,0 +1,7 @@
+declare module "*.css";
+declare module "*.scss";
+declare module "@carbon/react";
+declare type HeaderPanelProps = {};
+declare type SideNavProps = {
+  isChildOfHeader: boolean;
+};

--- a/packages/apps/esm-primary-navigation-app/src/declarations.d.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/declarations.d.tsx
@@ -1,2 +1,0 @@
-declare module "*.css";
-declare module "*.scss";

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -62,6 +62,7 @@
 - [formatDate](API.md#formatdate)
 - [formatDatetime](API.md#formatdatetime)
 - [formatTime](API.md#formattime)
+- [getLocale](API.md#getlocale)
 - [isOmrsDateStrict](API.md#isomrsdatestrict)
 - [isOmrsDateToday](API.md#isomrsdatetoday)
 - [parseDate](API.md#parsedate)
@@ -818,6 +819,16 @@ and *must* only be used once within that `<ExtensionSlot>`.
 
 ___
 
+### OpenmrsDatePicker
+
+• `Const` **OpenmrsDatePicker**: `React.FC`<`OpenmrsDatePickerProps`\>
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/datepicker/openmrs/openmrs-date-picker.component.tsx:41](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs/openmrs-date-picker.component.tsx#L41)
+
+___
+
 ### backendDependencies
 
 • `Const` **backendDependencies**: `Object`
@@ -839,7 +850,7 @@ ___
 
 ### LeftNavMenu
 
-• `Const` **LeftNavMenu**: `ForwardRefExoticComponent`<`Pick`<`SideNavProps`, `string` \| `number` \| `symbol`\> & `RefAttributes`<`HTMLElement`\>\>
+• `Const` **LeftNavMenu**: `ForwardRefExoticComponent`<`RefAttributes`<`HTMLElement`\>\>
 
 #### Defined in
 
@@ -1969,6 +1980,20 @@ Formats the input as a time, according to the current locale.
 
 ___
 
+### getLocale
+
+▸ **getLocale**(): `string`
+
+#### Returns
+
+`string`
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:269](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L269)
+
+___
+
 ### isOmrsDateStrict
 
 ▸ **isOmrsDateStrict**(`omrsPayloadString`): `boolean`
@@ -2383,7 +2408,7 @@ An array of extensions assigned to the named slot
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:373](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L373)
+[packages/framework/esm-extensions/src/extensions.ts:375](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L375)
 
 ___
 

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -40,8 +40,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@carbon/charts": "^1.6.3",
-    "@carbon/react": "^1.12.0",
+    "@carbon/charts": "^1.12.0",
+    "@carbon/react": "^1.37.0",
     "@internationalized/date": "^3.2.0",
     "@react-spectrum/datepicker": "^3.5.0",
     "@react-spectrum/provider": "^3.7.1",

--- a/packages/framework/esm-styleguide/src/declarations.d.ts
+++ b/packages/framework/esm-styleguide/src/declarations.d.ts
@@ -1,6 +1,8 @@
+declare module "@carbon/react";
 declare module "*.svg" {
   const content: string;
   export = content;
 }
 declare module "*.css";
 declare module "*.scss";
+declare type SideNavProps = {};

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@carbon/react": "^1.12.0",
+    "@carbon/react": "^1.37.0",
     "@openmrs/esm-framework": "5.1.0",
     "@openmrs/esm-styleguide": "5.1.0",
     "dayjs": "^1.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1297,12 +1297,21 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.1, @babel/runtime@npm:^7.9.2":
+"@babel/runtime@npm:^7.10.2, @babel/runtime@npm:^7.11.2, @babel/runtime@npm:^7.12.0, @babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.15.4, @babel/runtime@npm:^7.17.2, @babel/runtime@npm:^7.18.3, @babel/runtime@npm:^7.18.9, @babel/runtime@npm:^7.5.5, @babel/runtime@npm:^7.7.2, @babel/runtime@npm:^7.8.4, @babel/runtime@npm:^7.9.2":
   version: 7.19.4
   resolution: "@babel/runtime@npm:7.19.4"
   dependencies:
     regenerator-runtime: ^0.13.4
   checksum: 66b7e3c13e9ee1d2c9397ea89144f29a875edee266a0eb2d9971be51b32fdbafc85808c7a45e011e6681899bb804b4e2ee2aed6dc07108dbbd6b11b6cc2afba6
+  languageName: node
+  linkType: hard
+
+"@babel/runtime@npm:^7.14.8, @babel/runtime@npm:^7.21.0":
+  version: 7.22.15
+  resolution: "@babel/runtime@npm:7.22.15"
+  dependencies:
+    regenerator-runtime: ^0.14.0
+  checksum: 793296df1e41599a935a3d77ec01eb6088410d3fd4dbe4e92f06c6b7bb2f8355024e6d78621a3a35f44e0e23b0b59107f23d585384df4f3123256a1e1492040e
   languageName: node
   linkType: hard
 
@@ -1362,95 +1371,105 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/charts@npm:^1.6.3":
-  version: 1.6.3
-  resolution: "@carbon/charts@npm:1.6.3"
+"@carbon/charts@npm:^1.12.0":
+  version: 1.12.0
+  resolution: "@carbon/charts@npm:1.12.0"
   dependencies:
-    "@carbon/styles": ^1.4.0
-    "@carbon/telemetry": 0.1.0
-    "@carbon/utils-position": 1.1.1
-    carbon-components: 10.56.0
-    d3-cloud: 1.2.5
-    d3-sankey: 0.12.3
-    date-fns: 2.8.1
-    lodash-es: 4.17.21
-    resize-observer-polyfill: 1.5.0
+    "@carbon/colors": ^11.19.0
+    "@carbon/telemetry": ~0.1.0
+    "@carbon/utils-position": ^1.1.4
+    carbon-components: ^10.58.10
+    d3: ^7.8.5
+    d3-cloud: ^1.2.7
+    d3-sankey: ^0.12.3
+    date-fns: ^2.30.0
+    html-to-image: ^1.11.11
+    lodash-es: ^4.17.21
+    topojson-client: ^3.1.0
+    tslib: ^2.6.2
   peerDependencies:
-    d3: 7.x
-  checksum: 482cabba5c6a5e0890540f7c5fdacfee11f54b26e02a7bc09d6013fdd29b6d303e1dcbe1c87cd3fec0ed16ae7a584b38b2a39cb97d8ac115b2a9b84868747f7c
+    d3: ^7.0.0
+    d3-cloud: ^1.2.5
+    d3-sankey: ^0.12.3
+  peerDependenciesMeta:
+    d3-cloud:
+      optional: true
+    d3-sankey:
+      optional: true
+  checksum: 87a6ebab9898dc62141fa608c7491d7821f5b8a26f0ea0c3fd4826ae3ae7ac1f55bce30b9bdae3572b18ccd471f6899d57097677ff362de47be72f33ef34adb9
   languageName: node
   linkType: hard
 
-"@carbon/colors@npm:^11.6.0":
-  version: 11.6.0
-  resolution: "@carbon/colors@npm:11.6.0"
-  checksum: e9a3aba64618fb7f7de3acdbfd37041560f93e765b010356ab86fc6ec06d761a1ff7670473c4e42bd8649f664e85732ea706c2e6f16556b1356c21e2411a678e
+"@carbon/colors@npm:^11.19.0":
+  version: 11.19.0
+  resolution: "@carbon/colors@npm:11.19.0"
+  checksum: ea0448e90e05768c615af71955e5fe4435583e3637d039912336ba8b123fbbd841078df98cb71e56ebb0a0be04c88fed3fe34408585bdf3a11cb6297b9ce14b5
   languageName: node
   linkType: hard
 
-"@carbon/feature-flags@npm:^0.9.0":
-  version: 0.9.0
-  resolution: "@carbon/feature-flags@npm:0.9.0"
-  checksum: a0891698cf10c9698e9782c68d928a45b969cd260e3b9459163efa2cec7a848dc89561872e3fb889954fad111fb7f186718cd68577f20ad20c948f30160f474b
+"@carbon/feature-flags@npm:^0.16.0":
+  version: 0.16.0
+  resolution: "@carbon/feature-flags@npm:0.16.0"
+  checksum: 1fb964311f240c65fd57ee5971234b0c7b665d660b89ac931d0acc3d140ae0bed1b04eb8fc629f675a307be9579d9c4de317987749878b5a48bb364cbffd85d1
   languageName: node
   linkType: hard
 
-"@carbon/grid@npm:^11.7.0":
-  version: 11.7.0
-  resolution: "@carbon/grid@npm:11.7.0"
+"@carbon/grid@npm:^11.19.0":
+  version: 11.19.0
+  resolution: "@carbon/grid@npm:11.19.0"
   dependencies:
-    "@carbon/layout": ^11.7.0
-  checksum: ca366f44476a815bbb2a7d8e53ba2f44f8dafa92b9c510d23dffc86b9331384dbe5edf3bd3e927a19d69b46a7f3ee5fcee1193f250f4add6557f3530d2dd85b8
+    "@carbon/layout": ^11.19.0
+  checksum: c49a85e4784993a678db72c7825e0bf4e2c7ca23167ba074522e2ecca43578472b29327ad88ff6682931d500b5e981da41a9a266fff204a95ed69c1e8b082c1c
   languageName: node
   linkType: hard
 
-"@carbon/icon-helpers@npm:^10.34.0":
-  version: 10.34.0
-  resolution: "@carbon/icon-helpers@npm:10.34.0"
-  checksum: ed06c8c098e3bcb5b31d83e59794c1079a3a0bf379cb1088c7523f48aad0ad3704b274644214720d78b863809882884c361690a59f327749dab70cb918d61db0
+"@carbon/icon-helpers@npm:^10.44.0":
+  version: 10.44.0
+  resolution: "@carbon/icon-helpers@npm:10.44.0"
+  checksum: c61b711ef78ba5546514917571ccec01c0943a2dc53d34a90987985bd839de7c164ce7bf9890d21012e585c1a655f6a5a9ac88492af4345653f095f9ddebe54a
   languageName: node
   linkType: hard
 
-"@carbon/icons-react@npm:^11.9.0":
-  version: 11.9.0
-  resolution: "@carbon/icons-react@npm:11.9.0"
+"@carbon/icons-react@npm:^11.26.0":
+  version: 11.26.0
+  resolution: "@carbon/icons-react@npm:11.26.0"
   dependencies:
-    "@carbon/icon-helpers": ^10.34.0
+    "@carbon/icon-helpers": ^10.44.0
     "@carbon/telemetry": 0.1.0
     prop-types: ^15.7.2
   peerDependencies:
     react: ">=16"
-  checksum: 86bb7523ea7e733cf9fef24cee240db0384bce91e6f7a0771d7a2f0208ac0e26f4fecf8730c037b36375ac1ba738f1d62a768b861d199854b93ed246444224e2
+  checksum: dabc6e7896d2a089aaabac78af9161720995f9e5b0f28694ac664459c5fae164a3d0c16b9cb22f6ab37f01b736cd2613cf232a6b6577b396afd8c083171cae67
   languageName: node
   linkType: hard
 
-"@carbon/layout@npm:^11.7.0":
-  version: 11.7.0
-  resolution: "@carbon/layout@npm:11.7.0"
-  checksum: 75cd8ebdd7810aff37289258e55f70cfa63bd352130e1bbcf4240b7b4a561e95f26298fcddd13c2a9e14b345f4bf5694eadd588f244d1578bd6a6b2d28a2fed3
+"@carbon/layout@npm:^11.19.0":
+  version: 11.19.0
+  resolution: "@carbon/layout@npm:11.19.0"
+  checksum: 9786a9d13fc81132c33a05019fae1d6ed786739a285e276f76857d30bba7b5a58cb093c700fb7c8b697d7a199459c398f842d6a42351d02c3d67e7961fadd901
   languageName: node
   linkType: hard
 
-"@carbon/motion@npm:^11.5.0":
-  version: 11.5.0
-  resolution: "@carbon/motion@npm:11.5.0"
-  checksum: a0c583ce0a9370beb08061463566a3b41c427190d297cdad1631384a27e241334640afdd246b9c0fca62f58d51e8a5b8c7954a234118195f403cd8c13c8a1f09
+"@carbon/motion@npm:^11.15.0":
+  version: 11.15.0
+  resolution: "@carbon/motion@npm:11.15.0"
+  checksum: 985a559324fb4cb6b1df50ead3d9c1ceefec338f075f5cca4a9d937888cb6b357207a20493807eed47627e41529de215e4b51e0e217eee12970c1b8da2ce1b90
   languageName: node
   linkType: hard
 
-"@carbon/react@npm:^1.12.0":
-  version: 1.14.0
-  resolution: "@carbon/react@npm:1.14.0"
+"@carbon/react@npm:^1.37.0":
+  version: 1.37.0
+  resolution: "@carbon/react@npm:1.37.0"
   dependencies:
     "@babel/runtime": ^7.18.3
-    "@carbon/feature-flags": ^0.9.0
-    "@carbon/icons-react": ^11.9.0
-    "@carbon/layout": ^11.7.0
-    "@carbon/styles": ^1.14.0
+    "@carbon/feature-flags": ^0.16.0
+    "@carbon/icons-react": ^11.26.0
+    "@carbon/layout": ^11.19.0
+    "@carbon/styles": ^1.37.0
     "@carbon/telemetry": 0.1.0
     classnames: 2.3.2
     copy-to-clipboard: ^3.3.1
-    downshift: 5.2.1
+    downshift: 8.1.0
     flatpickr: 4.6.9
     invariant: ^2.2.3
     lodash.debounce: ^4.0.8
@@ -1459,37 +1478,40 @@ __metadata:
     lodash.omit: ^4.5.0
     lodash.throttle: ^4.1.1
     prop-types: ^15.7.2
-    react-is: ^17.0.2
+    react-is: ^18.2.0
     use-resize-observer: ^6.0.0
     wicg-inert: ^3.1.1
     window-or-global: ^1.0.1
   peerDependencies:
-    react: ^16.8.6 || ^17.0.1
-    react-dom: ^16.8.6 || ^17.0.1
+    react: ^16.8.6 || ^17.0.1 || ^18.2.0
+    react-dom: ^16.8.6 || ^17.0.1 || ^18.2.0
     sass: ^1.33.0
-  checksum: 6a19a7bddc300a744d405fd050deb4d448b5f235ba01e5fc1088a3bdedb69b2724ac7902f66fc2b68ce15a68fec3384dc50fcd9eee05cf2cfca45f249ce5a7aa
+  checksum: 40ba04d687462d178227080582a074ca6a7b7515f7f08f602fef9fd96bb90918e0051d5ce7adc9c9a5140bd9f724634a14fd06701afa23aa2bd023c6d14efd44
   languageName: node
   linkType: hard
 
-"@carbon/styles@npm:^1.14.0, @carbon/styles@npm:^1.4.0":
-  version: 1.14.0
-  resolution: "@carbon/styles@npm:1.14.0"
+"@carbon/styles@npm:^1.37.0":
+  version: 1.37.0
+  resolution: "@carbon/styles@npm:1.37.0"
   dependencies:
-    "@carbon/colors": ^11.6.0
-    "@carbon/feature-flags": ^0.9.0
-    "@carbon/grid": ^11.7.0
-    "@carbon/layout": ^11.7.0
-    "@carbon/motion": ^11.5.0
-    "@carbon/themes": ^11.10.0
-    "@carbon/type": ^11.10.0
+    "@carbon/colors": ^11.19.0
+    "@carbon/feature-flags": ^0.16.0
+    "@carbon/grid": ^11.19.0
+    "@carbon/layout": ^11.19.0
+    "@carbon/motion": ^11.15.0
+    "@carbon/themes": ^11.24.0
+    "@carbon/type": ^11.23.0
     "@ibm/plex": 6.0.0-next.6
   peerDependencies:
     sass: ^1.33.0
-  checksum: 33a875fef6518b0d692eb45b201ceebf537fcc19c84c0ba2f2b416c24bf5d15a24c7c99c765f83414541d702cdb08130aa97eafcc98d254bddde21897f75fb67
+  peerDependenciesMeta:
+    sass:
+      optional: true
+  checksum: 85e0d468a1bfe99742f280545c73addea7b8737af61fac4d9832fedb4e0d8ff3a2659058758b69ecc33eea169f09850413d841e5015474c1e82a7c0162047b72
   languageName: node
   linkType: hard
 
-"@carbon/telemetry@npm:0.1.0":
+"@carbon/telemetry@npm:0.1.0, @carbon/telemetry@npm:~0.1.0":
   version: 0.1.0
   resolution: "@carbon/telemetry@npm:0.1.0"
   bin:
@@ -1498,32 +1520,32 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/themes@npm:^11.10.0":
-  version: 11.10.0
-  resolution: "@carbon/themes@npm:11.10.0"
+"@carbon/themes@npm:^11.24.0":
+  version: 11.24.0
+  resolution: "@carbon/themes@npm:11.24.0"
   dependencies:
-    "@carbon/colors": ^11.6.0
-    "@carbon/layout": ^11.7.0
-    "@carbon/type": ^11.10.0
+    "@carbon/colors": ^11.19.0
+    "@carbon/layout": ^11.19.0
+    "@carbon/type": ^11.23.0
     color: ^4.0.0
-  checksum: 4b89665904ba9e233c715b19d2e94d8dfc8fbda9fe5aac429e943527d846b8485b046ccd82f4cd623de828d1ee9a5f568af9c9f022c9130e8f9480364d996fd8
+  checksum: 709739b4e7dab3078c8c5340fd5248edd64959c104ba469164bb6cfe1317425bf724deec2267e0aa63398e4c1ead667a38a8849c73813f93fcd5b2de2e6c0d8c
   languageName: node
   linkType: hard
 
-"@carbon/type@npm:^11.10.0":
-  version: 11.10.0
-  resolution: "@carbon/type@npm:11.10.0"
+"@carbon/type@npm:^11.23.0":
+  version: 11.23.0
+  resolution: "@carbon/type@npm:11.23.0"
   dependencies:
-    "@carbon/grid": ^11.7.0
-    "@carbon/layout": ^11.7.0
-  checksum: 3b8556cfa1b42cfa34b420bf82fb806addc7abecb53c9025748ea7876042a9296a20047c2b84fac90e830ba436a9cbbc23402ba0d144dd6b52ccaac6c654bc2d
+    "@carbon/grid": ^11.19.0
+    "@carbon/layout": ^11.19.0
+  checksum: 2235dce83d4cc7d4dabb625e33e24a59643e8da297fadcef1ebbd37beba10bb6d4e4508b5b52e7ca26d6afea29631174451bda5064cc484722715564cee83234
   languageName: node
   linkType: hard
 
-"@carbon/utils-position@npm:1.1.1":
-  version: 1.1.1
-  resolution: "@carbon/utils-position@npm:1.1.1"
-  checksum: 4919f41e07c54068cea6dab9e5a649772d4c8c6c45ac9121592e726fe3efd7f21b7e8c1ce233832f35894c6e1d0c4012aaeb950f55ed196e15d8e5decd89b2f6
+"@carbon/utils-position@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@carbon/utils-position@npm:1.1.4"
+  checksum: b62b469e7985689f3f2b4afece26a60b08511eebe74ccb585e6fee65daf5973992c58ded70176230e5c5fcccd2dbf7a65280abd7607a99739e2f4004fb69b1ec
   languageName: node
   linkType: hard
 
@@ -3628,7 +3650,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-app-shell@workspace:packages/shell/esm-app-shell"
   dependencies:
-    "@carbon/react": ^1.12.0
+    "@carbon/react": ^1.37.0
     "@openmrs/esm-framework": 5.1.0
     "@openmrs/esm-styleguide": 5.1.0
     cross-env: ^7.0.3
@@ -3741,7 +3763,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-devtools-app@workspace:packages/apps/esm-devtools-app"
   dependencies:
-    "@carbon/react": ^1.12.0
+    "@carbon/react": ^1.37.0
     "@openmrs/esm-framework": ^5.1.0
     "@openmrs/webpack-config": ^5.1.0
     react: ^18.1.0
@@ -3855,7 +3877,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-implementer-tools-app@workspace:packages/apps/esm-implementer-tools-app"
   dependencies:
-    "@carbon/react": ^1.12.0
+    "@carbon/react": ^1.37.0
     "@openmrs/esm-framework": ^5.1.0
     "@openmrs/webpack-config": ^5.1.0
     ace-builds: ^1.4.14
@@ -3880,7 +3902,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-login-app@workspace:packages/apps/esm-login-app"
   dependencies:
-    "@carbon/react": ^1.12.0
+    "@carbon/react": ^1.37.0
     "@openmrs/esm-framework": ^5.1.0
     "@openmrs/webpack-config": ^5.1.0
     jest: ^28.1.0
@@ -3906,7 +3928,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-offline-tools-app@workspace:packages/apps/esm-offline-tools-app"
   dependencies:
-    "@carbon/react": ^1.12.0
+    "@carbon/react": ^1.37.0
     "@openmrs/esm-framework": ^5.1.0
     "@openmrs/webpack-config": ^5.1.0
     "@types/lodash-es": ^4.17.5
@@ -3955,7 +3977,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-primary-navigation-app@workspace:packages/apps/esm-primary-navigation-app"
   dependencies:
-    "@carbon/react": ^1.12.0
+    "@carbon/react": ^1.37.0
     "@openmrs/esm-framework": ^5.1.0
     "@openmrs/webpack-config": ^5.1.0
     jest: ^28.1.0
@@ -4025,8 +4047,8 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-styleguide@workspace:packages/framework/esm-styleguide"
   dependencies:
-    "@carbon/charts": ^1.6.3
-    "@carbon/react": ^1.12.0
+    "@carbon/charts": ^1.12.0
+    "@carbon/react": ^1.37.0
     "@internationalized/date": ^3.2.0
     "@openmrs/esm-extensions": ^5.1.0
     "@openmrs/esm-react-utils": ^5.1.0
@@ -7659,15 +7681,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"carbon-components@npm:10.56.0":
-  version: 10.56.0
-  resolution: "carbon-components@npm:10.56.0"
+"carbon-components@npm:^10.58.10":
+  version: 10.58.10
+  resolution: "carbon-components@npm:10.58.10"
   dependencies:
     "@carbon/telemetry": 0.1.0
     flatpickr: 4.6.1
     lodash.debounce: ^4.0.8
     warning: ^3.0.0
-  checksum: 399e53d8072c9094230ab83ffe1f2eb2361e029b80efe0332e7ca2503954c7a7b3b5f43427b68c4302377be0f8ed756eb15f3f3a06501137184f367b7c88693c
+  checksum: 8a01d957844df11c9350cba13855aa7f23bdd0cbc4a2af3e8e35a068cd007e5f04cc441d7fe7aff4da40e7497d5e9b02a4af382ede4ed8c08f590c825019c71f
   languageName: node
   linkType: hard
 
@@ -8094,17 +8116,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:2, commander@npm:^2.20.0":
+  version: 2.20.3
+  resolution: "commander@npm:2.20.3"
+  checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
+  languageName: node
+  linkType: hard
+
 "commander@npm:7, commander@npm:^7.0.0, commander@npm:^7.2.0":
   version: 7.2.0
   resolution: "commander@npm:7.2.0"
   checksum: 53501cbeee61d5157546c0bef0fedb6cdfc763a882136284bed9a07225f09a14b82d2a84e7637edfd1a679fb35ed9502fd58ef1d091e6287f60d790147f68ddc
-  languageName: node
-  linkType: hard
-
-"commander@npm:^2.20.0":
-  version: 2.20.3
-  resolution: "commander@npm:2.20.3"
-  checksum: ab8c07884e42c3a8dbc5dd9592c606176c7eb5c1ca5ff274bcf907039b2c41de3626f684ea75ccf4d361ba004bbaff1f577d5384c155f3871e456bdf27becf9e
   languageName: node
   linkType: hard
 
@@ -8163,10 +8185,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"compute-scroll-into-view@npm:^1.0.13":
-  version: 1.0.17
-  resolution: "compute-scroll-into-view@npm:1.0.17"
-  checksum: b20c05a10c37813c5a6e4bf053c00f65c88d23afed7a6bd7a2a69e05e2ffc2df3483ecfe407d36bf16b8cec8be21ae1966c9c523093a03117e567156cd79a51e
+"compute-scroll-into-view@npm:^2.0.4":
+  version: 2.0.4
+  resolution: "compute-scroll-into-view@npm:2.0.4"
+  checksum: f3d1db9276c16af42155b572750514939cd0ab0a0f46498906f6811c5b654c5ff2b3f9bfd65958e57439e000a5e1ae092eb96b9e153d194a73e52ffd2380550c
   languageName: node
   linkType: hard
 
@@ -8890,12 +8912,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-cloud@npm:1.2.5":
-  version: 1.2.5
-  resolution: "d3-cloud@npm:1.2.5"
+"d3-cloud@npm:^1.2.7":
+  version: 1.2.7
+  resolution: "d3-cloud@npm:1.2.7"
   dependencies:
     d3-dispatch: ^1.0.3
-  checksum: e01d6f7adcc75d58b4de0f206cb2937bf840845efd7521e9530b81fa93524861e83884c0c9b75c86177619fbe64fefd54d654b6b51ab304267e795f4422c6080
+  checksum: 6217c46e32250daf1cfd71c2f5515a433b12bdb28affff55d27bf3249b8b12ebaab391d15ed973cbf0790758d8834d9870b9315790691dfcdc3e2b82a6f20631
   languageName: node
   linkType: hard
 
@@ -9063,7 +9085,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"d3-sankey@npm:0.12.3":
+"d3-sankey@npm:^0.12.3":
   version: 0.12.3
   resolution: "d3-sankey@npm:0.12.3"
   dependencies:
@@ -9212,6 +9234,44 @@ __metadata:
   languageName: node
   linkType: hard
 
+"d3@npm:^7.8.5":
+  version: 7.8.5
+  resolution: "d3@npm:7.8.5"
+  dependencies:
+    d3-array: 3
+    d3-axis: 3
+    d3-brush: 3
+    d3-chord: 3
+    d3-color: 3
+    d3-contour: 4
+    d3-delaunay: 6
+    d3-dispatch: 3
+    d3-drag: 3
+    d3-dsv: 3
+    d3-ease: 3
+    d3-fetch: 3
+    d3-force: 3
+    d3-format: 3
+    d3-geo: 3
+    d3-hierarchy: 3
+    d3-interpolate: 3
+    d3-path: 3
+    d3-polygon: 3
+    d3-quadtree: 3
+    d3-random: 3
+    d3-scale: 4
+    d3-scale-chromatic: 3
+    d3-selection: 3
+    d3-shape: 3
+    d3-time: 3
+    d3-time-format: 4
+    d3-timer: 3
+    d3-transition: 3
+    d3-zoom: 3
+  checksum: e407e79731f74d946a5eb8dec2f037b5a4ad33c294409b1d3531fdf7094de48adfe364974cb37e2396bdb81e23149d56d0ede716c004d6aebb52b3cc114cd15c
+  languageName: node
+  linkType: hard
+
 "damerau-levenshtein@npm:^1.0.8":
   version: 1.0.8
   resolution: "damerau-levenshtein@npm:1.0.8"
@@ -9253,10 +9313,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"date-fns@npm:2.8.1":
-  version: 2.8.1
-  resolution: "date-fns@npm:2.8.1"
-  checksum: 7c4b21843e79dff2a1ac9f1c6996b72fd57ed70529ccb0a915751150710654eff8dc50366a59a9d01085207edf60bb1fd0fe95118e6ce38c149548a7426d645d
+"date-fns@npm:^2.30.0":
+  version: 2.30.0
+  resolution: "date-fns@npm:2.30.0"
+  dependencies:
+    "@babel/runtime": ^7.21.0
+  checksum: f7be01523282e9bb06c0cd2693d34f245247a29098527d4420628966a2d9aad154bd0e90a6b1cf66d37adcb769cd108cf8a7bd49d76db0fb119af5cdd13644f4
   languageName: node
   linkType: hard
 
@@ -9767,17 +9829,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"downshift@npm:5.2.1":
-  version: 5.2.1
-  resolution: "downshift@npm:5.2.1"
+"downshift@npm:8.1.0":
+  version: 8.1.0
+  resolution: "downshift@npm:8.1.0"
   dependencies:
-    "@babel/runtime": ^7.9.1
-    compute-scroll-into-view: ^1.0.13
+    "@babel/runtime": ^7.14.8
+    compute-scroll-into-view: ^2.0.4
     prop-types: ^15.7.2
-    react-is: ^16.13.1
+    react-is: ^17.0.2
+    tslib: ^2.3.0
   peerDependencies:
-    react: ">=0.14.9"
-  checksum: fc8e731106cdaa9bfcd1d855d8b25dbaaa6fb22dfb51a3c32e51f460c199730a6ddfbd311891bbdc4bba642238d2239f1fb7642ce5d3f616f09fc68abd6a76f4
+    react: ">=16.12.0"
+  checksum: 5ede6190dc85ad295f623b30d3ad035a83b9ef5753084096e71e6fad5276a9abd3b1c1a26583958368e4e7fe14a40ef8b5a246f9f6eec058c4eba30a5104539d
   languageName: node
   linkType: hard
 
@@ -11638,6 +11701,13 @@ __metadata:
   dependencies:
     void-elements: 3.1.0
   checksum: 334fdebd4b5c355dba8e95284cead6f62bf865a2359da2759b039db58c805646350016d2017875718bc3c4b9bf81a0d11be5ee0cf4774a3a5a7b97cde21cfd67
+  languageName: node
+  linkType: hard
+
+"html-to-image@npm:^1.11.11":
+  version: 1.11.11
+  resolution: "html-to-image@npm:1.11.11"
+  checksum: b453beca72a697bf06fae4945e5460d1d9b1751e8569a0d721dda9485df1dde093938cc9bd9172b8df5fc23133a53a4d619777b3d22f7211cd8a67e3197ab4e8
   languageName: node
   linkType: hard
 
@@ -17149,7 +17219,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^18.0.0":
+"react-is@npm:^18.0.0, react-is@npm:^18.2.0":
   version: 18.2.0
   resolution: "react-is@npm:18.2.0"
   checksum: e72d0ba81b5922759e4aff17e0252bd29988f9642ed817f56b25a3e217e13eea8a7f2322af99a06edb779da12d5d636e9fda473d620df9a3da0df2a74141d53e
@@ -17450,6 +17520,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"regenerator-runtime@npm:^0.14.0":
+  version: 0.14.0
+  resolution: "regenerator-runtime@npm:0.14.0"
+  checksum: 1c977ad82a82a4412e4f639d65d22be376d3ebdd30da2c003eeafdaaacd03fc00c2320f18120007ee700900979284fc78a9f00da7fb593f6e6eeebc673fba9a3
+  languageName: node
+  linkType: hard
+
 "regenerator-transform@npm:^0.15.0":
   version: 0.15.0
   resolution: "regenerator-transform@npm:0.15.0"
@@ -17610,13 +17687,6 @@ __metadata:
   version: 1.0.0
   resolution: "requires-port@npm:1.0.0"
   checksum: eee0e303adffb69be55d1a214e415cf42b7441ae858c76dfc5353148644f6fd6e698926fc4643f510d5c126d12a705e7c8ed7e38061113bdf37547ab356797ff
-  languageName: node
-  linkType: hard
-
-"resize-observer-polyfill@npm:1.5.0":
-  version: 1.5.0
-  resolution: "resize-observer-polyfill@npm:1.5.0"
-  checksum: ecc6aab5d4f967f1b76cee0748c1967c8b6b5d8c4393764ca3b788dbd15c0f846326c4ebff9f4f39aba45fea8016cd42bb95e28e8fab1d14349e173790c58133
   languageName: node
   linkType: hard
 
@@ -19276,6 +19346,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"topojson-client@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "topojson-client@npm:3.1.0"
+  dependencies:
+    commander: 2
+  bin:
+    topo2geo: bin/topo2geo
+    topomerge: bin/topomerge
+    topoquantize: bin/topoquantize
+  checksum: 8c029a4f18324ace0b8b55dd90edbd40c9e3c6de18bafbb5da37ca20ebf20e26fbd4420891acb3c2c264e214185f7557871f5651a9eee517028663be98d836de
+  languageName: node
+  linkType: hard
+
 "totalist@npm:^1.0.0":
   version: 1.1.0
   resolution: "totalist@npm:1.1.0"
@@ -19364,6 +19447,13 @@ __metadata:
   version: 2.4.0
   resolution: "tslib@npm:2.4.0"
   checksum: 8c4aa6a3c5a754bf76aefc38026134180c053b7bd2f81338cb5e5ebf96fefa0f417bff221592bf801077f5bf990562f6264fecbc42cd3309b33872cb6fc3b113
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.3.0, tslib@npm:^2.6.2":
+  version: 2.6.2
+  resolution: "tslib@npm:2.6.2"
+  checksum: 329ea56123005922f39642318e3d1f0f8265d1e7fcb92c633e0809521da75eeaca28d2cf96d7248229deb40e5c19adf408259f4b9640afd20d13aecc1430f3ad
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

In this PR, I bumped the `@carbon/charts` and `@carbon/react` packages to their latest versions. In https://github.com/openmrs/openmrs-esm-core/pull/755, some of the changes included are obviated by upstream changes to @carbon/react. This upgrade allows us to leverage some [potential bundle size reductions](https://github.com/carbon-design-system/carbon-charts/pull/1652) and improved functionality per the associated release notes for each package. The Carbon team are working on adding type support to individual components incrementally. This has led to some known issues with typings, which is why I've elected to add ambient type declarations from `@carbon/react` to each individual package's declarations file and omit some type declarations (for now). 

## Related Issue

https://github.com/openmrs/openmrs-esm-core/pull/755
