### PR TITLE
(fix) Try to temporarily pin @carbon/icons-react version

### DIFF
--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -29,6 +29,7 @@
   ],
   "homepage": "https://github.com/openmrs/openmrs-esm-core#readme",
   "dependencies": {
+    "@carbon/icons-react": "11.26.0",
     "@openmrs/esm-app-shell": "workspace:*",
     "@openmrs/webpack-config": "workspace:*",
     "@pnpm/npm-conf": "^2.1.0",
@@ -67,8 +68,5 @@
     "@types/react": "^18.0.9",
     "@types/rimraf": "^2.0.2",
     "@types/tar": "^4.0.3"
-  },
-  "overrides": {
-    "@carbon/icons-react": "11.26.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1423,7 +1423,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@carbon/icons-react@npm:^11.26.0":
+"@carbon/icons-react@npm:11.26.0, @carbon/icons-react@npm:^11.26.0":
   version: 11.26.0
   resolution: "@carbon/icons-react@npm:11.26.0"
   dependencies:
@@ -12659,6 +12659,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "openmrs@workspace:packages/tooling/openmrs"
   dependencies:
+    "@carbon/icons-react": "npm:11.26.0"
     "@openmrs/esm-app-shell": "workspace:*"
     "@openmrs/webpack-config": "workspace:*"
     "@pnpm/npm-conf": "npm:^2.1.0"


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Retry of #833 with a slightly different technique. I think this works, but only because the version of @carbon/react is pinned as well.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
