### PR TITLE
(chore) Add a `start` script to Core

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "build": "turbo run build",
     "build:apps": "turbo run build --filter='@openmrs/*-app'",
     "setup": "yarn install && turbo run build",
-    "start": "openmrs develop --sources packages/apps/esm-*-app",
+    "start": "openmrs develop",
     "verify": "turbo run lint && turbo run test && turbo run typescript",
     "prettier": "prettier \"packages/**/src/**/*\" --write",
     "postinstall": "husky install",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build": "turbo run build",
     "build:apps": "turbo run build --filter='@openmrs/*-app'",
     "setup": "yarn install && turbo run build",
+    "start": "openmrs develop --sources packages/apps/esm-*-app",
     "verify": "turbo run lint && turbo run test && turbo run typescript",
     "prettier": "prettier \"packages/**/src/**/*\" --write",
     "postinstall": "husky install",


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) label. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and **design documentation**.

#### If applicable
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

I've added a `start` script to Core. This means we can now provide a similar DX when it comes to spawning dev servers across other O3 repositories.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
