### PR TITLE
(test) Add restBaseUrl to esm-framework mock

### DIFF
--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -35,6 +35,7 @@ export const mockSessionStore = createGlobalStore<SessionStore>('mock-session-st
 export const getSessionStore = jest.fn(() => mockSessionStore);
 export const setCurrentVisit = jest.fn();
 export const newWorkspaceItem = jest.fn();
+export const restBaseURL = '/ws/rest/v1';
 export const fhirBaseUrl = '/ws/fhir2/R4';
 export const attachmentUrl = '/ws/rest/v1/attachment';
 export const getAttachmentByUuid = jest.fn();


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This just adds `restBaseUrl` to the esm-framework mock so it's available in testing environments.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue

https://github.com/openmrs/openmrs-esm-patient-chart/pull/1661

## Other
<!-- Anything not covered above -->
