### PR TITLE
(feat) Synchronously load most extensions and pages

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/index.ts
+++ b/packages/apps/esm-implementer-tools-app/src/index.ts
@@ -1,4 +1,7 @@
-import { getAsyncLifecycle } from "@openmrs/esm-framework";
+import { getSyncLifecycle } from "@openmrs/esm-framework";
+import implementerToolsComponent from "./implementer-tools.component";
+import globalImplementerToolsComponent from "./global-implementer-tools.component";
+import implementerToolsButtonComponent from "./implementer-tools.button";
 
 export const importTranslation = require.context(
   "../translations",
@@ -13,18 +16,18 @@ const options = {
   moduleName,
 };
 
-export const implementerTools = getAsyncLifecycle(
-  () => import("./implementer-tools.component"),
+export const implementerTools = getSyncLifecycle(
+  implementerToolsComponent,
   options
 );
 
-export const globalImplementerTools = getAsyncLifecycle(
-  () => import("./global-implementer-tools.component"),
+export const globalImplementerTools = getSyncLifecycle(
+  globalImplementerToolsComponent,
   options
 );
 
-export const implementerToolsButton = getAsyncLifecycle(
-  () => import("./implementer-tools.button"),
+export const implementerToolsButton = getSyncLifecycle(
+  implementerToolsButtonComponent,
   options
 );
 

--- a/packages/apps/esm-login-app/src/index.ts
+++ b/packages/apps/esm-login-app/src/index.ts
@@ -1,5 +1,9 @@
-import { getAsyncLifecycle, defineConfigSchema } from "@openmrs/esm-framework";
+import { defineConfigSchema, getSyncLifecycle } from "@openmrs/esm-framework";
 import { configSchema } from "./config-schema";
+import rootComponent from "./root.component";
+import locationPickerComponent from "./location-picker/location-picker.component";
+import changeLocationLinkComponent from "./change-location-link/change-location-link.component";
+import logoutButtonComponent from "./logout/logout.component";
 
 const moduleName = "@openmrs/esm-login-app";
 
@@ -19,19 +23,13 @@ export function startupApp() {
   defineConfigSchema(moduleName, configSchema);
 }
 
-export const root = getAsyncLifecycle(
-  () => import("./root.component"),
+export const root = getSyncLifecycle(rootComponent, options);
+export const locationPicker = getSyncLifecycle(
+  locationPickerComponent,
   options
 );
-export const locationPicker = getAsyncLifecycle(
-  () => import("./location-picker/location-picker.component"),
-  options
-);
-export const logoutButton = getAsyncLifecycle(
-  () => import("./logout/logout.component"),
-  options
-);
-export const changeLocationLink = getAsyncLifecycle(
-  () => import("./change-location-link/change-location-link.component"),
+export const logoutButton = getSyncLifecycle(logoutButtonComponent, options);
+export const changeLocationLink = getSyncLifecycle(
+  changeLocationLinkComponent,
   options
 );

--- a/packages/apps/esm-offline-tools-app/src/index.ts
+++ b/packages/apps/esm-offline-tools-app/src/index.ts
@@ -1,15 +1,25 @@
 import {
   defineConfigSchema,
-  getAsyncLifecycle,
   getSyncLifecycle,
   registerBreadcrumbs,
 } from "@openmrs/esm-framework";
 import { routes } from "./constants";
 import { createDashboardLink } from "./createDashboardLink";
 import { dashboardMeta } from "./dashboard.meta";
-import OfflineToolsNavLink from "./nav/offline-tools-nav-link.component";
 import { setupOffline } from "./offline";
 import { setupSynchronizingOfflineActionsNotifications } from "./offline-actions/synchronizing-notification";
+import offlineToolsComponent from "./root.component";
+import offlineToolsLinkComponent from "./offline-tools-app-menu-link.component";
+import offlineToolsNavItemsComponent from "./nav/offline-tools-nav-menu.component";
+import offlineToolsConfirmationModalComponent from "./components/confirmation-modal.component";
+import offlineToolsPatientsCardComponent from "./offline-patients/patients-overview-card.component";
+import offlineToolsActionsCardComponent from "./offline-actions/offline-actions-overview-card.component";
+import offlineToolsActionsComponent from "./offline-actions/offline-actions.component";
+import offlineToolsPatientsComponent from "./offline-patients/offline-patients.component";
+import offlineToolsPageActionsComponent from "./offline-actions/offline-actions-page.component";
+import offlineToolsPatientChartComponent from "./offline-actions/offline-actions-patient-chart-widget.component";
+import offlineToolsOptInButtonComponent from "./offline-actions/offline-actions-mode-button.component";
+import OfflineToolsNavLink from "./nav/offline-tools-nav-link.component";
 
 export const importTranslation = require.context(
   "../translations",
@@ -24,36 +34,33 @@ const options = {
   moduleName,
 };
 
-export const offlineTools = getAsyncLifecycle(
-  () => import("./root.component"),
+export const offlineTools = getSyncLifecycle(offlineToolsComponent, options);
+
+export const offlineToolsLink = getSyncLifecycle(
+  offlineToolsLinkComponent,
   options
 );
 
-export const offlineToolsLink = getAsyncLifecycle(
-  () => import("./offline-tools-app-menu-link.component"),
-  options
-);
-
-export const offlineToolsNavItems = getAsyncLifecycle(
-  () => import("./nav/offline-tools-nav-menu.component"),
+export const offlineToolsNavItems = getSyncLifecycle(
+  offlineToolsNavItemsComponent,
   {
     featureName: "nav-items",
     moduleName,
   }
 );
 
-export const offlineToolsConfirmationModal = getAsyncLifecycle(
-  () => import("./components/confirmation-modal.component"),
+export const offlineToolsConfirmationModal = getSyncLifecycle(
+  offlineToolsConfirmationModalComponent,
   options
 );
 
-export const offlineToolsPatientsCard = getAsyncLifecycle(
-  () => import("./offline-patients/patients-overview-card.component"),
+export const offlineToolsPatientsCard = getSyncLifecycle(
+  offlineToolsPatientsCardComponent,
   options
 );
 
-export const offlineToolsActionsCard = getAsyncLifecycle(
-  () => import("./offline-actions/offline-actions-overview-card.component"),
+export const offlineToolsActionsCard = getSyncLifecycle(
+  offlineToolsActionsCardComponent,
   options
 );
 
@@ -75,30 +82,23 @@ export const offlineToolsActionsLink = getSyncLifecycle(
   options
 );
 
-export const offlineToolsActions = getAsyncLifecycle(
-  () => import("./offline-actions/offline-actions.component"),
+export const offlineToolsActions = getSyncLifecycle(
+  offlineToolsActionsComponent,
   options
 );
 
-export const offlineToolsPatients = getAsyncLifecycle(
-  () => import("./offline-patients/offline-patients.component"),
+export const offlineToolsPatients = getSyncLifecycle(
+  offlineToolsPatientsComponent,
   options
 );
 
-export const offlineToolsPageActions = getAsyncLifecycle(
-  () => import("./offline-actions/offline-actions-page.component"),
+export const offlineToolsPageActions = getSyncLifecycle(
+  offlineToolsPageActionsComponent,
   options
 );
 
-export const offlineToolsPatientChartActions = getAsyncLifecycle(
-  () =>
-    import("./offline-actions/offline-actions-patient-chart-widget.component"),
-  options
-);
-
-export const offlineToolsPatientChartActionsDashboard = getAsyncLifecycle(
-  () =>
-    import("./offline-actions/offline-actions-patient-chart-widget.component"),
+export const offlineToolsPatientChartActions = getSyncLifecycle(
+  offlineToolsPatientChartComponent,
   options
 );
 
@@ -117,8 +117,8 @@ export const offlineToolsPatientChartActionsDashboardLink = getSyncLifecycle(
   options
 );
 
-export const offlineToolsOptInButton = getAsyncLifecycle(
-  () => import("./offline-actions/offline-actions-mode-button.component"),
+export const offlineToolsOptInButton = getSyncLifecycle(
+  offlineToolsOptInButtonComponent,
   options
 );
 

--- a/packages/apps/esm-primary-navigation-app/src/index.ts
+++ b/packages/apps/esm-primary-navigation-app/src/index.ts
@@ -2,13 +2,20 @@ import {
   defineConfigSchema,
   defineExtensionConfigSchema,
   getAsyncLifecycle,
+  getSyncLifecycle,
+  navigate,
   setupOfflineSync,
 } from "@openmrs/esm-framework";
-import { Application, navigateToUrl } from "single-spa";
+import { type Application } from "single-spa";
 import { configSchema } from "./config-schema";
 import { moduleName, userPropertyChange } from "./constants";
 import { syncUserLanguagePreference } from "./offline";
-import { genericLinkConfigSchema } from "./components/generic-link/generic-link.component";
+import primaryNavRootComponent from "./root.component";
+import userPanelComponent from "./components/user-panel-switcher-item/user-panel-switcher.component";
+import localeChangerComponent from "./components/choose-locale/change-locale.component";
+import genericLinkComponent, {
+  genericLinkConfigSchema,
+} from "./components/generic-link/generic-link.component";
 
 export const importTranslation = require.context(
   "../translations",
@@ -29,35 +36,19 @@ export function startupApp() {
   setupOfflineSync(userPropertyChange, [], syncUserLanguagePreference);
 }
 
-export const root = getAsyncLifecycle(
-  () => import("./root.component"),
-  options
-);
+export const root = getSyncLifecycle(primaryNavRootComponent, options);
 
 export const redirect: Application = async () => ({
-  bootstrap: async () =>
-    await navigateToUrl(window.getOpenmrsSpaBase() + "home"),
+  bootstrap: async () => navigate({ to: "${openmrsSpaBase}/home" }),
   mount: async () => undefined,
   unmount: async () => undefined,
 });
 
-export const userPanel = getAsyncLifecycle(
-  () =>
-    import(
-      "./components/user-panel-switcher-item/user-panel-switcher.component"
-    ),
-  options
-);
+export const userPanel = getSyncLifecycle(userPanelComponent, options);
 
-export const localeChanger = getAsyncLifecycle(
-  () => import("./components/choose-locale/change-locale.component"),
-  options
-);
+export const localeChanger = getSyncLifecycle(localeChangerComponent, options);
 
-export const linkComponent = getAsyncLifecycle(
-  () => import("./components/generic-link/generic-link.component"),
-  {
-    featureName: "Link",
-    moduleName,
-  }
-);
+export const linkComponent = getSyncLifecycle(genericLinkComponent, {
+  featureName: "Link",
+  moduleName,
+});

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "npm run watch",
     "test": "jest --passWithNoTests",
-    "watch": "cross-env OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" webpack serve --mode development",
+    "watch": "cross-env OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" OMRS_OFFLINE=\"disable\" webpack serve --mode development",
     "watch:ref": "cross-env OMRS_ESM_IMPORTMAP_URL=\"https://dev3.openmrs.org/openmrs/spa/importmap.json\" OMRS_OFFLINE=\"disable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" webpack serve --mode development",
     "build:production": "cross-env OMRS_ESM_IMPORTMAP_URL=\"https://dev3.openmrs.org/openmrs/spa/importmap.json\" OMRS_OFFLINE=\"enable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"production\" webpack --mode production",
     "build:development": "cross-env OMRS_OFFLINE=\"enable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" webpack --mode development",

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -40,13 +40,23 @@ import ForkTsCheckerWebpackPlugin from "fork-ts-checker-webpack-plugin";
 import { resolve, dirname, basename } from "path";
 import { CleanWebpackPlugin } from "clean-webpack-plugin";
 import CopyWebpackPlugin from "copy-webpack-plugin";
-import { DefinePlugin, container } from "webpack";
+import {
+  DefinePlugin,
+  container,
+  type ModuleOptions,
+  type WebpackOptionsNormalized as WebpackConfiguration,
+  type RuleSetRule,
+} from "webpack";
 import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer";
 import { StatsWriterPlugin } from "webpack-stats-plugin";
 // eslint-disable-next-line no-restricted-imports
 import { merge, mergeWith, isArray } from "lodash";
 import { existsSync, statSync } from "fs";
 import { inc } from "semver";
+
+type OpenmrsWebpackConfig = Omit<Partial<WebpackConfiguration>, "module"> & {
+  module: ModuleOptions;
+};
 
 const production = "production";
 const { ModuleFederationPlugin } = container;
@@ -91,49 +101,57 @@ function fileExistsSync(name: string) {
  * Array values will be concatenated with the existing array.
  * Make sure to modify this object and not reassign it.
  */
-export const overrides = {};
+export const overrides: Partial<OpenmrsWebpackConfig> = {};
 
 /**
  * The keys of this object will override the top-level keys
  * of the webpack config.
  * Make sure to modify this object and not reassign it.
  */
-export const additionalConfig = {};
+export const additionalConfig: Partial<OpenmrsWebpackConfig> = {};
 
 /**
  * This object will be merged into the webpack rule governing
  * the loading of JS, JSX, TS, etc. files.
  * Make sure to modify this object and not reassign it.
  */
-export const scriptRuleConfig = {};
+export const scriptRuleConfig: Partial<RuleSetRule> = {};
 
 /**
  * This object will be merged into the webpack rule governing
  * the loading of CSS files.
  * Make sure to modify this object and not reassign it.
  */
-export const cssRuleConfig = {};
+export const cssRuleConfig: Partial<RuleSetRule> = {};
 
 /**
  * This object will be merged into the webpack rule governing
  * the loading of SCSS files.
  * Make sure to modify this object and not reassign it.
  */
-export const scssRuleConfig = {};
+export const scssRuleConfig: Partial<RuleSetRule> = {};
 
 /**
  * This object will be merged into the webpack rule governing
  * the loading of static asset files.
  * Make sure to modify this object and not reassign it.
  */
-export const assetRuleConfig = {};
+export const assetRuleConfig: Partial<RuleSetRule> = {};
 
 /**
  * This object will be merged into the webpack rule governing
  * the watch options.
  * Make sure to modify this object and not reassign it.
  */
-export const watchConfig = {};
+export const watchConfig: Partial<WebpackConfiguration["watchOptions"]> = {};
+
+/**
+ * This object will be merged with the webpack optimization
+ * object.
+ * Make sure to modify this object and not reassign it.
+ */
+export const optimizationConfig: Partial<WebpackConfiguration["optimization"]> =
+  {};
 
 export default (
   env: Record<string, string>,
@@ -148,7 +166,10 @@ export default (
     main,
     types,
   } = require(resolve(root, "package.json"));
-  const mode = argv.mode || process.env.NODE_ENV || "development";
+  // this typing is provably incorrect, but actually works
+  const mode = (argv.mode ||
+    process.env.NODE_ENV ||
+    "development") as WebpackConfiguration["mode"];
   const filename = basename(browser || main);
   const outDir = dirname(browser || main);
   const srcFile = resolve(root, browser ? main : types);
@@ -175,7 +196,7 @@ export default (
     },
   };
 
-  const baseConfig = {
+  const baseConfig: OpenmrsWebpackConfig = {
     // The only `entry` in the application is the app shell. Everything else is
     // a Webpack Module Federation "remote." This ensures that there is always
     // only one container context--i.e., if we had an entry point per module,
@@ -245,6 +266,17 @@ export default (
     performance: {
       hints: mode === production && "warning",
     },
+    optimization: merge(
+      {
+        // The defaults for both of these are 30; however, due to the modular nature of
+        // the frontend, we want each app to produce substantially
+        splitChunks: {
+          maxAsyncRequests: 3,
+          maxInitialRequests: 1,
+        },
+      },
+      optimizationConfig
+    ),
     plugins: [
       new ForkTsCheckerWebpackPlugin(),
       new CleanWebpackPlugin(),


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This ensures that all components are in the main chunk of the apps in esm-core. This reduces the number of JS requests by about 13, though I think there are more significant gains to be had by adopting this in the patient-chart and patient-management repos, especially.

At least for me, the primary navigation is, expected, a little snappier under this change.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

Added bonus: this adds types for the Webpack config.
