### PR TITLE
(fix) Make ConfigurableLink call onBeforeNavigate for alternative clicks

### DIFF
--- a/packages/framework/esm-react-utils/src/ConfigurableLink.test.tsx
+++ b/packages/framework/esm-react-utils/src/ConfigurableLink.test.tsx
@@ -56,7 +56,7 @@ describe(`ConfigurableLink`, () => {
     expect(navigate).toHaveBeenCalledWith({ to: path });
   });
 
-  it('executes onBeforeNavigate callback if provided', async () => {
+  it('executes onBeforeNavigate callback on any click that would open the page (including ctrl-click etc)', async () => {
     const onBeforeNavigate = jest.fn();
     render(
       <ConfigurableLink to={path} onBeforeNavigate={onBeforeNavigate}>
@@ -69,5 +69,19 @@ describe(`ConfigurableLink`, () => {
     await user.click(link);
     expect(onBeforeNavigate).toHaveBeenCalled();
     expect(navigate).toHaveBeenCalledWith({ to: path });
+    onBeforeNavigate.mockClear();
+    await user.pointer({ target: link, keys: '[MouseRight]' });
+    expect(onBeforeNavigate).not.toHaveBeenCalled();
+    // Note: This ought to work, but doesn't because of
+    //   https://github.com/testing-library/user-event/issues/1083
+    //   `event.button` is getting set to 0 when it should be 1.
+    // await user.pointer({ target: link, keys: '[MouseMiddle]' });
+    // expect(onBeforeNavigate).toHaveBeenCalled();
+    // onBeforeNavigate.mockClear();
+    await user.pointer({ target: link, keys: '[ControlLeft][MouseLeft][/ControlLeft]' });
+    expect(onBeforeNavigate).toHaveBeenCalled();
+    onBeforeNavigate.mockClear();
+    await user.pointer({ target: link, keys: '[ShiftLeft][MouseLeft][/ShiftLeft]' });
+    expect(onBeforeNavigate).toHaveBeenCalled();
   });
 });

--- a/packages/framework/esm-react-utils/src/ConfigurableLink.tsx
+++ b/packages/framework/esm-react-utils/src/ConfigurableLink.tsx
@@ -9,10 +9,26 @@ function handleClick(
   templateParams?: TemplateParams,
   onBeforeNavigate?: (event: MouseEvent) => void,
 ) {
-  if (!event.metaKey && !event.ctrlKey && !event.shiftKey && event.button == 0) {
+  // Left click without modifiers (normal navigation)
+  if (event.button === 0 && !event.ctrlKey && !event.shiftKey && !event.altKey && !event.metaKey) {
     event.preventDefault();
     onBeforeNavigate?.(event);
     navigate({ to, templateParams });
+  }
+
+  // Left click with Ctrl key (or Cmd key on Mac) - Open in new tab
+  if (event.button === 0 && (event.ctrlKey || event.metaKey)) {
+    onBeforeNavigate?.(event);
+  }
+
+  // Left click with Shift key - Open in new window
+  if (event.button === 0 && event.shiftKey) {
+    onBeforeNavigate?.(event);
+  }
+
+  // Middle click - Open in new background tab
+  if (event.button === 1) {
+    onBeforeNavigate?.(event);
   }
 }
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

It was the case that `onBeforeNavigate` wouldn't be called when the user ctrl-clicks something. Since ctrl-click still navigates the user to the target page, albeit in a different tab, it seems like the app should probably behave in the same way as if the user had clicked the link normally. I'm not aware of any bugs that this fixes, but it seems like it should produce more consistent behavior.
