### PR TITLE
(fix) Remove background color from overflow menu buttons

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -292,6 +292,11 @@
   width: spacing.$spacing-09;
 }
 
+.cds--overflow-menu {
+  // overflow menu buttons shouldn't have a background color
+  background: none;
+}
+
 /* Search inputs */
 .cds--search-input:focus {
   outline: 2px solid colors.$orange-40;

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -293,8 +293,7 @@
 }
 
 .cds--overflow-menu {
-  // overflow menu buttons shouldn't have a background color
-  background: none;
+  background-color: unset;
 }
 
 /* Search inputs */


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR fixes an issue with the background color of OverflowMenu buttons.

## Screenshots

> Before

![CleanShot 2023-11-21 at 11  55 22@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/d54e2d50-af6e-4019-a517-5ec77c113a3e)

> After

![CleanShot 2023-11-21 at 11  59 31@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/911ae2c5-1729-46d4-8dc8-4fffc7ab1a89)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
