### PR TITLE
O3-2697 Add ability to configure icons on side links

### DIFF
--- a/packages/framework/esm-react-utils/src/ConfigurableLinkIcon.test.tsx
+++ b/packages/framework/esm-react-utils/src/ConfigurableLinkIcon.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { navigate } from '@openmrs/esm-navigation';
+import ConfigurableLinkIcon from './ConfigurableLinkIcon';
+import { Events } from '@carbon/react/icons';
+
+jest.mock('single-spa');
+
+const mockNavigate = navigate as jest.Mock;
+
+const testProps = {
+  path: '${openmrsSpaBase}/home/appointments',
+  renderIcon: Events,
+  name: 'Appointments',
+};
+
+describe(`ConfigurableLinkIcon`, () => {
+  beforeEach(() => {
+    mockNavigate.mockClear();
+  });
+
+  it(`interpolates the link`, async () => {
+    render(<ConfigurableLinkIcon {...testProps} />);
+
+    const link = screen.getByRole('link', { name: /Appointments/i });
+    expect(link).toBeTruthy();
+    expect(link.closest('a')).toHaveAttribute('href', '/openmrs/spa/home/appointments');
+    const button = screen.getByLabelText('Configurable link icon');
+
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('aria-labelledby', 'tooltip-:r1:');
+    expect(button).toHaveAttribute('type', 'button');
+  
+    // Trigger the click event to display the tooltip
+    fireEvent.click(button);
+  
+    // Check if the tooltip is displayed
+    const tooltipContent = screen.getByText('Link');
+    expect(tooltipContent).toBeInTheDocument();
+  });
+});

--- a/packages/framework/esm-react-utils/src/ConfigurableLinkIcon.tsx
+++ b/packages/framework/esm-react-utils/src/ConfigurableLinkIcon.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import { ConfigurableLink } from '@openmrs/esm-react-utils/src/ConfigurableLink';
+import { Button } from '@carbon/react';
+
+export interface ConfigurableIconProps {
+  renderIcon: React.ComponentType<any>;
+  path: string;
+  name: string;
+}
+const ConfigurableLinkIcon: React.FC<ConfigurableIconProps> = ({ renderIcon, path, name }) => {
+  return (
+    <ConfigurableLink to={path}>
+      <Button
+        styles={{ marginTop: '0.75rem' }}
+        hasIconOnly
+        aria-label="Configurable link icon"
+        size="sm"
+        kind="ghost"
+        renderIcon={renderIcon}
+        iconDescription="Link"
+      /> {name}
+    </ConfigurableLink>
+  );
+};
+
+export default ConfigurableLinkIcon;


### PR DESCRIPTION
# Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
- This component will support rendering side nav links with icons , its a follow up for this conversation [here](https://github.com/openmrs/openmrs-esm-patient-management/pull/922/files)

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="247" alt="Screenshot 2024-01-05 at 14 24 37" src="https://github.com/openmrs/openmrs-esm-core/assets/19533785/46702897-753e-46fe-9cb1-ede3d1994e74">


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
