### PR TITLE
(feat) Add some colors to CLI output

### DIFF
--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -37,6 +37,7 @@
     "autoprefixer": "^10.4.2",
     "axios": "^0.21.1",
     "browserslist-config-openmrs": "^1.0.1",
+    "chalk": "^4.1.2",
     "copy-webpack-plugin": "^11.0.0",
     "cssnano": "^5.0.16",
     "ejs": "^3.1.8",

--- a/packages/tooling/openmrs/src/utils/importmap.ts
+++ b/packages/tooling/openmrs/src/utils/importmap.ts
@@ -1,13 +1,12 @@
-import { URL } from "url";
-import { basename, resolve } from "path";
-import { existsSync, readFileSync } from "fs";
+import axios from "axios";
+import glob from "glob";
+import { URL } from "node:url";
+import { basename, resolve } from "node:path";
+import { existsSync, readFileSync } from "node:fs";
 import { exec } from "child_process";
 import { logFail, logInfo, logWarn } from "./logger";
 import { startWebpack } from "./webpack";
 import { getMainBundle, getAppRoutes } from "./dependencies";
-import axios from "axios";
-
-import glob = require("glob");
 
 async function readImportmap(path: string, backend?: string, spaPath?: string) {
   if (path.startsWith("http://") || path.startsWith("https://")) {

--- a/packages/tooling/openmrs/src/utils/logger.ts
+++ b/packages/tooling/openmrs/src/utils/logger.ts
@@ -1,13 +1,14 @@
 /* eslint-disable no-console */
+import chalk from "chalk";
 
 export function logInfo(message: string) {
-  console.log(`[openmrs] ${message}`);
+  console.log(`${chalk.green.bold("[openmrs]")} ${message}`);
 }
 
 export function logWarn(message: string) {
-  console.warn(`[openmrs] ${message}`);
+  console.warn(`${chalk.yellow.bold("[openmrs]")} ${chalk.yellow(message)}`);
 }
 
 export function logFail(message: string) {
-  console.error(`[openmrs] ${message}`);
+  console.error(`${chalk.red.bold("[openmrs]")} ${chalk.red(message)}`);
 }

--- a/packages/tooling/openmrs/tsconfig.json
+++ b/packages/tooling/openmrs/tsconfig.json
@@ -2,15 +2,14 @@
   "compilerOptions": {
     "esModuleInterop": true,
     "module": "CommonJS",
-    "target": "es2015",
+    "target": "ES2020",
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
-    "jsx": "react",
     "strictNullChecks": true,
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "outDir": "dist",
-    "lib": ["es5", "es2015", "es2015.promise", "es2016.array.include", "es2018"]
+    "lib": ["es5", "es2020"]
   },
   "include": ["src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -12675,6 +12675,7 @@ __metadata:
     autoprefixer: "npm:^10.4.2"
     axios: "npm:^0.21.1"
     browserslist-config-openmrs: "npm:^1.0.1"
+    chalk: "npm:^4.1.2"
     copy-webpack-plugin: "npm:^11.0.0"
     cssnano: "npm:^5.0.16"
     ejs: "npm:^3.1.8"


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Very simple PR that just adds some colors to output from the CLI. Normal messages have a green prefix. Warnings are displayed entirely in yellow, and errors entirely in red.

## Screenshots

![Screenshot 2023-12-07 at 9 34 20 AM](https://github.com/openmrs/openmrs-esm-core/assets/52504170/bd56a7a9-2b4a-44b1-b688-4ce7c6770956)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
