### PR TITLE
(fix) O3-2543 useSession not always receiving updated session object

### DIFF
--- a/packages/framework/esm-react-utils/src/useSession.test.tsx
+++ b/packages/framework/esm-react-utils/src/useSession.test.tsx
@@ -81,4 +81,25 @@ describe("useSession", () => {
     );
     expect(screen.getByText(/"authenticated":false/)).toBeInTheDocument();
   });
+
+  it("supports multiple instances of useSession that all receive updates", async () => {
+    mockSessionStore.setState({
+      loaded: true,
+      session: { authenticated: false, sessionId: "test2" },
+    });
+    render(<Suspense fallback={"suspended"}>
+      <div data-testid="component1"><Component /></div>
+      <div data-testid="component2"><Component /></div>
+      </Suspense>)
+    expect(screen.getByTestId("component1")).toHaveTextContent(/"authenticated":false/)
+    expect(screen.getByTestId("component2")).toHaveTextContent(/"authenticated":false/)
+    act(() => {
+      mockSessionStore.setState({
+        loaded: true,
+        session: { authenticated: true, sessionId: "test3" },
+      });
+    });
+    expect(screen.getByTestId("component1")).toHaveTextContent(/"authenticated":true/)
+    expect(screen.getByTestId("component2")).toHaveTextContent(/"authenticated":true/)
+  });
 });

--- a/packages/framework/esm-react-utils/src/useSession.test.tsx
+++ b/packages/framework/esm-react-utils/src/useSession.test.tsx
@@ -87,19 +87,33 @@ describe("useSession", () => {
       loaded: true,
       session: { authenticated: false, sessionId: "test2" },
     });
-    render(<Suspense fallback={"suspended"}>
-      <div data-testid="component1"><Component /></div>
-      <div data-testid="component2"><Component /></div>
-      </Suspense>)
-    expect(screen.getByTestId("component1")).toHaveTextContent(/"authenticated":false/)
-    expect(screen.getByTestId("component2")).toHaveTextContent(/"authenticated":false/)
+    render(
+      <Suspense fallback={"suspended"}>
+        <div data-testid="component1">
+          <Component />
+        </div>
+        <div data-testid="component2">
+          <Component />
+        </div>
+      </Suspense>
+    );
+    expect(screen.getByTestId("component1")).toHaveTextContent(
+      /"authenticated":false/
+    );
+    expect(screen.getByTestId("component2")).toHaveTextContent(
+      /"authenticated":false/
+    );
     act(() => {
       mockSessionStore.setState({
         loaded: true,
         session: { authenticated: true, sessionId: "test3" },
       });
     });
-    expect(screen.getByTestId("component1")).toHaveTextContent(/"authenticated":true/)
-    expect(screen.getByTestId("component2")).toHaveTextContent(/"authenticated":true/)
+    expect(screen.getByTestId("component1")).toHaveTextContent(
+      /"authenticated":true/
+    );
+    expect(screen.getByTestId("component2")).toHaveTextContent(
+      /"authenticated":true/
+    );
   });
 });

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -255,7 +255,7 @@ export default (
         "process.env.FRAMEWORK_VERSION": JSON.stringify(frameworkVersion),
       }),
       new ModuleFederationPlugin({
-        // See `esm-app-shell/src/load-modules.ts` for an explanation of how modules
+        // Look in the `esm-dynamic-loading` framework package for an explanation of how modules
         // get loaded into the application.
         name,
         library: { type: "var", name: slugify(name) },


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
The problem was that the `unsubscribe` variable was at module level, so only one instance of `useSession` was actually able to get its subscription set up properly.

## Related Issue
https://issues.openmrs.org/browse/O3-2543

## Other
Unblocks https://github.com/openmrs/openmrs-esm-patient-management/pull/775
