### PR TITLE
(fix) Ensure extension slots receive correct list of extensions on first render

### DIFF
--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -169,7 +169,9 @@ export function attach(slotName: string, extensionId: string) {
   });
 }
 
-/** Avoid using this. Extension attachments should be considered declarative. */
+/**
+ * @deprecated Avoid using this. Extension attachments should be considered declarative.
+ */
 export function detach(extensionSlotName: string, extensionId: string) {
   updateInternalExtensionStore((state) => {
     const existingSlot = state.slots[extensionSlotName];
@@ -191,7 +193,9 @@ export function detach(extensionSlotName: string, extensionId: string) {
   });
 }
 
-/** Avoid using this. Extension attachments should be considered declarative. */
+/**
+ * @deprecated Avoid using this. Extension attachments should be considered declarative.
+ */
 export function detachAll(extensionSlotName: string) {
   updateInternalExtensionStore((state) => {
     const existingSlot = state.slots[extensionSlotName];

--- a/packages/framework/esm-react-utils/src/useAssignedExtensions.ts
+++ b/packages/framework/esm-react-utils/src/useAssignedExtensions.ts
@@ -1,8 +1,6 @@
 /** @module @category Extension */
-import { useEffect, useState } from 'react';
-import type { AssignedExtension, ExtensionStore } from '@openmrs/esm-extensions';
-import { getExtensionStore } from '@openmrs/esm-extensions';
-import isEqual from 'lodash-es/isEqual';
+import { useMemo } from 'react';
+import { useExtensionStore } from './useExtensionStore';
 
 /**
  * Gets the assigned extensions for a given extension slot name.
@@ -10,18 +8,11 @@ import isEqual from 'lodash-es/isEqual';
  * @param slotName The name of the slot to get the assigned extensions for.
  */
 export function useAssignedExtensions(slotName: string) {
-  const [extensions, setExtensions] = useState<Array<AssignedExtension>>([]);
+  const { slots } = useExtensionStore();
 
-  useEffect(() => {
-    function update(state: ExtensionStore) {
-      const newExtensions = state.slots[slotName]?.assignedExtensions ?? [];
-      if (!isEqual(newExtensions, extensions)) {
-        setExtensions(newExtensions);
-      }
-    }
-    update(getExtensionStore().getState());
-    return getExtensionStore().subscribe(update);
-  }, [slotName, extensions]);
+  const extensions = useMemo(() => {
+    return slots[slotName]?.assignedExtensions ?? [];
+  }, [slots, slotName]);
 
   return extensions;
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

When the extension slot component renders, it was first rendering with no extensions. This ensures that it has the right list of extensions at the first render.

## Screenshots

Before, with some logging added to `ExtensionSlot.tsx`:

![image](https://github.com/openmrs/openmrs-esm-core/assets/1031876/f6758b1d-62e7-446b-be5c-e1501237ab32)

after this change, there is only the second message.

Also deprecates `detach` and `detachAll`.