### PR TITLE
(fix) Make navbar not re-render like crazy (fixes O3-2692)

### DIFF
--- a/packages/apps/esm-login-app/src/logout/logout.scss
+++ b/packages/apps/esm-login-app/src/logout/logout.scss
@@ -1,8 +1,7 @@
 @import '../root.scss';
 
-/* Repeat selector for specificity */
-button.logout.logout {
-  color: $field-01;
+button.logout {
+  color: $field-01 !important;
   font-size: 1rem;
   width: 16rem;
 

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/user-menu-panel.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/user-menu-panel.scss
@@ -1,6 +1,10 @@
 @import '~@openmrs/esm-styleguide/src/vars';
 @import '../../root.scss';
 
+.headerPanel {
+  transition: none;
+}
+
 .userPanelSwitcher {
   padding-top: 1rem;
   align-items: start;

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -1,9 +1,8 @@
-import React, { memo, useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { Navigate } from 'react-router-dom';
 import classNames from 'classnames';
 import { HeaderContainer, Header, HeaderMenuButton, HeaderGlobalBar, HeaderGlobalAction } from '@carbon/react';
 import { Close, Switcher, UserAvatarFilledAlt } from '@carbon/react/icons';
-import type { LoggedInUser } from '@openmrs/esm-framework';
 import {
   useLayoutType,
   ExtensionSlot,
@@ -21,14 +20,11 @@ import UserMenuPanel from '../navbar-header-panels/user-menu-panel.component';
 import SideMenuPanel from '../navbar-header-panels/side-menu-panel.component';
 import styles from './navbar.scss';
 
-const Navbar: React.FC = () => {
-  const session = useSession();
+const HeaderItems: React.FC = () => {
   const config = useConfig();
-  const [user, setUser] = useState<LoggedInUser | null | false>(session?.user ?? null);
   const [activeHeaderPanel, setActiveHeaderPanel] = useState<string>(null);
   const layout = useLayoutType();
   const navMenuItems = useConnectedExtensions('patient-chart-dashboard-slot').map((e) => e.id);
-  const openmrsSpaBase = window['getOpenmrsSpaBase']();
   const appMenuItems = useConnectedExtensions('app-menu-slot');
   const userMenuItems = useConnectedExtensions('user-panel-slot');
   const isActivePanel = useCallback((panelName: string) => activeHeaderPanel === panelName, [activeHeaderPanel]);
@@ -46,7 +42,7 @@ const Navbar: React.FC = () => {
   const showHamburger = useMemo(() => !isDesktop(layout) && navMenuItems.length > 0, [navMenuItems.length, layout]);
   const showAppMenu = useMemo(() => appMenuItems.length > 0, [appMenuItems.length]);
   const showUserMenu = useMemo(() => userMenuItems.length > 0, [userMenuItems.length]);
-  const HeaderItems = () => (
+  return (
     <>
       <OfflineBanner />
       <Header aria-label="OpenMRS">
@@ -123,10 +119,15 @@ const Navbar: React.FC = () => {
       </Header>
     </>
   );
+};
 
-  if (user && session) {
+const Navbar: React.FC = () => {
+  const session = useSession();
+  const openmrsSpaBase = window['getOpenmrsSpaBase']();
+
+  if (session?.user?.person) {
     return session.sessionLocation ? (
-      <HeaderContainer render={memo(HeaderItems)}></HeaderContainer>
+      <HeaderContainer render={HeaderItems}></HeaderContainer>
     ) : (
       <Navigate
         to={`/login/location`}

--- a/packages/apps/esm-primary-navigation-app/src/components/user-panel-switcher-item/user-panel-switcher.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/user-panel-switcher-item/user-panel-switcher.component.tsx
@@ -5,11 +5,10 @@ import { useSession } from '@openmrs/esm-framework';
 
 const UserPanelSwitcher: React.FC = () => {
   const session = useSession();
-  const user = session?.user;
   return (
     <SwitcherItem aria-label="User">
       <UserAvatarFilledAlt size={20} />
-      <p>{user.person.display}</p>
+      <p>{session?.user?.person?.display}</p>
     </SwitcherItem>
   );
 };


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

You know how the right side of the navbar has been blinky for a long time and we all kind of assumed it was a tricky extension thing?

https://github.com/openmrs/openmrs-esm-core/assets/1031876/cfef9b9b-16e8-4998-a183-efa6c7a2938a

It was actually just a classic React "don't define a component within another component" issue.

This gets rid of all the visual glitching, unmounting/remounting, etc. shown above.

It also fixes https://openmrs.atlassian.net/browse/O3-2692 "Two errors on logout: person is undefined and Language ID should be string or object," which was caused by an extension within the user panel not getting unmounted when it should, which somehow was being caused by the erratic re-rendering behavior of the navbar, in which its slot was contained.

NB: Yes, this does indicate that there is a subtle bug in the extension system that can cause extensions to fail to be unmounted if there is a chaotic amount of churn. I haven't solved that. But hopefully we just don't have churn.

## Screenshots

https://github.com/openmrs/openmrs-esm-core/assets/1031876/76df5822-e810-4a3c-8889-061d8bf5d20c


## Related Issue
https://openmrs.atlassian.net/browse/O3-2692
