### PR TITLE
(chore) Removed icon button overrides from the esm-styleguide

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -37,14 +37,6 @@
   display: none;
 }
 
-/* Icon button */
-.cds--btn--icon-only {
-  // Apply a size layout token that sets the default size of the icon-only button to `sm`
-  @include layout.use('size', $default: 'sm');
-  // Remove extraneous top padding from the icon-only button
-  padding-block-start: 0;
-}
-
 /* Side nav */
 .cds--side-nav {
   overflow: auto;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Removes the icon button overrides from esm-styleguide.

## Screenshots
None

## Related Issue
None

## Other
Related PR: https://github.com/openmrs/openmrs-esm-patient-chart/pull/1541

