### PR TITLE
(feat) Show a more useful script loading error

### DIFF
--- a/packages/framework/esm-dynamic-loading/src/dynamic-loading.ts
+++ b/packages/framework/esm-dynamic-loading/src/dynamic-loading.ts
@@ -154,7 +154,7 @@ function loadScript(url: string, resolve: (value: unknown) => void, reject: (rea
       scriptLoading.delete(url);
       console.error(`Failed to load script from ${url}`, ev);
       element.removeEventListener('error', errFn);
-      reject(ev.message);
+      reject(ev.message ?? `Failed to load script from ${url}`);
     };
     element.addEventListener('error', errFn);
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This changes the error message shown when scripts fail to load using the [loadScript](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-dynamic-loading/src/dynamic-loading.ts#L133) function to something that's more descriptive.

## Screenshots

### Before

![CleanShot 2024-02-20 at 11  50 43@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/f47d9044-95a0-4786-9bd5-1db84775543a)

### After

![CleanShot 2024-02-21 at 12  01 32@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/3bde5c67-7f1c-415c-8af7-c5472301fceb)

## Related Issue

https://openmrs.atlassian.net/browse/O3-2883

## Other
<!-- Anything not covered above -->
