### PR TITLE
(chore) Only trigger e2e tests when relevant code has changed

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      changes: ${{ steps.filter.outputs.changes.test-sources }}
+      test-changes: ${{ steps.changes.outputs.test-sources }}
 
     steps: 
       - name: Checkout repo
@@ -41,7 +41,7 @@ jobs:
 
   main:
     needs: changes
-    if: ${{ needs.changes.outputs.changes == ['test-sources'] }}
+    if: ${{ needs.changes.outputs.test-changes == 'true' }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -9,9 +9,43 @@ on:
       - main
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      changes: ${{ steps.filter.outputs.changes }}
+
+    steps: 
+      - name: Checkout repo
+        uses: actions/checkout@v4
+      
+      - name: Check if any source code has changed
+        id: changes
+        uses: dorny/paths-filter@v2
+        with:
+          filters: |
+            src:
+              - 'packages/**/src/**/*!(.test).ts'
+              - 'packages/**/src/**/*!(.test).tsx'
+              - 'packages/**/src/**/*!(.test).js'
+              - 'packages/**/src/**/*!(.test).jsx'
+              - 'packages/**/src/**/*.scss'
+              - 'packages/**/src/routes.json'
+              - 'playwright.config.ts'
+              - 'e2e/**/*.ts'
+              - 'e2e/**/*.js'
+              - 'e2e/support/github/**/*.*'
+              - 'example.env'
+              - '.github/workflows/e2e.yml'
+
   main:
+    needs: changes
+    if: ${{ needs.changes.outputs.changes == 'true' }}
+
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -14,7 +14,7 @@ jobs:
     permissions:
       pull-requests: read
     outputs:
-      changes: ${{ steps.filter.outputs.changes }}
+      changes: ${{ steps.filter.outputs.changes.test-sources }}
 
     steps: 
       - name: Checkout repo
@@ -25,7 +25,7 @@ jobs:
         uses: dorny/paths-filter@v2
         with:
           filters: |
-            src:
+            test-sources:
               - 'packages/**/src/**/*!(.test).ts'
               - 'packages/**/src/**/*!(.test).tsx'
               - 'packages/**/src/**/*!(.test).js'

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -41,7 +41,7 @@ jobs:
 
   main:
     needs: changes
-    if: ${{ needs.changes.outputs.changes == 'true' }}
+    if: ${{ needs.changes.outputs.changes == ['test-sources'] }}
 
     runs-on: ubuntu-latest
     timeout-minutes: 15


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This adds a step to the e2e test workflow that will skip running the actual tests unless some relevant file has been modified (basically, relevant files are any source code that is not simply in a Jest test). I think I've got everything and got the picomatch syntax right, but we should verify that. Note that since this PR updates the e2e workflow file itself, it _should_ trigger a full e2e test run.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
