### PR TITLE
(fix) O3-2742: History API should properly handle the back button

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -910,6 +910,20 @@ ___
 
 ___
 
+### ResponsiveWrapper
+
+• `Const` **ResponsiveWrapper**: `React.FC`<[`ResponsiveWrapperProps`](interfaces/ResponsiveWrapperProps.md)\>
+
+ResponsiveWrapper enables a responsive behavior for the component its wraps, providing a different rendering based on the current layout type.
+On desktop, it renders the children as is, while on a tablet, it wraps them in a Carbon Layer https://react.carbondesignsystem.com/?path=/docs/components-layer--overview component.
+This provides a light background for form inputs on tablets, in accordance with the design requirements.
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/responsive-wrapper/responsive-wrapper.component.tsx:14](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/responsive-wrapper/responsive-wrapper.component.tsx#L14)
+
+___
+
 ### backendDependencies
 
 • `Const` **backendDependencies**: `Object`
@@ -3192,7 +3206,7 @@ Returns a list of URLs representing the history of the current window session.
 
 #### Defined in
 
-[packages/framework/esm-navigation/src/history/history.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-navigation/src/history/history.ts#L39)
+[packages/framework/esm-navigation/src/history/history.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-navigation/src/history/history.ts#L47)
 
 ___
 
@@ -3215,7 +3229,7 @@ Rolls back the history to the specified point and navigates to that URL.
 
 #### Defined in
 
-[packages/framework/esm-navigation/src/history/history.ts:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-navigation/src/history/history.ts#L50)
+[packages/framework/esm-navigation/src/history/history.ts:58](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-navigation/src/history/history.ts#L58)
 
 ___
 

--- a/packages/framework/esm-navigation/package.json
+++ b/packages/framework/esm-navigation/package.json
@@ -44,6 +44,7 @@
     "@openmrs/esm-state": "5.x"
   },
   "devDependencies": {
-    "@openmrs/esm-state": "workspace:*"
+    "@openmrs/esm-state": "workspace:*",
+    "lodash": "^4.17.21"
   }
 }

--- a/packages/framework/esm-navigation/src/history/history.ts
+++ b/packages/framework/esm-navigation/src/history/history.ts
@@ -25,9 +25,17 @@ export function setupHistory() {
     addToHistory(document.referrer);
   }
 
-  window.addEventListener('single-spa:routing-event', (evt) => {
+  window.addEventListener('single-spa:routing-event', (evt: CustomEvent) => {
     const history = getHistory();
-    if (history[history.length - 1] !== window.location.href) {
+    if (evt.detail.originalEvent?.singleSpaTrigger == 'replaceState') {
+      // handle redirect
+      history[history.length - 1] = window.location.href;
+      sessionStorage.setItem(historyKey, JSON.stringify(history));
+    } else if (!evt.detail.originalEvent?.singleSpa && history.includes(window.location.href)) {
+      // handle back button (as best we can tell whether it was used or not)
+      goBackInHistory({ toUrl: window.location.href });
+    } else if (history[history.length - 1] !== window.location.href) {
+      // handle normal navigation
       addToHistory(window.location.href);
     }
   });

--- a/yarn.lock
+++ b/yarn.lock
@@ -2900,6 +2900,7 @@ __metadata:
   resolution: "@openmrs/esm-navigation@workspace:packages/framework/esm-navigation"
   dependencies:
     "@openmrs/esm-state": "workspace:*"
+    lodash: "npm:^4.17.21"
     path-to-regexp: "npm:6.1.0"
   peerDependencies:
     "@openmrs/esm-state": 5.x


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Gets the history system to more or less correctly handle SPA redirects / replaceState and back button presses. "More or less" because there's actually not really a way to detect browser back button presses; so this just makes an educated guess by looking at whether the navigation was triggered by a SPA navigation event and whether the page is in the history. If it's a non-SPA navigation to a page in history, we assume it was the back button and roll back history to there.

This resolves a problematic flow described in the ticket description.

## Screenshots


https://github.com/openmrs/openmrs-esm-core/assets/1031876/156daaa9-0d2b-4c22-9e7c-f6174facc0fe


## Related Issue
https://openmrs.atlassian.net/browse/O3-2742
