### PR TITLE
(chore) Switch to using SwcMinifyWebpackPlugin

### DIFF
--- a/packages/framework/esm-framework/package.json
+++ b/packages/framework/esm-framework/package.json
@@ -66,6 +66,7 @@
     "jest": "^29.7.0",
     "jest-cli": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",
+    "swc-minify-webpack-plugin": "^2.1.1",
     "webpack": "^5.88.0"
   }
 }

--- a/packages/framework/esm-framework/webpack.config.js
+++ b/packages/framework/esm-framework/webpack.config.js
@@ -3,6 +3,7 @@ const { resolve, basename } = require("path");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const { ModuleFederationPlugin } = require("webpack").container;
+const { SwcMinifyWebpackPlugin } = require("swc-minify-webpack-plugin");
 
 const { name, browser, main, peerDependencies } = require("./package.json");
 
@@ -18,6 +19,10 @@ module.exports = (env) => ({
     library: { type: "system" },
   },
   devtool: "source-map",
+  optimization: {
+    minimize: true,
+    minimizer: [new SwcMinifyWebpackPlugin()],
+  },
   module: {
     rules: [
       {

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -72,6 +72,7 @@
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "rxjs": "^6.5.3",
+    "swc-minify-webpack-plugin": "^2.1.1",
     "webpack": "^5.88.0"
   }
 }

--- a/packages/framework/esm-styleguide/webpack.config.js
+++ b/packages/framework/esm-styleguide/webpack.config.js
@@ -3,6 +3,7 @@ const CssMinimizerPlugin = require("css-minimizer-webpack-plugin");
 const { resolve } = require("path");
 const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
+const { SwcMinifyWebpackPlugin } = require("swc-minify-webpack-plugin");
 
 const { peerDependencies } = require("./package.json");
 
@@ -65,7 +66,7 @@ module.exports = (env) => ({
   },
   optimization: {
     minimize: true,
-    minimizer: [new CssMinimizerPlugin(), "..."],
+    minimizer: [new CssMinimizerPlugin(), new SwcMinifyWebpackPlugin()],
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -49,6 +49,7 @@
     "postcss-loader": "^6.2.1",
     "rimraf": "^3.0.2",
     "swc-loader": "^0.2.3",
+    "swc-minify-webpack-plugin": "^2.1.1",
     "tar": "^6.0.5",
     "typescript": "^4.6.4",
     "webpack": "^5.88.0",

--- a/packages/tooling/webpack-config/package.json
+++ b/packages/tooling/webpack-config/package.json
@@ -41,6 +41,7 @@
     "sass-loader": "^12.3.0",
     "style-loader": "^3.3.1",
     "swc-loader": "^0.2.3",
+    "swc-minify-webpack-plugin": "^2.1.1",
     "webpack": "^5.88.0",
     "webpack-bundle-analyzer": "^4.5.0",
     "webpack-stats-plugin": "^1.0.3"

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -49,6 +49,7 @@ import {
 } from "webpack";
 import { BundleAnalyzerPlugin } from "webpack-bundle-analyzer";
 import { StatsWriterPlugin } from "webpack-stats-plugin";
+import { SwcMinifyWebpackPlugin } from "swc-minify-webpack-plugin";
 // eslint-disable-next-line no-restricted-imports
 import { merge, mergeWith, isArray } from "lodash";
 import { existsSync, statSync } from "fs";
@@ -274,7 +275,9 @@ export default (
           maxAsyncRequests: 3,
           maxInitialRequests: 1,
         },
-      },
+        minimize: true,
+        minimizer: [new SwcMinifyWebpackPlugin()],
+      } as WebpackConfiguration["optimization"],
       optimizationConfig
     ),
     plugins: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -2916,6 +2916,7 @@ __metadata:
     jest: "npm:^29.7.0"
     jest-cli: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
+    swc-minify-webpack-plugin: "npm:^2.1.1"
     webpack: "npm:^5.88.0"
   peerDependencies:
     dayjs: 1.x
@@ -3139,6 +3140,7 @@ __metadata:
     react: "npm:^18.1.0"
     react-dom: "npm:^18.1.0"
     rxjs: "npm:^6.5.3"
+    swc-minify-webpack-plugin: "npm:^2.1.1"
     webpack: "npm:^5.88.0"
   peerDependencies:
     "@openmrs/esm-extensions": 5.x
@@ -3181,6 +3183,7 @@ __metadata:
     sass-loader: "npm:^12.3.0"
     style-loader: "npm:^3.3.1"
     swc-loader: "npm:^0.2.3"
+    swc-minify-webpack-plugin: "npm:^2.1.1"
     typescript: "npm:^4.6.4"
     webpack: "npm:^5.88.0"
     webpack-bundle-analyzer: "npm:^4.5.0"
@@ -12963,6 +12966,7 @@ __metadata:
     postcss-loader: "npm:^6.2.1"
     rimraf: "npm:^3.0.2"
     swc-loader: "npm:^0.2.3"
+    swc-minify-webpack-plugin: "npm:^2.1.1"
     tar: "npm:^6.0.5"
     typescript: "npm:^4.6.4"
     webpack: "npm:^5.88.0"
@@ -16017,6 +16021,16 @@ __metadata:
     "@swc/core": ^1.2.147
     webpack: ">=2"
   checksum: 010d84d399525c0185d36d62c86c55ae017e7a90046bc8a39be4b7e07526924037868049f6037bc966da98151cb2600934b96a66279b742d3c413a718b427251
+  languageName: node
+  linkType: hard
+
+"swc-minify-webpack-plugin@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "swc-minify-webpack-plugin@npm:2.1.1"
+  peerDependencies:
+    "@swc/core": ^1.0.0
+    webpack: ^5.0.0
+  checksum: 700b763bda9d77882b36600f14bf1859c9bd44a6953a7c0ae4ad4c21a924f2993427ca1d6c83a5dd502309d84009ead873d4033ac050718959f84a9e552df0b4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Switches from using Terser (default) to SwcMinifyWebpackPlugin, which runs SWC's minifier.

The main goal here is to reduce memory consumption in builds.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
