### PR TITLE
(fix) O3-2625: Adjust snackbar container position

### DIFF
--- a/packages/framework/esm-styleguide/src/snackbars/_snackbars.scss
+++ b/packages/framework/esm-styleguide/src/snackbars/_snackbars.scss
@@ -1,7 +1,7 @@
 @use "@carbon/styles/scss/spacing";
 
 .omrs-snackbars-container {
-  z-index: 10000;
+  z-index: 1000;
   position: fixed;
   width: 20rem;
   display: flex;
@@ -12,6 +12,13 @@
   flex-direction: column;
   align-items: flex-start;
   justify-content: center;
+}
+
+/* Tablet */
+.omrs-breakpoint-lt-desktop {
+  .omrs-snackbars-container {
+    bottom: 5rem;
+  }
 }
 
 .omrs-snackbar-mounting,

--- a/packages/framework/esm-styleguide/src/snackbars/_snackbars.scss
+++ b/packages/framework/esm-styleguide/src/snackbars/_snackbars.scss
@@ -17,7 +17,7 @@
 /* Tablet */
 .omrs-breakpoint-lt-desktop {
   .omrs-snackbars-container {
-    bottom: 5rem;
+    bottom: 5.5rem;
   }
 }
 

--- a/packages/framework/esm-styleguide/src/snackbars/_snackbars.scss
+++ b/packages/framework/esm-styleguide/src/snackbars/_snackbars.scss
@@ -1,7 +1,7 @@
 @use "@carbon/styles/scss/spacing";
 
 .omrs-snackbars-container {
-  z-index: 1000;
+  z-index: 10000;
   position: fixed;
   width: 20rem;
   display: flex;


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [x]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This fix adjusts the vertical position of the snack bar container in tablet mode so it's not covered by the side rail. It does so by upping its `bottom` positional property value to `5.5rem` so that the element gets positioned 5.5rem above the page's bottom margin.

## Screenshots

> Bug

<img width="809" alt="Screenshot 2023-12-04 at 15 01 35" src="https://github.com/openmrs/openmrs-esm-core/assets/30952856/9f15c4e7-6452-4a94-9f2a-ae5082d7435e">

> Fix

https://github.com/openmrs/openmrs-esm-core/assets/30952856/43d32927-6125-4190-a301-06b05a2179a3

## Related Issue
- https://openmrs.atlassian.net/browse/O3-2625

## Other
<!-- Anything not covered above -->
