### PR TITLE
(fix) Fix table header color for datatables

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1507,7 +1507,7 @@ Current user session information
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useSession.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useSession.ts#L17)
+[packages/framework/esm-react-utils/src/useSession.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useSession.ts#L16)
 
 ___
 

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -169,6 +169,7 @@
 .cds--data-table thead,
 .cds--data-table tr,
 .cds--data-table td,
+.cds--data-table th,
 .cds--data-table--sort th,
 .cds--data-table--sort th .cds--table-sort__flex {
   min-height: unset;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR adds a style override that tweaks the color of DataTable `th` elements to get them in line with the [designs]
(https://zeroheight.com/23a080e38/p/41d6df-data-tile). 

Presently, following the Carbon version bump, table headers without sorting have a color of #161616, whereas table headers without sorting have a color value of #525252.

![CleanShot 2023-11-07 at 2  08 01@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/f2cc6958-19d0-4715-9da6-8f3e4330edef)


## Screenshots

![CleanShot 2023-11-07 at 1  58 38@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/695203b7-84d7-4630-8584-d1afc891854a)


## Related Issue
*None*

## Other
*None*