### PR TITLE
O3-2691: Add E2E logout test

### DIFF
--- a/e2e/pages/login-page.ts
+++ b/e2e/pages/login-page.ts
@@ -6,4 +6,13 @@ export class LoginPage {
   async goto() {
     await this.page.goto(`${process.env.E2E_BASE_URL}/spa/login`);
   }
+
+  async enterLoginCredentials() {
+    await this.page.getByLabel(/username/i).fill(`${process.env.E2E_USER_ADMIN_USERNAME}`);
+    await this.page.getByText(/continue/i).click();
+    await this.page.getByLabel(/password/i).fill(`${process.env.E2E_USER_ADMIN_PASSWORD}`);
+    await this.page.getByRole('button', { name: /log in/i }).click();
+    await this.page.getByText(/inpatient ward/i).click();
+    await this.page.getByRole('button', { name: /confirm/i }).click();
+  }
 }

--- a/e2e/specs/login.spec.ts
+++ b/e2e/specs/login.spec.ts
@@ -5,37 +5,42 @@ import { LoginPage } from '../pages';
 test('Login as Admin user', async ({ page }) => {
   const loginPage = new LoginPage(page);
 
-  await test.step('When I navigate to the login page', async () => {
+  await test.step('When a user navigates to the login page', async () => {
     await loginPage.goto();
   });
 
-  await test.step('And I enter my username', async () => {
+  await test.step('And enters the username', async () => {
     await page.getByLabel(/username/i).fill(`${process.env.E2E_USER_ADMIN_USERNAME}`);
     await page.getByText(/continue/i).click();
   });
 
-  await test.step('And I enter my password', async () => {
+  await test.step('And enters the password', async () => {
     await page.getByLabel(/password/i).fill(`${process.env.E2E_USER_ADMIN_PASSWORD}`);
   });
 
-  await test.step('And I click the `Log in` button', async () => {
+  await test.step('And clicks on `Log in` button', async () => {
     await page.getByRole('button', { name: /log in/i }).click();
   });
 
-  await test.step('And I choose a login location', async () => {
+  await test.step('And chooses a login location', async () => {
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/login/location`);
     await page.getByText(/outpatient clinic/i).click();
     await page.getByRole('button', { name: /confirm/i }).click();
   });
 
-  await test.step('Then I should get navigated to the home page', async () => {
+  await test.step('Then the system loads home page', async () => {
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home`);
-  });
-
-  await test.step('And I should be able to see various elements on the page', async () => {
     await page.getByRole('button', { name: /user/i }).click();
     await expect(page.getByText(/super user/i)).toBeVisible();
     await expect(page.getByText(/outpatient clinic/i)).toBeVisible();
     await expect(page.getByRole('button', { name: /logout/i })).toBeVisible();
+  });
+
+  await test.step('And click on `Logout` button', async () => {
+    await page.getByRole('button', { name: /logout/i }).click();
+    await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/login`);
+    await expect(page.getByTitle('close notification')).not.toBeVisible();
+    await expect(page.getByText('Language ID should be string or object.')).not.toBeVisible();
+    await expect(page.getByText('Cannot read properties of undefined (reading `person`)')).not.toBeVisible();
   });
 });

--- a/e2e/specs/login.spec.ts
+++ b/e2e/specs/login.spec.ts
@@ -5,42 +5,37 @@ import { LoginPage } from '../pages';
 test('Login as Admin user', async ({ page }) => {
   const loginPage = new LoginPage(page);
 
-  await test.step('When a user navigates to the login page', async () => {
+  await test.step('When I navigate to the login page', async () => {
     await loginPage.goto();
   });
 
-  await test.step('And enters the username', async () => {
+  await test.step('And I enter my username', async () => {
     await page.getByLabel(/username/i).fill(`${process.env.E2E_USER_ADMIN_USERNAME}`);
     await page.getByText(/continue/i).click();
   });
 
-  await test.step('And enters the password', async () => {
+  await test.step('And I enter my password', async () => {
     await page.getByLabel(/password/i).fill(`${process.env.E2E_USER_ADMIN_PASSWORD}`);
   });
 
-  await test.step('And clicks on `Log in` button', async () => {
+  await test.step('And I click the `Log in` button', async () => {
     await page.getByRole('button', { name: /log in/i }).click();
   });
 
-  await test.step('And chooses a login location', async () => {
+  await test.step('And I choose a login location', async () => {
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/login/location`);
     await page.getByText(/outpatient clinic/i).click();
     await page.getByRole('button', { name: /confirm/i }).click();
   });
 
-  await test.step('Then the system loads home page', async () => {
+  await test.step('Then I should get navigated to the home page', async () => {
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home`);
+  });
+
+  await test.step('And I should be able to see various elements on the page', async () => {
     await page.getByRole('button', { name: /user/i }).click();
     await expect(page.getByText(/super user/i)).toBeVisible();
     await expect(page.getByText(/outpatient clinic/i)).toBeVisible();
     await expect(page.getByRole('button', { name: /logout/i })).toBeVisible();
-  });
-
-  await test.step('And click on `Logout` button', async () => {
-    await page.getByRole('button', { name: /logout/i }).click();
-    await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/login`);
-    await expect(page.getByTitle('close notification')).not.toBeVisible();
-    await expect(page.getByText('Language ID should be string or object.')).not.toBeVisible();
-    await expect(page.getByText('Cannot read properties of undefined (reading `person`)')).not.toBeVisible();
   });
 });

--- a/e2e/specs/logout.spec.ts
+++ b/e2e/specs/logout.spec.ts
@@ -5,17 +5,21 @@ import { LoginPage } from '../pages';
 test('Logout as Admin user', async ({ page }) => {
   const loginPage = new LoginPage(page);
 
-  await test.step('When I navigate to the home page', async () => {
+  await test.step('When I go to Login page', async () => {
     await loginPage.goto();
+  });
+
+  await test.step('And I enter the login credentials', async () => {
     await loginPage.enterLoginCredentials();
-    await page.goto('home');
+  });
+
+  await test.step('Then I should be in the Home page', async () => {
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home`);
   });
 
   await test.step('And I click the `User` button', async () => {
     await page.getByRole('button', { name: /user/i }).click();
     await expect(page.getByText(/super user/i)).toBeVisible();
-    await expect(page.getByRole('button', { name: /logout/i })).toBeVisible();
   });
 
   await test.step('And I click the `Logout` button', async () => {
@@ -24,6 +28,9 @@ test('Logout as Admin user', async ({ page }) => {
 
   await test.step('Then I should be redirected to the login page', async () => {
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/login`);
+  });
+
+  await test.step('And I should not see any error messages', async () => {
     await expect(page.getByText('error')).not.toBeVisible();
   });
 });

--- a/e2e/specs/logout.spec.ts
+++ b/e2e/specs/logout.spec.ts
@@ -13,13 +13,12 @@ test('Logout as Admin user', async ({ page }) => {
     await loginPage.enterLoginCredentials();
   });
 
-  await test.step('Then I should be in the Home page', async () => {
+  await test.step('Then I should be on the Home page', async () => {
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home`);
   });
 
-  await test.step('And I click the `User` button', async () => {
+  await test.step('When I click the `User` button', async () => {
     await page.getByRole('button', { name: /user/i }).click();
-    await expect(page.getByText(/super user/i)).toBeVisible();
   });
 
   await test.step('And I click the `Logout` button', async () => {

--- a/e2e/specs/logout.spec.ts
+++ b/e2e/specs/logout.spec.ts
@@ -1,0 +1,31 @@
+import { test } from '../core';
+import { expect } from '@playwright/test';
+import { LoginPage } from '../pages';
+
+test('Logout as Admin user', async ({ page }) => {
+  const loginPage = new LoginPage(page);
+
+  await test.step('When I navigate to the home page', async () => {
+    await loginPage.goto();
+    await loginPage.enterLoginCredentials();
+    await page.goto('home');
+    await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home`);
+  });
+
+  await test.step('And I click the `User` button', async () => {
+    await page.getByRole('button', { name: /user/i }).click();
+    await expect(page.getByText(/super user/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: /logout/i })).toBeVisible();
+  });
+
+  await test.step('And I click the `Logout` button', async () => {
+    await page.getByRole('button', { name: /logout/i }).click();
+  });
+
+  await test.step('Then I should be redirected to the login page', async () => {
+    await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/login`);
+    await expect(page.getByTitle('close notification')).not.toBeVisible();
+    await expect(page.getByText('Language ID should be string or object.')).not.toBeVisible();
+    await expect(page.getByText('Cannot read properties of undefined (reading `person`)')).not.toBeVisible();
+  });
+});

--- a/e2e/specs/logout.spec.ts
+++ b/e2e/specs/logout.spec.ts
@@ -24,8 +24,6 @@ test('Logout as Admin user', async ({ page }) => {
 
   await test.step('Then I should be redirected to the login page', async () => {
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/login`);
-    await expect(page.getByTitle('close notification')).not.toBeVisible();
-    await expect(page.getByText('Language ID should be string or object.')).not.toBeVisible();
-    await expect(page.getByText('Cannot read properties of undefined (reading `person`)')).not.toBeVisible();
+    await expect(page.getByText('error')).not.toBeVisible();
   });
 });


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This Pull request adds E2E logout test. It is intended to catch UI errors that pop up when a user logout of the system.
Previously, UI errors could pop up when a user logout of the system and this was fixed in [O3-1242](https://openmrs.atlassian.net/browse/O3-1242) and [O3-2692](https://openmrs.atlassian.net/browse/O3-2692)

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
 https://issues.openmrs.org/browse/O3-2691

## Other
<!-- Anything not covered above -->
