### PR TITLE
(fix) O3-2752: RTL fixes - tables content alignment, breadcrumbs & pre-loader

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -167,6 +167,14 @@
   background: transparent;
 }
 
+.cds--data-table {
+  td,
+  th,
+  .cds--table-header-label {
+    text-align: start;
+  }
+}
+
 .cds--data-table-container {
   background: $ui-02;
   position: relative;
@@ -330,6 +338,25 @@
 /* Radio buttons */
 .cds--radio-button-group--vertical .cds--radio-button-wrapper:not(:last-of-type) {
   margin-bottom: 0;
+}
+
+/* Breadcrumbs */
+.cds--breadcrumb-item {
+  &,
+  &:after {
+    margin-left: unset;
+    margin-right: unset;
+  }
+
+  &:after,
+  &:last-child:after {
+    margin-inline: spacing.$spacing-03;
+  }
+}
+
+/* Preloader */
+.cds--inline-loading__animation {
+  margin-inline: spacing.$spacing-03;
 }
 
 html[dir='rtl'] {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR contains fixes for alignment the content of tables, breadcrumbs and pre-loader if RTL language is selected

## Screenshots
![image](https://github.com/openmrs/openmrs-esm-core/assets/17073192/e239d543-d90e-4264-8512-e59c1c9d1077)
![image](https://github.com/openmrs/openmrs-esm-core/assets/17073192/8fb4eb66-882b-4289-ad6a-62172cc7733b)

## Related Issue
[O3-2752](https://openmrs.atlassian.net/browse/O3-2752)
