### PR TITLE
(refactor) Replace usages of `/ws/rest/v1/` with `restBaseUrl`

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
+++ b/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
@@ -76,7 +76,7 @@ function checkIfModulesAreInstalled(
 }
 
 function fetchInstalledBackendModules() {
-  return openmrsFetch(`${restBaseUrl}module?v=custom:(uuid,version)`, {
+  return openmrsFetch(`${restBaseUrl}/module?v=custom:(uuid,version)`, {
     method: 'GET',
   });
 }

--- a/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
+++ b/packages/apps/esm-implementer-tools-app/src/backend-dependencies/openmrs-backend-dependencies.ts
@@ -1,4 +1,4 @@
-import { isVersionSatisfied, openmrsFetch } from '@openmrs/esm-framework';
+import { isVersionSatisfied, openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 import difference from 'lodash-es/difference';
 
 export type ResolvedBackendModuleType = 'missing' | 'version-mismatch' | 'okay';
@@ -76,7 +76,7 @@ function checkIfModulesAreInstalled(
 }
 
 function fetchInstalledBackendModules() {
-  return openmrsFetch(`/ws/rest/v1/module?v=custom:(uuid,version)`, {
+  return openmrsFetch(`${restBaseUrl}module?v=custom:(uuid,version)`, {
     method: 'GET',
   });
 }

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/concept-search.resource.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/concept-search.resource.tsx
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 
 export type Concept = {
   answers: Array<ConceptAnswer>;
@@ -18,7 +18,7 @@ type Mappings = {
 };
 
 export function useConceptLookup(query: string) {
-  const conceptLookupUrl = `/ws/rest/v1/concept/?q=${query}`;
+  const conceptLookupUrl = `${restBaseUrl}concept/?q=${query}`;
 
   const { data, error } = useSWR<{ data: { results: Array<Concept> } }, Error>(
     query ? conceptLookupUrl : null,
@@ -33,7 +33,7 @@ export function useConceptLookup(query: string) {
 }
 
 export function useGetConceptByUuid(conceptUuid: string) {
-  const fetchConceptUrl = `/ws/rest/v1/concept/${conceptUuid}`;
+  const fetchConceptUrl = `${restBaseUrl}concept/${conceptUuid}`;
 
   const { data, error } = useSWR<{ data: Concept }, Error>(conceptUuid ? fetchConceptUrl : null, openmrsFetch);
 

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/concept-search.resource.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/concept-search.resource.tsx
@@ -18,7 +18,7 @@ type Mappings = {
 };
 
 export function useConceptLookup(query: string) {
-  const conceptLookupUrl = `${restBaseUrl}concept/?q=${query}`;
+  const conceptLookupUrl = `${restBaseUrl}/concept/?q=${query}`;
 
   const { data, error } = useSWR<{ data: { results: Array<Concept> } }, Error>(
     query ? conceptLookupUrl : null,
@@ -33,7 +33,7 @@ export function useConceptLookup(query: string) {
 }
 
 export function useGetConceptByUuid(conceptUuid: string) {
-  const fetchConceptUrl = `${restBaseUrl}concept/${conceptUuid}`;
+  const fetchConceptUrl = `${restBaseUrl}/concept/${conceptUuid}`;
 
   const { data, error } = useSWR<{ data: Concept }, Error>(conceptUuid ? fetchConceptUrl : null, openmrsFetch);
 

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type.resource.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type.resource.tsx
@@ -17,7 +17,7 @@ export function usePatientIdentifierTypes(): {
   isLoading: boolean;
 } {
   const { data, error } = useSWR<FetchResponse<PatientIdentifierTypeResponse>, Error>(
-    `${restBaseUrl}patientidentifiertype`,
+    `${restBaseUrl}/patientidentifiertype`,
     openmrsFetch,
   );
   const memoisedPatientIdentifierTypeData = useMemo(

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type.resource.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/patient-identifier-type.resource.tsx
@@ -1,5 +1,5 @@
 import useSWR from 'swr';
-import type { FetchResponse } from '@openmrs/esm-framework';
+import { type FetchResponse, restBaseUrl } from '@openmrs/esm-framework';
 import { openmrsFetch } from '@openmrs/esm-framework';
 import { useMemo } from 'react';
 
@@ -17,7 +17,7 @@ export function usePatientIdentifierTypes(): {
   isLoading: boolean;
 } {
   const { data, error } = useSWR<FetchResponse<PatientIdentifierTypeResponse>, Error>(
-    `/ws/rest/v1/patientidentifiertype`,
+    `${restBaseUrl}patientidentifiertype`,
     openmrsFetch,
   );
   const memoisedPatientIdentifierTypeData = useMemo(

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/person-attribute-search.resource.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/person-attribute-search.resource.tsx
@@ -1,13 +1,13 @@
 import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 
 export function fetchPersonAttributeTypeByUuid(personAttributeTypeUuid: string) {
-  return openmrsFetch(`${restBaseUrl}personattributetype/${personAttributeTypeUuid}`, {
+  return openmrsFetch(`${restBaseUrl}/personattributetype/${personAttributeTypeUuid}`, {
     method: 'GET',
   });
 }
 
 export function performPersonAttributeTypeSearch(query: string) {
-  return openmrsFetch(`${restBaseUrl}personattributetype/?q=${query}`, {
+  return openmrsFetch(`${restBaseUrl}/personattributetype/?q=${query}`, {
     method: 'GET',
   });
 }

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/person-attribute-search.resource.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/person-attribute-search.resource.tsx
@@ -1,13 +1,13 @@
-import { openmrsFetch } from '@openmrs/esm-framework';
+import { openmrsFetch, restBaseUrl } from '@openmrs/esm-framework';
 
 export function fetchPersonAttributeTypeByUuid(personAttributeTypeUuid: string) {
-  return openmrsFetch(`/ws/rest/v1/personattributetype/${personAttributeTypeUuid}`, {
+  return openmrsFetch(`${restBaseUrl}personattributetype/${personAttributeTypeUuid}`, {
     method: 'GET',
   });
 }
 
 export function performPersonAttributeTypeSearch(query: string) {
-  return openmrsFetch(`/ws/rest/v1/personattributetype/?q=${query}`, {
+  return openmrsFetch(`${restBaseUrl}personattributetype/?q=${query}`, {
     method: 'GET',
   });
 }

--- a/packages/apps/esm-login-app/src/login.resource.ts
+++ b/packages/apps/esm-login-app/src/login.resource.ts
@@ -96,7 +96,7 @@ export function useLoginLocations(
 }
 
 export function useValidateLocationUuid(userPreferredLocationUuid: string) {
-  const url = userPreferredLocationUuid ? `/ws/fhir2/R4/Location?_id=${userPreferredLocationUuid}` : null;
+  const url = userPreferredLocationUuid ? `${fhirBaseUrl}/Location?_id=${userPreferredLocationUuid}` : null;
   const { data, error, isLoading } = useSwrImmutable<FetchResponse<LocationResponse>>(url, openmrsFetch, {
     shouldRetryOnError(err) {
       if (err?.response?.status) {

--- a/packages/apps/esm-login-app/src/redirect-logout/logout.resource.ts
+++ b/packages/apps/esm-login-app/src/redirect-logout/logout.resource.ts
@@ -1,8 +1,8 @@
-import { clearCurrentUser, openmrsFetch, refetchCurrentUser } from '@openmrs/esm-framework';
+import { clearCurrentUser, openmrsFetch, refetchCurrentUser, restBaseUrl } from '@openmrs/esm-framework';
 import { mutate } from 'swr';
 
 export async function performLogout() {
-  await openmrsFetch('/ws/rest/v1/session', {
+  await openmrsFetch(`${restBaseUrl}/session`, {
     method: 'DELETE',
   });
 

--- a/packages/apps/esm-login-app/src/redirect-logout/redirect-logout.test.tsx
+++ b/packages/apps/esm-login-app/src/redirect-logout/redirect-logout.test.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
-import { cleanup, render, waitFor } from '@testing-library/react';
+import { render, waitFor } from '@testing-library/react';
 import RedirectLogout from './redirect-logout.component';
-import { performLogout } from './logout.resource';
 import {
   Session,
   clearCurrentUser,
   navigate,
   openmrsFetch,
   refetchCurrentUser,
+  restBaseUrl,
   setUserLanguage,
   useConfig,
   useConnectivity,
@@ -19,6 +19,15 @@ jest.mock('swr', () => ({
   mutate: jest.fn(),
 }));
 
+jest.mock('@openmrs/esm-framework', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-framework');
+
+  return {
+    ...originalModule,
+    restBaseUrl: '/ws/rest/v1',
+  };
+});
+
 Object.defineProperty(document, 'documentElement', {
   value: {
     getAttribute: jest.fn().mockReturnValue('km'),
@@ -27,7 +36,6 @@ Object.defineProperty(document, 'documentElement', {
 
 describe('Testing Logout', () => {
   beforeEach(() => {
-    cleanup();
     jest.clearAllMocks();
     (useConnectivity as jest.Mock).mockReturnValue(true);
     (openmrsFetch as jest.Mock).mockResolvedValue({});
@@ -43,12 +51,12 @@ describe('Testing Logout', () => {
   });
   it('should render Logout and redirect to login page', async () => {
     render(<RedirectLogout />);
-    expect(openmrsFetch).toHaveBeenCalledWith('/ws/rest/v1/session', {
+    expect(openmrsFetch).toHaveBeenCalledWith(`${restBaseUrl}/session`, {
       method: 'DELETE',
     });
-    await waitFor(() => expect(mutate).toBeCalled());
-    expect(clearCurrentUser).toBeCalled();
-    expect(refetchCurrentUser).toBeCalled();
+    await waitFor(() => expect(mutate).toHaveBeenCalled());
+    expect(clearCurrentUser).toHaveBeenCalled();
+    expect(refetchCurrentUser).toHaveBeenCalled();
     expect(setUserLanguage).toHaveBeenCalledWith({
       locale: 'km',
       authenticated: false,
@@ -65,12 +73,12 @@ describe('Testing Logout', () => {
       },
     });
     render(<RedirectLogout />);
-    expect(openmrsFetch).toHaveBeenCalledWith('/ws/rest/v1/session', {
+    expect(openmrsFetch).toHaveBeenCalledWith(`${restBaseUrl}/session`, {
       method: 'DELETE',
     });
-    await waitFor(() => expect(mutate).toBeCalled());
-    expect(clearCurrentUser).toBeCalled();
-    expect(refetchCurrentUser).toBeCalled();
+    await waitFor(() => expect(mutate).toHaveBeenCalled());
+    expect(clearCurrentUser).toHaveBeenCalled();
+    expect(refetchCurrentUser).toHaveBeenCalled();
     expect(setUserLanguage).toHaveBeenCalledWith({
       locale: 'km',
       authenticated: false,

--- a/packages/apps/esm-primary-navigation-app/src/root.resource.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/root.resource.tsx
@@ -2,12 +2,13 @@ import {
   getCurrentUser,
   getSynchronizationItemsFor,
   openmrsObservableFetch,
+  restBaseUrl,
 } from '@openmrs/esm-framework/src/internal';
 import { mergeMap } from 'rxjs/operators';
 import { userPropertyChange } from './constants';
 
 export function getCurrentSession() {
-  return openmrsObservableFetch(`/ws/rest/v1/session`);
+  return openmrsObservableFetch(`${restBaseUrl}session`);
 }
 
 /**

--- a/packages/apps/esm-primary-navigation-app/src/root.resource.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/root.resource.tsx
@@ -8,7 +8,7 @@ import { mergeMap } from 'rxjs/operators';
 import { userPropertyChange } from './constants';
 
 export function getCurrentSession() {
-  return openmrsObservableFetch(`${restBaseUrl}session`);
+  return openmrsObservableFetch(`${restBaseUrl}/session`);
 }
 
 /**

--- a/packages/framework/esm-api/src/attachments.ts
+++ b/packages/framework/esm-api/src/attachments.ts
@@ -1,8 +1,9 @@
 /** @module @category API */
 import type { UploadedFile } from './types';
-import { openmrsFetch } from './openmrs-fetch';
+import { openmrsFetch, restBaseUrl } from './openmrs-fetch';
 
-export const attachmentUrl = '/ws/rest/v1/attachment';
+export const attachmentUrl = `${restBaseUrl}/attachment`;
+
 
 export function getAttachmentByUuid(attachmentUuid: string, abortController: AbortController) {
   return openmrsFetch(`${attachmentUrl}/${attachmentUuid}`, {

--- a/packages/framework/esm-api/src/attachments.ts
+++ b/packages/framework/esm-api/src/attachments.ts
@@ -4,7 +4,6 @@ import { openmrsFetch, restBaseUrl } from './openmrs-fetch';
 
 export const attachmentUrl = `${restBaseUrl}/attachment`;
 
-
 export function getAttachmentByUuid(attachmentUuid: string, abortController: AbortController) {
   return openmrsFetch(`${attachmentUrl}/${attachmentUuid}`, {
     signal: abortController.signal,

--- a/packages/framework/esm-api/src/openmrs-fetch.ts
+++ b/packages/framework/esm-api/src/openmrs-fetch.ts
@@ -55,7 +55,7 @@ export function makeUrl(path: string) {
  * ```js
  * import { openmrsFetch } from '@openmrs/esm-api'
  * const abortController = new AbortController();
- * openmrsFetch('/ws/rest/v1/session', {signal: abortController.signal})
+ * openmrsFetch(`${restBaseUrl}session', {signal: abortController.signal})
  *   .then(response => {
  *     console.log(response.data.authenticated)
  *   })
@@ -63,7 +63,7 @@ export function makeUrl(path: string) {
  *     console.error(err.status);
  *   })
  * abortController.abort();
- * openmrsFetch('/ws/rest/v1/session', {
+ * openmrsFetch(`${restBaseUrl}session', {
  *   method: 'POST',
  *   body: {
  *     username: 'hi',
@@ -248,7 +248,7 @@ export function openmrsFetch<T = any>(path: string, fetchInit: FetchConfig = {})
  *
  * ```js
  * import { openmrsObservableFetch } from '@openmrs/esm-api'
- * const subscription = openmrsObservableFetch('/ws/rest/v1/session').subscribe(
+ * const subscription = openmrsObservableFetch(`${restBaseUrl}session').subscribe(
  *   response => console.log(response.data),
  *   err => {throw err},
  *   () => console.log('finished')

--- a/packages/framework/esm-api/src/openmrs-fetch.ts
+++ b/packages/framework/esm-api/src/openmrs-fetch.ts
@@ -55,7 +55,7 @@ export function makeUrl(path: string) {
  * ```js
  * import { openmrsFetch } from '@openmrs/esm-api'
  * const abortController = new AbortController();
- * openmrsFetch(`${restBaseUrl}session', {signal: abortController.signal})
+ * openmrsFetch(`${restBaseUrl}/session', {signal: abortController.signal})
  *   .then(response => {
  *     console.log(response.data.authenticated)
  *   })
@@ -63,7 +63,7 @@ export function makeUrl(path: string) {
  *     console.error(err.status);
  *   })
  * abortController.abort();
- * openmrsFetch(`${restBaseUrl}session', {
+ * openmrsFetch(`${restBaseUrl}/session', {
  *   method: 'POST',
  *   body: {
  *     username: 'hi',
@@ -248,7 +248,7 @@ export function openmrsFetch<T = any>(path: string, fetchInit: FetchConfig = {})
  *
  * ```js
  * import { openmrsObservableFetch } from '@openmrs/esm-api'
- * const subscription = openmrsObservableFetch(`${restBaseUrl}session').subscribe(
+ * const subscription = openmrsObservableFetch(`${restBaseUrl}/session').subscribe(
  *   response => console.log(response.data),
  *   err => {throw err},
  *   () => console.log('finished')

--- a/packages/framework/esm-api/src/shared-api-objects/current-user.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/current-user.ts
@@ -3,7 +3,7 @@ import { reportError } from '@openmrs/esm-error-handling';
 import { createGlobalStore } from '@openmrs/esm-state';
 import isUndefined from 'lodash-es/isUndefined';
 import { Observable } from 'rxjs';
-import { openmrsFetch, sessionEndpoint } from '../openmrs-fetch';
+import { openmrsFetch, restBaseUrl, sessionEndpoint } from '../openmrs-fetch';
 import type { LoggedInUser, SessionLocation, Privilege, Role, Session, FetchResponse } from '../types';
 
 export type SessionStore = LoadedSessionStore | UnloadedSessionStore;
@@ -239,8 +239,7 @@ export async function setUserProperties(
   if (!abortController) {
     abortController = new AbortController();
   }
-
-  await openmrsFetch(`/ws/rest/v1/user/${userUuid}`, {
+  await openmrsFetch(`${restBaseUrl}/user/${userUuid}`, {
     method: 'POST',
     body: { userProperties },
     headers: {

--- a/packages/framework/esm-api/src/shared-api-objects/location.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/location.ts
@@ -1,7 +1,7 @@
 /** @module @category API */
 import type { Observable } from 'rxjs';
 import { map, take } from 'rxjs/operators';
-import { openmrsObservableFetch } from '../openmrs-fetch';
+import { openmrsObservableFetch, restBaseUrl } from '../openmrs-fetch';
 import type { Location } from '../types';
 
 export function toLocationObject(openmrsRestForm: any): Location {
@@ -12,7 +12,7 @@ export function toLocationObject(openmrsRestForm: any): Location {
 }
 
 export function getLocations(tagUuidOrName: string | null = null): Observable<Array<Location>> {
-  const url = `/ws/rest/v1/location` + (tagUuidOrName ? '?tag=' + tagUuidOrName : '');
+  const url = `${restBaseUrl}location` + (tagUuidOrName ? '?tag=' + tagUuidOrName : '');
   return openmrsObservableFetch<any>(url)
     .pipe(
       map((results) => {

--- a/packages/framework/esm-api/src/shared-api-objects/location.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/location.ts
@@ -12,7 +12,7 @@ export function toLocationObject(openmrsRestForm: any): Location {
 }
 
 export function getLocations(tagUuidOrName: string | null = null): Observable<Array<Location>> {
-  const url = `${restBaseUrl}location` + (tagUuidOrName ? '?tag=' + tagUuidOrName : '');
+  const url = `${restBaseUrl}/location` + (tagUuidOrName ? '?tag=' + tagUuidOrName : '');
   return openmrsObservableFetch<any>(url)
     .pipe(
       map((results) => {

--- a/packages/framework/esm-api/src/shared-api-objects/visit-type.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/visit-type.ts
@@ -13,7 +13,7 @@ export function toVisitTypeObject(openmrsRestForm: any): VisitType {
 }
 
 export function getVisitTypes(): Observable<Array<VisitType>> {
-  return openmrsObservableFetch<any>(`${restBaseUrl}visittype`)
+  return openmrsObservableFetch<any>(`${restBaseUrl}/visittype`)
     .pipe(
       map((results) => {
         const visitTypes: Array<VisitType> = results.data.results.map(toVisitTypeObject);

--- a/packages/framework/esm-api/src/shared-api-objects/visit-type.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/visit-type.ts
@@ -1,7 +1,7 @@
 /** @module @category API */
 import type { Observable } from 'rxjs';
 import { map, take } from 'rxjs/operators';
-import { openmrsObservableFetch } from '../openmrs-fetch';
+import { openmrsObservableFetch, restBaseUrl } from '../openmrs-fetch';
 import type { VisitType } from '../types';
 
 export function toVisitTypeObject(openmrsRestForm: any): VisitType {
@@ -13,7 +13,7 @@ export function toVisitTypeObject(openmrsRestForm: any): VisitType {
 }
 
 export function getVisitTypes(): Observable<Array<VisitType>> {
-  return openmrsObservableFetch<any>(`/ws/rest/v1/visittype`)
+  return openmrsObservableFetch<any>(`${restBaseUrl}visittype`)
     .pipe(
       map((results) => {
         const visitTypes: Array<VisitType> = results.data.results.map(toVisitTypeObject);

--- a/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts
@@ -55,7 +55,7 @@ export function getVisitsForPatient(
 ): Observable<FetchResponse<{ results: Array<Visit> }>> {
   const custom = v ?? defaultVisitCustomRepresentation;
 
-  return openmrsObservableFetch(`${restBaseUrl}visit?patient=${patientUuid}&v=${custom}`, {
+  return openmrsObservableFetch(`${restBaseUrl}/visit?patient=${patientUuid}&v=${custom}`, {
     signal: abortController.signal,
     method: 'GET',
     headers: {
@@ -71,7 +71,7 @@ export function getVisitsForPatient(
 }
 
 export function saveVisit(payload: NewVisitPayload, abortController: AbortController): Observable<FetchResponse<any>> {
-  return openmrsObservableFetch(`${restBaseUrl}visit`, {
+  return openmrsObservableFetch(`${restBaseUrl}/visit`, {
     signal: abortController.signal,
     method: 'POST',
     headers: {
@@ -86,7 +86,7 @@ export function updateVisit(
   payload: UpdateVisitPayload,
   abortController: AbortController,
 ): Observable<any> {
-  return openmrsObservableFetch(`${restBaseUrl}visit/${uuid}`, {
+  return openmrsObservableFetch(`${restBaseUrl}/visit/${uuid}`, {
     signal: abortController.signal,
     method: 'POST',
     headers: {

--- a/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts
@@ -2,7 +2,7 @@
 import type { Observable } from 'rxjs';
 import { BehaviorSubject } from 'rxjs';
 import { take, map } from 'rxjs/operators';
-import { openmrsObservableFetch } from '../openmrs-fetch';
+import { openmrsObservableFetch, restBaseUrl } from '../openmrs-fetch';
 import type { FetchResponse, NewVisitPayload, UpdateVisitPayload, Visit } from '../types';
 import { getGlobalStore } from '@openmrs/esm-state';
 
@@ -55,7 +55,7 @@ export function getVisitsForPatient(
 ): Observable<FetchResponse<{ results: Array<Visit> }>> {
   const custom = v ?? defaultVisitCustomRepresentation;
 
-  return openmrsObservableFetch(`/ws/rest/v1/visit?patient=${patientUuid}&v=${custom}`, {
+  return openmrsObservableFetch(`${restBaseUrl}visit?patient=${patientUuid}&v=${custom}`, {
     signal: abortController.signal,
     method: 'GET',
     headers: {
@@ -71,7 +71,7 @@ export function getVisitsForPatient(
 }
 
 export function saveVisit(payload: NewVisitPayload, abortController: AbortController): Observable<FetchResponse<any>> {
-  return openmrsObservableFetch(`/ws/rest/v1/visit`, {
+  return openmrsObservableFetch(`${restBaseUrl}visit`, {
     signal: abortController.signal,
     method: 'POST',
     headers: {
@@ -86,7 +86,7 @@ export function updateVisit(
   payload: UpdateVisitPayload,
   abortController: AbortController,
 ): Observable<any> {
-  return openmrsObservableFetch(`/ws/rest/v1/visit/${uuid}`, {
+  return openmrsObservableFetch(`${restBaseUrl}visit/${uuid}`, {
     signal: abortController.signal,
     method: 'POST',
     headers: {

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -747,7 +747,7 @@ ___
 
 ### attachmentUrl
 
-• `Const` **attachmentUrl**: ``"`${restBaseUrl}attachment"``
+• `Const` **attachmentUrl**: `string`
 
 #### Defined in
 
@@ -1330,7 +1330,7 @@ A [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Gl
 ```js
 import { openmrsFetch } from '@openmrs/esm-api'
 const abortController = new AbortController();
-openmrsFetch(`${restBaseUrl}session`, {signal: abortController.signal})
+openmrsFetch(`${restBaseUrl}/session', {signal: abortController.signal})
   .then(response => {
     console.log(response.data.authenticated)
   })
@@ -1338,7 +1338,7 @@ openmrsFetch(`${restBaseUrl}session`, {signal: abortController.signal})
     console.error(err.status);
   })
 abortController.abort();
-openmrsFetch(`${restBaseUrl}session', {
+openmrsFetch(`${restBaseUrl}/session', {
   method: 'POST',
   body: {
     username: 'hi',
@@ -1394,7 +1394,7 @@ The response object is exactly the same as for [openmrsFetch](API.md#openmrsfetc
 
 ```js
 import { openmrsObservableFetch } from '@openmrs/esm-api'
-const subscription = openmrsObservableFetch(`${restBaseUrl}session`).subscribe(
+const subscription = openmrsObservableFetch(`${restBaseUrl}/session').subscribe(
   response => console.log(response.data),
   err => {throw err},
   () => console.log('finished')

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -747,7 +747,7 @@ ___
 
 ### attachmentUrl
 
-• `Const` **attachmentUrl**: ``"/ws/rest/v1/attachment"``
+• `Const` **attachmentUrl**: ``"`${restBaseUrl}attachment"``
 
 #### Defined in
 
@@ -1330,7 +1330,7 @@ A [Promise](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Gl
 ```js
 import { openmrsFetch } from '@openmrs/esm-api'
 const abortController = new AbortController();
-openmrsFetch('/ws/rest/v1/session', {signal: abortController.signal})
+openmrsFetch(`${restBaseUrl}session`, {signal: abortController.signal})
   .then(response => {
     console.log(response.data.authenticated)
   })
@@ -1338,7 +1338,7 @@ openmrsFetch('/ws/rest/v1/session', {signal: abortController.signal})
     console.error(err.status);
   })
 abortController.abort();
-openmrsFetch('/ws/rest/v1/session', {
+openmrsFetch(`${restBaseUrl}session', {
   method: 'POST',
   body: {
     username: 'hi',
@@ -1394,7 +1394,7 @@ The response object is exactly the same as for [openmrsFetch](API.md#openmrsfetc
 
 ```js
 import { openmrsObservableFetch } from '@openmrs/esm-api'
-const subscription = openmrsObservableFetch('/ws/rest/v1/session').subscribe(
+const subscription = openmrsObservableFetch(`${restBaseUrl}session`).subscribe(
   response => console.log(response.data),
   err => {throw err},
   () => console.log('finished')

--- a/packages/framework/esm-react-utils/src/useVisit.ts
+++ b/packages/framework/esm-react-utils/src/useVisit.ts
@@ -1,5 +1,5 @@
 /** @module @category API */
-import type { Visit } from '@openmrs/esm-api';
+import { restBaseUrl, type Visit } from '@openmrs/esm-api';
 import { defaultVisitCustomRepresentation, getVisitStore, openmrsFetch } from '@openmrs/esm-api';
 import useSWR from 'swr';
 import dayjs from 'dayjs';
@@ -52,7 +52,7 @@ export function useVisit(patientUuid: string): VisitReturnType {
     isValidating: activeIsValidating,
   } = useSWR<{
     data: Visit | { results: Array<Visit> };
-  }>(patientUuid ? `/ws/rest/v1/visit${activeVisitUrlSuffix}` : null, openmrsFetch);
+  }>(patientUuid ? `${restBaseUrl}visit${activeVisitUrlSuffix}` : null, openmrsFetch);
 
   const {
     data: retroData,
@@ -61,7 +61,7 @@ export function useVisit(patientUuid: string): VisitReturnType {
     isValidating: retroIsValidating,
   } = useSWR<{
     data: Visit | { results: Array<Visit> };
-  }>(patientUuid && retrospectiveVisitUuid ? `/ws/rest/v1/visit${retrospectiveVisitUrlSuffix}` : null, openmrsFetch);
+  }>(patientUuid && retrospectiveVisitUuid ? `${restBaseUrl}visit${retrospectiveVisitUrlSuffix}` : null, openmrsFetch);
 
   const activeVisit = useMemo(
     () => activeData?.data.results.find((visit) => visit.stopDatetime === null) ?? null,

--- a/packages/framework/esm-react-utils/src/useVisit.ts
+++ b/packages/framework/esm-react-utils/src/useVisit.ts
@@ -52,7 +52,7 @@ export function useVisit(patientUuid: string): VisitReturnType {
     isValidating: activeIsValidating,
   } = useSWR<{
     data: Visit | { results: Array<Visit> };
-  }>(patientUuid ? `${restBaseUrl}visit${activeVisitUrlSuffix}` : null, openmrsFetch);
+  }>(patientUuid ? `${restBaseUrl}/visit${activeVisitUrlSuffix}` : null, openmrsFetch);
 
   const {
     data: retroData,
@@ -61,7 +61,7 @@ export function useVisit(patientUuid: string): VisitReturnType {
     isValidating: retroIsValidating,
   } = useSWR<{
     data: Visit | { results: Array<Visit> };
-  }>(patientUuid && retrospectiveVisitUuid ? `${restBaseUrl}visit${retrospectiveVisitUrlSuffix}` : null, openmrsFetch);
+  }>(patientUuid && retrospectiveVisitUuid ? `${restBaseUrl}/visit${retrospectiveVisitUrlSuffix}` : null, openmrsFetch);
 
   const activeVisit = useMemo(
     () => activeData?.data.results.find((visit) => visit.stopDatetime === null) ?? null,

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -1,5 +1,5 @@
 import { start, triggerAppChange } from 'single-spa';
-import type { OpenmrsAppRoutes } from '@openmrs/esm-framework/src/internal';
+import { type OpenmrsAppRoutes, restBaseUrl } from '@openmrs/esm-framework/src/internal';
 import {
   setupApiModule,
   renderLoadingSpinner,
@@ -354,7 +354,7 @@ async function precacheGlobalStaticDependencies() {
 
   // By default, cache the session endpoint.
   // This ensures that a lot of user/session related functions also work offline.
-  const sessionPathUrl = new URL(`${window.openmrsBase}/ws/rest/v1/session`, window.location.origin).href;
+  const sessionPathUrl = new URL(`${window.openmrsBase}${restBaseUrl}/session`, window.location.origin).href;
 
   await messageOmrsServiceWorker({
     type: 'registerDynamicRoute',
@@ -362,7 +362,7 @@ async function precacheGlobalStaticDependencies() {
     strategy: 'network-first',
   });
 
-  await openmrsFetch('/ws/rest/v1/session').catch((e) =>
+  await openmrsFetch(`${restBaseUrl}/session`).catch((e) =>
     console.warn(
       'Failed to precache the user session data from the app shell. MFs depending on this data may run into problems while offline.',
       e,


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Change all instances of the hard-coded API base URL '/ws/rest/v1/' to use the `restBaseUrl` variable instead. This enhances maintainability and flexibility of the API base URL configuration.

## Screenshots
None!

## Related Issue
https://openmrs.atlassian.net/browse/O3-2815

## Other
<!-- Anything not covered above -->
