### PR TITLE
(fix) O3-2526 Resolve Overlay Issue Blocking LeftNav Access on Tablet Devices

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -33,6 +33,10 @@
   border-right: none;
 }
 
+.cds--side-nav__overlay-active {
+  display: none;
+}
+
 /* Icon button */
 .cds--btn--icon-only {
   // Apply a size layout token that sets the default size of the icon-only button to `sm`


### PR DESCRIPTION

## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
The active overlay on the side navigation, due to its high z-index, obstructs access to the LeftNavMenu on both the patient-chart and home page. This PR addresses the issue by adjusting the overlay's visibility, ensuring users can seamlessly access the navigation links.

## Screenshots
## Bug
![Kapture 2023-10-26 at 10 45 01](https://github.com/openmrs/openmrs-esm-core/assets/28008754/f4fffa83-b567-4d99-9953-853827943de3)
## Fix
![Kapture 2023-10-26 at 11 41 15](https://github.com/openmrs/openmrs-esm-core/assets/28008754/1df86fb5-638c-462e-a7af-fe5ba3d6da0e)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
