### PR TITLE
(fix) Restore top nav margin to render offline banner

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -52,7 +52,7 @@ const Navbar: React.FC = () => {
   const HeaderItems = () => (
     <>
       <OfflineBanner />
-      <Header aria-label="OpenMRS">
+      <Header aria-label="OpenMRS" className={styles.topNavHeader}>
         {showHamburger && (
           <HeaderMenuButton
             aria-label="Open menu"


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This pull request addresses the issue where the offline banner overlaps with the top nav header due to the removal of the "margin".

The class already existed but was removed by mistake when some changes were made to this component.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![image](https://github.com/openmrs/openmrs-esm-core/assets/94977371/9bca4884-52fa-420a-9809-439847aa1864)

After:
![image](https://github.com/openmrs/openmrs-esm-core/assets/94977371/94a8bd17-768b-4e29-b226-b8944c032605)
## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

Thanks,
CC: @ibacher 
