### PR TITLE
(chore) Add ResponsiveWrapper stub to framework mock

### DIFF
--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -275,7 +275,7 @@ export const showModal = jest.fn();
 export const LeftNavMenu = jest.fn(() => <div>Left Nav Menu</div>);
 export const setLeftNav = jest.fn();
 export const unsetLeftNav = jest.fn();
-
+export const ResponsiveWrapper = jest.fn(({ children }) => <>{children}</>);
 export const OpenmrsDatePicker = jest.fn(() => <div>OpenMRS DatePicker</div>);
 
 /* esm-utils */

--- a/packages/framework/esm-styleguide/src/responsive-wrapper/responsive-wrapper.component.tsx
+++ b/packages/framework/esm-styleguide/src/responsive-wrapper/responsive-wrapper.component.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Layer } from '@carbon/react';
 import { useLayoutType } from '@openmrs/esm-framework';
 
-type ResponsiveWrapperProps = {
+export type ResponsiveWrapperProps = {
   children: React.ReactNode;
 };
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Adds a stub for the [ResponsiveWrapper](#909) component to the esm-framework mock.  

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
