### PR TITLE
(fix) O3-1419: Config validation errors should only be shown once

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/configuration/configuration.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/configuration.component.tsx
@@ -6,6 +6,7 @@ import cloneDeep from 'lodash-es/cloneDeep';
 import isEmpty from 'lodash-es/isEmpty';
 import type { Config } from '@openmrs/esm-framework/src/internal';
 import {
+  clearConfigErrors,
   getExtensionInternalStore,
   implementerToolsConfigStore,
   temporaryConfigStore,
@@ -154,6 +155,7 @@ export const Configuration: React.FC<ConfigurationProps> = () => {
                   renderIcon={(props) => <TrashCan size={16} {...props} />}
                   onClick={() => {
                     temporaryConfigStore.setState({ config: {} });
+                    clearConfigErrors();
                   }}
                 >
                   {t('clearConfig', 'Clear Local Config')}

--- a/packages/apps/esm-implementer-tools-app/src/configuration/configuration.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/configuration.component.tsx
@@ -154,8 +154,8 @@ export const Configuration: React.FC<ConfigurationProps> = () => {
                   iconDescription="Clear local config"
                   renderIcon={(props) => <TrashCan size={16} {...props} />}
                   onClick={() => {
-                    temporaryConfigStore.setState({ config: {} });
                     clearConfigErrors();
+                    temporaryConfigStore.setState({ config: {} });
                   }}
                 >
                   {t('clearConfig', 'Clear Local Config')}

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/editable-value.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/editable-value.component.tsx
@@ -6,7 +6,7 @@ import styles from './editable-value.styles.scss';
 import { Button } from '@carbon/react';
 import { Edit, Reset } from '@carbon/react/icons';
 import type { ConfigValue, Validator, Type, Config } from '@openmrs/esm-framework/src/internal';
-import { temporaryConfigStore } from '@openmrs/esm-framework/src/internal';
+import { clearConfigErrors, temporaryConfigStore } from '@openmrs/esm-framework/src/internal';
 import type { CustomValueType } from './value-editor';
 import { ValueEditor } from './value-editor';
 import type { ImplementerToolsStore } from '../../store';
@@ -92,6 +92,7 @@ export default function EditableValue({ path, element, customType }: EditableVal
                   const result = JSON.parse(val);
                   const tempConfigUpdate = set(cloneDeep(temporaryConfigStore.getState()), ['config', ...path], result);
                   temporaryConfigStore.setState(tempConfigUpdate);
+                  clearConfigErrors(path.join('.'));
                   setValueString(val);
                   closeEditor();
                 } catch (e) {
@@ -122,6 +123,7 @@ export default function EditableValue({ path, element, customType }: EditableVal
                 hasIconOnly
                 onClick={() => {
                   temporaryConfigStore.setState(unset(temporaryConfigStore.getState(), ['config', ...path]) as any);
+                  clearConfigErrors(path.join('.'));
                 }}
               />
             ) : null}

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/editable-value.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/editable-value.component.tsx
@@ -91,8 +91,8 @@ export default function EditableValue({ path, element, customType }: EditableVal
                 try {
                   const result = JSON.parse(val);
                   const tempConfigUpdate = set(cloneDeep(temporaryConfigStore.getState()), ['config', ...path], result);
-                  temporaryConfigStore.setState(tempConfigUpdate);
                   clearConfigErrors(path.join('.'));
+                  temporaryConfigStore.setState(tempConfigUpdate);
                   setValueString(val);
                   closeEditor();
                 } catch (e) {
@@ -122,8 +122,8 @@ export default function EditableValue({ path, element, customType }: EditableVal
                 iconDescription={t('resetToDefaultValueButtonText', 'Reset to default')}
                 hasIconOnly
                 onClick={() => {
-                  temporaryConfigStore.setState(unset(temporaryConfigStore.getState(), ['config', ...path]) as any);
                   clearConfigErrors(path.join('.'));
+                  temporaryConfigStore.setState(unset(temporaryConfigStore.getState(), ['config', ...path]) as any);
                 }}
               />
             ) : null}

--- a/packages/apps/esm-implementer-tools-app/src/configuration/json-editor/json-editor.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/json-editor/json-editor.component.tsx
@@ -27,8 +27,8 @@ export default function JsonEditor({ height }: JsonEditorProps) {
       return;
     }
     setError('');
-    temporaryConfigStore.setState({ config });
     clearConfigErrors();
+    temporaryConfigStore.setState({ config });
   }, [editorValue, temporaryConfigStore]);
 
   useEffect(() => {

--- a/packages/apps/esm-implementer-tools-app/src/configuration/json-editor/json-editor.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/json-editor/json-editor.component.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { temporaryConfigStore, useStore } from '@openmrs/esm-framework/src/internal';
+import { clearConfigErrors, temporaryConfigStore, useStore } from '@openmrs/esm-framework/src/internal';
 import { Button } from '@carbon/react';
 import AceEditor from 'react-ace';
 import style from './json-editor.scss';
@@ -28,6 +28,7 @@ export default function JsonEditor({ height }: JsonEditorProps) {
     }
     setError('');
     temporaryConfigStore.setState({ config });
+    clearConfigErrors();
   }, [editorValue, temporaryConfigStore]);
 
   useEffect(() => {

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -172,7 +172,7 @@ export function defineExtensionConfigSchema(extensionName: string, schema: Confi
 
   const state = configInternalStore.getState();
   if (state.schemas[extensionName]) {
-    console.warn(
+    console.error(
       `Config schema for extension ${extensionName} already exists. If there are multiple extensions with this same name, one will probably crash.`,
     );
   }
@@ -359,29 +359,30 @@ function validateAllExtensionSlotConfigs(slotConfigPerModule: Record<string, Rec
 }
 
 function validateExtensionSlotConfig(config: ExtensionSlotConfig, moduleName: string, slotName: string): void {
-  const errorPrefix = `Extension slot config '${moduleName}.extensionSlots.${slotName}`;
+  const keyPath = `${moduleName}.extensionSlots.${slotName}`;
+  const errorPrefix = `Extension slot config '${keyPath}'`;
   const invalidKeys = Object.keys(config).filter((k) => !['add', 'remove', 'order', 'configure'].includes(k));
   if (invalidKeys.length) {
-    console.error(errorPrefix + `' contains invalid keys '${invalidKeys.join("', '")}'`);
+    logError(keyPath, errorPrefix + `' contains invalid keys '${invalidKeys.join("', '")}'`);
   }
   if (config.add) {
     if (!Array.isArray(config.add) || !config.add.every((n) => typeof n === 'string')) {
-      console.error(errorPrefix + `.add' is invalid. Must be an array of strings (extension IDs)`);
+      logError(keyPath, errorPrefix + `.add' is invalid. Must be an array of strings (extension IDs)`);
     }
   }
   if (config.remove) {
     if (!Array.isArray(config.remove) || !config.remove.every((n) => typeof n === 'string')) {
-      console.error(errorPrefix + `.remove' is invalid. Must be an array of strings (extension IDs)`);
+      logError(keyPath, errorPrefix + `.remove' is invalid. Must be an array of strings (extension IDs)`);
     }
   }
   if (config.order) {
     if (!Array.isArray(config.order) || !config.order.every((n) => typeof n === 'string')) {
-      console.error(errorPrefix + `.order' is invalid. Must be an array of strings (extension IDs)`);
+      logError(keyPath, errorPrefix + `.order' is invalid. Must be an array of strings (extension IDs)`);
     }
   }
   if (config.configure) {
     if (!isOrdinaryObject(config.configure)) {
-      console.error(errorPrefix + `.configure' is invalid. Must be an object with extension IDs for keys`);
+      logError(keyPath, errorPrefix + `.configure' is invalid. Must be an object with extension IDs for keys`);
     }
   }
 }
@@ -390,6 +391,11 @@ function getProvidedConfigs(configState: ConfigInternalStore, tempConfigState: T
   return [...configState.providedConfigs.map((c) => c.config), tempConfigState.config];
 }
 
+/**
+ * Validates the config schema for a module. Since problems identified here are programming errors
+ * that hopefully will be caught during development, this function logs errors to the console directly;
+ * it's fine if we spam the user with these errors.
+ */
 function validateConfigSchema(moduleName: string, schema: ConfigSchema, keyPath = '') {
   const updateMessage = `Please verify that you are running the latest version and, if so, alert the maintainer.`;
 
@@ -510,7 +516,7 @@ function validateStructure(schema: ConfigSchema, config: ConfigObject, keyPath =
 
     if (!schema.hasOwnProperty(key)) {
       if (!(key === 'extensionSlots' && keyPath !== '')) {
-        console.error(`Unknown config key '${thisKeyPath}' provided. Ignoring.`);
+        logError(thisKeyPath, `Unknown config key '${thisKeyPath}' provided. Ignoring.`);
       }
 
       continue;
@@ -616,11 +622,11 @@ function runValidators(keyPath: string, validators: Array<Function> | undefined,
         const validatorResult = validator(value);
 
         if (typeof validatorResult === 'string') {
-          if (typeof value === 'object') {
-            console.error(`Invalid configuration for ${keyPath}: ${validatorResult}`);
-          } else {
-            console.error(`Invalid configuration value ${value} for ${keyPath}: ${validatorResult}`);
-          }
+          const message =
+            typeof value === 'object'
+              ? `Invalid configuration for ${keyPath}: ${validatorResult}`
+              : `Invalid configuration value ${value} for ${keyPath}: ${validatorResult}`;
+          logError(keyPath, message);
         }
       }
     } catch (e) {
@@ -689,6 +695,34 @@ function hasObjectSchema(elementsSchema: Object | undefined): elementsSchema is 
 
 function isOrdinaryObject(value) {
   return typeof value === 'object' && !Array.isArray(value) && value !== null;
+}
+
+/** Keep track of which validation errors we have displayed. Each one should only be displayed once. */
+const displayedValidationMessages = new Set<string>();
+(window as any).displayedValidationMessages = displayedValidationMessages;
+
+function logError(keyPath: string, message: string) {
+  const key = `${keyPath}:::${message}`;
+  if (!displayedValidationMessages.has(key)) {
+    console.error(message);
+    displayedValidationMessages.add(key);
+  }
+}
+
+/**
+ * Normally, configuration errors are only displayed once. This function clears the list of
+ * displayed errors, so that they will be displayed again.
+ */
+export function clearConfigErrors(keyPath?: string) {
+  if (keyPath) {
+    displayedValidationMessages.forEach((key) => {
+      if (key.startsWith(keyPath)) {
+        displayedValidationMessages.delete(key);
+      }
+    });
+  } else {
+    displayedValidationMessages.clear();
+  }
 }
 
 /**

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -699,7 +699,6 @@ function isOrdinaryObject(value) {
 
 /** Keep track of which validation errors we have displayed. Each one should only be displayed once. */
 const displayedValidationMessages = new Set<string>();
-(window as any).displayedValidationMessages = displayedValidationMessages;
 
 function logError(keyPath: string, message: string) {
   const key = `${keyPath}:::${message}`;
@@ -712,6 +711,8 @@ function logError(keyPath: string, message: string) {
 /**
  * Normally, configuration errors are only displayed once. This function clears the list of
  * displayed errors, so that they will be displayed again.
+ *
+ * @internal
  */
 export function clearConfigErrors(keyPath?: string) {
   if (keyPath) {

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -131,6 +131,8 @@ export function defineExtensionConfigSchema(extensionName, schema) {
   configSchema = schema;
 }
 
+export const clearConfigErrors = jest.fn();
+
 /* esm-dynamic-loading */
 export const importDynamic = jest.fn();
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Right now config validation errors are shown over and over. This makes it so they are only shown once.

## Screenshots

https://github.com/openmrs/openmrs-esm-core/assets/1031876/bf6dc3e0-931c-48c7-ab04-075fb27b06ef

## Related Issue

https://openmrs.atlassian.net/browse/O3-1419
