### PR TITLE
(feat) Extend `createAttachment` to handle descriptions of image uploads

### DIFF
--- a/packages/framework/esm-api/src/attachments.ts
+++ b/packages/framework/esm-api/src/attachments.ts
@@ -19,7 +19,8 @@ export function getAttachments(patientUuid: string, includeEncounterless: boolea
 export async function createAttachment(patientUuid: string, fileToUpload: UploadedFile) {
   const formData = new FormData();
 
-  formData.append('fileCaption', fileToUpload.fileName);
+  formData.append('fileName', fileToUpload.fileName);
+  formData.append('fileCaption', fileToUpload.fileDescription);
   formData.append('patient', patientUuid);
 
   if (fileToUpload.file) {
@@ -28,6 +29,7 @@ export async function createAttachment(patientUuid: string, fileToUpload: Upload
     formData.append('file', new File([''], fileToUpload.fileName), fileToUpload.fileName);
     formData.append('base64Content', fileToUpload.base64Content);
   }
+
   return openmrsFetch(`${attachmentUrl}`, {
     method: 'POST',
     body: formData,

--- a/packages/framework/esm-api/src/attachments.ts
+++ b/packages/framework/esm-api/src/attachments.ts
@@ -19,7 +19,6 @@ export function getAttachments(patientUuid: string, includeEncounterless: boolea
 export async function createAttachment(patientUuid: string, fileToUpload: UploadedFile) {
   const formData = new FormData();
 
-  formData.append('fileName', fileToUpload.fileName);
   formData.append('fileCaption', fileToUpload.fileDescription);
   formData.append('patient', patientUuid);
 

--- a/packages/framework/esm-api/src/types/attachments-types.ts
+++ b/packages/framework/esm-api/src/types/attachments-types.ts
@@ -10,12 +10,13 @@ export interface UploadedFile {
 export interface Attachment {
   id: string;
   src: string;
-  title: string;
-  description: string;
+  filename: string;
+  comment: string;
   dateTime: string;
   bytesMimeType: string;
   bytesContentFamily: string;
 }
+
 export interface AttachmentResponse {
   bytesContentFamily: string;
   bytesMimeType: string;

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -991,7 +991,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/attachments.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/attachments.ts#L39)
+[packages/framework/esm-api/src/attachments.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/attachments.ts#L38)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -991,7 +991,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/attachments.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/attachments.ts#L37)
+[packages/framework/esm-api/src/attachments.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/attachments.ts#L39)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/Attachment.md
+++ b/packages/framework/esm-framework/docs/interfaces/Attachment.md
@@ -8,11 +8,11 @@
 
 - [bytesContentFamily](Attachment.md#bytescontentfamily)
 - [bytesMimeType](Attachment.md#bytesmimetype)
+- [comment](Attachment.md#comment)
 - [dateTime](Attachment.md#datetime)
-- [description](Attachment.md#description)
+- [filename](Attachment.md#filename)
 - [id](Attachment.md#id)
 - [src](Attachment.md#src)
-- [title](Attachment.md#title)
 
 ## Properties
 
@@ -36,6 +36,16 @@ ___
 
 ___
 
+### comment
+
+• **comment**: `string`
+
+#### Defined in
+
+[packages/framework/esm-api/src/types/attachments-types.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L14)
+
+___
+
 ### dateTime
 
 • **dateTime**: `string`
@@ -46,13 +56,13 @@ ___
 
 ___
 
-### description
+### filename
 
-• **description**: `string`
+• **filename**: `string`
 
 #### Defined in
 
-[packages/framework/esm-api/src/types/attachments-types.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L14)
+[packages/framework/esm-api/src/types/attachments-types.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L13)
 
 ___
 
@@ -73,13 +83,3 @@ ___
 #### Defined in
 
 [packages/framework/esm-api/src/types/attachments-types.ts:12](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L12)
-
-___
-
-### title
-
-• **title**: `string`
-
-#### Defined in
-
-[packages/framework/esm-api/src/types/attachments-types.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L13)

--- a/packages/framework/esm-framework/docs/interfaces/AttachmentResponse.md
+++ b/packages/framework/esm-framework/docs/interfaces/AttachmentResponse.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/framework/esm-api/src/types/attachments-types.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L20)
+[packages/framework/esm-api/src/types/attachments-types.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L21)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/types/attachments-types.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L21)
+[packages/framework/esm-api/src/types/attachments-types.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L22)
 
 ___
 
@@ -40,7 +40,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/types/attachments-types.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L22)
+[packages/framework/esm-api/src/types/attachments-types.ts:23](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L23)
 
 ___
 
@@ -50,7 +50,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/types/attachments-types.ts:23](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L23)
+[packages/framework/esm-api/src/types/attachments-types.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L24)
 
 ___
 
@@ -60,4 +60,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/types/attachments-types.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L24)
+[packages/framework/esm-api/src/types/attachments-types.ts:25](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/types/attachments-types.ts#L25)

--- a/packages/framework/esm-react-utils/src/useAttachments.ts
+++ b/packages/framework/esm-react-utils/src/useAttachments.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import useSWR from 'swr';
-import type { FetchResponse, AttachmentResponse } from '@openmrs/esm-api';
-import { attachmentUrl, openmrsFetch } from '@openmrs/esm-api';
+import { attachmentUrl, openmrsFetch, type AttachmentResponse, type FetchResponse } from '@openmrs/esm-api';
+
 export function useAttachments(patientUuid: string, includeEncounterless: boolean) {
   const { data, error, mutate, isLoading, isValidating } = useSWR<
     FetchResponse<{ results: Array<AttachmentResponse> }>


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Related to https://github.com/openmrs/openmrs-esm-patient-chart/pull/1626.

https://github.com/openmrs/openmrs-module-attachments/commit/613f3b01fcb2c55faf98f49bccced48fa722643b introduced the ability to persist a description for an image upload using the `fileCaption` property of the payload. The API response contains a `comment` property that returns the description. This PR amends the `createAttachment` function and type annotations for attachments to incorporate these new changes. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
