### PR TITLE
(chore) Separate formatting and linting concerns

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,7 @@
     "node": true,
     "browser": true
   },
-  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "prettier"],
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended"],
   "parser": "@typescript-eslint/parser",
   "plugins": ["@typescript-eslint"],
   "ignorePatterns": ["**/*.test.tsx"],

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -3,6 +3,6 @@
 
 set -e  # die on error
 
+npx lint-staged
 yarn turbo extract-translations
-yarn prettier && npx lint-staged
 yarn turbo document --since main

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
     "setup": "yarn install && turbo run build",
     "start": "openmrs develop",
     "verify": "turbo run lint && turbo run test && turbo run typescript",
-    "prettier": "prettier --config prettier.config.js --write \"packages/**/*.{ts,tsx,css,scss}\" \"e2e/**/*.ts\" --list-different",
     "postinstall": "husky install",
     "test": "cross-env TZ=UTC jest --config jest.config.json --verbose false --passWithNoTests",
     "test-watch": "cross-env TZ=UTC jest --watch --config jest.config.json",
@@ -45,7 +44,6 @@
     "cross-env": "7.0.2",
     "dotenv": "^16.0.3",
     "eslint": "^8.55.0",
-    "eslint-config-prettier": "^9.1.0",
     "fake-indexeddb": "^4.0.1",
     "fork-ts-checker-webpack-plugin": "^7.2.13",
     "husky": "^8.0.1",
@@ -70,7 +68,10 @@
     "webpack": "^5.88.0"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": "eslint --cache --fix"
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --cache --fix",
+      "prettier --cache --write --ignore-unknown --list-different"
+    ]
   },
   "resolutions": {
     "minipass": "3.3.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2875,7 +2875,6 @@ __metadata:
     cross-env: "npm:7.0.2"
     dotenv: "npm:^16.0.3"
     eslint: "npm:^8.55.0"
-    eslint-config-prettier: "npm:^9.1.0"
     fake-indexeddb: "npm:^4.0.1"
     fork-ts-checker-webpack-plugin: "npm:^7.2.13"
     husky: "npm:^8.0.1"
@@ -8824,17 +8823,6 @@ __metadata:
     escodegen: bin/escodegen.js
     esgenerate: bin/esgenerate.js
   checksum: 10/0f7e404b19b14047dd12b62b2267ba9b68fff02be0d40d71fdcc27dfdd664720e1afae34680892b8a34cdd9280b7b4f81c02f7c7597a8eda0c6d2b4c2b7d07f0
-  languageName: node
-  linkType: hard
-
-"eslint-config-prettier@npm:^9.1.0":
-  version: 9.1.0
-  resolution: "eslint-config-prettier@npm:9.1.0"
-  peerDependencies:
-    eslint: ">=7.0.0"
-  bin:
-    eslint-config-prettier: bin/cli.js
-  checksum: 10/411e3b3b1c7aa04e3e0f20d561271b3b909014956c4dba51c878bf1a23dbb8c800a3be235c46c4732c70827276e540b6eed4636d9b09b444fd0a8e07f0fcd830
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Our current setup is running Prettier as a part of ESLint. These are two separate concerns that should be handled separately by different tools.

This PR removes [eslint-plugin-prettier](https://github.com/prettier/eslint-plugin-prettier) and [eslint-config-prettier](https://github.com/prettier/eslint-config-prettier) from our linting config as recommended [here](https://prettier.io/docs/en/integrating-with-linters.html#notes) and [here](https://www.joshuakgoldberg.com/blog/you-probably-dont-need-eslint-config-prettier-or-eslint-plugin-prettier/). I've also separated ESLint concerns from Prettier so that ESLint doesn't handle both. The recommended modern approach treats Prettier and ESLint as separate unrelated tools.

I've also removed the `prettier` script from the root-level package.json to the `lint-staged` config so that `lint-staged` runs Prettier after ESLint.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
