### PR TITLE
fix: Fix config mocks

### DIFF
--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import type {} from '@openmrs/esm-globals';
-import { createStore, StoreApi } from 'zustand';
+import { createStore, type StoreApi } from 'zustand';
 import { NEVER, of } from 'rxjs';
 import { interpolateUrl } from '@openmrs/esm-config';
-import { SessionStore } from '@openmrs/esm-api';
+import { type SessionStore } from '@openmrs/esm-api';
 export { parseDate, formatDate, formatDatetime, formatTime, age } from '@openmrs/esm-utils';
 export { interpolateString, interpolateUrl, validators, validator } from '@openmrs/esm-config';
 
@@ -144,9 +144,9 @@ function isOrdinaryObject(x) {
   return !!x && x.constructor === Object;
 }
 
-export const getConfig = jest.fn().mockReturnValue(getDefaults(configSchema));
+export const getConfig = jest.fn().mockImplementation(() => Promise.resolve(getDefaults(configSchema)));
 
-export const useConfig = jest.fn().mockReturnValue(getDefaults(configSchema));
+export const useConfig = jest.fn().mockImplementation(() => getDefaults(configSchema));
 
 export function defineConfigSchema(moduleName, schema) {
   configSchema = schema;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

These mocks weren't working because the return value of the mock was getting set at initialization time, which was before `defineConfigSchema` would get called. This should make it possible to replace a lot of config-mocking code with calls to `defineConfigSchema`.
