### PR TITLE
(feat) Add loud error messages if script loading fails

### DIFF
--- a/packages/framework/esm-dynamic-loading/src/dynamic-loading.ts
+++ b/packages/framework/esm-dynamic-loading/src/dynamic-loading.ts
@@ -22,16 +22,41 @@ export function slugify(name: string) {
  * const { someComponent } = importDynamic("@openmrs/esm-template-app")
  * ```
  *
- * @param jsPackage The package to load the export from
+ * @param jsPackage The package to load the export from.
  * @param share Indicates the name of the shared module; this is an advanced feature if the package you are loading
- *   doesn't use the default OpenMRS shared module name "./start"
+ *   doesn't use the default OpenMRS shared module name "./start".
+ * @param options Additional options to control loading this script.
+ * @param options.importMap The import map to use to load the script. This is useful for situations where you're
+ *   loading multiple scripts at a time, since it allows the calling code to supply an importMap, saving multiple
+ *   calls to `getCurrentImportMap()`.
+ * @param options.maxLoadingTime A positive integer representing the maximum number of milliseconds to wait for the
+ *   script to load before the promise returned from this function will be rejected. Defaults to 600,000 milliseconds,
+ *   i.e., 10 minutes.
  */
 export async function importDynamic<T = any>(
   jsPackage: string,
   share: string = './start',
-  options?: { importMap?: ImportMap },
+  options?: {
+    importMap?: ImportMap;
+    maxLoadingTime?: number;
+  },
 ): Promise<T> {
-  await preloadImport(jsPackage, options?.importMap);
+  // default to 10 minutes
+  const maxLoadingTime = !options?.maxLoadingTime || options.maxLoadingTime <= 0 ? 600_000 : options.maxLoadingTime;
+
+  let timeout: ReturnType<typeof setTimeout> | undefined = undefined;
+  await Promise.race([
+    preloadImport(jsPackage, options?.importMap),
+    new Promise((_, reject) => {
+      timeout = setTimeout(() => {
+        reject(
+          new Error(`Could not resolve requested script, ${jsPackage}, within ${humanReadableMs(maxLoadingTime)}.`),
+        );
+      }, maxLoadingTime);
+    }),
+  ]);
+
+  timeout && clearTimeout(timeout);
 
   const jsPackageSlug = slugify(jsPackage);
 
@@ -54,6 +79,27 @@ export async function importDynamic<T = any>(
   }
 
   return module as unknown as T;
+}
+
+/**
+ * Utility function to convert milliseconds into human-readable strings with rather absurd
+ * levels of precision.
+ *
+ * @param ms Number of milliseconds
+ * @returns A human-readable string useful only for error logging, where we can assume English
+ */
+function humanReadableMs(ms: number) {
+  if (ms < 1_000) {
+    return `${ms} milliseconds`;
+  } else if (ms < 60_000) {
+    return `${Math.floor(ms / 1000)} seconds`;
+  } else if (ms < 3_600_000) {
+    return `${Math.floor(ms / 60_000)} minutes`;
+  } else if (ms < 86_400_000) {
+    return `${Math.floor(ms / 3_600_000)} hours`;
+  } else {
+    return `${Math.floor(ms / 86_400_000)} days`;
+  }
 }
 
 /**
@@ -89,10 +135,12 @@ export async function preloadImport(jsPackage: string, importMap?: ImportMap) {
       url = window.spaBase + url.substring(1);
     }
 
-    await new Promise((resolve, reject) => {
+    return await new Promise<void>((resolve, reject) => {
       loadScript(url, resolve, reject);
     });
   }
+
+  return Promise.resolve();
 }
 
 /**
@@ -130,7 +178,11 @@ const OPENMRS_SCRIPT_LOADING = Symbol('__openmrs_script_loading');
 /**
  * Appends a `<script>` to the DOM with the given URL.
  */
-function loadScript(url: string, resolve: (value: unknown) => void, reject: (reason?: any) => void) {
+function loadScript(
+  url: string,
+  resolve: (value: unknown | PromiseLike<unknown>) => void,
+  reject: (reason?: any) => void,
+) {
   const scriptElement = document.head.querySelector(`script[src="${url}"]`);
   let scriptLoading: Set<String> = window[OPENMRS_SCRIPT_LOADING];
   if (!scriptLoading) {
@@ -143,38 +195,65 @@ function loadScript(url: string, resolve: (value: unknown) => void, reject: (rea
     element.src = url;
     element.type = 'text/javascript';
     element.async = true;
-    const loadFn = () => {
+
+    // loadTime() displays an error if a script takes more than 5 seconds to load
+    const loadTimeout = setTimeout(() => {
+      console.error(
+        `The script at ${url} did not load within 5 seconds. This may indicate an issue with the imports in the script's entry-point file or with the script's bundler configuration.`,
+      );
+    }, 5_000); // 5 seconds; this is arbitrary
+
+    let loadFn: () => void, errFn: (ev: ErrorEvent) => void, finishScriptLoading: () => void;
+
+    finishScriptLoading = () => {
+      clearTimeout(loadTimeout);
       scriptLoading.delete(url);
-      element.removeEventListener('load', loadFn);
+      loadFn && element.removeEventListener('load', loadFn);
+      errFn && element.removeEventListener('error', errFn);
+    };
+
+    loadFn = () => {
+      finishScriptLoading();
       resolve(null);
     };
-    element.addEventListener('load', loadFn);
 
-    const errFn = (ev: ErrorEvent) => {
-      scriptLoading.delete(url);
-      console.error(`Failed to load script from ${url}`, ev);
-      element.removeEventListener('error', errFn);
-      reject(ev.message ?? `Failed to load script from ${url}`);
+    errFn = (ev: ErrorEvent) => {
+      finishScriptLoading();
+      const msg = `Failed to load script from ${url}`;
+      console.error(msg, ev);
+      reject(ev.message ?? msg);
     };
+
+    element.addEventListener('load', loadFn);
     element.addEventListener('error', errFn);
 
     document.head.appendChild(element);
   } else {
     if (scriptLoading.has(url)) {
-      const loadFn = () => {
-        scriptElement?.removeEventListener('load', loadFn);
+      let loadFn: () => void, errFn: (ev: ErrorEvent) => void;
+      loadFn = () => {
+        if (scriptElement) {
+          scriptElement.removeEventListener('load', loadFn);
+          scriptElement.removeEventListener('error', errFn);
+        }
+
         resolve(null);
       };
-      scriptElement.addEventListener('load', loadFn);
 
-      const errFn = (ev: ErrorEvent) => {
-        console.error(`Failed to load script from ${url}`, ev);
-        scriptElement?.removeEventListener('error', errFn);
+      // this errFn does not log anything
+      errFn = (ev: ErrorEvent) => {
+        if (scriptElement) {
+          scriptElement.removeEventListener('load', loadFn);
+          scriptElement.removeEventListener('error', errFn);
+        }
+
         reject(ev.message);
       };
+
+      scriptElement.addEventListener('load', loadFn);
       scriptElement.addEventListener('error', errFn);
     } else {
-      console.warn('Script already loaded. Not loading it again.', url);
+      console.warn(`Script at ${url} already loaded. Not loading it again.`);
       resolve(null);
     }
   }

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -2543,10 +2543,11 @@ const { someComponent } = importDynamic("@openmrs/esm-template-app")
 
 | Name | Type | Default value | Description |
 | :------ | :------ | :------ | :------ |
-| `jsPackage` | `string` | `undefined` | The package to load the export from |
-| `share` | `string` | `'./start'` | Indicates the name of the shared module; this is an advanced feature if the package you are loading   doesn't use the default OpenMRS shared module name "./start" |
-| `options?` | `Object` | `undefined` | - |
+| `jsPackage` | `string` | `undefined` | The package to load the export from. |
+| `share` | `string` | `'./start'` | Indicates the name of the shared module; this is an advanced feature if the package you are loading   doesn't use the default OpenMRS shared module name "./start". |
+| `options?` | `Object` | `undefined` | Additional options to control loading this script. |
 | `options.importMap?` | [`ImportMap`](interfaces/ImportMap.md) | `undefined` |  |
+| `options.maxLoadingTime?` | `number` | `undefined` |  |
 
 #### Returns
 
@@ -2554,7 +2555,7 @@ const { someComponent } = importDynamic("@openmrs/esm-template-app")
 
 #### Defined in
 
-[packages/framework/esm-dynamic-loading/src/dynamic-loading.ts:29](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-dynamic-loading/src/dynamic-loading.ts#L29)
+[packages/framework/esm-dynamic-loading/src/dynamic-loading.ts:36](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-dynamic-loading/src/dynamic-loading.ts#L36)
 
 ___
 

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -196,10 +196,12 @@ function runShell() {
 async function preloadScripts() {
   const [, importMap] = await Promise.all([window[REGISTRATION_PROMISES], getCurrentImportMap()]);
 
-  window.installedModules.map(async ([module]) => {
-    // we simply swallow the error here since this is only a preload
-    importDynamic(module, undefined, { importMap }).catch();
-  });
+  return Promise.all(
+    window.installedModules.map(async ([module]) => {
+      // we simply swallow the error here since this is only a preload
+      return importDynamic<unknown>(module, undefined, { importMap }).catch();
+    }),
+  );
 }
 
 function handleInitFailure(e: Error) {

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -196,12 +196,10 @@ function runShell() {
 async function preloadScripts() {
   const [, importMap] = await Promise.all([window[REGISTRATION_PROMISES], getCurrentImportMap()]);
 
-  return Promise.all(
-    window.installedModules.map(async ([module]) => {
-      // we simply swallow the error here since this is only a preload
-      return importDynamic<unknown>(module, undefined, { importMap }).catch();
-    }),
-  );
+  window.installedModules.map(async ([module]) => {
+    // we simply swallow the error here since this is only a preload
+    importDynamic(module, undefined, { importMap }).catch();
+  });
 }
 
 function handleInitFailure(e: Error) {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This adds some new features to `importDynamic()` primarily aimed at making the application noisier in case things like the recent issue with OHRI's PMTCT module re-appears. This adds a few related features:

1. `importDynamic()` now supports a `maxLoadingTime` optional parameter that will cause the promise returned by `importDynamic()` to reject if the loading isn't finished in the specified period of time. This defaults to the rather absurdly long 10 minutes.
2. A console error is now generated if it takes longer than 5 seconds for any added script tag to either load or error out. This is separate from and does not cause the `importDynamic()` call to reject; it is more or less intended as a warning to give developers some insight.
3. I cleaned up the various event listeners, which didn't always get removed.
4. I toned down the logging that can happen if there was an error loading the script. Previously, all places that were waiting for the script to finish loading would write an error message to the console and reject the promise. Now the console error message is only written by the initial request for a specific script.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

I went back and forth quite a bit on the timing before landing on these defaults. I'm not entirely sure that 5 seconds is the right amount of time, but usually `importDynamic()` is only responsible for loading the entry point of a module, and subsequent chunks are loaded via the Webpack runtime. These initial chunks are usually less than 10kB each, so 5 seconds feels generous. Even throttling my connection down to "Good 2G", I only get one error message (though the app is _painfully_ slow).

Note that the two timeouts are not directly connected, and we do not make any attempt to stop the browser from downloading the script (it's done asynchronously anyways).

It would be possible to have the 5 second console error message configurable through `importDynamic()`. I just didn't do that because it's unlikely to be that useful (there are many use-cases for `importDynamic()` outside of the shell itself.