### PR TITLE
(fix) Fix spacing around address empty state in patient banner

### DIFF
--- a/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx
+++ b/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx
@@ -91,7 +91,7 @@ const Address: React.FC<{ patientId: string }> = ({ patientId }) => {
               )}
           </React.Fragment>
         ) : (
-          '--'
+          <li>'--'</li>
         )}
       </ul>
     </>

--- a/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx
+++ b/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx
@@ -91,7 +91,7 @@ const Address: React.FC<{ patientId: string }> = ({ patientId }) => {
               )}
           </React.Fragment>
         ) : (
-          <li>'--'</li>
+          <li>--</li>
         )}
       </ul>
     </>


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Redoing https://github.com/openmrs/openmrs-esm-patient-chart/pull/1729 because the banner lives here now
