### PR TITLE
(fix) Fix requiredVersion for SWR share

### DIFF
--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -271,7 +271,7 @@ export default (
             // SWR is annoying with Module Federation
             // See: https://github.com/webpack/webpack/issues/16125 and https://github.com/vercel/swr/issues/2356
             obj["swr/"] = {
-              requiredVersion: version,
+              requiredVersion: peerDependencies["swr"] ?? false,
               singleton: true,
               import: "swr/",
               shareKey: "swr/",


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Mistake on my part flags the required version of SWR as being the version of the app rather than the version in `peerDependencies`. This is harmless, but will display warnings in production, so should be fixed.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
