### PR TITLE
(feat) Allow user to reset the importmap and reload if overridden script fails to load

### DIFF
--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -10,7 +10,7 @@
     "watch:ref": "cross-env OMRS_ESM_IMPORTMAP_URL=\"https://dev3.openmrs.org/openmrs/spa/importmap.json\" OMRS_OFFLINE=\"disable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" webpack serve --mode development",
     "build:production": "cross-env OMRS_ESM_IMPORTMAP_URL=\"https://dev3.openmrs.org/openmrs/spa/importmap.json\" OMRS_OFFLINE=\"enable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"production\" webpack --mode production",
     "build:development": "cross-env OMRS_OFFLINE=\"enable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" webpack --mode development",
-    "build": "npm run build:production && npm run build:development",
+    "build": "yarn run build:development",
     "analyze": "webpack --mode=production --env analyze=true",
     "lint": "eslint src --ext ts,tsx"
   },


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Displays an error toast if we fail to load a script that is overridden on the import map with the opportunity to reset and overload it.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="316" alt="Screenshot of example notification" src="https://github.com/openmrs/openmrs-esm-core/assets/52504170/62d22386-af39-4511-b245-05d20c94ffb7">

## Related Issue

<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

Future work:

* This should be translatable, but because we don't have a good pattern for translating things in the framework, I've left that aside for now.
* Currently the `unhandledrejection` handler is getting called when this fires as well. This needs a little care, because we fundamentally do want most of the promises to reject. The issue is that [this line](https://github.com/openmrs/openmrs-esm-core/blob/25ca4080f3b0963c8b5ea7d3bc8e5528ea8fa71c/packages/shell/esm-app-shell/src/run.ts#L201) isn't doing anything. In any case, the additional toast is a somewhat separate issue from this PR.
* If you've overridden a lot of modules, you will get one error-per-module. It would probably be best to simplify this case so only a single error gets displayed, but that probably requires working out the above point.