### PR TITLE
(feat) O3-2753: Support multiple configurations when running assemble

### DIFF
--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -258,10 +258,10 @@ yargs.command(
         coerce: (arg) => trimEnd(arg, '/'),
       })
       .option('config', {
-        default: 'spa-build-config.json',
+        default: ['spa-build-config.json'],
         description: 'Path to a SPA build config JSON.',
-        type: 'string',
-        coerce: (arg) => resolve(process.cwd(), arg),
+        type: 'array',
+        coerce: (arg: Array<string>) => arg.map((p) => resolve(process.cwd(), p)),
       })
       .option('hash-importmap', {
         default: false,


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This PR adds a couple of features to the `assemble` command of the CLI, both aimed at assisting with downstream distributions built on top of the reference application:

* The `assemble` command now supports multiple configurations, which are merged in the order they are provided, e.g.,
  ```bash
   npx openmrs@next assemble --mode config --config base-config.json --config override-config.json
  ```
  The goal here is to allow implementations to take the RefApp's assemble configuration as a base and apply overrides.
* Relatedly, the `assemble` command supports a new configuration key `frontendModuleExcludes`, which is an array of strings of frontend modules to remove from the current configuration. `frontendModuleExcludes` are applied in the order that the configuration files are specified, allowing a module to be excluded by one configuration and added by a later one. (I don't imagine there's a lot of use for more than two configuration files, but it seemed like the behaviour should be defined).
* I have renamed the versions manifest `spa-assemble-config.json`. This is technically a breaking change, but there is very little chance that it affects anyone, as this is a sparsely documented feature. The renaming reflects a change in goal for this file. (See below).
* Somewhat incidentally, the various `tgz` files are now handled entirely in memory and not written to disk. This was mostly done to be able to do away with the `baseDir` property, since this was determined relative to the path of the assemble configuration file, which doesn't make a lot of sense if there are multiple files potentially from multiple directories.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-2753

## Other
<!-- Anything not covered above -->

(Reading this is entirely optional)

I originally added `spa-module-versions.json` in #577, with the goal of having some mechanism for tracking the versions of apps available in a distribution. With the update to esm-core V5, all app version numbers are now part of the JSON registry and in #671 I switched things so these versions are leveraged in the implementer tools. 

As part of O3-2753, I'm also trying to solve a long-standing problem of recording the concrete versions that make up an distribution of the O3 RefApp (and, optionally, any downstream applications). Consequently, I'm repurposing this file (which is, in essence, just the final assemble configuration) as an artifact that will be published as part of the distribution. So basically, this becomes a manifest file showing the configuration used for to generate a particular version of the Reference Application, hence the new name `spa-assemble-config.json`, which is a little clearer about its purpose.

Eventually, I'm hoping to restore writing the `tgz` files to disk, but this time into some sort of proper caching directory with actual caching logic, so we don't always have to re-download everything.