### PR TITLE
(feat) O3-2304: Hide primary side menu panel on item click

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
@@ -10,8 +10,8 @@ const SideMenuPanel: React.FC<SideMenuPanelProps> = ({ expanded, hidePanel }) =>
   const menuRef = useOnClickOutside(hidePanel, expanded);
 
   useEffect(() => {
-    window.addEventListener('single-spa:before-mount-routing-event', hidePanel);
-    return () => window.addEventListener('single-spa:before-mount-routing-event', hidePanel);
+    window.addEventListener('popstate', hidePanel);
+    return () => window.removeEventListener('popstate', hidePanel);
   }, [hidePanel]);
 
   return expanded && <LeftNavMenu ref={menuRef} isChildOfHeader />;

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect } from 'react';
 import { LeftNavMenu, useOnClickOutside } from '@openmrs/esm-framework';
 
 interface SideMenuPanelProps {
@@ -10,8 +10,8 @@ const SideMenuPanel: React.FC<SideMenuPanelProps> = ({ expanded, hidePanel }) =>
   const menuRef = useOnClickOutside(hidePanel, expanded);
 
   useEffect(() => {
-    window.addEventListener('popstate', hidePanel);
-    return window.removeEventListener('popstate', hidePanel);
+    window.addEventListener('single-spa:before-mount-routing-event', hidePanel);
+    return window.addEventListener('single-spa:before-mount-routing-event', hidePanel);
   }, [hidePanel]);
 
   return expanded && <LeftNavMenu ref={menuRef} isChildOfHeader />;

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
@@ -11,7 +11,7 @@ const SideMenuPanel: React.FC<SideMenuPanelProps> = ({ expanded, hidePanel }) =>
 
   useEffect(() => {
     window.addEventListener('single-spa:before-mount-routing-event', hidePanel);
-    return window.addEventListener('single-spa:before-mount-routing-event', hidePanel);
+    return () => window.addEventListener('single-spa:before-mount-routing-event', hidePanel);
   }, [hidePanel]);
 
   return expanded && <LeftNavMenu ref={menuRef} isChildOfHeader />;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds closing the side menu drawer when user clicks on an item

## Screenshots
<!-- Required if you are making UI changes. -->
https://github.com/openmrs/openmrs-esm-core/assets/53287480/30b9743a-f9bb-4cf3-9089-f82e1499f90b


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
[O3-2304](https://openmrs.atlassian.net/browse/O3-2304)

## Other
<!-- Anything not covered above -->
