### PR TITLE
(feat) O3-1426: Modals should not be extensions

### DIFF
--- a/packages/apps/esm-devtools-app/src/routes.json
+++ b/packages/apps/esm-devtools-app/src/routes.json
@@ -8,7 +8,7 @@
       "offline": true
     }
   ],
-  "extensions": [
+  "modals": [
     {
       "name": "importmap-override-modal",
       "component": "importmapOverrideModal"

--- a/packages/apps/esm-offline-tools-app/src/routes.json
+++ b/packages/apps/esm-offline-tools-app/src/routes.json
@@ -26,12 +26,6 @@
       "offline": true
     },
     {
-      "name": "offline-tools-confirmation-modal",
-      "component": "offlineToolsConfirmationModal",
-      "online": true,
-      "offline": true
-    },
-    {
       "name": "offline-tools-dashboard-patients-card",
       "slot": "offline-tools-dashboard-cards",
       "component": "offlineToolsPatientsCard",
@@ -139,6 +133,12 @@
       "online": true,
       "offline": true,
       "order": 1
+    }
+  ],
+  "modals": [
+    {
+      "name": "offline-tools-confirmation-modal",
+      "component": "offlineToolsConfirmationModal"
     }
   ]
 }

--- a/packages/apps/esm-primary-navigation-app/src/routes.json
+++ b/packages/apps/esm-primary-navigation-app/src/routes.json
@@ -37,12 +37,6 @@
       "order": 1
     },
     {
-      "name": "change-language-modal",
-      "component": "changeLanguageModal",
-      "online": true,
-      "offline": true
-    },
-    {
       "name": "offline-banner",
       "slot": "user-panel-slot",
       "component": "offlineBanner",
@@ -55,6 +49,12 @@
       "component": "linkComponent",
       "online": true,
       "offline": true
+    }
+  ],
+  "modals": [
+    {
+      "name": "change-language-modal",
+      "component": "changeLanguageModal"
     }
   ]
 }

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -432,7 +432,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L38)
+[packages/framework/esm-config/src/types.ts:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L40)
 
 ___
 
@@ -468,6 +468,18 @@ ___
 
 ___
 
+### ModalDefintion
+
+Ƭ **ModalDefintion**: { `name`: `string`  } & { `component`: `string`  } \| { `component?`: `never`  }
+
+A definition of an modal as extracted from an app's routes.json
+
+#### Defined in
+
+[packages/framework/esm-globals/src/types.ts:237](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L237)
+
+___
+
 ### OpenmrsRoutes
 
 Ƭ **OpenmrsRoutes**: `Record`<`string`, [`OpenmrsAppRoutes`](interfaces/OpenmrsAppRoutes.md)\>
@@ -477,7 +489,7 @@ Basically, this is the same as the app routes, with each routes definition keyed
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:260](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L260)
+[packages/framework/esm-globals/src/types.ts:295](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L295)
 
 ___
 
@@ -506,7 +518,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:60](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L60)
+[packages/framework/esm-config/src/types.ts:62](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L62)
 
 ___
 
@@ -562,7 +574,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:67](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L67)
+[packages/framework/esm-config/src/types.ts:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L69)
 
 ___
 
@@ -586,7 +598,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:65](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L65)
+[packages/framework/esm-config/src/types.ts:67](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L67)
 
 ___
 
@@ -4749,17 +4761,20 @@ ___
 
 ### showModal
 
-▸ **showModal**(`extensionId`, `props?`, `onClose?`): () => `void`
+▸ **showModal**(`modalName`, `props?`, `onClose?`): () => `void`
 
-Shows the provided extension component in a modal dialog.
+Shows a modal dialog.
+
+The modal must have been registered by name. This should be done in the `routes.json` file of the
+app that defines the modal.
 
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `extensionId` | `string` | The id of the extension to show. |
-| `props` | `Record`<`string`, `any`\> | The optional props to provide to the extension. |
-| `onClose` | () => `void` | The optional notification to receive when the modal is closed. |
+| `modalName` | `string` | The name of the modal to show. |
+| `props` | `Record`<`string`, `any`\> | The optional props to provide to the modal. |
+| `onClose` | () => `void` | The optional callback to call when the modal is closed. |
 
 #### Returns
 
@@ -4775,7 +4790,7 @@ The dispose function to force closing the modal dialog.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/modals/index.tsx:160](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/modals/index.tsx#L160)
+[packages/framework/esm-styleguide/src/modals/index.tsx:208](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/modals/index.tsx#L208)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/DisplayConditionsConfigObject.md
+++ b/packages/framework/esm-framework/docs/interfaces/DisplayConditionsConfigObject.md
@@ -6,9 +6,31 @@
 
 ### Properties
 
+- [offline](DisplayConditionsConfigObject.md#offline)
+- [online](DisplayConditionsConfigObject.md#online)
 - [privileges](DisplayConditionsConfigObject.md#privileges)
 
 ## Properties
+
+### offline
+
+• `Optional` **offline**: `boolean`
+
+#### Defined in
+
+[packages/framework/esm-config/src/types.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L37)
+
+___
+
+### online
+
+• `Optional` **online**: `boolean`
+
+#### Defined in
+
+[packages/framework/esm-config/src/types.ts:36](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L36)
+
+___
 
 ### privileges
 

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfig.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfig.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:41](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L41)
+[packages/framework/esm-config/src/types.ts:43](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L43)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L44)
+[packages/framework/esm-config/src/types.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L46)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:43](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L43)
+[packages/framework/esm-config/src/types.ts:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L45)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:42](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L42)
+[packages/framework/esm-config/src/types.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L44)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfigObject.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotConfigObject.md
@@ -20,7 +20,7 @@ Additional extension IDs to assign to this slot, in addition to those `attach`ed
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:53](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L53)
+[packages/framework/esm-config/src/types.ts:55](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L55)
 
 ___
 
@@ -32,7 +32,7 @@ Overrides the default ordering of extensions.
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:57](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L57)
+[packages/framework/esm-config/src/types.ts:59](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L59)
 
 ___
 
@@ -44,4 +44,4 @@ Extension IDs which were `attach`ed to the slot but which should not be assigned
 
 #### Defined in
 
-[packages/framework/esm-config/src/types.ts:55](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L55)
+[packages/framework/esm-config/src/types.ts:57](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/types.ts#L57)

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
@@ -10,6 +10,7 @@ This interface describes the format of the routes provided by an app
 
 - [backendDependencies](OpenmrsAppRoutes.md#backenddependencies)
 - [extensions](OpenmrsAppRoutes.md#extensions)
+- [modals](OpenmrsAppRoutes.md#modals)
 - [pages](OpenmrsAppRoutes.md#pages)
 - [version](OpenmrsAppRoutes.md#version)
 
@@ -23,7 +24,7 @@ A list of backend modules necessary for this frontend module and the correspondi
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:245](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L245)
+[packages/framework/esm-globals/src/types.ts:276](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L276)
 
 ___
 
@@ -35,7 +36,19 @@ An array of all extensions supported by this frontend module. Extensions can be 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:253](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L253)
+[packages/framework/esm-globals/src/types.ts:284](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L284)
+
+___
+
+### modals
+
+• `Optional` **modals**: [`ModalDefintion`](../API.md#modaldefintion)[]
+
+An array of all modals supported by this frontend module. Modals can be launched by name.
+
+#### Defined in
+
+[packages/framework/esm-globals/src/types.ts:288](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L288)
 
 ___
 
@@ -47,7 +60,7 @@ An array of all pages supported by this frontend module. Pages are automatically
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:249](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L249)
+[packages/framework/esm-globals/src/types.ts:280](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L280)
 
 ___
 
@@ -59,4 +72,4 @@ The version of this frontend module.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:241](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L241)
+[packages/framework/esm-globals/src/types.ts:272](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L272)

--- a/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
+++ b/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
@@ -20,4 +20,4 @@
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:263](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L263)
+[packages/framework/esm-globals/src/types.ts:298](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L298)

--- a/packages/framework/esm-globals/src/types.ts
+++ b/packages/framework/esm-globals/src/types.ts
@@ -232,6 +232,37 @@ export type ExtensionDefinition = {
 );
 
 /**
+ * A definition of an modal as extracted from an app's routes.json
+ */
+export type ModalDefintion = {
+  /**
+   * The name of this modal. This is used to launch the modal.
+   */
+  name: string;
+} & (
+  | {
+      /**
+       * The name of the component exported by this frontend module.
+       */
+      component: string;
+      /**
+       * @internal
+       */
+      load?: never;
+    }
+  | {
+      /**
+       * The name of the component exported by this frontend module.
+       */
+      component?: never;
+      /**
+       * @internal
+       */
+      load: () => Promise<{ default?: LifeCycles } & LifeCycles>;
+    }
+);
+
+/**
  * This interface describes the format of the routes provided by an app
  */
 export interface OpenmrsAppRoutes {
@@ -251,6 +282,10 @@ export interface OpenmrsAppRoutes {
    * An array of all extensions supported by this frontend module. Extensions can be mounted in extension slots, either via declarations in this file or configuration.
    */
   extensions?: Array<ExtensionDefinition>;
+  /**
+   * An array of all modals supported by this frontend module. Modals can be launched by name.
+   */
+  modals?: Array<ModalDefintion>;
 }
 
 /**

--- a/packages/framework/esm-styleguide/src/modals/registry.ts
+++ b/packages/framework/esm-styleguide/src/modals/registry.ts
@@ -1,0 +1,48 @@
+import { getExtensionRegistration } from '@openmrs/esm-extensions';
+import { createGlobalStore } from '@openmrs/esm-state';
+import type { LifeCycles } from 'single-spa';
+
+/** @internal */
+export interface ModalRegistration {
+  name: string;
+  load(): Promise<{ default?: LifeCycles } & LifeCycles>;
+  moduleName: string;
+}
+
+interface ModalRegistry {
+  /** Modals indexed by name */
+  modals: Record<string, ModalRegistration>;
+}
+
+const modalRegistryStore = createGlobalStore<ModalRegistry>('modalRegistry', {
+  modals: {},
+});
+
+/** @internal */
+export function registerModal(modalRegistration: ModalRegistration) {
+  modalRegistryStore.setState((state) => {
+    state.modals[modalRegistration.name] = modalRegistration;
+    return state;
+  });
+}
+
+/** @internal */
+export function getModalRegistration(modalName: string): ModalRegistration | undefined {
+  let modalRegistration = modalRegistryStore.getState().modals[modalName];
+  if (!modalRegistration) {
+    const extensionRegistration = getExtensionRegistration(modalName);
+    if (extensionRegistration) {
+      modalRegistration = {
+        name: modalName,
+        load: extensionRegistration.load,
+        moduleName: extensionRegistration.moduleName,
+      };
+      console.warn(
+        `Modal ${modalName} was registered as an extension. This is deprecated and will be removed in the future. Please register it in the "modals" section of routes.json instead of the "extensions" section.`,
+      );
+      // Register it so the warning only appears once
+      registerModal(modalRegistration);
+    }
+  }
+  return modalRegistration;
+}

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -23,7 +23,7 @@ import {
   messageOmrsServiceWorker,
   subscribeConnectivity,
   getCurrentUser,
-  renderModals,
+  setupModals,
   dispatchPrecacheStaticDependencies,
   activateOfflineCapability,
   subscribePrecacheStaticDependencies,
@@ -288,7 +288,7 @@ function showSnackbars() {
 }
 
 function showModals() {
-  renderModals(document.querySelector('.omrs-modals-container'));
+  setupModals(document.querySelector('.omrs-modals-container'));
 }
 
 function showLoadingSpinner() {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This creates a new "modal system" specifically for modals. Apps should move modals out of the "extensions" section of `routes.json` and into the "modals" section. The modals system is much simpler than the extension system. Modals defined as extensions are supported for backwards compatibility, but a console warning is logged.

There should be no UI change associated with this change.

## Screenshots

https://github.com/openmrs/openmrs-esm-core/assets/1031876/35394b6f-d66b-4b27-9d9a-c2e170fe0739

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->

https://issues.openmrs.org/browse/O3-1426

## Other

Requires routes JSON Schema update. PR: https://github.com/openmrs/openmrs-contrib-json-schemas/pull/6
