### PR TITLE
(feat) O3-2115: Using name templates in O3

### DIFF
--- a/packages/apps/esm-login-app/src/location-picker/location-picker.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.component.tsx
@@ -16,6 +16,7 @@ import { useLoginLocations } from '../login.resource';
 import styles from './location-picker.scss';
 import { useDefaultLocation } from './location-picker.resource';
 import type { ConfigSchema } from '../config-schema';
+import { PatientName } from '@openmrs/esm-framework';
 
 interface LocationPickerProps {
   hideWelcomeMessage?: boolean;
@@ -169,7 +170,7 @@ const LocationPicker: React.FC<LocationPickerProps> = ({ hideWelcomeMessage, cur
         <div className={styles.locationCard}>
           <div className={styles.paddedContainer}>
             <p className={styles.welcomeTitle}>
-              {t('welcome', 'Welcome')} {currentUser}
+              {t('welcome', 'Welcome')} <PatientName patientUuid={user?.person?.uuid} />
             </p>
             <p className={styles.welcomeMessage}>
               {t(

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
@@ -22,7 +22,7 @@ const SideMenuPanel: React.FC<SideMenuPanelProps> = ({ expanded, hidePanel }) =>
 
   useEffect(() => {
     window.addEventListener('popstate', hidePanel);
-    return window.addEventListener('popstate', hidePanel);
+    return window.removeEventListener('popstate', hidePanel);
   }, [hidePanel]);
 
   return expanded && <LeftNavMenu ref={menuRef} isChildOfHeader />;

--- a/packages/apps/esm-primary-navigation-app/src/components/user-panel-switcher-item/user-panel-switcher.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/user-panel-switcher-item/user-panel-switcher.component.tsx
@@ -3,6 +3,7 @@ import { Switcher } from '@carbon/react';
 import { UserAvatarFilledAlt } from '@carbon/react/icons';
 import type { LoggedInUser } from '@openmrs/esm-framework';
 import styles from './user-panel-switcher.scss';
+import { PatientName } from '@openmrs/esm-framework';
 
 export interface UserPanelSwitcherItemProps {
   user: LoggedInUser;
@@ -12,7 +13,9 @@ const UserPanelSwitcher: React.FC<UserPanelSwitcherItemProps> = ({ user }) => (
   <div className={styles.switcherContainer}>
     <Switcher aria-label="Switcher Container">
       <UserAvatarFilledAlt size={20} />
-      <p>{user.person.display}</p>
+      <p>
+        <PatientName patientUuid={user?.person?.uuid} />
+      </p>
     </Switcher>
   </div>
 );

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -455,6 +455,16 @@ ___
 
 ___
 
+### NameToken
+
+Ƭ **NameToken**: ``"givenName"`` \| ``"middleName"`` \| ``"familyName"`` \| ``"familyName2"`` \| `string`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L15)
+
+___
+
 ### OpenmrsRoutes
 
 Ƭ **OpenmrsRoutes**: `Record`<`string`, [`OpenmrsAppRoutes`](interfaces/OpenmrsAppRoutes.md)\>

--- a/packages/framework/esm-framework/docs/interfaces/NameTemplate.md
+++ b/packages/framework/esm-framework/docs/interfaces/NameTemplate.md
@@ -1,0 +1,85 @@
+[@openmrs/esm-framework](../API.md) / NameTemplate
+
+# Interface: NameTemplate
+
+## Table of contents
+
+### Properties
+
+- [codeName](NameTemplate.md#codename)
+- [country](NameTemplate.md#country)
+- [displayName](NameTemplate.md#displayname)
+- [lineByLineFormat](NameTemplate.md#linebylineformat)
+- [lines](NameTemplate.md#lines)
+- [nameMappings](NameTemplate.md#namemappings)
+- [sizeMappings](NameTemplate.md#sizemappings)
+
+## Properties
+
+### codeName
+
+• **codeName**: `string`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L19)
+
+___
+
+### country
+
+• **country**: ``null``
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L20)
+
+___
+
+### displayName
+
+• **displayName**: `string`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L18)
+
+___
+
+### lineByLineFormat
+
+• **lineByLineFormat**: `string`[]
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:27](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L27)
+
+___
+
+### lines
+
+• **lines**: { `codeName?`: `string` ; `displaySize?`: ``"30"`` ; `displayText`: `string` ; `isToken`: ``"IS_NOT_NAME_TOKEN"`` \| ``"IS_NAME_TOKEN"``  }[]
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L21)
+
+___
+
+### nameMappings
+
+• **nameMappings**: `Object`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:28](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L28)
+
+___
+
+### sizeMappings
+
+• **sizeMappings**: `Object`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:31](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L31)

--- a/packages/framework/esm-framework/docs/interfaces/PatientPreferredName.md
+++ b/packages/framework/esm-framework/docs/interfaces/PatientPreferredName.md
@@ -1,0 +1,85 @@
+[@openmrs/esm-framework](../API.md) / PatientPreferredName
+
+# Interface: PatientPreferredName
+
+## Table of contents
+
+### Properties
+
+- [display](PatientPreferredName.md#display)
+- [familyName](PatientPreferredName.md#familyname)
+- [familyName2](PatientPreferredName.md#familyname2)
+- [givenName](PatientPreferredName.md#givenname)
+- [middleName](PatientPreferredName.md#middlename)
+- [uuid](PatientPreferredName.md#uuid)
+- [voided](PatientPreferredName.md#voided)
+
+## Properties
+
+### display
+
+• **display**: `string`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:6](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L6)
+
+___
+
+### familyName
+
+• **familyName**: `string`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L10)
+
+___
+
+### familyName2
+
+• **familyName2**: `string`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:11](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L11)
+
+___
+
+### givenName
+
+• **givenName**: `string`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L8)
+
+___
+
+### middleName
+
+• **middleName**: `string`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:9](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L9)
+
+___
+
+### uuid
+
+• **uuid**: `string`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:7](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L7)
+
+___
+
+### voided
+
+• **voided**: `boolean`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/usePatientName.ts:12](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/usePatientName.ts#L12)

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -283,6 +283,12 @@ export function useOpenmrsSWR(key: string | Array<any>) {
 
 export const useDebounce = jest.fn().mockImplementation((value) => value);
 
+export const usePatientName = jest.fn().mockImplementation(() => ({
+  isLoadingName: false,
+  patientName: 'Patient Name',
+  nameTemplate: null,
+}));
+
 /* esm-styleguide */
 
 export const showNotification = jest.fn();

--- a/packages/framework/esm-react-utils/src/PatientName.tsx
+++ b/packages/framework/esm-react-utils/src/PatientName.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import usePatientName from './usePatientName';
+import { SkeletonText } from '@carbon/react';
+
+interface PatientNameProps {
+  patientUuid: string;
+  className?: any;
+}
+const PatientName: React.FC<PatientNameProps> = ({ patientUuid }) => {
+  const { patientName, isLoadingName } = usePatientName(patientUuid);
+
+  if (isLoadingName) {
+    return <SkeletonText />;
+  }
+
+  return <>{patientName}</>;
+};
+
+export default PatientName;

--- a/packages/framework/esm-react-utils/src/PatientName.tsx
+++ b/packages/framework/esm-react-utils/src/PatientName.tsx
@@ -6,6 +6,12 @@ interface PatientNameProps {
   patientUuid: string;
   className?: any;
 }
+
+/**
+ * A react component to render patient name
+ *
+ * Please note that the person and patient UUID are the same.
+ */
 const PatientName: React.FC<PatientNameProps> = ({ patientUuid }) => {
   const { patientName, isLoadingName } = usePatientName(patientUuid);
 

--- a/packages/framework/esm-react-utils/src/index.ts
+++ b/packages/framework/esm-react-utils/src/index.ts
@@ -30,3 +30,5 @@ export * from './useStore';
 export * from './useVisit';
 export * from './useVisitTypes';
 export * from './usePagination';
+export * from './PatientName';
+export * from './usePatientName';

--- a/packages/framework/esm-react-utils/src/public.ts
+++ b/packages/framework/esm-react-utils/src/public.ts
@@ -26,3 +26,5 @@ export * from './useStore';
 export * from './useVisit';
 export * from './useVisitTypes';
 export * from './usePagination';
+export * from './PatientName';
+export * from './usePatientName';

--- a/packages/framework/esm-react-utils/src/usePatientName.ts
+++ b/packages/framework/esm-react-utils/src/usePatientName.ts
@@ -55,6 +55,12 @@ function useNameTemplate() {
   };
 }
 
+/**
+ * This react hook returns the name of the patient/ person according
+ * to the name template defined in the global properties
+ * @param patientUuid string
+ */
+
 export default function usePatientName(patientUuid: string) {
   const { isLoadingPersonName, preferredName } = useRestPatient(patientUuid);
   const { isLoadingNameTemplate, nameTemplate } = useNameTemplate();

--- a/packages/framework/esm-react-utils/src/usePatientName.ts
+++ b/packages/framework/esm-react-utils/src/usePatientName.ts
@@ -1,0 +1,82 @@
+import { useMemo } from 'react';
+import { type FetchResponse, openmrsFetch } from '@openmrs/esm-framework';
+import useSWR from 'swr';
+
+export interface PatientPreferredName {
+  display: string;
+  uuid: string;
+  givenName: string;
+  middleName: string;
+  familyName: string;
+  familyName2: string;
+  voided: boolean;
+}
+
+export type NameToken = 'givenName' | 'middleName' | 'familyName' | 'familyName2' | string;
+
+export interface NameTemplate {
+  displayName: string;
+  codeName: string;
+  country: null;
+  lines: Array<{
+    isToken: 'IS_NOT_NAME_TOKEN' | 'IS_NAME_TOKEN';
+    displayText: string;
+    codeName?: NameToken;
+    displaySize?: '30';
+  }>;
+  lineByLineFormat: Array<NameToken>;
+  nameMappings: {
+    [x in NameToken]: string;
+  };
+  sizeMappings: {
+    [x in NameToken]: string;
+  };
+}
+
+function useRestPatient(patientUuid: string) {
+  const { isLoading: isLoadingPersonName, data } = useSWR<FetchResponse<{ preferredName: PatientPreferredName }>>(
+    `/ws/rest/v1/person/${patientUuid}?v=custom:(preferredName)`,
+    openmrsFetch,
+  );
+  return {
+    isLoadingPersonName,
+    preferredName: data?.data?.preferredName,
+  };
+}
+
+function useNameTemplate() {
+  const { isLoading: isLoadingNameTemplate, data } = useSWR<FetchResponse<NameTemplate>>(
+    '/ws/rest/v1/nametemplate',
+    openmrsFetch,
+  );
+  return {
+    isLoadingNameTemplate,
+    nameTemplate: data?.data,
+  };
+}
+
+export default function usePatientName(patientUuid: string) {
+  const { isLoadingPersonName, preferredName } = useRestPatient(patientUuid);
+  const { isLoadingNameTemplate, nameTemplate } = useNameTemplate();
+
+  const patientName = useMemo(() => {
+    if (isLoadingNameTemplate || isLoadingPersonName) {
+      return '';
+    }
+    const lineByLineFormat = nameTemplate?.lineByLineFormat ?? [];
+    return lineByLineFormat
+      ?.reduce((acc: Array<string>, nameToken) => {
+        if (preferredName?.[nameToken]) {
+          acc.push(preferredName?.[nameToken]);
+        }
+        return acc;
+      }, [])
+      ?.join(' ');
+  }, [isLoadingNameTemplate, isLoadingPersonName, nameTemplate, preferredName]);
+
+  return {
+    patientName,
+    nameTemplate,
+    isLoadingName: isLoadingNameTemplate || isLoadingPersonName,
+  };
+}

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -106,6 +106,15 @@
 }
 
 /* Tabs */
+
+.cds--tabs .cds--tabs__nav-item--selected {
+  border-bottom: 2px solid var(--brand-03);
+}
+.cds--tabs .cds--tabs__nav-link:active,
+.cds--tabs .cds--tabs__nav-link:focus {
+  outline: 2px solid var(--brand-03);
+}
+
 .cds--tabs--scrollable .cds--tabs--scrollable__nav-item--selected .cds--tabs--scrollable__nav-link,
 .cds--tabs--scrollable .cds--tabs--scrollable__nav-item--selected .cds--tabs--scrollable__nav-link:active,
 .cds--tabs--scrollable .cds--tabs--scrollable__nav-item--selected .cds--tabs--scrollable__nav-link:focus {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR introduces the name templates in the O3 framework. To use the name templates to get the name of the patient, you can use either of the 2 options below.

1. `PatientName` component
```
import {PatientName} from '@openmrs/esm-framework';

...

return <PatientName patientUuid={patientUuid} />
```

2. `usePatientName`
```
import {usePatientName} from '@openmrs/esm-framework';

const { isLoadingName, patientName, nameTemplate} = usePatientName(patientUuid) 
```

> **Please note that the person and patient UUIDs are the same.**


## Screenshots
None

## Related Issue
https://openmrs.atlassian.net/browse/O3-2115

## Other
<!-- Anything not covered above -->
