### PR TITLE
(fix) Update offline tools to support i18next interpolation syntax

### DIFF
--- a/packages/apps/esm-offline-tools-app/src/index.ts
+++ b/packages/apps/esm-offline-tools-app/src/index.ts
@@ -44,7 +44,7 @@ export const offlineToolsPatientsLink = getSyncLifecycle(
   () =>
     OfflineToolsNavLink({
       page: 'patients',
-      title: 'patients',
+      title: 'offlinePatients',
     }),
   options,
 );
@@ -53,7 +53,7 @@ export const offlineToolsActionsLink = getSyncLifecycle(
   () =>
     OfflineToolsNavLink({
       page: 'actions',
-      title: 'actions',
+      title: 'offlineActions',
     }),
   options,
 );

--- a/packages/apps/esm-offline-tools-app/src/offline-actions/synchronizing-notification.tsx
+++ b/packages/apps/esm-offline-tools-app/src/offline-actions/synchronizing-notification.tsx
@@ -47,7 +47,7 @@ function SynchronizingNotification({ mySynchronizationIndex }) {
     <div className={styles.notificationLoadingContainer}>
       {isCanceled
         ? t('offlineActionsSynchronizationNotificationCanceling', 'Canceling...')
-        : t('offlineActionsSynchronizationNotificationStatus', '{current} / {total} actions', {
+        : t('offlineActionsSynchronizationNotificationStatus', '{{current}} / {{total}} actions', {
             current: synchronization.totalCount - synchronization.pendingCount,
             total: synchronization.totalCount,
           })}

--- a/packages/apps/esm-offline-tools-app/translations/am.json
+++ b/packages/apps/esm-offline-tools-app/translations/am.json
@@ -53,5 +53,10 @@
   "offlinePatientSyncDetailsFallbackErrorMessage": "Unknown error.",
   "offlinePatientSyncDetailsHeader": "Offline patient details",
   "offlineReady": "Offline Ready",
-  "offlineToolsAppMenuLink": "Offline tools"
+  "offlineToolsAppMenuLink": "Offline tools",
+  "offlineActionsSynchronizationNotificationTitle": "Upload",
+  "offlineActionsSynchronizationNotificationSynchronized": "The offline action synchronization has finished.",
+  "offlineActionsSynchronizationNotificationCanceling": "Canceling...",
+  "offlineActionsSynchronizationNotificationStatus": "{{current}} / {{total}} actions",
+  "offlineActionsSynchronizationNotificationCancelUpload": "Cancel upload"
 }

--- a/packages/apps/esm-offline-tools-app/translations/ar.json
+++ b/packages/apps/esm-offline-tools-app/translations/ar.json
@@ -57,5 +57,10 @@
   "offlinePatientSyncDetailsFallbackErrorMessage": "خطأ غير معروف.",
   "offlinePatientSyncDetailsHeader": "تفاصيل المريض بدون اتصال",
   "offlineReady": "جاهز للعمل بدون اتصال",
-  "offlineToolsAppMenuLink": "أدوات العمل بدون اتصال"
+  "offlineToolsAppMenuLink": "أدوات العمل بدون اتصال",
+  "offlineActionsSynchronizationNotificationTitle": "تحميل",
+  "offlineActionsSynchronizationNotificationSynchronized": "انتهت مزامنة الإجراءات غير المتصلة.",
+  "offlineActionsSynchronizationNotificationCanceling": "إلغاء...",
+  "offlineActionsSynchronizationNotificationStatus": "{{current}} / {{total}} إجراء",
+  "offlineActionsSynchronizationNotificationCancelUpload": "إلغاء التحميل"
 }

--- a/packages/apps/esm-offline-tools-app/translations/en.json
+++ b/packages/apps/esm-offline-tools-app/translations/en.json
@@ -53,5 +53,10 @@
   "offlinePatientSyncDetailsFallbackErrorMessage": "Unknown error.",
   "offlinePatientSyncDetailsHeader": "Offline patient details",
   "offlineReady": "Offline Ready",
-  "offlineToolsAppMenuLink": "Offline tools"
+  "offlineToolsAppMenuLink": "Offline tools",
+  "offlineActionsSynchronizationNotificationTitle": "Upload",
+  "offlineActionsSynchronizationNotificationSynchronized": "The offline action synchronization has finished.",
+  "offlineActionsSynchronizationNotificationCanceling": "Canceling...",
+  "offlineActionsSynchronizationNotificationStatus": "{{current}} / {{total}} actions",
+  "offlineActionsSynchronizationNotificationCancelUpload": "Cancel upload"
 }

--- a/packages/apps/esm-offline-tools-app/translations/es.json
+++ b/packages/apps/esm-offline-tools-app/translations/es.json
@@ -54,5 +54,10 @@
   "offlinePatientSyncDetailsFallbackErrorMessage": "Error desconocido.",
   "offlinePatientSyncDetailsHeader": "Detalles de pacientes offline",
   "offlineReady": "Listo offline",
-  "offlineToolsAppMenuLink": "Herramientas offline"
+  "offlineToolsAppMenuLink": "Herramientas offline",
+  "offlineActionsSynchronizationNotificationTitle": "Subir",
+  "offlineActionsSynchronizationNotificationSynchronized": "La sincronización de acciones sin conexión ha finalizado.",
+  "offlineActionsSynchronizationNotificationCanceling": "Cancelando...",
+  "offlineActionsSynchronizationNotificationStatus": "{{current}} / {{total}} acciones",
+  "offlineActionsSynchronizationNotificationCancelUpload": "Cancelar subida"
 }

--- a/packages/apps/esm-offline-tools-app/translations/fr.json
+++ b/packages/apps/esm-offline-tools-app/translations/fr.json
@@ -54,5 +54,10 @@
   "offlinePatientSyncDetailsFallbackErrorMessage": "Erreur inconnue.",
   "offlinePatientSyncDetailsHeader": "Détails des patients hors ligne",
   "offlineReady": "Prêt pour être hors ligne",
-  "offlineToolsAppMenuLink": "Outils hors ligne"
+  "offlineToolsAppMenuLink": "Outils hors ligne",
+  "offlineActionsSynchronizationNotificationTitle": "Téléversement",
+  "offlineActionsSynchronizationNotificationSynchronized": "La synchronisation des actions hors ligne est terminée.",
+  "offlineActionsSynchronizationNotificationCanceling": "Annulation...",
+  "offlineActionsSynchronizationNotificationStatus": "{{current}} / {{total}} actions",
+  "offlineActionsSynchronizationNotificationCancelUpload": "Annuler le téléversement"
 }

--- a/packages/apps/esm-offline-tools-app/translations/he.json
+++ b/packages/apps/esm-offline-tools-app/translations/he.json
@@ -55,5 +55,10 @@
   "offlinePatientSyncDetailsFallbackErrorMessage": "שגיאה לא ידועה.",
   "offlinePatientSyncDetailsHeader": "פרטי מטופל לא מקוון",
   "offlineReady": "מצב לא מקוון מוכן",
-  "offlineToolsAppMenuLink": "כלי לא מקוונים"
+  "offlineToolsAppMenuLink": "כלי לא מקוונים",
+  "offlineActionsSynchronizationNotificationTitle": "העלאה",
+  "offlineActionsSynchronizationNotificationSynchronized": "הסנכרון של הפעולות במצב לא מקוון הושלם.",
+  "offlineActionsSynchronizationNotificationCanceling": "מבטל...",
+  "offlineActionsSynchronizationNotificationStatus": "{{current}} / {{total}} פעולות",
+  "offlineActionsSynchronizationNotificationCancelUpload": "בטל העלאה"
 }

--- a/packages/apps/esm-offline-tools-app/translations/km.json
+++ b/packages/apps/esm-offline-tools-app/translations/km.json
@@ -52,5 +52,10 @@
   "offlinePatientSyncDetailsFallbackErrorMessage": "Unknown error.",
   "offlinePatientSyncDetailsHeader": "Offline patient details",
   "offlineReady": "Offline Ready",
-  "offlineToolsAppMenuLink": "Offline tools"
+  "offlineToolsAppMenuLink": "Offline tools",
+  "offlineActionsSynchronizationNotificationTitle": "Upload",
+  "offlineActionsSynchronizationNotificationSynchronized": "The offline action synchronization has finished.",
+  "offlineActionsSynchronizationNotificationCanceling": "Canceling...",
+  "offlineActionsSynchronizationNotificationStatus": "{{current}} / {{total}} actions",
+  "offlineActionsSynchronizationNotificationCancelUpload": "Cancel upload"
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This pull request includes updates to the internationalization (I18n) labels for offline tools. The changes aim to improve the user experience of the offline tools by ensuring accurate and clear translations.
<!-- Please describe what problems your PR addresses. -->

## Screenshots
eg:
<!-- Required if you are making UI changes. -->
![image](https://github.com/openmrs/openmrs-esm-core/assets/94977371/55957f7a-41f8-4232-9d85-20b24b77b5c0)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
CC: @ibacher 
Thanks,
