### PR TITLE
(fix) Add ability to resize nav header panel based on available content

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/root.scss
+++ b/packages/apps/esm-primary-navigation-app/src/root.scss
@@ -15,6 +15,7 @@
 
 .headerPanel {
   height: max-content;
+  width: fit-content;
 }
 
 .primaryNavContainer {


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Adds the to resize header panels in the navigation bar based on the width of their content.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="528" alt="Capture" src="https://github.com/openmrs/openmrs-esm-core/assets/19533785/7a711448-592a-4699-bd6a-5686a6b79513">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
