### PR TITLE
(Refactor) O3-2705: Remove box-shadows on some-action buttons (table-row-expand-buttons)

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -33,6 +33,11 @@
   border-right: none;
 }
 
+a.cds--side-nav__link:focus,
+a.cds--header__menu-item:focus {
+  box-shadow: none;
+}
+
 .cds--side-nav__overlay-active {
   display: none;
 }
@@ -83,6 +88,10 @@
   border: none;
   border-top: 1px solid colors.$blue-30;
   border-bottom: 1px solid colors.$blue-30;
+
+  &:focus {
+    box-shadow: none;
+  }
 
   &::after {
     background-color: transparent !important;
@@ -149,8 +158,8 @@
 }
 
 .cds--tabs--scrollable.cds--tabs--scrollable--container
-  .cds--tabs--scrollable__nav-item--selected
-  .cds--tabs--scrollable__nav-link {
+.cds--tabs--scrollable__nav-item--selected
+.cds--tabs--scrollable__nav-link {
   box-shadow: inset 0 2px 0 0 var(--brand-03);
 }
 
@@ -222,6 +231,10 @@
 .cds--data-table--zebra tbody tr[data-parent-row]:nth-child(4n + 3) td {
   background-color: $ui-01;
   border-bottom: 1px solid $ui-03;
+}
+
+.cds--table-expand__button:focus {
+  box-shadow: none;
 }
 
 /* Misc */
@@ -401,6 +414,10 @@ html[dir='rtl'] {
     p {
       text-align: right;
     }
+
+    &:focus::before {
+      box-shadow: none;
+    }
   }
 
   .cds--select__page-number {
@@ -443,6 +460,10 @@ html[dir='rtl'] {
   }
 
   .cds--content-switcher-btn {
+    &:focus {
+      box-shadow: none;
+    }
+
     &::after {
       background-color: transparent !important;
     }

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -158,8 +158,8 @@ a.cds--header__menu-item:focus {
 }
 
 .cds--tabs--scrollable.cds--tabs--scrollable--container
-.cds--tabs--scrollable__nav-item--selected
-.cds--tabs--scrollable__nav-link {
+  .cds--tabs--scrollable__nav-item--selected
+  .cds--tabs--scrollable__nav-link {
   box-shadow: inset 0 2px 0 0 var(--brand-03);
 }
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
- I have added overrides to  not show box shadows when table-expand-button, accordion-heading,  side-nav-link, menu-item-tem when on focus

## Screenshots
<!-- Required if you are making UI changes. -->
![image](https://github.com/openmrs/openmrs-esm-core/assets/53287480/edeef3ab-943b-4eae-add9-8e8291b57288)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-2705](https://openmrs.atlassian.net/browse/O3-2705)

## Other
<!-- Anything not covered above -->
