### PR TITLE
Adding configuration to load css loaders for react-html5-camera-photo

### DIFF
--- a/packages/framework/esm-framework/webpack.config.js
+++ b/packages/framework/esm-framework/webpack.config.js
@@ -69,3 +69,18 @@ module.exports = (env) => ({
     },
   },
 });
+
+const cfgCreator = require('openmrs/default-webpack-config');
+
+module.exports = (env, argv) => {
+  const config = cfgCreator(env, argv);
+  const cssLoaderMode = resourcePath => {
+    if (/.*react-html5-camera-photo\/build\/css\/index.css/i.test(resourcePath) || /styles.css$/i.test(resourcePath)) {
+      return 'global';
+    }
+    return 'local';
+  };
+  config.module.rules[1].use[1].options.modules['mode'] = cssLoaderMode;
+  config.module.rules[2].use[1].options.modules['mode'] = cssLoaderMode;
+  return config;
+};


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR adds configuration to the webpack.config.js file inside openmrs core that will load the css loaders necessary for allowing styles to be applied to the react-html5-camera-photo, which currently is being hindered by lack of the said configurations.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
