### PR TITLE
(fix) PWA Manifest should respect the OpenMRS public path

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -279,20 +279,6 @@ module.exports = (env, argv = {}) => {
     },
     plugins: [
       openmrsCleanBeforeBuild && new CleanWebpackPlugin(),
-      new WebpackPwaManifest({
-        name: "OpenMRS",
-        short_name: "OpenMRS",
-        description:
-          "Open source Health IT by and for the entire planet, starting with the developing world.",
-        background_color: "#ffffff",
-        theme_color: "#000000",
-        icons: [
-          {
-            src: resolve(__dirname, "src/assets/logo-512.png"),
-            sizes: [96, 128, 144, 192, 256, 384, 512],
-          },
-        ],
-      }),
       new HtmlWebpackPlugin({
         inject: false,
         scriptLoading: "blocking",
@@ -316,6 +302,21 @@ module.exports = (env, argv = {}) => {
           openmrsCoreRoutes:
             Object.keys(coreRoutes).length > 0 && JSON.stringify(coreRoutes),
         },
+      }),
+      new WebpackPwaManifest({
+        name: "OpenMRS",
+        short_name: "OpenMRS",
+        publicPath: openmrsPublicPath,
+        description:
+          "Open source Health IT by and for the entire planet, starting with the developing world.",
+        background_color: "#ffffff",
+        theme_color: "#000000",
+        icons: [
+          {
+            src: resolve(__dirname, "src/assets/logo-512.png"),
+            sizes: [96, 128, 144, 192, 256, 384, 512],
+          },
+        ],
       }),
       new CopyWebpackPlugin({
         patterns: [{ from: resolve(__dirname, "src/assets") }, ...appPatterns],


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Ensure the PWA manifest uses the `openmrsPublicPath`. NB We should probably remove this at some point or figure out how to enable white-labeling here too.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
