### PR TITLE
O3-2583: Configure Password Field Placement on Login Screen

### DIFF
--- a/packages/apps/esm-login-app/__mocks__/config.mock.ts
+++ b/packages/apps/esm-login-app/__mocks__/config.mock.ts
@@ -1,4 +1,6 @@
-export const mockConfig = {
+import { ConfigSchema } from "../src/config-schema";
+
+export const mockConfig: ConfigSchema = {
   provider: {
     type: "basic",
     loginUrl: "",
@@ -8,6 +10,7 @@ export const mockConfig = {
     enabled: true,
     numberToShow: 3,
     useLoginLocationTag: true,
+    locationsPerRequest: 50,
   },
   logo: {
     src: null,
@@ -16,4 +19,5 @@ export const mockConfig = {
   links: {
     loginSuccess: "${openmrsSpaBase}/home",
   },
+  passwordOnSeparateScreen: true,
 };

--- a/packages/apps/esm-login-app/src/config-schema.ts
+++ b/packages/apps/esm-login-app/src/config-schema.ts
@@ -71,6 +71,12 @@ export const configSchema = {
       _description: "Alt text, shown on hover",
     },
   },
+  passwordOnSeparateScreen: {
+    _type: Type.Boolean,
+    _default: true,
+    _description:
+      "Whether to show the password field on a separate screen. If false, the password field will be shown on the same screen.",
+  },
 };
 
 export interface ConfigSchema {
@@ -81,7 +87,7 @@ export interface ConfigSchema {
   };
   chooseLocation: {
     enabled: boolean;
-    numberToShow: boolean;
+    numberToShow: number;
     locationsPerRequest: number;
     useLoginLocationTag: boolean;
   };
@@ -92,4 +98,5 @@ export interface ConfigSchema {
     src: string;
     alt: string;
   };
+  passwordOnSeparateScreen: boolean;
 }

--- a/packages/apps/esm-login-app/src/login/login.component.tsx
+++ b/packages/apps/esm-login-app/src/login/login.component.tsx
@@ -40,6 +40,7 @@ export interface LoginProps extends LoginReferrer {}
 
 const Login: React.FC<LoginProps> = () => {
   const config = useConfig();
+  const { passwordOnSeparateScreen } = config;
   const isLoginEnabled = useConnectivity();
   const { t } = useTranslation();
   const { user } = useSession();
@@ -52,7 +53,10 @@ const Login: React.FC<LoginProps> = () => {
   const passwordInputRef = useRef<HTMLInputElement>(null);
   const usernameInputRef = useRef<HTMLInputElement>(null);
   const formRef = useRef<HTMLFormElement>(null);
-  const showPassword = location.pathname === "/login/confirm";
+
+  const showUsername = location.pathname === "/login";
+  const showPassword =
+    !passwordOnSeparateScreen || location.pathname === "/login/confirm";
 
   const handleLogin = useCallback(
     (session: Session) => {
@@ -195,7 +199,7 @@ const Login: React.FC<LoginProps> = () => {
           />
         )}
         <Tile className={styles["login-card"]}>
-          {showPassword ? (
+          {passwordOnSeparateScreen && showPassword ? (
             <div className={styles["back-button-div"]}>
               <Button
                 className={styles["back-button"]}
@@ -216,7 +220,7 @@ const Login: React.FC<LoginProps> = () => {
           ) : null}
           <div className={styles["center"]}>{logo}</div>
           <form onSubmit={handleSubmit} ref={formRef}>
-            {!showPassword && (
+            {showUsername && (
               <div className={styles["input-group"]}>
                 <TextInput
                   id="username"
@@ -229,38 +233,22 @@ const Login: React.FC<LoginProps> = () => {
                   autoFocus
                   required
                 />
-                <input
-                  id="password"
-                  style={hidden}
-                  type="password"
-                  name="password"
-                  value={password}
-                  onChange={changePassword}
-                />
-                <Button
-                  className={styles.continueButton}
-                  renderIcon={(props) => <ArrowRight size={24} {...props} />}
-                  type="submit"
-                  iconDescription="Continue to login"
-                  onClick={continueLogin}
-                  disabled={!isLoginEnabled}
-                >
-                  {t("continue", "Continue")}
-                </Button>
+                {passwordOnSeparateScreen && (
+                  <Button
+                    className={styles.continueButton}
+                    renderIcon={(props) => <ArrowRight size={24} {...props} />}
+                    type="submit"
+                    iconDescription="Continue to login"
+                    onClick={continueLogin}
+                    disabled={!isLoginEnabled}
+                  >
+                    {t("continue", "Continue")}
+                  </Button>
+                )}
               </div>
             )}
             {showPassword && (
               <div className={styles["input-group"]}>
-                <input
-                  id="username"
-                  type="text"
-                  name="username"
-                  style={hidden}
-                  value={username}
-                  onChange={changeUsername}
-                  required
-                />
-
                 <PasswordInput
                   id="password"
                   invalidText={t(

--- a/packages/apps/esm-login-app/src/login/login.scss
+++ b/packages/apps/esm-login-app/src/login/login.scss
@@ -96,6 +96,10 @@
   :global(.cds--text-input__field-outer-wrapper) {
     width: 18rem;
   }
+
+  &:not(:last-child) {
+    margin-bottom: 1rem;
+  }
 }
 
 .continueButton {


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.


## Summary
<!-- Please describe what problems your PR addresses. -->

This pull request addresses the enhancement outlined in the ["Configure Password Field Placement on Login Screen (O3-2583)"](https://issues.openmrs.org/browse/O3-2583) ticket under the ["Enhance Login Page Configurability"](https://issues.openmrs.org/browse/O3-2582) epic.

#### Changes Introduced:
1. New Configuration Variable:
    - Introduced a new configuration variable named 'passwordOnSeparateScreen' to allow implementers to customize the placement of the password field on the login screen.
    - The default value is set to 'true' to maintain the existing behavior of having the password field on a separate screen.

2. Configuration Usage:
    - When 'passwordOnSeparateScreen' is set to 'true', the password field appears on a separate screen. (default behaviour)
    - When set to 'false', the password field is displayed on the same screen as the username and other login elements.

## Other
<!-- Anything not covered above -->
Other Changes I've done:
1. The `mockConfig` didn't use the correct type and there were some missing fields, I've fixed it
2. There were some routes passed to the memory router in each tests which haven't any usage. Therefore, I removed them.
1. There were two hidden input fields in the login page for the username and passwords, which I'm not sure the usage of them. I've removed them, but I would appreciate it if @denniskigen @ibacher and @vasharma05  could confirm and validate this modification.. 




## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1025" alt="Screenshot 2023-11-21 at 15 18 40" src="https://github.com/openmrs/openmrs-esm-core/assets/33048395/b6dec9d4-e079-47c5-9ecc-68655aaba0a1">
<img width="1025" alt="image" src="https://github.com/openmrs/openmrs-esm-core/assets/33048395/2ed62cb0-2846-4ff6-ab18-ec4e0e31b4cb">

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://issues.openmrs.org/browse/O3-2583

