### PR TITLE
(feat) Smoother scrolling for locations

### DIFF
--- a/packages/apps/esm-login-app/src/login.resource.ts
+++ b/packages/apps/esm-login-app/src/login.resource.ts
@@ -60,7 +60,17 @@ export function useLoginLocations(
         return null;
       }
 
-      return nextLink.url;
+      const nextUrl = new URL(nextLink.url);
+      // default for production
+      if (nextUrl.origin === window.location.origin) {
+        return nextLink.url;
+      }
+
+      // in development, the request should be funnelled through the local proxy
+      return new URL(
+        `${nextUrl.pathname}${nextUrl.search ? `?${nextUrl.search}` : ""}`,
+        window.location.origin
+      ).toString();
     }
 
     let url = `${fhirBaseUrl}/Location?`;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This PR has two main goals:

1. Supporting scrolling location when run by a developer
2. Making scrolling through the whole location list a little smoother

1 is accomplished just by re-writing the `next` URL. If this comes up, we can think about centralizing the logic. This should keep things reasonably quick for production and enable better caching, while still letting local development work with long location lists.

2 is accomplished by moving the point at which we start to load new locations from the end of the list to about half-way through the list. This may not be the optimal algorithm (and see the attached GIF, it's a little choppy), but its better than only loading new results at the end of the list.

## Screenshots
<!-- Required if you are making UI changes. -->

![location_scroll](https://github.com/openmrs/openmrs-esm-core/assets/52504170/097e694f-f46c-4748-9897-0854960e006c)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
