### PR TITLE
(fix) No toast should be shown if the checkbox for location preference in the location picker wasn't checked

### DIFF
--- a/packages/apps/esm-login-app/src/location-picker/location-picker.resource.ts
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.resource.ts
@@ -83,7 +83,7 @@ export function useDefaultLocation(isUpdateFlow: boolean) {
                 ),
             kind: "success",
           });
-        } else {
+        } else if (defaultLocation) {
           showToast({
             title: t(
               "locationPreferenceRemoved",

--- a/packages/apps/esm-login-app/src/location-picker/location-picker.test.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.test.tsx
@@ -159,6 +159,7 @@ describe("LocationPicker", () => {
       );
 
       expect(setUserProperties).not.toBeCalled();
+      expect(showToast).not.toBeCalled();
     });
 
     it("should redirect to home if user preference in the userProperties is present and the location preference is valid", async () => {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR adds the fix to not show the toast for removed preference if the user doesn't check the checkbox for remembering the location selected for future logins.

## Screenshots
None

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
