### PR TITLE
(fix) O3-2994: App switcher menu should be hidden after clicking a link

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/app-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/app-menu-panel.component.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { HeaderPanel } from '@carbon/react';
@@ -16,25 +16,32 @@ const AppMenuPanel: React.FC<AppMenuProps> = ({ expanded, hidePanel }) => {
   const config = useConfig();
   const { t } = useTranslation();
 
+  useEffect(() => {
+    window.addEventListener('popstate', hidePanel);
+    return () => window.removeEventListener('popstate', hidePanel);
+  }, [hidePanel]);
+
   return (
-    <HeaderPanel
-      ref={appMenuRef}
-      className={classNames({ [styles.headerPanel]: expanded })}
-      aria-label="App Menu Panel"
-      expanded={expanded}
-    >
-      <ExtensionSlot className={styles.menuLink} name="app-menu-slot" />
-      {config?.externalRefLinks?.length > 0 && (
-        <div className={classNames(styles.menuLink, styles.externalLinks)}>
-          {config?.externalRefLinks?.map((link) => (
-            <a target="_blank" rel="noopener noreferrer" href={link?.redirect}>
-              {t(link?.title)}
-              <Launch size={16} className={styles.launchIcon} />
-            </a>
-          ))}
-        </div>
-      )}
-    </HeaderPanel>
+    expanded && (
+      <HeaderPanel
+        ref={appMenuRef}
+        className={classNames({ [styles.headerPanel]: expanded })}
+        aria-label="App Menu Panel"
+        expanded={expanded}
+      >
+        <ExtensionSlot className={styles.menuLink} name="app-menu-slot" />
+        {config?.externalRefLinks?.length > 0 && (
+          <div className={classNames(styles.menuLink, styles.externalLinks)}>
+            {config?.externalRefLinks?.map((link) => (
+              <a target="_blank" rel="noopener noreferrer" href={link?.redirect}>
+                {t(link?.title)}
+                <Launch size={16} className={styles.launchIcon} />
+              </a>
+            ))}
+          </div>
+        )}
+      </HeaderPanel>
+    )
   );
 };
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.





## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This pull request addresses the issue where the dropdown menu in the header does not close automatically after selecting an option. Currently, the dropdown remains open. with this pr, the dropdown will close itself upon selecting an option.

## Screenshots
<!-- Required if you are making UI changes. -->
https://github.com/openmrs/openmrs-esm-core/assets/29108523/b21e40e6-056e-4b96-9796-d54344e497e8

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-2994

## Other
<!-- Anything not covered above -->
