### PR TITLE
(feat) Adds support for non-Gregorian calendars, with special work-arounds for Amharic

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -67,6 +67,7 @@
 - [isOmrsDateStrict](API.md#isomrsdatestrict)
 - [isOmrsDateToday](API.md#isomrsdatetoday)
 - [parseDate](API.md#parsedate)
+- [registerDefaultCalendar](API.md#registerdefaultcalendar)
 - [toDateObjectStrict](API.md#todateobjectstrict)
 - [toOmrsDateFormat](API.md#toomrsdateformat)
 - [toOmrsDayDateFormat](API.md#toomrsdaydateformat)
@@ -298,6 +299,7 @@ ___
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
+| `calendar?` | `string` | The calendar to use when formatting this date. |
 | `day` | `boolean` | Whether to include the day number |
 | `mode` | [`FormatDateMode`](API.md#formatdatemode) | - `standard`: "03 Feb 2022" - `wide`:     "03 — Feb — 2022" |
 | `noToday` | `boolean` | Disables the special handling of dates that are today. If false (the default), then dates that are today will be formatted as "Today" in the locale language. If true, then dates that are today will be formatted the same as all other dates. |
@@ -1962,8 +1964,6 @@ When time is included, it is appended with a comma and a space. This
 agrees with the output of `Date.prototype.toLocaleString` for *most*
 locales.
 
-TODO: Shouldn't throw on null input
-
 #### Parameters
 
 | Name | Type |
@@ -1977,7 +1977,7 @@ TODO: Shouldn't throw on null input
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:195](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L195)
+[packages/framework/esm-utils/src/omrs-dates.ts:261](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L261)
 
 ___
 
@@ -2006,7 +2006,7 @@ output of `Date.prototype.toLocaleString` for *most* locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:262](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L262)
+[packages/framework/esm-utils/src/omrs-dates.ts:357](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L357)
 
 ___
 
@@ -2029,7 +2029,7 @@ Formats the input as a time, according to the current locale.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:246](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L246)
+[packages/framework/esm-utils/src/omrs-dates.ts:341](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L341)
 
 ___
 
@@ -2047,7 +2047,7 @@ string
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:273](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L273)
+[packages/framework/esm-utils/src/omrs-dates.ts:368](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L368)
 
 ___
 
@@ -2114,6 +2114,32 @@ Uses `dayjs(dateString)`.
 #### Defined in
 
 [packages/framework/esm-utils/src/omrs-dates.ts:137](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L137)
+
+___
+
+### registerDefaultCalendar
+
+▸ **registerDefaultCalendar**(`locale`, `calendar`): `void`
+
+Provides the name of the calendar to associate, as a default, with the given base locale.
+
+For example:
+`registerDefaultCalendar('en', 'buddhist')` sets the default calendar for the 'en' locale to Buddhist.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `locale` | `string` | - |
+| `calendar` | `string` | the calendar to use for this registration |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:238](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L238)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -2006,7 +2006,7 @@ output of `Date.prototype.toLocaleString` for *most* locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:357](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L357)
+[packages/framework/esm-utils/src/omrs-dates.ts:381](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L381)
 
 ___
 
@@ -2029,7 +2029,7 @@ Formats the input as a time, according to the current locale.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:341](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L341)
+[packages/framework/esm-utils/src/omrs-dates.ts:365](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L365)
 
 ___
 
@@ -2047,7 +2047,7 @@ string
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:368](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L368)
+[packages/framework/esm-utils/src/omrs-dates.ts:392](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L392)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -63,6 +63,7 @@
 - [formatDate](API.md#formatdate)
 - [formatDatetime](API.md#formatdatetime)
 - [formatTime](API.md#formattime)
+- [getDefaultCalendar](API.md#getdefaultcalendar)
 - [getLocale](API.md#getlocale)
 - [isOmrsDateStrict](API.md#isomrsdatestrict)
 - [isOmrsDateToday](API.md#isomrsdatetoday)
@@ -1977,7 +1978,7 @@ locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:261](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L261)
+[packages/framework/esm-utils/src/omrs-dates.ts:276](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L276)
 
 ___
 
@@ -2006,7 +2007,7 @@ output of `Date.prototype.toLocaleString` for *most* locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:381](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L381)
+[packages/framework/esm-utils/src/omrs-dates.ts:390](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L390)
 
 ___
 
@@ -2029,7 +2030,29 @@ Formats the input as a time, according to the current locale.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:365](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L365)
+[packages/framework/esm-utils/src/omrs-dates.ts:374](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L374)
+
+___
+
+### getDefaultCalendar
+
+▸ **getDefaultCalendar**(`locale`): `undefined` \| `string`
+
+Retrieves the default calendar for the specified locale if any.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `locale` | `undefined` \| `string` \| `Locale` | the locale to look-up |
+
+#### Returns
+
+`undefined` \| `string`
+
+#### Defined in
+
+[packages/framework/esm-utils/src/omrs-dates.ts:249](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L249)
 
 ___
 
@@ -2047,7 +2070,7 @@ string
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:392](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L392)
+[packages/framework/esm-utils/src/omrs-dates.ts:401](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L401)
 
 ___
 
@@ -2123,8 +2146,10 @@ ___
 
 Provides the name of the calendar to associate, as a default, with the given base locale.
 
-For example:
-`registerDefaultCalendar('en', 'buddhist')` sets the default calendar for the 'en' locale to Buddhist.
+**`example`**
+```
+registerDefaultCalendar('en', 'buddhist') // sets the default calendar for the 'en' locale to Buddhist.
+```
 
 #### Parameters
 
@@ -2139,7 +2164,7 @@ For example:
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:238](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L238)
+[packages/framework/esm-utils/src/omrs-dates.ts:240](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L240)
 
 ___
 

--- a/packages/framework/esm-utils/src/omrs-dates.test.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.test.ts
@@ -88,6 +88,46 @@ describe("Openmrs Dates", () => {
     );
   });
 
+  it("formats dates with respect to the active calendar", () => {
+    timezoneMock.register("UTC");
+    const testDate = new Date("2021-12-09T13:15:33");
+    window.i18next.language = "am";
+    expect(formatDate(testDate)).toEqual("30-Hedar-2014");
+    expect(formatDate(testDate, { day: false })).toEqual("Hedar 2014");
+    expect(formatDate(testDate, { year: false })).toEqual("30 Hedar");
+    expect(formatDate(testDate, { mode: "wide" })).toEqual("30 — Hedar — 2014");
+    expect(formatDate(testDate, { mode: "wide", year: false })).toEqual(
+      "30 — Hedar"
+    );
+
+    window.i18next.language = "am-ET";
+    expect(formatDate(testDate)).toEqual("30-Hedar-2014");
+    expect(formatDate(testDate, { day: false })).toEqual("Hedar 2014");
+    expect(formatDate(testDate, { year: false })).toEqual("30 Hedar");
+    expect(formatDate(testDate, { mode: "wide" })).toEqual("30 — Hedar — 2014");
+    expect(formatDate(testDate, { mode: "wide", year: false })).toEqual(
+      "30 — Hedar"
+    );
+
+    window.i18next.language = "en-u-ca-ethiopic";
+    expect(formatDate(testDate)).toEqual("30-Hedar-2014");
+    expect(formatDate(testDate, { day: false })).toEqual("Hedar 2014");
+    expect(formatDate(testDate, { year: false })).toEqual("30 Hedar");
+    expect(formatDate(testDate, { mode: "wide" })).toEqual("30 — Hedar — 2014");
+    expect(formatDate(testDate, { mode: "wide", year: false })).toEqual(
+      "30 — Hedar"
+    );
+
+    window.i18next.language = "th-TH";
+    expect(formatDate(testDate)).toEqual("09 ธ.ค. 2564");
+    expect(formatDate(testDate, { day: false })).toEqual("ธ.ค. 2564");
+    expect(formatDate(testDate, { year: false })).toEqual("09 ธ.ค.");
+    expect(formatDate(testDate, { mode: "wide" })).toEqual("09 — ธ.ค. — 2564");
+    expect(formatDate(testDate, { mode: "wide", year: false })).toEqual(
+      "09 — ธ.ค."
+    );
+  });
+
   it("respects the `time` option", () => {
     timezoneMock.register("UTC");
     const testDate = new Date("2021-12-09T13:15:33");

--- a/packages/framework/esm-utils/src/omrs-dates.test.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.test.ts
@@ -128,6 +128,20 @@ describe("Openmrs Dates", () => {
     );
   });
 
+  it("handles leap years correctly in Ethiopian locales", () => {
+    timezoneMock.register("UTC");
+    const dateBeforeLeapYear = new Date("2023-09-11T09:00:00");
+
+    window.i18next.language = "en";
+    expect(formatDate(dateBeforeLeapYear)).toEqual("11-Sept-2023");
+
+    window.i18next.language = "am";
+    expect(formatDate(dateBeforeLeapYear)).toEqual("06-Pagumen-2015");
+
+    const dateAfterLeapYear = new Date("2023-09-12T09:00:00");
+    expect(formatDate(dateAfterLeapYear)).toEqual("01-Meskerem-2016");
+  });
+
   it("respects the `time` option", () => {
     timezoneMock.register("UTC");
     const testDate = new Date("2021-12-09T13:15:33");

--- a/packages/framework/esm-utils/src/omrs-dates.test.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.test.ts
@@ -92,21 +92,21 @@ describe("Openmrs Dates", () => {
     timezoneMock.register("UTC");
     const testDate = new Date("2021-12-09T13:15:33");
     window.i18next.language = "am";
-    expect(formatDate(testDate)).toEqual("30-Hedar-2014");
-    expect(formatDate(testDate, { day: false })).toEqual("Hedar 2014");
-    expect(formatDate(testDate, { year: false })).toEqual("30 Hedar");
-    expect(formatDate(testDate, { mode: "wide" })).toEqual("30 — Hedar — 2014");
+    expect(formatDate(testDate)).toEqual("30-ኅዳር-2014");
+    expect(formatDate(testDate, { day: false })).toEqual("ኅዳር 2014");
+    expect(formatDate(testDate, { year: false })).toEqual("ኅዳር 30");
+    expect(formatDate(testDate, { mode: "wide" })).toEqual("30 — ኅዳር — 2014");
     expect(formatDate(testDate, { mode: "wide", year: false })).toEqual(
-      "30 — Hedar"
+      "ኅዳር — 30"
     );
 
     window.i18next.language = "am-ET";
-    expect(formatDate(testDate)).toEqual("30-Hedar-2014");
-    expect(formatDate(testDate, { day: false })).toEqual("Hedar 2014");
-    expect(formatDate(testDate, { year: false })).toEqual("30 Hedar");
-    expect(formatDate(testDate, { mode: "wide" })).toEqual("30 — Hedar — 2014");
+    expect(formatDate(testDate)).toEqual("30-ኅዳር-2014");
+    expect(formatDate(testDate, { day: false })).toEqual("ኅዳር 2014");
+    expect(formatDate(testDate, { year: false })).toEqual("ኅዳር 30");
+    expect(formatDate(testDate, { mode: "wide" })).toEqual("30 — ኅዳር — 2014");
     expect(formatDate(testDate, { mode: "wide", year: false })).toEqual(
-      "30 — Hedar"
+      "ኅዳር — 30"
     );
 
     window.i18next.language = "en-u-ca-ethiopic";
@@ -136,10 +136,10 @@ describe("Openmrs Dates", () => {
     expect(formatDate(dateBeforeLeapYear)).toEqual("11-Sept-2023");
 
     window.i18next.language = "am";
-    expect(formatDate(dateBeforeLeapYear)).toEqual("06-Pagumen-2015");
+    expect(formatDate(dateBeforeLeapYear)).toEqual("06-ጳጉሜን-2015");
 
     const dateAfterLeapYear = new Date("2023-09-12T09:00:00");
-    expect(formatDate(dateAfterLeapYear)).toEqual("01-Meskerem-2016");
+    expect(formatDate(dateAfterLeapYear)).toEqual("01-መስከረም-2016");
   });
 
   it("respects the `time` option", () => {

--- a/packages/framework/esm-utils/src/omrs-dates.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.ts
@@ -229,14 +229,29 @@ const registeredLocaleCalendars = new LocaleCalendars();
 /**
  * Provides the name of the calendar to associate, as a default, with the given base locale.
  *
- * For example:
- * `registerDefaultCalendar('en', 'buddhist')` sets the default calendar for the 'en' locale to Buddhist.
+ * @example
+ * ```
+ * registerDefaultCalendar('en', 'buddhist') // sets the default calendar for the 'en' locale to Buddhist.
+ * ```
  *
  * @param baseLocale the locale to register this calendar for
  * @param calendar the calendar to use for this registration
  */
 export function registerDefaultCalendar(locale: string, calendar: string) {
   registeredLocaleCalendars.register(locale, calendar);
+}
+
+/**
+ * Retrieves the default calendar for the specified locale if any.
+ *
+ * @param locale the locale to look-up
+ */
+export function getDefaultCalendar(locale: Intl.Locale | string | undefined) {
+  const locale_ = locale ?? getLocale();
+
+  return registeredLocaleCalendars.getCalendar(
+    locale_ instanceof Intl.Locale ? locale_ : new Intl.Locale(locale_)
+  );
 }
 
 /**
@@ -268,8 +283,7 @@ export function formatDate(date: Date, options?: Partial<FormatDateOptions>) {
     ...options,
   };
 
-  const formatCalendar =
-    calendar ?? registeredLocaleCalendars.getCalendar(_locale);
+  const formatCalendar = calendar ?? getDefaultCalendar(_locale);
 
   const formatterOptions: Intl.DateTimeFormatOptions = {
     calendar: formatCalendar,
@@ -290,11 +304,6 @@ export function formatDate(date: Date, options?: Partial<FormatDateOptions>) {
     if (_locale.language === "en") {
       // This locale override is here rather than in `getLocale`
       // because Americans should see AM/PM for times.
-      locale = "en-GB";
-    }
-
-    if (_locale.language === "am") {
-      // Hack to keep month names in English
       locale = "en-GB";
     }
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Basically, this has the same intention as #786, but with a somewhat cleaner implementation, utilising the standard JS library. It also adds support for registering default custom calendars on a per-locale basis, which is currently only used to use the Ethiopian calendar when the locale is Amharic.

See the added tests for some of what this PR allows.

## Screenshots
<!-- Required if you are making UI changes. -->

<img width="920" alt="Date Formatting" src="https://github.com/openmrs/openmrs-esm-core/assets/52504170/885c8109-a030-48e7-b046-b9b08cef5573">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

There's a hack in here I don't love: if the locale is set to Amharic, we format the date in English, but using the Ethiopic calendar, but this was done to produce the same results as #786.

#786 also basically stops the display of time strings, but this is a configurable option for the call to `formatDate()`, and we should probably have a mechanism to handle the implementation-specific defaults rather than just relying on the workaround of having a separate formatter that doesn't display time in some circumstances.
