### PR TITLE
(fix) O3-2733: Automatically close header panels on panel selection

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -53,9 +53,8 @@ const HeaderItems: React.FC = () => {
             aria-label="Open menu"
             isCollapsible
             className={styles.headerMenuButton}
-            onClick={(event) => {
-              togglePanel('sideMenu');
-              event.stopPropagation();
+            onClick={() => {
+              setTimeout(() => togglePanel('sideMenu'), 0);
             }}
             isActive={isActivePanel('sideMenu')}
           />
@@ -86,27 +85,13 @@ const HeaderItems: React.FC = () => {
               enterDelayMs={500}
               name="User"
               isActive={isActivePanel('userMenu')}
-              onClick={(event) => {
-                setTimeout(() => {
-                togglePanel('userMenu');
-              }, 100);
-            }}
+              onClick={() => {
+                setTimeout(() => togglePanel('userMenu'), 0);
+              }}
             >
-              {isActivePanel('userMenu') ? (
-               <button
-               className={styles.closeButton}
-               onClick={(event) => {
-                 togglePanel('userMenu');
-                 event.stopPropagation();
-               }}
-             >
-               <Close size={20} />
-             </button>
-           ) : (
-             <UserAvatarFilledAlt size={20} />
-           )}
-         </HeaderGlobalAction>
-       )}
+              {isActivePanel('userMenu') ? <Close size={20} /> : <UserAvatarFilledAlt size={20} />}
+            </HeaderGlobalAction>
+          )}
           {showAppMenu && (
             <HeaderGlobalAction
               aria-label="App Menu"
@@ -118,25 +103,11 @@ const HeaderItems: React.FC = () => {
               enterDelayMs={500}
               isActive={isActivePanel('appMenu')}
               tooltipAlignment="end"
-              onClick={(event) => {
-                setTimeout(() => {
-                  togglePanel('appMenu');
-                }, 100);
+              onClick={() => {
+                setTimeout(() => togglePanel('appMenu'), 0);
               }}
-              >
-              {isActivePanel('appMenu') ? (
-                <button
-                  className={styles.closeButton}
-                  onClick={(event) => {
-                    togglePanel('appMenu');
-                    event.stopPropagation();
-                  }}
-                >
-                  <Close size={20} />
-                </button>
-              ) : (
-                <Switcher size={20} />
-              )}
+            >
+              {isActivePanel('appMenu') ? <Close size={20} /> : <Switcher size={20} />}
             </HeaderGlobalAction>
           )}
         </HeaderGlobalBar>

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -87,13 +87,26 @@ const HeaderItems: React.FC = () => {
               name="User"
               isActive={isActivePanel('userMenu')}
               onClick={(event) => {
+                setTimeout(() => {
                 togglePanel('userMenu');
-                event.stopPropagation();
-              }}
+              }, 100);
+            }}
             >
-              {isActivePanel('userMenu') ? <Close size={20} /> : <UserAvatarFilledAlt size={20} />}
-            </HeaderGlobalAction>
-          )}
+              {isActivePanel('userMenu') ? (
+               <button
+               className={styles.closeButton}
+               onClick={(event) => {
+                 togglePanel('userMenu');
+                 event.stopPropagation();
+               }}
+             >
+               <Close size={20} />
+             </button>
+           ) : (
+             <UserAvatarFilledAlt size={20} />
+           )}
+         </HeaderGlobalAction>
+       )}
           {showAppMenu && (
             <HeaderGlobalAction
               aria-label="App Menu"
@@ -106,11 +119,24 @@ const HeaderItems: React.FC = () => {
               isActive={isActivePanel('appMenu')}
               tooltipAlignment="end"
               onClick={(event) => {
-                togglePanel('appMenu');
-                event.stopPropagation();
+                setTimeout(() => {
+                  togglePanel('appMenu');
+                }, 100);
               }}
-            >
-              {isActivePanel('appMenu') ? <Close size={20} /> : <Switcher size={20} />}
+              >
+              {isActivePanel('appMenu') ? (
+                <button
+                  className={styles.closeButton}
+                  onClick={(event) => {
+                    togglePanel('appMenu');
+                    event.stopPropagation();
+                  }}
+                >
+                  <Close size={20} />
+                </button>
+              ) : (
+                <Switcher size={20} />
+              )}
             </HeaderGlobalAction>
           )}
         </HeaderGlobalBar>

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.scss
@@ -34,11 +34,3 @@
 .spacedLogo {
   margin-left: 1rem;
 }
-
-.closeButton {
-  @include brand-01(background-color);
-  height: spacing.$spacing-09;
-  width: spacing.$spacing-09;
-  padding: spacing.$spacing-04;
-  margin-right: spacing.$spacing-02;
-}

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.scss
@@ -34,3 +34,11 @@
 .spacedLogo {
   margin-left: 1rem;
 }
+
+.closeButton {
+  @include brand-01(background-color);
+  height: spacing.$spacing-09;
+  width: spacing.$spacing-09;
+  padding: spacing.$spacing-04;
+  margin-right: spacing.$spacing-02;
+}


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
I modified the code when the Menu" button is clicked, it toggles the visibility of the "App Menu" or Use Menu panel after a short delay and displays either a close button or a switcher icon based on the current state of the panel. The delay is introduced to allow any animations or transitions to complete before changing the panel's visibility.

## Screenshots
**Before**

https://github.com/openmrs/openmrs-esm-core/assets/33891016/31ce7f75-7bad-4de4-9d1f-33866138a3d6


**After fixing**

https://github.com/openmrs/openmrs-esm-core/assets/33891016/8fff2f76-848c-4d7d-9939-6bbeca923c9f

## Related Issue
https://openmrs.atlassian.net/browse/O3-2733

## Other
<!-- Anything not covered above -->
