### PR TITLE
(chore) Enable `continue-on-error` for deploy job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
     steps:
       - name: Trigger RefApp Build
         uses: fjogeleit/http-request-action@master
+        continue-on-error: true
         with:
           url: https://ci.openmrs.org/rest/api/latest/queue/REFAPP-D3X
           method: "POST"


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR adds a `continue-on-error` option to the deploy-patient-chart job and sets its value to true. This makes it so that the workflow will continue to execute even if that step or job encounters an error. This is a prerequisite for additional changes earmarked for the Bamboo deployment job further downstream.

## Screenshots
*None*

## Related Issue
*None*

## Other
*None*