### PR TITLE
(feat) Add ResponsiveWrapper to style guide

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1861,7 +1861,7 @@ for more information about defining a config schema.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:142](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L142)
+[packages/framework/esm-config/src/module-config/module-config.ts:164](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L164)
 
 ___
 
@@ -1893,7 +1893,7 @@ for more information about defining a config schema.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:169](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L169)
+[packages/framework/esm-config/src/module-config/module-config.ts:209](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L209)
 
 ___
 
@@ -1925,7 +1925,7 @@ of the execution of a function.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:201](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L201)
+[packages/framework/esm-config/src/module-config/module-config.ts:241](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L241)
 
 ___
 
@@ -1946,7 +1946,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:185](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L185)
+[packages/framework/esm-config/src/module-config/module-config.ts:225](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L225)
 
 ___
 
@@ -5138,7 +5138,7 @@ ___
 
 ### useOpenmrsSWR
 
-▸ **useOpenmrsSWR**(`key`, `options?`): `SWRResponse`<[`FetchResponse`](interfaces/FetchResponse.md)<`any`\>, `any`, `undefined` \| `Partial`<`PublicConfiguration`<`any`, `any`, `BareFetcher`<`any`\>\>\>\>
+▸ **useOpenmrsSWR**<`DataType`, `ErrorType`\>(`key`, `options?`): `SWRResponse`<[`FetchResponse`](interfaces/FetchResponse.md)<`DataType`\>, `ErrorType`, `undefined` \| `Partial`<`PublicConfiguration`<[`FetchResponse`](interfaces/FetchResponse.md)<`DataType`\>, `ErrorType`, `BareFetcher`<[`FetchResponse`](interfaces/FetchResponse.md)<`DataType`\>\>\>\>\>
 
 **`beta`**
 
@@ -5175,6 +5175,13 @@ function MyComponent() {
 }
 ```
 
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `DataType` | `any` |
+| `ErrorType` | `any` |
+
 #### Parameters
 
 | Name | Type | Description |
@@ -5184,7 +5191,7 @@ function MyComponent() {
 
 #### Returns
 
-`SWRResponse`<[`FetchResponse`](interfaces/FetchResponse.md)<`any`\>, `any`, `undefined` \| `Partial`<`PublicConfiguration`<`any`, `any`, `BareFetcher`<`any`\>\>\>\>
+`SWRResponse`<[`FetchResponse`](interfaces/FetchResponse.md)<`DataType`\>, `ErrorType`, `undefined` \| `Partial`<`PublicConfiguration`<[`FetchResponse`](interfaces/FetchResponse.md)<`DataType`\>, `ErrorType`, `BareFetcher`<[`FetchResponse`](interfaces/FetchResponse.md)<`DataType`\>\>\>\>\>
 
 #### Defined in
 

--- a/packages/framework/esm-styleguide/src/index.ts
+++ b/packages/framework/esm-styleguide/src/index.ts
@@ -13,6 +13,7 @@ export * from './modals';
 export * from './left-nav';
 export * from './error-state';
 export * from './datepicker';
+export * from './responsive-wrapper';
 
 defineConfigSchema('@openmrs/esm-styleguide', esmStyleGuideSchema);
 setupBranding();

--- a/packages/framework/esm-styleguide/src/responsive-wrapper/index.ts
+++ b/packages/framework/esm-styleguide/src/responsive-wrapper/index.ts
@@ -1,0 +1,1 @@
+export * from './responsive-wrapper.component';

--- a/packages/framework/esm-styleguide/src/responsive-wrapper/responsive-wrapper.component.tsx
+++ b/packages/framework/esm-styleguide/src/responsive-wrapper/responsive-wrapper.component.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Layer } from '@carbon/react';
+import { useLayoutType } from '@openmrs/esm-framework';
+
+type ResponsiveWrapperProps = {
+  children: React.ReactNode;
+};
+
+/**
+ * ResponsiveWrapper enables a responsive behavior for the component its wraps, providing a different rendering based on the current layout type.
+ * On desktop, it renders the children as is, while on a tablet, it wraps them in a Carbon Layer https://react.carbondesignsystem.com/?path=/docs/components-layer--overview component.
+ * This provides a light background for form inputs on tablets, in accordance with the design requirements.
+ */
+export default function ResponsiveWrapper({ children }: ResponsiveWrapperProps) {
+  const layout = useLayoutType();
+  const isTablet = layout === 'tablet';
+
+  if (isTablet) {
+    return <Layer>{children}</Layer>;
+  }
+
+  return <>{children}</>;
+}


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR adds a new component, `ResponsiveWrapper` to the style guide that makes it easier to provide responsive behaviour for form inputs. 

In our [form designs](https://zeroheight.com/23a080e38/p/448ac6-vitals-input), inputs have a light background on tablet and a grey background on desktop. This component wraps its children within a Carbon [Layer](https://react.carbondesignsystem.com/?path=/docs/components-layer--overview) component on tablet, and renders them as is on desktop. In older versions of carbon, form inputs such as `TextInput`, `NumberInput` and `Textarea` exposed a `light` prop that could be used to toggle similar behaviour. v11 of Carbon deprecated the `light` prop in favour of the `Layer` component. This component leverages `Layer` to provide consistent rendering behaviour on both desktop and tablet.

I'd originally added this component to the `@openmrs/esm-patient-common-lib` library in https://github.com/openmrs/openmrs-esm-patient-chart/pull/1622, but it seems more appropriate to have it here as it'll likely be used in many other places than just the Patient Chart.

## Screenshots

### Light inputs on tablet, gray inputs on desktop

![CleanShot 2024-01-26 at 12  54 46@2x](https://github.com/openmrs/openmrs-esm-patient-chart/assets/8509731/eb250563-9612-436c-b585-4dbdb26467fc)

## Related Issue
*None*

## Other
*None*