### PR TITLE
(fix) Clicking close button should hide the importmap modal

### DIFF
--- a/packages/apps/esm-devtools-app/src/devtools/import-map-list/modal.component.tsx
+++ b/packages/apps/esm-devtools-app/src/devtools/import-map-list/modal.component.tsx
@@ -58,6 +58,7 @@ const ImportMapModal: React.FC<ImportMapModalProps> = ({ module, isNew, close })
   return (
     <>
       <ModalHeader
+        closeModal={close}
         title={
           isNew
             ? t('addModule', 'Add Module')


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR adds a `closeModal` prop to the modal's `ModalHeader` component so that clicking on the 'x' button on the modal invokes the `close` function.

## Screenshots

https://github.com/openmrs/openmrs-esm-core/assets/8509731/59858e96-7b8c-46b6-a21d-10caee47e8e0

## Related Issue

*None*

## Other

*None*