### PR TITLE
(feat) Enable online and offline extensions through configuration

### DIFF
--- a/packages/framework/esm-config/src/types.ts
+++ b/packages/framework/esm-config/src/types.ts
@@ -33,6 +33,8 @@ export interface ConfigObject {
 
 export interface DisplayConditionsConfigObject {
   privileges?: string[];
+  online?: boolean;
+  offline?: boolean;
 }
 
 export type ConfigValue = string | number | boolean | void | Array<any> | object;

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -322,8 +322,8 @@ function getAssignedExtensionsFromSlotData(
         config: extensionConfig,
         featureFlag: extension.featureFlag,
         meta: extension.meta,
-        online: extension.online ?? true,
-        offline: extension.offline ?? false,
+        online: extensionConfig?.['Display conditions']?.online ?? extension.online ?? true,
+        offline: extensionConfig?.['Display conditions']?.offline ?? extension.offline ?? false,
       });
     }
   }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Implemented feature to enable both online and offline extensions based on configuration settings. The configuration options provide users with control over the extension. 

Below is an example of how to change/enable the display condition (online and offline) using configuration:

```{
  "@openmrs/esm-home-app": {
    "extensionSlots": {
      "homepage-widgets-slot": {
        "order": [
          "active-visits-widget"
        ],
        "configure": {
          "active-visits-widget": {
            "Display conditions": {
              "online": true,
              "offline": true,
              "privileges": [
                "Widget: active visits"
              ]
            }
          }
        }
      }
    }
  }
}
```

In this case, the widget would be shown in both online and offline mode.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

Thanks, 
CC: @ibacher 
