### PR TITLE
(fix) useOnClickOutside should not use the click event

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/app-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/app-menu-panel.component.tsx
@@ -8,11 +8,11 @@ import styles from './app-menu-panel.scss';
 
 interface AppMenuProps {
   expanded: boolean;
-  hidePanel: () => void;
+  hidePanel: Parameters<typeof useOnClickOutside>[0];
 }
 
 const AppMenuPanel: React.FC<AppMenuProps> = ({ expanded, hidePanel }) => {
-  const appMenuRef = useOnClickOutside<HTMLDivElement>(hidePanel, expanded);
+  const appMenuRef = useOnClickOutside(hidePanel, expanded);
   const config = useConfig();
   const { t } = useTranslation();
 
@@ -22,7 +22,6 @@ const AppMenuPanel: React.FC<AppMenuProps> = ({ expanded, hidePanel }) => {
       className={classNames({ [styles.headerPanel]: expanded })}
       aria-label="App Menu Panel"
       expanded={expanded}
-      onClick={() => hidePanel()}
     >
       <ExtensionSlot className={styles.menuLink} name="app-menu-slot" />
       {config?.externalRefLinks?.length > 0 && (

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
@@ -1,28 +1,17 @@
 import React, { useEffect, useRef } from 'react';
-import { LeftNavMenu } from '@openmrs/esm-framework';
+import { LeftNavMenu, useOnClickOutside } from '@openmrs/esm-framework';
 
 interface SideMenuPanelProps {
   expanded: boolean;
-  hidePanel: () => void;
+  hidePanel: Parameters<typeof useOnClickOutside>[0];
 }
 
 const SideMenuPanel: React.FC<SideMenuPanelProps> = ({ expanded, hidePanel }) => {
-  const menuRef = useRef(null);
-
-  useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
-      if (menuRef?.current && !menuRef.current.contains(event.target)) {
-        hidePanel();
-      }
-    };
-
-    document.addEventListener('click', handleClickOutside);
-    return () => document.removeEventListener('click', handleClickOutside);
-  }, [menuRef, hidePanel]);
+  const menuRef = useOnClickOutside(hidePanel, expanded);
 
   useEffect(() => {
     window.addEventListener('popstate', hidePanel);
-    return window.addEventListener('popstate', hidePanel);
+    return window.removeEventListener('popstate', hidePanel);
   }, [hidePanel]);
 
   return expanded && <LeftNavMenu ref={menuRef} isChildOfHeader />;

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/user-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/user-menu-panel.component.tsx
@@ -5,7 +5,7 @@ import styles from './user-menu-panel.scss';
 
 interface UserMenuPanelProps extends HeaderPanelProps {
   expanded: boolean;
-  hidePanel: () => void;
+  hidePanel: Parameters<typeof useOnClickOutside>[0];
 }
 
 /**
@@ -13,7 +13,7 @@ interface UserMenuPanelProps extends HeaderPanelProps {
  * general be wrapped in the `SwitcherItem` Carbon component.
  */
 const UserMenuPanel: React.FC<UserMenuPanelProps> = ({ expanded, hidePanel }) => {
-  const userMenuRef = useOnClickOutside<HTMLDivElement>(hidePanel, expanded);
+  const userMenuRef = useOnClickOutside(hidePanel, expanded);
 
   return (
     <HeaderPanel

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -31,15 +31,16 @@ const HeaderItems: React.FC = () => {
   const userMenuItems = useConnectedExtensions('user-panel-slot');
   const isActivePanel = useCallback((panelName: string) => activeHeaderPanel === panelName, [activeHeaderPanel]);
 
-  const togglePanel = useCallback(
-    (panelName: string) =>
-      setActiveHeaderPanel((activeHeaderPanel) => (activeHeaderPanel === panelName ? null : panelName)),
+  const togglePanel = useCallback((panelName: string) => {
+    setActiveHeaderPanel((activeHeaderPanel) => (activeHeaderPanel === panelName ? null : panelName));
+  }, []);
+
+  const hidePanel = useCallback(
+    (panelName: string) => () => {
+      setActiveHeaderPanel((activeHeaderPanel) => (activeHeaderPanel === panelName ? null : activeHeaderPanel));
+    },
     [],
   );
-
-  const hidePanel = useCallback(() => {
-    setActiveHeaderPanel(null);
-  }, []);
 
   const showHamburger = useMemo(() => !isDesktop(layout) && navMenuItems.length > 0, [navMenuItems.length, layout]);
   const showAppMenu = useMemo(() => appMenuItems.length > 0, [appMenuItems.length]);
@@ -53,8 +54,8 @@ const HeaderItems: React.FC = () => {
             aria-label="Open menu"
             isCollapsible
             className={styles.headerMenuButton}
-            onClick={() => {
-              setTimeout(() => togglePanel('sideMenu'), 0);
+            onClick={(event) => {
+              togglePanel('sideMenu');
             }}
             isActive={isActivePanel('sideMenu')}
           />
@@ -86,7 +87,7 @@ const HeaderItems: React.FC = () => {
               name="User"
               isActive={isActivePanel('userMenu')}
               onClick={() => {
-                setTimeout(() => togglePanel('userMenu'), 0);
+                togglePanel('userMenu');
               }}
             >
               {isActivePanel('userMenu') ? <Close size={20} /> : <UserAvatarFilledAlt size={20} />}
@@ -104,17 +105,17 @@ const HeaderItems: React.FC = () => {
               isActive={isActivePanel('appMenu')}
               tooltipAlignment="end"
               onClick={() => {
-                setTimeout(() => togglePanel('appMenu'), 0);
+                togglePanel('appMenu');
               }}
             >
               {isActivePanel('appMenu') ? <Close size={20} /> : <Switcher size={20} />}
             </HeaderGlobalAction>
           )}
         </HeaderGlobalBar>
-        {!isDesktop(layout) && <SideMenuPanel hidePanel={hidePanel} expanded={isActivePanel('sideMenu')} />}
-        {showAppMenu && <AppMenuPanel expanded={isActivePanel('appMenu')} hidePanel={hidePanel} />}
+        {!isDesktop(layout) && <SideMenuPanel hidePanel={hidePanel('sideMenu')} expanded={isActivePanel('sideMenu')} />}
+        {showAppMenu && <AppMenuPanel expanded={isActivePanel('appMenu')} hidePanel={hidePanel('appMenu')} />}
         <NotificationsMenuPanel expanded={isActivePanel('notificationsMenu')} />
-        {showUserMenu && <UserMenuPanel expanded={isActivePanel('userMenu')} hidePanel={hidePanel} />}
+        {showUserMenu && <UserMenuPanel expanded={isActivePanel('userMenu')} hidePanel={hidePanel('userMenu')} />}
       </Header>
     </>
   );

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -4758,7 +4758,7 @@ ___
 
 | Name | Type | Default value |
 | :------ | :------ | :------ |
-| `handler` | (`event`: `Event`) => `void` | `undefined` |
+| `handler` | (`event`: `MouseEvent`) => `void` | `undefined` |
 | `active` | `boolean` | `true` |
 
 #### Returns

--- a/packages/framework/esm-react-utils/src/useOnClickOutside.test.tsx
+++ b/packages/framework/esm-react-utils/src/useOnClickOutside.test.tsx
@@ -59,6 +59,7 @@ describe('useOnClickOutside', () => {
     ref.unmount();
 
     // verify
-    expect(spy).toHaveBeenCalledWith('click', expect.any(Function));
+    expect(spy).toHaveBeenCalledWith('mousedown', expect.any(Function));
+    expect(spy).toHaveBeenCalledWith('touchstart', expect.any(Function));
   });
 });

--- a/packages/framework/esm-react-utils/src/useOnClickOutside.ts
+++ b/packages/framework/esm-react-utils/src/useOnClickOutside.ts
@@ -1,22 +1,27 @@
 /** @module @category UI */
 import { useRef, useEffect } from 'react';
 
-export function useOnClickOutside<T extends HTMLElement = HTMLElement>(handler: (event: Event) => void, active = true) {
+export function useOnClickOutside<T extends HTMLElement = HTMLElement>(
+  handler: (event: MouseEvent) => void,
+  active = true,
+) {
   const ref = useRef<T>(null);
 
   useEffect(() => {
-    if (active) {
-      const listener = (event: Event) => {
-        if (ref?.current?.contains(event.target as Node)) {
-          return;
-        }
+    const listener = (event: MouseEvent) => {
+      if (!active || !ref.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
 
-        handler(event);
-      };
+      handler(event);
+    };
 
-      window.addEventListener(`click`, listener);
-      return () => window.removeEventListener(`click`, listener);
-    }
+    window.addEventListener(`mousedown`, listener);
+    window.addEventListener(`touchstart`, listener);
+    return () => {
+      window.removeEventListener(`mousedown`, listener);
+      window.removeEventListener(`touchstart`, listener);
+    };
   }, [handler, active]);
 
   return ref;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This reworks `useOnClickOutside()` so that it binds only to the `mousedown` or `touchstart` events rather than the `click` event.

A rationale for this with context is [here](https://openmrs.slack.com/archives/CHP5QAE5R/p1706810370264969), but, in essence, a React component can render in response to the React synthetic `click` event before the native DOM `click` has completed bubbling. This means that a component rendered as the result of a `onClick` event that uses this hook is likely to have its `OnClickOutside` handler fired before the component has actually appeared to the user, which is very undesirable. By binding to the `mousedown` or `touchstart` events, we bypass this issue, since the synthetic `click` event is only fired _after_ the native `mousedown` or `touchstart` event has completed.

Because of this fix, I've also reverted [9afd854](https://github.com/openmrs/openmrs-esm-core/commit/9afd85492ee53a60776b05fa984514dcdee0f2e5) and made a couple of small improvements in related code.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
