### PR TITLE
(fix) Fix the appearance of Carbon icon-only buttons

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -33,6 +33,14 @@
   border-right: none;
 }
 
+/* Icon button */
+.cds--btn--icon-only {
+  // Apply a size layout token that sets the default size of the icon-only button to `sm`
+  @include layout.use("size", $default: "sm");
+  // Remove extraneous top padding from the icon-only button
+  padding-block-start: 0;
+}
+
 /* Side nav */
 .cds--side-nav {
   overflow: auto;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR fixes a regression affecting the icon-only variant of the Carbon Button component. Before the recent Carbon version bump, the icon-only variant of the Button component would adjust its size according to whatever value passed to it via the `size` prop. This is owing to a new `--cds-layout-size-height-local` class that got added after an upstream [change](https://github.com/carbon-design-system/carbon/pull/13287) to the Button component that added [contextual layout tokens](https://github.com/carbon-design-system/carbon/issues/13923). 

It does so by setting the default size of the button to `sm` and removing some extraneous padding.

## Screenshots

> After 
![CleanShot 2023-10-05 at 9  31 58@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/02731662-92f4-4bb6-8261-8bf2499b3ae1)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
