### PR TITLE
fix: Better type support for getConfig

### DIFF
--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -198,9 +198,10 @@ describe('getConfig', () => {
 
   it('uses config values from the provided config file', async () => {
     Config.defineConfigSchema('foo-module', { foo: { _default: 'qux' } });
+    type FooConfig = { foo: string };
     const testConfig = { 'foo-module': { foo: 'bar' } };
     Config.provide(testConfig);
-    const config = await Config.getConfig('foo-module');
+    const config = await Config.getConfig<FooConfig>('foo-module');
     expect(config.foo).toBe('bar');
     expect(console.error).not.toHaveBeenCalled();
   });

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -198,13 +198,13 @@ export function provide(config: Config, sourceName = 'provided') {
  *
  * @param moduleName The name of the module for which to look up the config
  */
-export function getConfig(moduleName: string): Promise<Config> {
-  return new Promise<Config>((resolve) => {
+export function getConfig<T = Record<string, any>>(moduleName: string): Promise<T> {
+  return new Promise<T>((resolve) => {
     const store = getConfigStore(moduleName);
     function update(state: ConfigStore) {
       if (state.loaded && state.config) {
         const config = omit(['Display conditions', 'Translation overrides'], state.config);
-        resolve(config);
+        resolve(config as T);
         unsubscribe && unsubscribe();
       }
     }

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1796,13 +1796,19 @@ ___
 
 ### getConfig
 
-▸ **getConfig**(`moduleName`): `Promise`<[`Config`](interfaces/Config.md)\>
+▸ **getConfig**<`T`\>(`moduleName`): `Promise`<`T`\>
 
 A promise-based way to access the config as soon as it is fully loaded.
 If it is already loaded, resolves the config in its present state.
 
 This is a useful function if you need to get the config in the course
 of the execution of a function.
+
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | `Record`<`string`, `any`\> |
 
 #### Parameters
 
@@ -1812,7 +1818,7 @@ of the execution of a function.
 
 #### Returns
 
-`Promise`<[`Config`](interfaces/Config.md)\>
+`Promise`<`T`\>
 
 #### Defined in
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Allows providing a type to `getConfig` the way we do with `useConfig`.

e.g. `const config = getConfig<RegistrationConfig>("@openmrs/esm-patient-registration-app")`
