### PR TITLE
(feat) Load pure CSS files in the styleguide via `css-loader`

### DIFF
--- a/packages/framework/esm-styleguide/webpack.config.js
+++ b/packages/framework/esm-styleguide/webpack.config.js
@@ -23,10 +23,10 @@ module.exports = (env) => ({
     rules: [
       {
         test: /\.css$/,
-        use: ["style-loader", "css-loader"],
+        use: ["css-loader"],
       },
       {
-        test: /\.s?[ac]ss$/i,
+        test: /\.s[ac]ss$/i,
         use: [
           { loader: MiniCssExtractPlugin.loader },
           "css-loader",

--- a/packages/framework/esm-styleguide/webpack.config.js
+++ b/packages/framework/esm-styleguide/webpack.config.js
@@ -22,6 +22,10 @@ module.exports = (env) => ({
   module: {
     rules: [
       {
+        test: /\.css$/,
+        use: ["style-loader", "css-loader"],
+      },
+      {
         test: /\.s?[ac]ss$/i,
         use: [
           { loader: MiniCssExtractPlugin.loader },

--- a/packages/framework/esm-styleguide/webpack.config.js
+++ b/packages/framework/esm-styleguide/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = (env) => ({
     rules: [
       {
         test: /\.css$/,
-        use: ["css-loader"],
+        use: [{ loader: MiniCssExtractPlugin.loader }, "css-loader"],
       },
       {
         test: /\.s[ac]ss$/i,


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR attempts to fix an [issue](https://openmrs.slack.com/archives/C02UNMKFH8V/p1696278422399529) where the latest version of the openmrs tooling fails to build frontend assets as expected. More specifically, running `npx --legacy-peer-deps openmrs@next build --build-config /spa-build-config.json --target /app` (or its equivalents) yields the following error:

https://openmrs.slack.com/files/UJ8TY7J05/F05UG139EHM/cleanshot_2023-10-03_at_12___.10.08_2x.png?origin_team=T03U4PGDY&origin_channel=CHP5QAE5R

Digging deeper, this error stems from the tooling failing to load CSS provided by the React Spectrum library. As explained in the linked thread, the styleguide uses a custom webpack config which doesn't leverage either `style-loader` or `css-loader` for loading CSS modules. This PR adds a rule to the styleguide's webpack config that enables loading pure CSS files (such as the ones coming from external libraries) using `css-loader`.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
