### PR TITLE
(chore) Remove trailing slash from restBaseUrl

### DIFF
--- a/packages/framework/esm-api/src/openmrs-fetch.ts
+++ b/packages/framework/esm-api/src/openmrs-fetch.ts
@@ -3,14 +3,14 @@ import { Observable } from 'rxjs';
 import isPlainObject from 'lodash-es/isPlainObject';
 import { getConfig } from '@openmrs/esm-config';
 import { navigate } from '@openmrs/esm-navigation';
-import type { FetchResponse } from './types';
 import { clearHistory } from '@openmrs/esm-navigation/src/index';
+import type { FetchResponse } from './types';
 
-export const restBaseUrl = '/ws/rest/v1/';
+export const restBaseUrl = '/ws/rest/v1';
 
 export const fhirBaseUrl = '/ws/fhir2/R4';
 
-export const sessionEndpoint = `${restBaseUrl}session`;
+export const sessionEndpoint = `${restBaseUrl}/session`;
 
 /**
  * Append `path` to the OpenMRS SPA base.

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -789,7 +789,7 @@ ___
 
 ### restBaseUrl
 
-• `Const` **restBaseUrl**: ``"/ws/rest/v1/"``
+• `Const` **restBaseUrl**: ``"/ws/rest/v1"``
 
 #### Defined in
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

In this PR, I've removed the trailing slash from the `restBaseUrl` variable. The motivation for this change is twofold:

- To align `restBaseUrl` with the more widely used [fhirBaseUrl](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L11) export.
- To make [refactoring](https://github.com/openmrs/openmrs-esm-core/pull/932) easier to reason about (i.e. so you're sure that you need to append a trailing slash each time you use the variable).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
