### PR TITLE
(fix) Devtools panel Switcher components shouldn't truncate their content

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/popup/popup.styles.scss
+++ b/packages/apps/esm-implementer-tools-app/src/popup/popup.styles.scss
@@ -18,10 +18,14 @@
 }
 
 .tabs {
-  width: 30em;
+  min-width: 30rem;
   overflow-x: hidden;
   overflow-y: auto;
   position: relative;
+
+  :global(.cds--content-switcher-btn) {
+    min-width: fit-content;
+  }
 }
 
 .topBar {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

I've set the minimum width of the `Switch` components in the dev tools panel to the intrinsic width of their content so that all the content in the Switch gets displayed instead of getting cut off.

## Screenshots

> Before

![CleanShot 2023-10-20 at 4  02 08@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/5be1db23-68d2-4663-95ea-fc1c0e7ca69b)

> After

![CleanShot 2023-10-20 at 4  01 39@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/f60415fe-c605-44f4-966d-01c0e56ee207)

## Related Issue
*None*

## Other
*None*