### PR TITLE
(feat) Allow ConfigurableLink to have a callback before navigating

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -3174,7 +3174,7 @@ A React link component which calls [navigate](API.md#navigate) when clicked
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:29](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L29)
+[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:32](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L32)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/ConfigurableLinkProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/ConfigurableLinkProps.md
@@ -283,6 +283,10 @@
 - [unselectable](ConfigurableLinkProps.md#unselectable)
 - [vocab](ConfigurableLinkProps.md#vocab)
 
+### Navigation Methods
+
+- [onBeforeNavigate](ConfigurableLinkProps.md#onbeforenavigate)
+
 ## Navigation Properties
 
 ### templateParams
@@ -291,7 +295,7 @@
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L18)
+[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L19)
 
 ___
 
@@ -301,7 +305,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L17)
+[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L18)
 
 ___
 
@@ -4156,3 +4160,17 @@ AnchorHTMLAttributes.vocab
 #### Defined in
 
 node_modules/@types/react/index.d.ts:1882
+
+## Navigation Methods
+
+### onBeforeNavigate
+
+▸ `Optional` **onBeforeNavigate**(): `void`
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L20)

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import type {} from '@openmrs/esm-globals';
 import { createStore, type StoreApi } from 'zustand';
 import { NEVER, of } from 'rxjs';
-import { interpolateUrl } from '@openmrs/esm-config';
 import { type SessionStore } from '@openmrs/esm-api';
 import { getDefaultsFromConfigSchema } from '@openmrs/esm-utils';
 export {
@@ -14,6 +13,7 @@ export {
   age,
 } from '@openmrs/esm-utils';
 export { interpolateString, interpolateUrl, validators, validator } from '@openmrs/esm-config';
+export { ConfigurableLink } from '@openmrs/esm-react-utils';
 
 window.i18next = { ...window.i18next, language: 'en' };
 
@@ -157,12 +157,6 @@ export function defineExtensionConfigSchema(extensionName, schema) {
 }
 
 export const navigate = jest.fn();
-
-export const ConfigurableLink = jest
-  .fn()
-  .mockImplementation((config: { to: string; children: React.ReactNode }) => (
-    <a href={interpolateUrl(config.to)}>{config.children}</a>
-  ));
 
 /* esm-dynamic-loading */
 export const importDynamic = jest.fn();

--- a/packages/framework/esm-react-utils/src/ConfigurableLink.test.tsx
+++ b/packages/framework/esm-react-utils/src/ConfigurableLink.test.tsx
@@ -18,14 +18,14 @@ describe(`ConfigurableLink`, () => {
   const path = '${openmrsSpaBase}/home';
   beforeEach(() => {
     mockNavigate.mockClear();
+  });
+
+  it(`interpolates the link`, async () => {
     render(
       <ConfigurableLink to={path} className="fancy-link">
         SPA Home
       </ConfigurableLink>,
     );
-  });
-
-  it(`interpolates the link`, async () => {
     const link = screen.getByRole('link', { name: /spa home/i });
     expect(link).toBeTruthy();
     expect(link.closest('a')).toHaveClass('fancy-link');
@@ -33,6 +33,11 @@ describe(`ConfigurableLink`, () => {
   });
 
   it(`calls navigate on normal click but not special clicks`, async () => {
+    render(
+      <ConfigurableLink to={path} className="fancy-link">
+        SPA Home
+      </ConfigurableLink>,
+    );
     const user = userEvent.setup();
 
     const link = screen.getByRole('link', { name: /spa home/i });
@@ -43,6 +48,11 @@ describe(`ConfigurableLink`, () => {
   });
 
   it(`calls navigate on enter`, async () => {
+    render(
+      <ConfigurableLink to={path} className="fancy-link">
+        SPA Home
+      </ConfigurableLink>,
+    );
     const user = userEvent.setup();
 
     expect(navigate).not.toHaveBeenCalled();

--- a/packages/framework/esm-react-utils/src/ConfigurableLink.test.tsx
+++ b/packages/framework/esm-react-utils/src/ConfigurableLink.test.tsx
@@ -50,4 +50,19 @@ describe(`ConfigurableLink`, () => {
     await user.type(link, '{enter}');
     expect(navigate).toHaveBeenCalledWith({ to: path });
   });
+
+  it('executes onBeforeNavigate callback if provided', async () => {
+    const onBeforeNavigate = jest.fn();
+    render(
+      <ConfigurableLink to={path} onBeforeNavigate={onBeforeNavigate}>
+        SPA Home
+      </ConfigurableLink>,
+    );
+
+    const user = userEvent.setup();
+    const link = screen.getByRole('link', { name: /spa home/i });
+    await user.click(link);
+    expect(onBeforeNavigate).toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith({ to: path });
+  });
 });

--- a/packages/framework/esm-react-utils/src/ConfigurableLink.tsx
+++ b/packages/framework/esm-react-utils/src/ConfigurableLink.tsx
@@ -3,9 +3,10 @@ import React, { type MouseEvent, type AnchorHTMLAttributes, type PropsWithChildr
 import type { TemplateParams } from '@openmrs/esm-config';
 import { navigate, interpolateUrl } from '@openmrs/esm-config';
 
-function handleClick(event: MouseEvent, to: string, templateParams?: TemplateParams) {
+function handleClick(event: MouseEvent, to: string, templateParams?: TemplateParams, onBeforeNavigate?: () => void) {
   if (!event.metaKey && !event.ctrlKey && !event.shiftKey && event.button == 0) {
     event.preventDefault();
+    onBeforeNavigate?.();
     navigate({ to, templateParams });
   }
 }
@@ -16,25 +17,28 @@ function handleClick(event: MouseEvent, to: string, templateParams?: TemplatePar
 export interface ConfigurableLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string;
   templateParams?: TemplateParams;
+  onBeforeNavigate?: () => void;
 }
 
 /**
  * A React link component which calls [[navigate]] when clicked
  *
  * @param to The target path or URL. Supports interpolation. See [[navigate]]
- * @param urlParams: A dictionary of values to interpolate into the URL, in addition to the default keys `openmrsBase` and `openmrsSpaBase`.
+ * @param templateParams: A dictionary of values to interpolate into the URL, in addition to the default keys `openmrsBase` and `openmrsSpaBase`.
+ * @param onBeforeNavigate A callback to be called just before navigation occurs
  * @param children Inline elements within the link
  * @param otherProps Any other valid props for an <a> tag except `href` and `onClick`
  */
 export function ConfigurableLink({
   to,
   templateParams,
+  onBeforeNavigate,
   children,
   ...otherProps
 }: PropsWithChildren<ConfigurableLinkProps>) {
   return (
     <a
-      onClick={(event) => handleClick(event, to, templateParams)}
+      onClick={(event) => handleClick(event, to, templateParams, onBeforeNavigate)}
       href={interpolateUrl(to, templateParams)}
       {...otherProps}
     >


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Adds a callback parameter to `ConfigurableLink`. This will allow us to use it for patient name links. We used to use it for patient name links until https://github.com/openmrs/openmrs-esm-patient-management/pull/228 . But that change created regressions relating to alternative clicks. Using `ConfigurableLink` consistently will ensure we don't have bugs like https://openmrs.atlassian.net/browse/O3-1354.


## Related Issue
Related to https://openmrs.atlassian.net/browse/O3-1354

