### PR TITLE
(feat) Make the service worker opt-in for local dev

### DIFF
--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -176,7 +176,13 @@ yargs.command(
       )
       .string("routes")
       .default("routes", "routes.registry.json")
-      .describe("routes", "The routes.registry.json file to use."),
+      .describe("routes", "The routes.registry.json file to use.")
+      .boolean("support-offline")
+      .default("support-offline", false)
+      .describe(
+        "support-offline",
+        "Determines if a service worker should be installed for offline support."
+      ),
   async (args) =>
     runCommand("runDevelop", {
       configUrls: args["config-url"],

--- a/packages/tooling/openmrs/src/commands/develop.ts
+++ b/packages/tooling/openmrs/src/commands/develop.ts
@@ -22,10 +22,20 @@ export interface DevelopArgs {
   apiUrl: string;
   configUrls: Array<string>;
   addCookie: string;
+  supportOffline: boolean;
 }
 
 export function runDevelop(args: DevelopArgs) {
-  const { backend, host, port, open, importmap, configUrls, addCookie } = args;
+  const {
+    backend,
+    host,
+    port,
+    open,
+    importmap,
+    configUrls,
+    addCookie,
+    supportOffline,
+  } = args;
   const apiUrl = removeTrailingSlash(args.apiUrl);
   const spaPath = removeTrailingSlash(args.spaPath);
   const app = express();
@@ -44,7 +54,7 @@ export function runDevelop(args: DevelopArgs) {
           apiUrl: ${JSON.stringify(apiUrl)},
           spaPath: ${JSON.stringify(spaPath)},
           env: "development",
-          offline: true,
+          offline: ${supportOffline},
           configUrls: ${JSON.stringify(configUrls)},
         });
     </script>
@@ -96,9 +106,11 @@ export function runDevelop(args: DevelopArgs) {
   }
 
   // Route for custom `service-worker.js` before most things
-  app.get(`${spaPath}/service-worker.js`, (_, res) => {
-    res.contentType("js").send(swContent);
-  });
+  if (supportOffline) {
+    app.get(`${spaPath}/service-worker.js`, (_, res) => {
+      res.contentType("js").send(swContent);
+    });
+  }
 
   // Route for custom `index.html` goes above static assets
   app.get(indexHtmlPathMatcher, (_, res) =>


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Presently, our service worker implementation is buggy and slow. This PR aims to alleviate these performance bottlenecks by making the service worker installation opt-in when running a local dev server.

I've added a `support-offline` parameter to the `openmrs` CLI's `develop` command that should make it possible to disable the service worker when doing local development. This parameter defaults to `false` and will default to not installing a service worker when running a local dev server. To opt into installing a service worker, the user has to pass an additional flag to the `start` command with the `support-offline` flag set to true e.g. `yarn start --support-offline=true`.

It's entirely likely that in the future this flag will default to true once we fix the service worker.

## Screenshots

https://github.com/openmrs/openmrs-esm-core/assets/8509731/4d6d75ec-5b9c-4054-b0a1-d2e443ffc3e3

(I don't know why the server took so long to reload in both instances in the recording above).
