### PR TITLE
O3-2826: Reuse signed in state in esm-core E2E tests excluding login …

### DIFF
--- a/e2e/core/global-setup.ts
+++ b/e2e/core/global-setup.ts
@@ -1,0 +1,32 @@
+import { request } from '@playwright/test';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+/**
+ * This configuration is to reuse the signed-in state in the tests
+ * by log in only once using the API and then skip the log in step for all the tests.
+ *
+ * https://playwright.dev/docs/auth#reuse-signed-in-state
+ */
+
+async function globalSetup() {
+  const requestContext = await request.newContext();
+  const token = Buffer.from(`${process.env.E2E_USER_ADMIN_USERNAME}:${process.env.E2E_USER_ADMIN_PASSWORD}`).toString(
+    'base64',
+  );
+  await requestContext.post(`${process.env.E2E_BASE_URL}/ws/rest/v1/session`, {
+    data: {
+      sessionLocation: process.env.E2E_LOGIN_DEFAULT_LOCATION_UUID,
+      locale: 'en',
+    },
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Basic ${token}`,
+    },
+  });
+  await requestContext.storageState({ path: 'e2e/storageState.json' });
+  await requestContext.dispose();
+}
+
+export default globalSetup;

--- a/e2e/core/test.ts
+++ b/e2e/core/test.ts
@@ -1,4 +1,5 @@
-import { test as base } from '@playwright/test';
+import { type APIRequestContext, type Page, test as base } from '@playwright/test';
+import { api } from '../fixtures';
 
 // This file sets up our custom test harness using the custom fixtures.
 // See https://playwright.dev/docs/test-fixtures#creating-a-fixture for details.
@@ -6,4 +7,14 @@ import { test as base } from '@playwright/test';
 // exported from this file must be used instead of the default `test` function
 // provided by playwright.
 
-export const test = base.extend({});
+export interface CustomTestFixtures {
+  loginAsAdmin: Page;
+}
+
+export interface CustomWorkerFixtures {
+  api: APIRequestContext;
+}
+
+export const test = base.extend<CustomTestFixtures, CustomWorkerFixtures>({
+  api: [api, { scope: 'worker' }],
+});

--- a/e2e/fixtures/api.ts
+++ b/e2e/fixtures/api.ts
@@ -1,0 +1,26 @@
+import { type APIRequestContext, type PlaywrightWorkerArgs, type WorkerFixture } from '@playwright/test';
+
+/**
+ * A fixture which initializes an [`APIRequestContext`](https://playwright.dev/docs/api/class-apirequestcontext)
+ * that is bound to the configured OpenMRS API server. The context is automatically authenticated
+ * using the configured admin account.
+ *
+ * Use the request context like this:
+ * ```ts
+ * test('your test', async ({ api }) => {
+ *   const res = await api.get('patient/1234');
+ *   await expect(res.ok()).toBeTruthy();
+ * });
+ * ```
+ */
+export const api: WorkerFixture<APIRequestContext, PlaywrightWorkerArgs> = async ({ playwright }, use) => {
+  const ctx = await playwright.request.newContext({
+    baseURL: `${process.env.E2E_BASE_URL}/ws/rest/v1/`,
+    httpCredentials: {
+      username: process.env.E2E_USER_ADMIN_USERNAME ?? '',
+      password: process.env.E2E_USER_ADMIN_PASSWORD ?? '',
+    },
+  });
+
+  await use(ctx);
+};

--- a/e2e/fixtures/index.ts
+++ b/e2e/fixtures/index.ts
@@ -1,0 +1,1 @@
+export * from './api';

--- a/e2e/specs/login.spec.ts
+++ b/e2e/specs/login.spec.ts
@@ -2,6 +2,7 @@ import { test } from '../core';
 import { expect } from '@playwright/test';
 import { LoginPage } from '../pages';
 
+test.use({ storageState: { cookies: [], origins: [] } });
 test('Login as Admin user', async ({ page }) => {
   const loginPage = new LoginPage(page);
 

--- a/e2e/specs/logout.spec.ts
+++ b/e2e/specs/logout.spec.ts
@@ -1,22 +1,7 @@
 import { test } from '../core';
 import { expect } from '@playwright/test';
-import { LoginPage } from '../pages';
 
-test('Logout as Admin user', async ({ page }) => {
-  const loginPage = new LoginPage(page);
-
-  await test.step('When I go to Login page', async () => {
-    await loginPage.goto();
-  });
-
-  await test.step('And I enter the login credentials', async () => {
-    await loginPage.enterLoginCredentials();
-  });
-
-  await test.step('Then I should be on the Home page', async () => {
-    await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home`);
-  });
-
+test('Logout as Admin user', async ({ page, api }) => {
   await test.step('When I click the `User` button', async () => {
     await page.getByRole('button', { name: /user/i }).click();
   });

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,4 @@
-import { devices, PlaywrightTestConfig } from '@playwright/test';
+import { devices, type PlaywrightTestConfig } from '@playwright/test';
 import * as dotenv from 'dotenv';
 dotenv.config();
 
@@ -13,9 +13,11 @@ const config: PlaywrightTestConfig = {
   forbidOnly: !!process.env.CI,
   retries: 0,
   reporter: process.env.CI ? [['junit', { outputFile: 'results.xml' }], ['html']] : [['html']],
+  globalSetup: require.resolve('./e2e/core/global-setup'),
   use: {
     baseURL: `${process.env.E2E_BASE_URL}/spa/`,
     trace: 'retain-on-failure',
+    storageState: 'e2e/storageState.json',
     video: 'retain-on-failure',
   },
   projects: [


### PR DESCRIPTION
…test

# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-2826

## Other
<!-- Anything not covered above -->
