### PR TITLE
(fix) Fix ContentSwitcher style overrides

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -56,18 +56,18 @@
   border-bottom: 1px solid colors.$blue-30;
 
   &::after {
-    background-color: transparent;
+    background-color: transparent !important;
   }
 
   &:first-child {
     border-bottom-left-radius: 0.25rem;
-    border-left: 0.0625rem solid colors.$blue-30;
+    border-left: 0.0625rem solid colors.$blue-30 !important;
     border-top-left-radius: 0.25rem;
   }
 
   &:last-child {
     border-bottom-right-radius: 0.25rem;
-    border-right: 0.0625rem solid colors.$blue-30;
+    border-right: 0.0625rem solid colors.$blue-30 !important;
     border-top-right-radius: 0.25rem;
   }
 
@@ -78,12 +78,20 @@
   }
 
   &.cds--content-switcher--selected {
-    border: 1px solid colors.$blue-60;
+    border: 1px solid colors.$blue-60 !important;
     background-color: colors.$blue-10;
     color: colors.$blue-60;
 
     &::after {
       background-color: colors.$blue-10;
+    }
+
+    &::before {
+      background-color: transparent;
+    }
+
+    &:disabled {
+      border: 0 !important;
     }
   }
 }

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -1,4 +1,5 @@
 @use "@carbon/styles/scss/spacing";
+@use "@carbon/styles/scss/utilities/layout";
 @use "@carbon/colors";
 
 /* UI Shell Header */
@@ -49,6 +50,10 @@
 }
 
 /* Content Switcher */
+.cds--content-switcher {
+  @include layout.use("size", $default: "sm");
+}
+
 .cds--content-switcher-btn {
   background-color: $ui-02;
   border: none;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

In this PR, I've addressed some styling inconsistencies with the Carbon `ContentSwitcher` component following the recent Carbon [version bump](#770). 

This PR does not fix an issue where the `size` prop of the `ContentSwitcher` component is getting ignored:

> The value of the `size` prop of the ContentSwitcher is set to `sm` but it gets ignored


<img width="941" alt="CleanShot 2023-09-26 at 4 07 53@2x" src="https://github.com/openmrs/openmrs-esm-core/assets/8509731/3cb7b113-c524-4c36-813f-14399808ee14">


> The `size` prop of the ContentSwitcher is set to `sm` but is getting overriden by the `var(--cds-layout-size-height-local)` value of the height property.
 

<img width="1103" alt="styling affecting height" src="https://github.com/openmrs/openmrs-esm-core/assets/8509731/361d4e04-f94e-4059-8787-9b8c62d141a6">

This is owing to an [upstream change](https://github.com/carbon-design-system/carbon/blob/644bd5b67b70752a7bd9880a445e7b4e182f9b2d/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx#L12) where the ContentSwitcher got [wrapped](https://github.com/carbon-design-system/carbon/blame/main/packages/react/src/components/ContentSwitcher/ContentSwitcher.tsx) in a `LayoutConstraint` component. I'll address this using either an override or a tweak to the relevant layout token.
 
Layout constraints [explainer](https://github.com/carbon-design-system/carbon/pull/13287).
