### PR TITLE
(fix) Full-width switcher items in user menu panel

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/user-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/user-menu-panel.component.tsx
@@ -1,5 +1,4 @@
 import React from 'react';
-import type { HeaderPanelProps } from '@carbon/react';
 import { HeaderPanel, Switcher, SwitcherDivider } from '@carbon/react';
 import { ExtensionSlot, useOnClickOutside } from '@openmrs/esm-framework';
 import styles from './user-menu-panel.scss';
@@ -18,16 +17,16 @@ const UserMenuPanel: React.FC<UserMenuPanelProps> = ({ expanded, hidePanel }) =>
 
   return (
     <HeaderPanel
-      ref={userMenuRef as any}
+      ref={userMenuRef}
       className={styles.headerPanel}
       expanded={expanded}
       aria-label="Location"
       aria-labelledby="Location Icon"
     >
       <Switcher className={styles.userPanelSwitcher} aria-label="Switcher Container">
-        <ExtensionSlot name="user-panel-slot" />
+        <ExtensionSlot className={styles.fullWidth} name="user-panel-slot" />
         <SwitcherDivider className={styles.divider} />
-        <ExtensionSlot name="user-panel-bottom-slot" />
+        <ExtensionSlot className={styles.fullWidth} name="user-panel-bottom-slot" />
       </Switcher>
     </HeaderPanel>
   );

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/user-menu-panel.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/user-menu-panel.scss
@@ -5,6 +5,10 @@
   transition: none;
 }
 
+.fullWidth {
+  width: 100%;
+}
+
 .userPanelSwitcher {
   padding-top: 1rem;
   align-items: start;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR fixes the width of switcher items in the user menu panel so the items span the full width of the panel in Chrome-based browsers.  

## Screenshots

> Before:  Current behavior in Brave and Google Chrome

https://github.com/openmrs/openmrs-esm-core/assets/8509731/3fc37419-f718-4609-bed3-c5c86cef6f6c

> Before: RTL locales

![CleanShot 2024-01-05 at 9  18 34@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/49b87082-56eb-4bd5-b2a7-8c7a2f5f7013)

> After: Full-width switcher items on Chrome

![CleanShot 2024-01-05 at 8  07 44@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/5a34e88d-e58a-45cc-8fa0-3ea56bedc4bb)

![CleanShot 2024-01-05 at 8  07 56@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/7e3731c3-2a84-46e9-afe2-939930f7bfa7)

![CleanShot 2024-01-05 at 9  17 20@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/0217b26b-081b-412b-9411-a5834f1129fe)

## Related Issue
*None*

## Other
*None*