### PR TITLE
(fix) O3-2287: Config system reports unknown config keys for modules that haven't loaded yet

### DIFF
--- a/packages/framework/esm-config/src/module-config/state.ts
+++ b/packages/framework/esm-config/src/module-config/state.ts
@@ -13,12 +13,18 @@ export interface ConfigInternalStore {
   providedConfigs: Array<ProvidedConfig>;
   /** An object with module names for keys and schemas for values */
   schemas: Record<string, ConfigSchema>;
-  /** Whether to use dev defaults or not */
+  /**
+   * Before modules are loaded, they get implicit schemas added to `schemas`. Therefore
+   * we need to track separately whether they have actually been loaded (that is,
+   * whether the schema has actually been defined).
+   */
+  moduleLoaded: Record<string, boolean>;
 }
 
 const configInternalStoreInitialValue = {
   providedConfigs: [],
   schemas: {},
+  moduleLoaded: {},
 };
 
 /**
@@ -92,12 +98,14 @@ export const configExtensionStore = createGlobalStore<ConfigExtensionStore>('con
 export interface ConfigStore {
   config: ConfigObject | null;
   loaded: boolean;
+  translationOverridesLoaded: boolean;
 }
 
 function initializeConfigStore() {
   return {
     config: null,
     loaded: false,
+    translationOverridesLoaded: false,
   };
 }
 

--- a/packages/framework/esm-react-utils/src/useConfig.ts
+++ b/packages/framework/esm-react-utils/src/useConfig.ts
@@ -137,9 +137,9 @@ interface UseConfigOptions {
  * @param options Additional options that can be passed to useConfig()
  */
 export function useConfig<T = Record<string, any>>(options?: UseConfigOptions) {
-  // This hook uses the config of the MF defining the component.
-  // If the component is used in an extension slot then the slot
-  // may override (part of) its configuration.
+  // This hook gets the appropriate configuration depending on whether the caller is a module
+  // or an extension, which is determined from the ComponentContext. It will throw for suspense
+  // if the configuration is not yet loaded.
   const { moduleName: contextModuleName, extension } = useContext(ComponentContext);
   const moduleName = options?.externalModuleName ?? contextModuleName;
 

--- a/packages/shell/esm-app-shell/src/apps.ts
+++ b/packages/shell/esm-app-shell/src/apps.ts
@@ -5,9 +5,10 @@ import type {
   RouteDefinition,
   ExtensionRegistration,
 } from '@openmrs/esm-framework';
-import { attach, registerExtension, defineConfigSchema, importDynamic } from '@openmrs/esm-framework';
+import { attach, registerExtension, importDynamic } from '@openmrs/esm-framework';
 import { type ActivityFn, type LifeCycles, pathToActiveWhen, registerApplication } from 'single-spa';
 import { emptyLifecycle, routeRegex } from './helpers';
+import { registerModuleWithConfigSystem } from '@openmrs/esm-framework/src/internal';
 
 const pages: Array<RegisteredPageDefinition> = [];
 
@@ -127,7 +128,7 @@ function getLoader(appName: string, component: string): () => Promise<LifeCycles
  */
 export function registerApp(appName: string, routes: OpenmrsAppRoutes) {
   if (appName && routes && typeof routes === 'object') {
-    defineConfigSchema(appName, {});
+    registerModuleWithConfigSystem(appName);
 
     const availableExtensions: Array<ExtensionDefinition> = routes.extensions ?? [];
 

--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -2,7 +2,7 @@ import * as i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
 import merge from 'lodash-es/merge';
-import { getConfigInternal, importDynamic } from '@openmrs/esm-framework/src/internal';
+import { getTranslationOverrides, importDynamic } from '@openmrs/esm-framework/src/internal';
 
 export function setupI18n() {
   window.i18next = i18next.default || i18next;
@@ -33,14 +33,11 @@ export function setupI18n() {
           callback(Error(), null);
         } else if (namespace === '@openmrs/esm-app-shell') {
           // currently, we don't have translations in the app shell
-          getConfigInternal(namespace)
-            .then((config) => {
+          getTranslationOverrides(namespace)
+            .then((overrides) => {
               let translations = {};
-              if (config && 'Translation overrides' in config) {
-                const overrides = config['Translation overrides'];
-                if (language in overrides) {
-                  translations = overrides[language];
-                }
+              if (language in overrides) {
+                translations = overrides[language];
               }
 
               callback(null, translations);
@@ -51,16 +48,13 @@ export function setupI18n() {
         } else {
           importDynamic(namespace)
             .then((module) =>
-              Promise.all([getImportPromise(module, namespace, language), getConfigInternal(namespace)]),
+              Promise.all([getImportPromise(module, namespace, language), getTranslationOverrides(namespace)]),
             )
-            .then(([json, config]) => {
+            .then(([json, overrides]) => {
               let translations = json ?? {};
 
-              if (config && 'Translation overrides' in config) {
-                const overrides = config['Translation overrides'];
-                if (language in overrides) {
-                  translations = merge(translations, overrides[language]);
-                }
+              if (language in overrides) {
+                translations = merge(translations, overrides[language]);
               }
 
               callback(null, translations);


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This makes a clean demarcation between computing configs based on implicit schemas (provided at module registration time in the app shell), versus based on the actually defined schema provided by a loaded module. We need to be able to do the first prior to the second because translation loading will block module loading. Having these two phases distinguished, we can avoid running validations for schemas we don't actually have access to yet.

## Related Issue

https://openmrs.atlassian.net/browse/O3-2287

