### PR TITLE
(chore) Removing i18next-icu as it is supported for i18next v19 

### DIFF
--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "npm run watch",
     "test": "jest --passWithNoTests",
-    "watch": "cross-env OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" OMRS_OFFLINE=\"disable\" webpack serve --mode development",
+    "watch": "cross-env OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" webpack serve --mode development",
     "watch:ref": "cross-env OMRS_ESM_IMPORTMAP_URL=\"https://dev3.openmrs.org/openmrs/spa/importmap.json\" OMRS_OFFLINE=\"disable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" webpack serve --mode development",
     "build:production": "cross-env OMRS_ESM_IMPORTMAP_URL=\"https://dev3.openmrs.org/openmrs/spa/importmap.json\" OMRS_OFFLINE=\"enable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"production\" webpack --mode production",
     "build:development": "cross-env OMRS_OFFLINE=\"enable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" webpack --mode development",

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "npm run watch",
     "test": "jest --passWithNoTests",
-    "watch": "cross-env OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" webpack serve --mode development",
+    "watch": "cross-env OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" OMRS_OFFLINE=\"disable\" webpack serve --mode development",
     "watch:ref": "cross-env OMRS_ESM_IMPORTMAP_URL=\"https://dev3.openmrs.org/openmrs/spa/importmap.json\" OMRS_OFFLINE=\"disable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" webpack serve --mode development",
     "build:production": "cross-env OMRS_ESM_IMPORTMAP_URL=\"https://dev3.openmrs.org/openmrs/spa/importmap.json\" OMRS_OFFLINE=\"enable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"production\" webpack --mode production",
     "build:development": "cross-env OMRS_OFFLINE=\"enable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" webpack --mode development",
@@ -42,7 +42,6 @@
     "html-webpack-plugin": "^5.5.0",
     "i18next": "^21.10.0",
     "i18next-browser-languagedetector": "^6.1.8",
-    "i18next-icu": "^2.3.0",
     "import-map-overrides": "^3.0.0",
     "lodash-es": "4.17.21",
     "react": "^18.1.0",

--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -86,6 +86,10 @@ export function setupI18n() {
         lookupQuerystring: "lang",
       },
       fallbackLng: "en",
+      interpolation: {
+        prefix: "{",
+        suffix: "}",
+      },
     });
 }
 

--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -1,5 +1,4 @@
 import * as i18next from "i18next";
-import ICU from "i18next-icu";
 import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
 import merge from "lodash-es/merge";
@@ -81,7 +80,6 @@ export function setupI18n() {
       },
     })
     .use(initReactI18next)
-    .use(ICU)
     .init({
       detection: {
         order: ["querystring", "htmlTag", "localStorage", "navigator"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -3709,7 +3709,6 @@ __metadata:
     html-webpack-plugin: ^5.5.0
     i18next: ^21.10.0
     i18next-browser-languagedetector: ^6.1.8
-    i18next-icu: ^2.3.0
     import-map-overrides: ^3.0.0
     lodash-es: 4.17.21
     react: ^18.1.0
@@ -12058,15 +12057,6 @@ __metadata:
   dependencies:
     "@babel/runtime": ^7.19.0
   checksum: dd84d3c9cb693a70662436b06f5554898815df33b7641249a64876c74c38960f11ef17b4d7f49ee2da7262abe0f3ae73abe7f3a3b435a344d0d07e4ca7cb24c6
-  languageName: node
-  linkType: hard
-
-"i18next-icu@npm:^2.3.0":
-  version: 2.3.0
-  resolution: "i18next-icu@npm:2.3.0"
-  peerDependencies:
-    intl-messageformat: ^10.3.3
-  checksum: da5cbf1fed795921dc903f8bd9129b5ad8ef4c5acd9cdea00c096a2dd4fafc8007cdc0501c11db5f86c7bfda8cde71896f8a4321129ead3557196a76fd4ad2d0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR remove the `i18next-icu` to be used in the i18next initialization because it is supported till i18next's `v19`. Hence the pluralization translations weren't working in the application.

Basically `i18next-icu` was helping us to use `{` in the variables instead of `{{`. The `{{` interpolation is what i18next's default configuration.

(@jayasanka-sack I finally got the answer to why we were using `{` instead of `{{`)

## Screenshots
None

## Related Issue
None

## Other
<!-- Anything not covered above -->
