### PR TITLE
(fix) Amend ContentSwitcher style overrides

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -56,6 +56,26 @@
 /* Content Switcher */
 .cds--content-switcher {
   @include layout.use('size', $default: 'sm');
+
+  & > :first-child {
+    border-bottom-left-radius: 0.25rem;
+    border-right: unset !important;
+    border-top-left-radius: 0.25rem;
+
+    [aria-selected='false'] {
+      border-left: 0.0625rem solid colors.$blue-30 !important;
+    }
+  }
+
+  & > :last-child {
+    border-bottom-right-radius: 0.25rem;
+    border-left: unset !important;
+    border-top-right-radius: 0.25rem;
+
+    [aria-selected='false'] {
+      border-right: 0.0625rem solid colors.$blue-30 !important;
+    }
+  }
 }
 
 .cds--content-switcher-btn {
@@ -68,16 +88,12 @@
     background-color: transparent !important;
   }
 
-  &:first-child {
-    border-bottom-left-radius: 0.25rem;
-    border-left: 0.0625rem solid colors.$blue-30 !important;
-    border-top-left-radius: 0.25rem;
-  }
+  &.cds--btn--primary {
+    background-color: unset;
 
-  &:last-child {
-    border-bottom-right-radius: 0.25rem;
-    border-right: 0.0625rem solid colors.$blue-30 !important;
-    border-top-right-radius: 0.25rem;
+    &:hover {
+      background-color: colors.$gray-10-hover;
+    }
   }
 
   &::before {
@@ -88,8 +104,12 @@
 
   &.cds--content-switcher--selected {
     border: 1px solid colors.$blue-60 !important;
-    background-color: colors.$blue-10;
-    color: colors.$blue-60;
+    background-color: colors.$blue-10 !important;
+    color: colors.$blue-60 !important;
+
+    svg {
+      fill: colors.$blue-60 !important;
+    }
 
     &::after {
       background-color: colors.$blue-10;
@@ -103,6 +123,22 @@
       border: 0 !important;
     }
   }
+}
+
+.cds--content-switcher--icon-only .cds--content-switcher-popover__wrapper:first-child .cds--content-switcher-btn {
+  border-left: unset;
+}
+
+.cds--content-switcher--icon-only .cds--content-switcher-popover__wrapper:last-child .cds--content-switcher-btn {
+  border-right: unset;
+}
+
+.cds--content-switcher:not(.cds--content-switcher--icon-only) .cds--content-switcher-btn:first-child {
+  border-left: 0.0625rem solid colors.$blue-30;
+}
+
+.cds--content-switcher:not(.cds--content-switcher--icon-only) .cds--content-switcher-btn:last-child {
+  border-right: 0.0625rem solid colors.$blue-30;
 }
 
 /* Tabs */

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -356,7 +356,6 @@ html[dir='rtl'] {
   }
 
   .cds--btn--secondary {
-    padding: calc(0.375rem - 3px) 12px calc(0.375rem - 3px) 60px;
     svg {
       left: spacing.$spacing-05;
       right: unset;
@@ -407,20 +406,112 @@ html[dir='rtl'] {
   }
 
   .cds--content-switcher {
-    & > :last-child {
-      border-bottom-left-radius: 0.25rem;
-      border-top-left-radius: 0.25rem;
-      border-bottom-right-radius: unset;
-      border-top-right-radius: unset;
-      border-left: 0.0625rem solid #a6c8ff;
-    }
+    @include layout.use('size', $default: 'sm');
+
     & > :first-child {
-      border-right: 0.0625rem solid #a6c8ff;
-      border-bottom-right-radius: 0.25rem;
-      border-top-right-radius: 0.25rem;
-      border-bottom-left-radius: unset;
-      border-top-left-radius: unset;
+      border-bottom-right-radius: 0.25rem !important;
+      border-left: unset !important;
+      border-right: unset !important;
+      border-top-right-radius: 0.25rem !important;
+
+      [aria-selected='false'] {
+        border-right: 0.0625rem solid colors.$blue-30;
+        border-left: unset !important;
+      }
     }
+
+    & > :last-child {
+      border-bottom-left-radius: 0.25rem !important;
+      border-left: unset;
+      border-right: unset;
+      border-top-left-radius: 0.25rem !important;
+
+      [aria-selected='false'] {
+        border-left: 0.0625rem solid colors.$blue-30;
+        border-right: unset !important;
+      }
+    }
+
+    .cds--btn--icon-only {
+      display: flex;
+      align-items: center;
+    }
+  }
+
+  .cds--content-switcher-btn {
+    &::after {
+      background-color: transparent !important;
+    }
+
+    &.cds--btn--primary {
+      background-color: unset;
+
+      &:hover {
+        background-color: colors.$gray-10-hover;
+      }
+    }
+
+    &::before {
+      background-color: colors.$blue-30;
+      height: 100%;
+      z-index: 0;
+    }
+
+    &.cds--content-switcher--selected {
+      border: 1px solid colors.$blue-60 !important;
+      background-color: colors.$blue-10 !important;
+      color: colors.$blue-60 !important;
+
+      svg {
+        fill: colors.$blue-60 !important;
+      }
+
+      &::after {
+        background-color: colors.$blue-10;
+      }
+
+      &::before {
+        background-color: transparent;
+      }
+
+      &:disabled {
+        border: 0 !important;
+      }
+    }
+  }
+
+  .cds--content-switcher--icon-only .cds--content-switcher-popover__wrapper:first-child .cds--content-switcher-btn {
+    border-bottom-right-radius: 0.25rem !important;
+    border-top-right-radius: 0.25rem !important;
+    border-top-left-radius: unset !important;
+    border-bottom-left-radius: unset !important;
+  }
+
+  .cds--content-switcher--icon-only .cds--content-switcher-popover__wrapper:last-child .cds--content-switcher-btn {
+    border-bottom-left-radius: 0.25rem !important;
+    border-top-left-radius: 0.25rem !important;
+    border-top-right-radius: unset !important;
+    border-bottom-right-radius: unset !important;
+  }
+
+  .cds--content-switcher--icon-only .cds--content-switcher-popover__wrapper:first-child .cds--content-switcher-btn {
+    border-left: unset;
+  }
+
+  .cds--content-switcher--icon-only .cds--content-switcher-popover__wrapper:last-child .cds--content-switcher-btn {
+    border-right: unset;
+  }
+
+  .cds--content-switcher:not(.cds--content-switcher--icon-only) .cds--content-switcher-btn:first-child {
+    border-right: 0.0625rem solid colors.$blue-30;
+    border-bottom-left-radius: unset !important;
+    border-top-left-radius: unset !important;
+  }
+
+  .cds--content-switcher:not(.cds--content-switcher--icon-only) .cds--content-switcher-btn:last-child {
+    border-left: 0.0625rem solid colors.$blue-30;
+    border-bottom-right-radius: unset !important;
+    border-top-right-radius: unset !important;
   }
 
   .cds--date-picker-input__wrapper {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR updates style overrides affecting the Carbon [ContentSwitcher](https://react.carbondesignsystem.com/?path=/docs/components-contentswitcher--overview) component to align with the available [design guidelines](https://zeroheight.com/23a080e38/p/55274c-content-switcher/b/17b091). These changes were prompted by fixes in https://github.com/openmrs/openmrs-esm-patient-chart/pull/1553/files#diff-817781f77acfc04bd6794ae62d233f09be5f7cab6cf7b19ee80d568933d877c3 which updated the icon-only ContentSwitcher variant used in vitals and biometrics cards.

Specifically, that change switched to using the [IconSwitch](https://react.carbondesignsystem.com/?path=/story/components-contentswitcher--icon-only) instead of Switch component, enabling us to set an aria label via the text prop for improved accessibility. Because we use a [customized version](https://zeroheight.com/23a080e38/p/55274c-content-switcher/b/17b091) of the ContentSwitcher whose styling deviates from the default Carbon component, changes to the underlying elements necessitate amendments to the style overrides we apply.

## Screenshots

> Before (broken styles for Icon-only variant of the ContentSwitcher)

https://github.com/openmrs/openmrs-esm-core/assets/8509731/09acd0cf-8e4f-4f3c-bdd1-2c4c1f821dc5

> After (fixed styles for both the default ContentSwitcher and the Icon-only variant)

https://github.com/openmrs/openmrs-esm-core/assets/8509731/f2d9b508-41c4-40f1-94c9-cb7272d52dbd

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

TODO: Check that styles are not broken for RTL languages.
