### PR TITLE
(fix) Improvement to history mock

### DIFF
--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -166,7 +166,7 @@ export const getFeatureFlag = jest.fn().mockReturnValue(true);
 export const subscribeToFeatureFlag = jest.fn((name: string, callback) => callback(true));
 
 /* esm-navigation */
-export { goBackInHistory, interpolateUrl, interpolateString } from '@openmrs/esm-navigation';
+export { interpolateUrl, interpolateString } from '@openmrs/esm-navigation';
 export let history = ['https://o3.openmrs.org/home'];
 export const navigate = jest.fn(({ to, templateParams }: { to: string; templateParams?: TemplateParams }) => {
   let target = interpolateUrl(to, templateParams);
@@ -186,6 +186,16 @@ export const navigate = jest.fn(({ to, templateParams }: { to: string; templateP
 export const getHistory = jest.fn(() => history);
 export const clearHistory = jest.fn(() => {
   history = [];
+});
+export const goBackInHistory = jest.fn(({ toUrl }) => {
+  const toIndex = history.lastIndexOf(toUrl);
+  if (toIndex != -1) {
+    const newHistory = history.slice(0, toIndex + 1);
+    navigate({ to: history[toIndex] });
+    history = newHistory;
+  } else {
+    throw new Error(`URL ${toUrl} not found in history; cannot go back to it.`);
+  }
 });
 
 /* esm-offline */

--- a/packages/framework/esm-framework/src/mock-test.test.ts
+++ b/packages/framework/esm-framework/src/mock-test.test.ts
@@ -14,4 +14,12 @@ describe('@openmrs/esm-framework/mock', () => {
   xit('should have the same exports as @openmrs/esm-framework', () => {
     expect(new Set(Object.keys(real))).toEqual(new Set(Object.keys(mock)));
   });
+
+  it('should have a working goBackInHistory function', () => {
+    mock.navigate({ to: '/test' });
+    const history = mock.getHistory();
+    mock.goBackInHistory({ toUrl: history[0] });
+    expect(mock.getHistory()).toEqual([history[0]]);
+    expect(mock.navigate).toHaveBeenCalled();
+  });
 });

--- a/packages/framework/esm-navigation/src/history/history.test.ts
+++ b/packages/framework/esm-navigation/src/history/history.test.ts
@@ -72,5 +72,7 @@ describe('history', () => {
     });
     goBackInHistory({ toUrl: 'https://o3.openmrs.org/openmrs/spa/labs' });
     expect(getHistory()).toEqual([mockReferrer, 'https://o3.openmrs.org/openmrs/spa/labs']);
+    goBackInHistory({ toUrl: mockReferrer });
+    expect(getHistory()).toEqual([mockReferrer]);
   });
 });


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

`goBackInHistory` was using the real "history" in the text context rather than the mock one, causing inconsistent results. This properly mocks `goBackInHistory`. It also tests that mock. I'm on the fence about whether it's a good idea to test mocks at all, but my feeling is that as long as we keep it very minimal it's probably alright.


## Other

This should fix the tests for https://github.com/openmrs/openmrs-esm-patient-chart/pull/1581