### PR TITLE
(feat) O3-2808: Snackbars should be dismissed after 5 seconds

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -33,10 +33,6 @@
   border-right: none;
 }
 
-a.cds--side-nav__link:focus, a.cds--header__menu-item:focus {
-  box-shadow: none;
-}
-
 .cds--side-nav__overlay-active {
   display: none;
 }
@@ -87,10 +83,6 @@ a.cds--side-nav__link:focus, a.cds--header__menu-item:focus {
   border: none;
   border-top: 1px solid colors.$blue-30;
   border-bottom: 1px solid colors.$blue-30;
-
-  &:focus {
-    box-shadow: none;
-  }
 
   &::after {
     background-color: transparent !important;
@@ -238,10 +230,6 @@ a.cds--side-nav__link:focus, a.cds--header__menu-item:focus {
 .cds--data-table--zebra tbody tr[data-parent-row]:nth-child(4n + 3) td {
   background-color: $ui-01;
   border-bottom: 1px solid $ui-03;
-}
-
-.cds--table-expand__button:focus {
-  box-shadow: none;
 }
 
 /* Misc */
@@ -440,10 +428,6 @@ html[dir='rtl'] {
     p {
       text-align: right;
     }
-
-    &:focus::before {
-      box-shadow: none;
-    }
   }
 
   .cds--select__page-number {
@@ -486,10 +470,6 @@ html[dir='rtl'] {
   }
 
   .cds--content-switcher-btn {
-    &:focus {
-      box-shadow: none;
-    }
-
     &::after {
       background-color: transparent !important;
     }

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -33,6 +33,10 @@
   border-right: none;
 }
 
+a.cds--side-nav__link:focus, a.cds--header__menu-item:focus {
+  box-shadow: none;
+}
+
 .cds--side-nav__overlay-active {
   display: none;
 }
@@ -83,6 +87,10 @@
   border: none;
   border-top: 1px solid colors.$blue-30;
   border-bottom: 1px solid colors.$blue-30;
+
+  &:focus {
+    box-shadow: none;
+  }
 
   &::after {
     background-color: transparent !important;
@@ -230,6 +238,10 @@
 .cds--data-table--zebra tbody tr[data-parent-row]:nth-child(4n + 3) td {
   background-color: $ui-01;
   border-bottom: 1px solid $ui-03;
+}
+
+.cds--table-expand__button:focus {
+  box-shadow: none;
 }
 
 /* Misc */
@@ -428,6 +440,10 @@ html[dir='rtl'] {
     p {
       text-align: right;
     }
+
+    &:focus::before {
+      box-shadow: none;
+    }
   }
 
   .cds--select__page-number {
@@ -470,6 +486,10 @@ html[dir='rtl'] {
   }
 
   .cds--content-switcher-btn {
+    &:focus {
+      box-shadow: none;
+    }
+
     &::after {
       background-color: transparent !important;
     }

--- a/packages/framework/esm-styleguide/src/snackbars/snackbar.component.tsx
+++ b/packages/framework/esm-styleguide/src/snackbars/snackbar.component.tsx
@@ -30,19 +30,19 @@ export type SnackbarType = 'error' | 'info' | 'info-square' | 'success' | 'warni
 
 export const Snackbar: React.FC<SnackbarProps> = ({ snackbar, closeSnackbar: removeSnackBarFromDom }) => {
   const {
-    actionButtonLabel,
-    isLowContrast,
-    kind,
+    actionButtonLabel = '',
+    isLowContrast = true,
+    kind = 'info',
     onActionButtonClick = () => {},
     progressActionLabel,
-    subtitle,
+    subtitle = '',
     timeoutInMs = 5000,
     autoClose = kind !== 'error',
     title,
     ...props
   } = snackbar;
 
-  const [actionText, setActionText] = useState(actionButtonLabel || '');
+  const [actionText, setActionText] = useState(actionButtonLabel);
   const [applyAnimation, setApplyAnimation] = useState(true);
 
   const [isClosing, setIsClosing] = useState(false);
@@ -88,12 +88,12 @@ export const Snackbar: React.FC<SnackbarProps> = ({ snackbar, closeSnackbar: rem
         [styles.slideOut]: isClosing,
       })}
       inline
-      kind={kind || 'info'}
+      kind={kind}
       lowContrast={isLowContrast}
       onActionButtonClick={handleActionClick}
       onClose={closeSnackbar}
       statusIconDescription="Snackbar notification"
-      subtitle={subtitle || ''}
+      subtitle={subtitle}
       title={title}
       {...props}
     />

--- a/packages/framework/esm-styleguide/src/snackbars/snackbar.component.tsx
+++ b/packages/framework/esm-styleguide/src/snackbars/snackbar.component.tsx
@@ -1,5 +1,5 @@
 /** @module @category UI */
-import React, { useState, useEffect, useCallback, useMemo } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { ActionableNotification } from '@carbon/react';
 import classnames from 'classnames';
 import styles from './snackbar.module.scss';

--- a/packages/framework/esm-styleguide/src/snackbars/snackbar.component.tsx
+++ b/packages/framework/esm-styleguide/src/snackbars/snackbar.component.tsx
@@ -18,7 +18,7 @@ export interface SnackbarDescriptor {
   progressActionLabel?: string;
   subtitle?: string;
   timeoutInMs?: number;
-  userDismissible?: boolean;
+  autoClose?: boolean;
   title: string;
 }
 
@@ -28,7 +28,7 @@ export interface SnackbarMeta extends SnackbarDescriptor {
 
 export type SnackbarType = 'error' | 'info' | 'info-square' | 'success' | 'warning' | 'warning-alt';
 
-export const Snackbar: React.FC<SnackbarProps> = ({ snackbar, closeSnackbar }) => {
+export const Snackbar: React.FC<SnackbarProps> = ({ snackbar, closeSnackbar: removeSnackBarFromDom }) => {
   const {
     actionButtonLabel,
     isLowContrast,
@@ -36,8 +36,8 @@ export const Snackbar: React.FC<SnackbarProps> = ({ snackbar, closeSnackbar }) =
     onActionButtonClick = () => {},
     progressActionLabel,
     subtitle,
-    timeoutInMs,
-    userDismissible,
+    timeoutInMs = 5000,
+    autoClose = kind !== 'error',
     title,
     ...props
   } = snackbar;
@@ -46,6 +46,12 @@ export const Snackbar: React.FC<SnackbarProps> = ({ snackbar, closeSnackbar }) =
   const [applyAnimation, setApplyAnimation] = useState(true);
 
   const [isClosing, setIsClosing] = useState(false);
+
+  const closeSnackbar = () => {
+    // This is to add a slide out animation before closing the snackbar
+    // This animations lasts for 250ms, thus the timeout
+    setTimeout(removeSnackBarFromDom, 250);
+  };
 
   const onCloseSnackbar = useCallback(() => {
     setIsClosing(true);
@@ -59,14 +65,11 @@ export const Snackbar: React.FC<SnackbarProps> = ({ snackbar, closeSnackbar }) =
   };
 
   useEffect(() => {
-    // Snackbar can auto clear after 5s if it's a success or if it's warning and not user dismissible
-    const canAutoClear = kind === 'success' || (!userDismissible && (kind === 'warning' || kind === 'warning-alt'));
-
-    if (timeoutInMs || canAutoClear) {
-      const timeoutId = setTimeout(onCloseSnackbar, timeoutInMs || 5000);
+    if (autoClose) {
+      const timeoutId = setTimeout(onCloseSnackbar, timeoutInMs);
       return () => clearTimeout(timeoutId);
     }
-  }, [timeoutInMs, userDismissible, kind, onCloseSnackbar]);
+  }, [timeoutInMs, autoClose, onCloseSnackbar]);
 
   useEffect(() => {
     setApplyAnimation(false);

--- a/packages/framework/esm-styleguide/src/snackbars/snackbar.component.tsx
+++ b/packages/framework/esm-styleguide/src/snackbars/snackbar.component.tsx
@@ -31,9 +31,9 @@ export type SnackbarType = 'error' | 'info' | 'info-square' | 'success' | 'warni
 export const Snackbar: React.FC<SnackbarProps> = ({ snackbar, closeSnackbar: removeSnackBarFromDom }) => {
   const {
     actionButtonLabel = '',
-    isLowContrast = true,
-    kind = 'info',
+    kind = 'success',
     onActionButtonClick = () => {},
+    isLowContrast = kind !== 'error',
     progressActionLabel,
     subtitle = '',
     timeoutInMs = 5000,

--- a/packages/framework/esm-styleguide/src/snackbars/snackbar.component.tsx
+++ b/packages/framework/esm-styleguide/src/snackbars/snackbar.component.tsx
@@ -47,11 +47,11 @@ export const Snackbar: React.FC<SnackbarProps> = ({ snackbar, closeSnackbar: rem
 
   const [isClosing, setIsClosing] = useState(false);
 
-  const closeSnackbar = () => {
+  const closeSnackbar = useCallback(() => {
     // This is to add a slide out animation before closing the snackbar
-    // This animations lasts for 250ms, thus the timeout
+    // The animation lasts for 250ms, thus the timeout
     setTimeout(removeSnackBarFromDom, 250);
-  };
+  }, [removeSnackBarFromDom]);
 
   const onCloseSnackbar = useCallback(() => {
     setIsClosing(true);

--- a/packages/framework/esm-styleguide/src/snackbars/snackbar.component.tsx
+++ b/packages/framework/esm-styleguide/src/snackbars/snackbar.component.tsx
@@ -44,7 +44,6 @@ export const Snackbar: React.FC<SnackbarProps> = ({ snackbar, closeSnackbar: rem
 
   const [actionText, setActionText] = useState(actionButtonLabel);
   const [applyAnimation, setApplyAnimation] = useState(true);
-
   const [isClosing, setIsClosing] = useState(false);
 
   const closeSnackbar = useCallback(() => {
@@ -82,7 +81,7 @@ export const Snackbar: React.FC<SnackbarProps> = ({ snackbar, closeSnackbar: rem
   return (
     <ActionableNotification
       actionButtonLabel={actionText}
-      ariaLabel="Close snackbar"
+      aria-label="Close snackbar"
       className={classnames(styles.slideIn, {
         [styles.animated]: applyAnimation,
         [styles.slideOut]: isClosing,

--- a/packages/framework/esm-styleguide/src/snackbars/snackbar.test.tsx
+++ b/packages/framework/esm-styleguide/src/snackbars/snackbar.test.tsx
@@ -1,0 +1,117 @@
+import React from 'react';
+import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import { Snackbar } from './snackbar.component';
+import userEvent from '@testing-library/user-event';
+
+describe('Snackbar component', () => {
+  const closeSnackbarMock = jest.fn();
+  const user = userEvent.setup();
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the snackbar with default props', () => {
+    const snackbarProps = {
+      snackbar: {
+        id: 1,
+        title: 'Test Snackbar',
+      },
+      closeSnackbar: closeSnackbarMock,
+    };
+
+    const { getByText } = render(<Snackbar {...snackbarProps} />);
+    expect(getByText('Test Snackbar')).toBeInTheDocument();
+  });
+
+  it('calls closeSnackbar when the close button is clicked', () => {
+    const snackbarProps = {
+      snackbar: {
+        id: 1,
+        title: 'Test Snackbar',
+      },
+      closeSnackbar: closeSnackbarMock,
+    };
+
+    const { getByLabelText } = render(<Snackbar {...snackbarProps} />);
+    fireEvent.click(getByLabelText('Close snackbar'));
+
+    waitFor(() => expect(closeSnackbarMock).toHaveBeenCalled(), { timeout: 250});
+  });
+
+  it('calls onActionButtonClick when the action button is clicked', async () => {
+    const onActionButtonClickMock = jest.fn();
+    const snackbarProps = {
+      snackbar: {
+        id: 1,
+        title: 'Test Snackbar',
+        actionButtonLabel: 'undo',
+        onActionButtonClick: onActionButtonClickMock,
+      },
+      closeSnackbar: closeSnackbarMock,
+    };
+
+    render(<Snackbar {...snackbarProps} />);
+
+    await user.click(screen.getByText('undo'));
+    await waitFor(() => {
+      expect(onActionButtonClickMock).toHaveBeenCalled();
+    });
+  });
+
+  it('closes the snackbar after a timeout if autoClose is true', async () => {
+    jest.useFakeTimers();
+    const snackbarProps = {
+      snackbar: {
+        id: 1,
+        title: 'Test Snackbar',
+        autoClose: true,
+        timeoutInMs: 5000,
+      },
+      closeSnackbar: closeSnackbarMock,
+    };
+
+    render(<Snackbar {...snackbarProps} />);
+    jest.advanceTimersByTime(5000);
+    await waitFor(() => {
+      expect(closeSnackbarMock).toHaveBeenCalled();
+    });
+  });
+
+  it('does not close the snackbar after a timeout if autoClose is false', async () => {
+    jest.useFakeTimers();
+    const snackbarProps = {
+      snackbar: {
+        id: 1,
+        title: 'Test Snackbar',
+        kind: 'error',
+      },
+      closeSnackbar: closeSnackbarMock,
+    };
+
+    render(<Snackbar {...snackbarProps} />);
+    jest.advanceTimersByTime(5000);
+    await waitFor(() => {
+      expect(closeSnackbarMock).not.toHaveBeenCalled();
+    });
+  });
+
+  it('changes action text when action button is clicked', async () => {
+    const progressActionLabel = 'Progress Action';
+    const snackbarProps = {
+      snackbar: {
+        id: 1,
+        title: 'Test Snackbar',
+        actionButtonLabel: 'Undo',
+        progressActionLabel: progressActionLabel,
+      },
+      closeSnackbar: closeSnackbarMock,
+    };
+
+    render(<Snackbar {...snackbarProps} />);
+    await user.click(screen.getByText('Undo'));
+    await waitFor(() => {
+      expect(screen.getByText(progressActionLabel)).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/framework/esm-styleguide/src/snackbars/snackbar.test.tsx
+++ b/packages/framework/esm-styleguide/src/snackbars/snackbar.test.tsx
@@ -20,11 +20,11 @@ describe('Snackbar component', () => {
       closeSnackbar: closeSnackbarMock,
     };
 
-    const { getByText } = render(<Snackbar {...snackbarProps} />);
-    expect(getByText('Test Snackbar')).toBeInTheDocument();
+    render(<Snackbar {...snackbarProps} />);
+    expect(screen.getByText('Test Snackbar')).toBeInTheDocument();
   });
 
-  it('calls closeSnackbar when the close button is clicked', () => {
+  it('calls closeSnackbar when the close button is clicked', async () => {
     const snackbarProps = {
       snackbar: {
         id: 1,
@@ -33,10 +33,10 @@ describe('Snackbar component', () => {
       closeSnackbar: closeSnackbarMock,
     };
 
-    const { getByLabelText } = render(<Snackbar {...snackbarProps} />);
-    fireEvent.click(getByLabelText('Close snackbar'));
+    render(<Snackbar {...snackbarProps} />);
 
-    waitFor(() => expect(closeSnackbarMock).toHaveBeenCalled(), { timeout: 250 });
+    await user.click(screen.getByLabelText('Close snackbar'));
+    await waitFor(() => expect(closeSnackbarMock).toHaveBeenCalled());
   });
 
   it('calls onActionButtonClick when the action button is clicked', async () => {
@@ -45,7 +45,7 @@ describe('Snackbar component', () => {
       snackbar: {
         id: 1,
         title: 'Test Snackbar',
-        actionButtonLabel: 'undo',
+        actionButtonLabel: 'Undo',
         onActionButtonClick: onActionButtonClickMock,
       },
       closeSnackbar: closeSnackbarMock,
@@ -53,10 +53,8 @@ describe('Snackbar component', () => {
 
     render(<Snackbar {...snackbarProps} />);
 
-    await user.click(screen.getByText('undo'));
-    await waitFor(() => {
-      expect(onActionButtonClickMock).toHaveBeenCalled();
-    });
+    await user.click(screen.getByText('Undo'));
+    expect(onActionButtonClickMock).toHaveBeenCalled();
   });
 
   it('closes the snackbar after a timeout if autoClose is true', async () => {
@@ -73,9 +71,7 @@ describe('Snackbar component', () => {
 
     render(<Snackbar {...snackbarProps} />);
     jest.advanceTimersByTime(5000);
-    await waitFor(() => {
-      expect(closeSnackbarMock).toHaveBeenCalled();
-    });
+    await waitFor(() => expect(closeSnackbarMock).toHaveBeenCalled());
   });
 
   it('does not close the snackbar after a timeout if autoClose is false', async () => {
@@ -91,27 +87,6 @@ describe('Snackbar component', () => {
 
     render(<Snackbar {...snackbarProps} />);
     jest.advanceTimersByTime(5000);
-    await waitFor(() => {
-      expect(closeSnackbarMock).not.toHaveBeenCalled();
-    });
-  });
-
-  it('changes action text when action button is clicked', async () => {
-    const progressActionLabel = 'Progress Action';
-    const snackbarProps = {
-      snackbar: {
-        id: 1,
-        title: 'Test Snackbar',
-        actionButtonLabel: 'Undo',
-        progressActionLabel: progressActionLabel,
-      },
-      closeSnackbar: closeSnackbarMock,
-    };
-
-    render(<Snackbar {...snackbarProps} />);
-    await user.click(screen.getByText('Undo'));
-    await waitFor(() => {
-      expect(screen.getByText(progressActionLabel)).toBeInTheDocument();
-    });
+    expect(closeSnackbarMock).not.toHaveBeenCalled();
   });
 });

--- a/packages/framework/esm-styleguide/src/snackbars/snackbar.test.tsx
+++ b/packages/framework/esm-styleguide/src/snackbars/snackbar.test.tsx
@@ -36,7 +36,7 @@ describe('Snackbar component', () => {
     const { getByLabelText } = render(<Snackbar {...snackbarProps} />);
     fireEvent.click(getByLabelText('Close snackbar'));
 
-    waitFor(() => expect(closeSnackbarMock).toHaveBeenCalled(), { timeout: 250});
+    waitFor(() => expect(closeSnackbarMock).toHaveBeenCalled(), { timeout: 250 });
   });
 
   it('calls onActionButtonClick when the action button is clicked', async () => {

--- a/packages/framework/esm-styleguide/src/snackbars/snackbar.test.tsx
+++ b/packages/framework/esm-styleguide/src/snackbars/snackbar.test.tsx
@@ -1,92 +1,80 @@
 import React from 'react';
-import { render, fireEvent, waitFor, screen } from '@testing-library/react';
+import { act, render, screen, waitFor } from '@testing-library/react';
 import { Snackbar } from './snackbar.component';
 import userEvent from '@testing-library/user-event';
 
+jest.useFakeTimers();
+const mockedCloseSnackbar = jest.fn();
+
 describe('Snackbar component', () => {
-  const closeSnackbarMock = jest.fn();
-  const user = userEvent.setup();
+  afterEach(() => jest.clearAllMocks());
 
-  afterEach(() => {
-    jest.clearAllMocks();
+  it('renders a snackbar notification', () => {
+    renderSnackbar();
+
+    const snackbar = screen.getByRole('alertdialog', { name: /order submitted/i });
+    const closeButton = screen.getByRole('button', { name: /close snackbar/i });
+    expect(snackbar).toBeInTheDocument();
+    expect(snackbar.classList).toContainEqual(expect.stringMatching('success'));
+    expect(closeButton).toBeInTheDocument();
   });
 
-  it('renders the snackbar with default props', () => {
-    const snackbarProps = {
+  it('renders an error notification if kind is set to error', () => {
+    renderSnackbar({
       snackbar: {
-        id: 1,
-        title: 'Test Snackbar',
+        kind: 'error',
+        title: 'Error submitting order',
+        subtitle: 'Error contacting lab system. Please try again later',
       },
-      closeSnackbar: closeSnackbarMock,
-    };
+    });
 
-    render(<Snackbar {...snackbarProps} />);
-    expect(screen.getByText('Test Snackbar')).toBeInTheDocument();
+    const snackbar = screen.getByRole('alertdialog', { name: /error submitting order/i });
+    expect(snackbar).toBeInTheDocument();
+    expect(snackbar.classList).toContainEqual(expect.stringMatching('error'));
+    expect(screen.getByRole('button', { name: /close snackbar/i })).toBeInTheDocument();
+    expect(screen.getByText(/error contacting lab system. please try again later/i)).toBeInTheDocument();
   });
 
-  it('calls closeSnackbar when the close button is clicked', async () => {
-    const snackbarProps = {
+  it('automatically dismisses the snackbar after a timeout if autoClose is set to true', async () => {
+    renderSnackbar({
       snackbar: {
-        id: 1,
-        title: 'Test Snackbar',
-      },
-      closeSnackbar: closeSnackbarMock,
-    };
-
-    render(<Snackbar {...snackbarProps} />);
-
-    await user.click(screen.getByLabelText('Close snackbar'));
-    await waitFor(() => expect(closeSnackbarMock).toHaveBeenCalled());
-  });
-
-  it('calls onActionButtonClick when the action button is clicked', async () => {
-    const onActionButtonClickMock = jest.fn();
-    const snackbarProps = {
-      snackbar: {
-        id: 1,
-        title: 'Test Snackbar',
-        actionButtonLabel: 'Undo',
-        onActionButtonClick: onActionButtonClickMock,
-      },
-      closeSnackbar: closeSnackbarMock,
-    };
-
-    render(<Snackbar {...snackbarProps} />);
-
-    await user.click(screen.getByText('Undo'));
-    expect(onActionButtonClickMock).toHaveBeenCalled();
-  });
-
-  it('closes the snackbar after a timeout if autoClose is true', async () => {
-    jest.useFakeTimers();
-    const snackbarProps = {
-      snackbar: {
-        id: 1,
-        title: 'Test Snackbar',
         autoClose: true,
         timeoutInMs: 5000,
+        title: 'Order submitted',
       },
-      closeSnackbar: closeSnackbarMock,
-    };
+    });
 
-    render(<Snackbar {...snackbarProps} />);
-    jest.advanceTimersByTime(5000);
-    await waitFor(() => expect(closeSnackbarMock).toHaveBeenCalled());
+    const snackbar = screen.getByRole('alertdialog', { name: /order submitted/i });
+    expect(snackbar).toBeInTheDocument();
+
+    act(() => jest.advanceTimersByTime(5000));
+    await waitFor(() => expect(mockedCloseSnackbar).toHaveBeenCalledTimes(1));
   });
 
-  it('does not close the snackbar after a timeout if autoClose is false', async () => {
-    jest.useFakeTimers();
-    const snackbarProps = {
+  it('renders an actionable variant of the snackbar if actionButtonLabel is provided', () => {
+    renderSnackbar({
       snackbar: {
-        id: 1,
-        title: 'Test Snackbar',
-        kind: 'error',
+        actionButtonLabel: 'Undo',
+        title: 'Order submitted',
       },
-      closeSnackbar: closeSnackbarMock,
-    };
+    });
 
-    render(<Snackbar {...snackbarProps} />);
-    jest.advanceTimersByTime(5000);
-    expect(closeSnackbarMock).not.toHaveBeenCalled();
+    const snackbar = screen.getByRole('alertdialog', { name: /order submitted/i });
+    const actionButton = screen.getByRole('button', { name: /undo/i });
+    expect(snackbar).toBeInTheDocument();
+    expect(actionButton).toBeInTheDocument();
   });
 });
+
+function renderSnackbar(overrides = {}) {
+  const testProps = {
+    snackbar: {
+      id: 1,
+      autoClose: false,
+      title: 'Order submitted',
+    },
+    closeSnackbar: mockedCloseSnackbar,
+  };
+
+  render(<Snackbar {...testProps} {...overrides} />);
+}


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Snackbars should be dismissed after a 5 seconds. i.e  this is for non error snackbars. 
This PR also add `autoClose` prop that can be used to close error snackbars if needed.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/openmrs/openmrs-esm-core/assets/53287480/1c07671b-7677-4718-bb9d-f0ab95c1ae27

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-2808](https://openmrs.atlassian.net/browse/O3-2808)

## Other
<!-- Anything not covered above -->
