### PR TITLE
(fix) Fix regression in implementer tools affecting MultiSelect components

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/extension-slot-add.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/extension-slot-add.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { MultiSelect } from '@carbon/react';
+import { FilterableMultiSelect } from '@carbon/react';
 import { ExtensionInternalStore, getExtensionInternalStore } from '@openmrs/esm-framework/src/internal';
 
 const extensionInternalStore = getExtensionInternalStore();
@@ -16,7 +16,7 @@ export function ExtensionSlotAdd({ value, setValue }) {
   }, []);
 
   return (
-    <MultiSelect.Filterable
+    <FilterableMultiSelect
       id={`add-select`}
       items={availableExtensions.map((name) => ({ id: name, label: name }))}
       placeholder="Select extensions"

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/extension-slot-remove.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/extension-slot-remove.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
-import { MultiSelect } from '@carbon/react';
+import { FilterableMultiSelect } from '@carbon/react';
 import { useAssignedExtensions } from '@openmrs/esm-framework';
 
 export function ExtensionSlotRemove({ slotName, slotModuleName, value, setValue }) {
   const assignedIds = useAssignedExtensions(slotName).map((e) => e.id);
 
   return (
-    <MultiSelect.Filterable
+    <FilterableMultiSelect
       id={`add-select`}
       items={assignedIds.map((id) => ({ id, label: id }))}
       placeholder="Select extensions"
       onChange={(value) => setValue(value.selectedItems.map((v) => v.id))}
       initialSelectedItems={value}
+      itemToString={(item) => (item ? item?.label : '')}
     />
   );
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR fixes a regression in the implementer tools panel affecting Carbon [MultiSelect](https://react.carbondesignsystem.com/?path=/docs/components-multiselect--overview) components. It replaces the existing dropdown implementation with the [Filterable](https://react.carbondesignsystem.com/?path=/docs/components-multiselect--overview#filtering) variant of the `MultiSelect` component. See the linked GIF for a visual of the fix in practice. 

## Screenshots

> Before

https://github.com/openmrs/openmrs-esm-core/assets/8509731/80d597a7-712d-4d17-b032-64e3a3d83a67

> After

![implementer-tools-regression](https://github.com/openmrs/openmrs-esm-core/assets/8509731/9d6c563b-0b06-41f7-a562-74c10ddc5927)

## Related Issue
*None*

## Other
*None*