### PR TITLE
(fix) O3-2703: Error popup moves the login block downward

### DIFF
--- a/packages/apps/esm-login-app/src/login/login.scss
+++ b/packages/apps/esm-login-app/src/login/login.scss
@@ -5,6 +5,7 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
+  position: relative;
 }
 
 .center {
@@ -137,6 +138,9 @@
 }
 
 .errorMessage {
+  position: absolute;
+  top: 0;
+  margin-top: 0.25rem;
   margin-bottom: 3rem;
   width: 23rem;
 }


### PR DESCRIPTION
## Summary
The Error popup was moving the login block downwards making bad UX.
Now its fixed not to move the login block for a better UX

## Screan recording before fix
https://github.com/openmrs/openmrs-esm-core/assets/122885804/f96a38e0-9970-4aa9-b343-73b6d576174c

## Screenshots
<!-- Required if you are making UI changes. -->
###After fix
![login-block](https://github.com/openmrs/openmrs-esm-core/assets/122885804/90d9fd26-33e2-48d0-be52-e6b6cc4fe4e2)

## Related Issue
[https://openmrs.atlassian.net/browse/O3-2703](url)
