### PR TITLE
(fix) Make ConfigurableLink warn when bad props are provided

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -3176,7 +3176,7 @@ A React link component which calls [navigate](API.md#navigate) when clicked
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L37)
+[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:53](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L53)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -3176,7 +3176,7 @@ A React link component which calls [navigate](API.md#navigate) when clicked
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:32](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L32)
+[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L37)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/ConfigurableLinkProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/ConfigurableLinkProps.md
@@ -295,7 +295,7 @@
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L19)
+[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:24](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L24)
 
 ___
 
@@ -305,7 +305,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L18)
+[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:23](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L23)
 
 ___
 
@@ -4165,7 +4165,13 @@ node_modules/@types/react/index.d.ts:1882
 
 ### onBeforeNavigate
 
-▸ `Optional` **onBeforeNavigate**(): `void`
+▸ `Optional` **onBeforeNavigate**(`event`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `event` | `MouseEvent`<`Element`, `MouseEvent`\> |
 
 #### Returns
 
@@ -4173,4 +4179,4 @@ node_modules/@types/react/index.d.ts:1882
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L20)
+[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:25](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L25)

--- a/packages/framework/esm-framework/docs/interfaces/ConfigurableLinkProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/ConfigurableLinkProps.md
@@ -295,7 +295,7 @@
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:24](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L24)
+[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L40)
 
 ___
 
@@ -305,7 +305,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:23](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L23)
+[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L39)
 
 ___
 
@@ -4179,4 +4179,4 @@ node_modules/@types/react/index.d.ts:1882
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:25](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L25)
+[packages/framework/esm-react-utils/src/ConfigurableLink.tsx:41](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ConfigurableLink.tsx#L41)

--- a/packages/framework/esm-react-utils/src/ConfigurableLink.tsx
+++ b/packages/framework/esm-react-utils/src/ConfigurableLink.tsx
@@ -43,10 +43,14 @@ export function ConfigurableLink({
 }: PropsWithChildren<ConfigurableLinkProps>) {
   useEffect(() => {
     if (otherProps.href) {
-      console.warn('ConfigurableLink does not support the href prop. Use the `to` prop instead.');
+      console.warn(
+        `ConfigurableLink does not support the href prop. Use the 'to' prop instead. The provided href value is '${otherProps.href}'`,
+      );
     }
     if (otherProps.onClick) {
-      console.warn('ConfigurableLink does not support the onClick prop. Use the `onBeforeNavigate` prop instead.');
+      console.warn(
+        `ConfigurableLink does not support the onClick prop. Use the 'onBeforeNavigate' prop instead. The 'to' prop of the offending link is ${to}`,
+      );
     }
   }, []);
   return (

--- a/packages/framework/esm-react-utils/src/ConfigurableLink.tsx
+++ b/packages/framework/esm-react-utils/src/ConfigurableLink.tsx
@@ -1,12 +1,17 @@
 /** @module @category Navigation */
-import React, { type MouseEvent, type AnchorHTMLAttributes, type PropsWithChildren } from 'react';
+import React, { type MouseEvent, type AnchorHTMLAttributes, type PropsWithChildren, useEffect } from 'react';
 import type { TemplateParams } from '@openmrs/esm-navigation';
 import { navigate, interpolateUrl } from '@openmrs/esm-navigation';
 
-function handleClick(event: MouseEvent, to: string, templateParams?: TemplateParams, onBeforeNavigate?: () => void) {
+function handleClick(
+  event: MouseEvent,
+  to: string,
+  templateParams?: TemplateParams,
+  onBeforeNavigate?: (event: MouseEvent) => void,
+) {
   if (!event.metaKey && !event.ctrlKey && !event.shiftKey && event.button == 0) {
     event.preventDefault();
-    onBeforeNavigate?.();
+    onBeforeNavigate?.(event);
     navigate({ to, templateParams });
   }
 }
@@ -17,7 +22,7 @@ function handleClick(event: MouseEvent, to: string, templateParams?: TemplatePar
 export interface ConfigurableLinkProps extends AnchorHTMLAttributes<HTMLAnchorElement> {
   to: string;
   templateParams?: TemplateParams;
-  onBeforeNavigate?: () => void;
+  onBeforeNavigate?: (event: MouseEvent) => void;
 }
 
 /**
@@ -36,6 +41,14 @@ export function ConfigurableLink({
   children,
   ...otherProps
 }: PropsWithChildren<ConfigurableLinkProps>) {
+  useEffect(() => {
+    if (otherProps.href) {
+      console.warn('ConfigurableLink does not support the href prop. Use the `to` prop instead.');
+    }
+    if (otherProps.onClick) {
+      console.warn('ConfigurableLink does not support the onClick prop. Use the `onBeforeNavigate` prop instead.');
+    }
+  }, []);
   return (
     <a
       onClick={(event) => handleClick(event, to, templateParams, onBeforeNavigate)}


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

We should yell at people who use ConfigurableLink in ways that are illegal. This makes the computer yell

Also allows `onBeforeNavigate` users to receive the event. Maybe someone will want that at some point.

## Other

Vaguely related to https://github.com/openmrs/openmrs-esm-patient-management/pull/928