### PR TITLE
(feat) O3-3010: Disable triggering offline mode when offline disabled

### DIFF
--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -186,8 +186,6 @@ function connectivityChanged() {
  * Runs the shell by importing the translations and starting single SPA.
  */
 function runShell() {
-  window.addEventListener('offline', connectivityChanged);
-  window.addEventListener('online', connectivityChanged);
   return setupI18n()
     .catch((err) => console.error(`Failed to initialize translations`, err))
     .then(() => start());
@@ -378,6 +376,11 @@ async function precacheImportMap() {
   });
 }
 
+function registerOfflineHandlers() {
+  window.addEventListener('offline', connectivityChanged);
+  window.addEventListener('online', connectivityChanged);
+}
+
 function setupOfflineCssClasses() {
   subscribeConnectivity(({ online }) => {
     const body = document.querySelector('body')!;
@@ -410,7 +413,8 @@ export function run(configUrls: Array<string>, offline: boolean) {
 
   return setupApps()
     .then(finishRegisteringAllApps)
-    .then(setupOfflineCssClasses)
+    .then(offline ? setupOfflineCssClasses : undefined)
+    .then(offline ? registerOfflineHandlers : undefined)
     .then(provideConfigs)
     .then(runShell)
     .catch(handleInitFailure)


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

As reported on the squad call today, on a local machine with no internet connectivity, we end up triggering offline mode, which is unfortunate, since we do need to support single-machine installs with no internet connectivity.

This PR probably doesn't fully address the issue; however, what I've done is to move the event handlers that respond to connectivity changes so that they are only registered if offline mode is enabled. This should enable installations on a single machine with no network connectivity provided that offline mode is disabled in the build configuration, which is the default. Since such installations without LAN or internet connectivity have no real reason to use offline mode in any fashion, this seems to be a way of addressing the issue with the minimal amount of change.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-3010

## Other
<!-- Anything not covered above -->

A more thorough-going process would probably use something like a websocket to subscribe to the OpenMRS backend, which could be used to detect when the backend is down. Such a solution, however, requires additions to the backend as well as frontend and needs to be carefully considered, since it may cause some issues for clinics with many devices connecting to a server and a relatively small server instance.
