### PR TITLE
(fix) Pin Carbon versions

### DIFF
--- a/packages/apps/esm-devtools-app/package.json
+++ b/packages/apps/esm-devtools-app/package.json
@@ -50,6 +50,6 @@
     "webpack": "^5.88.0"
   },
   "dependencies": {
-    "@carbon/react": "^1.37.0"
+    "@carbon/react": "~1.37.0"
   }
 }

--- a/packages/apps/esm-implementer-tools-app/package.json
+++ b/packages/apps/esm-implementer-tools-app/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@carbon/react": "^1.37.0",
+    "@carbon/react": "~1.37.0",
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {

--- a/packages/apps/esm-login-app/package.json
+++ b/packages/apps/esm-login-app/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@carbon/react": "^1.37.0",
+    "@carbon/react": "~1.37.0",
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {

--- a/packages/apps/esm-offline-tools-app/package.json
+++ b/packages/apps/esm-offline-tools-app/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@carbon/react": "^1.37.0",
+    "@carbon/react": "~1.37.0",
     "lodash-es": "^4.17.21",
     "swr": "^2.2.2"
   },

--- a/packages/apps/esm-primary-navigation-app/package.json
+++ b/packages/apps/esm-primary-navigation-app/package.json
@@ -38,7 +38,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@carbon/react": "^1.37.0",
+    "@carbon/react": "~1.37.0",
     "lodash-es": "^4.17.21"
   },
   "peerDependencies": {

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@carbon/charts": "^1.12.0",
-    "@carbon/react": "^1.37.0",
+    "@carbon/react": "~1.37.0",
     "@internationalized/date": "^3.5.0",
     "@react-spectrum/datepicker": "^3.8.0",
     "@react-spectrum/provider": "^3.9.0",

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@carbon/react": "^1.37.0",
+    "@carbon/react": "~1.37.0",
     "@openmrs/esm-framework": "workspace:*",
     "@openmrs/esm-styleguide": "workspace:*",
     "dayjs": "^1.10.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1484,7 +1484,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/react@npm:^1.37.0":
+"@carbon/react@npm:~1.37.0":
   version: 1.37.0
   resolution: "@carbon/react@npm:1.37.0"
   dependencies:
@@ -2715,7 +2715,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-app-shell@workspace:packages/shell/esm-app-shell"
   dependencies:
-    "@carbon/react": "npm:^1.37.0"
+    "@carbon/react": "npm:~1.37.0"
     "@openmrs/esm-framework": "workspace:*"
     "@openmrs/esm-styleguide": "workspace:*"
     cross-env: "npm:^7.0.3"
@@ -2827,7 +2827,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-devtools-app@workspace:packages/apps/esm-devtools-app"
   dependencies:
-    "@carbon/react": "npm:^1.37.0"
+    "@carbon/react": "npm:~1.37.0"
     "@openmrs/esm-framework": "npm:^5.3.1"
     "@openmrs/webpack-config": "npm:^5.3.1"
     react: "npm:^18.1.0"
@@ -2943,7 +2943,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-implementer-tools-app@workspace:packages/apps/esm-implementer-tools-app"
   dependencies:
-    "@carbon/react": "npm:^1.37.0"
+    "@carbon/react": "npm:~1.37.0"
     "@openmrs/esm-framework": "npm:^5.3.1"
     "@openmrs/webpack-config": "npm:^5.3.1"
     ace-builds: "npm:^1.4.14"
@@ -2969,7 +2969,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-login-app@workspace:packages/apps/esm-login-app"
   dependencies:
-    "@carbon/react": "npm:^1.37.0"
+    "@carbon/react": "npm:~1.37.0"
     "@openmrs/esm-framework": "npm:^5.3.1"
     "@openmrs/webpack-config": "npm:^5.3.1"
     jest: "npm:^29.7.0"
@@ -2996,7 +2996,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-offline-tools-app@workspace:packages/apps/esm-offline-tools-app"
   dependencies:
-    "@carbon/react": "npm:^1.37.0"
+    "@carbon/react": "npm:~1.37.0"
     "@openmrs/esm-framework": "npm:^5.3.1"
     "@openmrs/webpack-config": "npm:^5.3.1"
     "@types/lodash-es": "npm:^4.17.5"
@@ -3046,7 +3046,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-primary-navigation-app@workspace:packages/apps/esm-primary-navigation-app"
   dependencies:
-    "@carbon/react": "npm:^1.37.0"
+    "@carbon/react": "npm:~1.37.0"
     "@openmrs/esm-framework": "npm:^5.3.1"
     "@openmrs/webpack-config": "npm:^5.3.1"
     jest: "npm:^29.7.0"
@@ -3120,7 +3120,7 @@ __metadata:
   resolution: "@openmrs/esm-styleguide@workspace:packages/framework/esm-styleguide"
   dependencies:
     "@carbon/charts": "npm:^1.12.0"
-    "@carbon/react": "npm:^1.37.0"
+    "@carbon/react": "npm:~1.37.0"
     "@internationalized/date": "npm:^3.5.0"
     "@openmrs/esm-extensions": "workspace:*"
     "@openmrs/esm-react-utils": "workspace:*"


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Frontend builds are currently broken because of how `npx` resolves transitive dependencies. The version of `@carbon/icons` getting resolved is broken [upstream](https://github.com/carbon-design-system/carbon/issues/15306). The fix is to pin the `@carbon/react` dependency to a known working version instead of the latest version.

## Screenshots

> Broken frontend build

![image](https://github.com/openmrs/openmrs-esm-core/assets/8509731/cf228790-0ea5-4e54-860f-3d58de445115)

## Related Issue
*None*

## Other
*None*