### PR TITLE
(feat) Add a global SWR configuration

### DIFF
--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
@@ -19,8 +19,6 @@ const defaultSwrConfig = {
   fetcher: openmrsFetch,
   // only revalidate once every 30 seconds
   focusThrottleInterval: 30000,
-  // https://swr.vercel.app/docs/revalidation#revalidate-on-focus
-  revalidateOnFocus: false,
 };
 
 export interface ComponentDecoratorOptions {

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
@@ -1,13 +1,26 @@
-import React, { type ComponentType, Suspense } from 'react';
+import React, { type ComponentType, type ErrorInfo, Suspense } from 'react';
 import { I18nextProvider } from 'react-i18next';
+import { SWRConfig } from 'swr';
 import type {} from '@openmrs/esm-globals';
-import type { ComponentConfig, ExtensionData } from './ComponentContext';
-import { ComponentContext } from './ComponentContext';
+import { openmrsFetch } from '@openmrs/esm-api';
+import { ComponentContext, type ComponentConfig, type ExtensionData } from './ComponentContext';
 
 const defaultOpts = {
   strictMode: true,
   throwErrorsToConsole: true,
   disableTranslations: false,
+};
+
+// Read more about the available config options here: https://swr.vercel.app/docs/api#configuration
+const defaultSwrConfig = {
+  // max number of retries after requests have failed
+  errorRetryCount: 3,
+  // default fetcher function
+  fetcher: openmrsFetch,
+  // only revalidate once every 30 seconds
+  focusThrottleInterval: 30000,
+  // https://swr.vercel.app/docs/revalidation#revalidate-on-focus
+  revalidateOnFocus: false,
 };
 
 export interface ComponentDecoratorOptions {
@@ -23,7 +36,7 @@ export interface OpenmrsReactComponentProps {
 
 export interface OpenmrsReactComponentState {
   caughtError: any;
-  caughtErrorInfo: any;
+  caughtErrorInfo: ErrorInfo | null;
   config: ComponentConfig;
 }
 
@@ -57,7 +70,7 @@ export function openmrsComponentDecorator<T>(userOpts: ComponentDecoratorOptions
         };
       }
 
-      componentDidCatch(err: any, info: any) {
+      componentDidCatch(err: any, info: ErrorInfo) {
         if (info && info.componentStack) {
           err.extra = Object.assign(err.extra || {}, {
             componentStack: info.componentStack,
@@ -83,15 +96,17 @@ export function openmrsComponentDecorator<T>(userOpts: ComponentDecoratorOptions
         } else {
           const content = (
             <Suspense fallback={null}>
-              <ComponentContext.Provider value={this.state.config}>
-                {opts.disableTranslations ? (
-                  <Comp {...this.props} />
-                ) : (
-                  <I18nextProvider i18n={window.i18next} defaultNS={opts.moduleName}>
+              <SWRConfig value={defaultSwrConfig}>
+                <ComponentContext.Provider value={this.state.config}>
+                  {opts.disableTranslations ? (
                     <Comp {...this.props} />
-                  </I18nextProvider>
-                )}
-              </ComponentContext.Provider>
+                  ) : (
+                    <I18nextProvider i18n={window.i18next} defaultNS={opts.moduleName}>
+                      <Comp {...this.props} />
+                    </I18nextProvider>
+                  )}
+                </ComponentContext.Provider>
+              </SWRConfig>
             </Suspense>
           );
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR adds a minimal [global SWR Configuration](https://swr.vercel.app/docs/global-configuration) to the `openmrsComponentDecorator` with some sensible defaults. These are:

```
const defaultSwrConfig = {
  errorRetryCount: 3,
  fetcher: openmrsFetch,
  focusThrottleInterval: 30000,
};
```

- `errorRetryCount` is the maximum number of retries to attempt after requests fail. SWR does not provide a default value out of the box AFAICT. 
- `focusThrottleInterval` - controls the throttling behaviour when revalidating stale data on focus. It sets a minimum interval between revalidation events when the window or tab regains focus. I've set it to 30000ms, which means that SWR will revalidate max once per 30 seconds of focus. The goal is to prevent load spikes from revalidation events but to keep the value low enough to get important updates. Defaults to 5 seconds.
- `fetcher` is the fetcher function to use.

An important things to note is that `SWRConfig` [merges](https://swr.vercel.app/docs/global-configuration#nesting-configurations) the configuration from the parent context. This means that alternative configurations provided further down the line will override the parent values.

For example, I've set the `refreshInterval` in the Active Visits frontend module to `500ms` here:

https://github.com/openmrs/openmrs-esm-core/assets/8509731/0f36566e-23a2-4b31-9bcb-0563159d6a6d

Consequently, revalidations are happening twice every second. All the other options from the global config are unaffected.

One other thing I've done here is cleaning up some of the type annotations for our custom error boundary component.

## TL;Dr

- SWR will retry failed requests for a maximum of three times.
- SWR will only revalidate on focus once every thirty seconds.
- The default fetcher is `openmrsFetch`.
- This top-level config can be overridden as `SWRConfig` merges configurations.
- These configuration options will apply for all SWR hooks unless configuration overrides are provided further downstream.

## Screenshots

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
