### PR TITLE
(fix) Make download config button in implementer tools fully clickable

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/configuration/configuration.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/configuration.component.tsx
@@ -164,8 +164,13 @@ export const Configuration: React.FC<ConfigurationProps> = () => {
                   kind="secondary"
                   iconDescription="Download config"
                   renderIcon={(props) => <Download size={16} {...props} />}
+                  onClick={(event: React.MouseEvent<HTMLAnchorElement>) => {
+                    if ((event.target as HTMLAnchorElement).id != 'downloadConfigBtn')
+                      document.getElementById('downloadConfigBtn')?.click();
+                  }}
                 >
                   <a
+                    id="downloadConfigBtn"
                     className={styles.downloadLink}
                     download="temporary_config.json"
                     href={window.URL.createObjectURL(tempConfigObjUrl)}


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
The Download Config button in the implementer tools downloads a json file only when clicked on the **Download Config** letters and does not download the file when pressed on the remaining area. Resolved this by capturing the click on the bubbling phase.

## Screenshots
<!-- Required if you are making UI changes. -->
![Screenshot (297)](https://github.com/openmrs/openmrs-esm-core/assets/115476530/31dc4b0f-3c9c-40a0-bc97-a553b75c39bc)


