### PR TITLE
(feat) Add a hook to get callable extensions outside of a slot

### DIFF
--- a/packages/framework/esm-react-utils/src/extensions.test.tsx
+++ b/packages/framework/esm-react-utils/src/extensions.test.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useReducer } from 'react';
+import '@testing-library/jest-dom';
 import { act, render, screen, waitFor, within } from '@testing-library/react';
 import {
   attach,
@@ -17,6 +18,7 @@ import {
 } from '.';
 import userEvent from '@testing-library/user-event';
 import { registerFeatureFlag, setFeatureFlag } from '@openmrs/esm-feature-flags';
+import useRenderableExtensions from './useRenderableExtensions';
 
 // For some reason in the test context `isEqual` always returns true
 // when using the import substitution in jest.config.js. Here's a custom
@@ -276,6 +278,25 @@ describe('ExtensionSlot, Extension, and useExtensionSlotMeta', () => {
     expect(screen.queryByText('Kurmanji')).not.toBeInTheDocument();
     act(() => setFeatureFlag('kurdish', true));
     await waitFor(() => expect(screen.getByText('Kurmanji')).toBeInTheDocument());
+  });
+
+  test('useRenderableExtensions returns registered extensions', async () => {
+    registerSimpleExtension('Spanish', 'esm-languages-app', undefined, {
+      code: 'es',
+    });
+    attach('Box', 'Spanish');
+    const App = openmrsComponentDecorator({
+      moduleName: 'esm-languages-app',
+      featureName: 'Languages',
+      disableTranslations: true,
+    })(() => {
+      const extensions = useRenderableExtensions('Box');
+      const Ext = extensions[0];
+      return <Ext />;
+    });
+    render(<App />);
+
+    await waitFor(() => expect(screen.getByText('Spanish')).toBeInTheDocument());
   });
 });
 

--- a/packages/framework/esm-react-utils/src/index.ts
+++ b/packages/framework/esm-react-utils/src/index.ts
@@ -25,6 +25,7 @@ export * from './useLocations';
 export * from './useOnClickOutside';
 export * from './useOpenmrsSWR';
 export * from './usePatient';
+export * from './useRenderableExtensions';
 export { useSession } from './useSession';
 export * from './useStore';
 export * from './useVisit';

--- a/packages/framework/esm-react-utils/src/public.ts
+++ b/packages/framework/esm-react-utils/src/public.ts
@@ -21,6 +21,7 @@ export * from './useLocations';
 export * from './useOnClickOutside';
 export * from './useOpenmrsSWR';
 export * from './usePatient';
+export * from './useRenderableExtensions';
 export { useSession } from './useSession';
 export * from './useStore';
 export * from './useVisit';

--- a/packages/framework/esm-react-utils/src/useRenderableExtensions.tsx
+++ b/packages/framework/esm-react-utils/src/useRenderableExtensions.tsx
@@ -1,0 +1,55 @@
+/** @module @category Extension */
+import React from 'react';
+import { ComponentContext, Extension, type ExtensionProps, useExtensionSlot } from '.';
+
+/**
+ * This is an advanced hook for use-cases where its useful to use the extension system,
+ * but not the `ExtensionSlot` component's rendering of extensions. Use of this hook
+ * should be avoided if possible.
+ *
+ * Functionally, this hook is very similar to the `ExtensionSlot` component, but whereas
+ * an `ExtensionSlot` renders a DOM tree of extensions bound to the slot, this hook simply
+ * returns the extensions as an array of React components that can be wired into a component
+ * however makes sense.
+ *
+ * Note that because these do not render as normal extension slots, they will not show
+ * up in the UI. This may require more documentation to explain to end-users how to use
+ * your slot used in this way.
+ *
+ * @param name The name of the extension slot
+ *
+ * @example
+ * ```ts
+ * const extensions = useRenderableExtensions('my-extension-slot');
+ * return (
+ *  <>
+ *    {extensions.map((Ext, index) => (
+ *      <React.Fragment key={index}>
+ *        <Ext state={{key: 'value'}} />
+ *      </React.Fragment>
+ *    ))}
+ *  </>
+ * )
+ * ```
+ */
+export default function useRenderableExtensions(name: string): Array<React.FC<Pick<ExtensionProps, 'state'>>> {
+  const { extensions, extensionSlotModuleName } = useExtensionSlot(name);
+
+  return name
+    ? extensions.map((extension) => (state: Record<string, unknown>) => (
+        <ComponentContext.Provider
+          value={{
+            moduleName: extensionSlotModuleName, // moduleName is not used by the receiving Extension
+            featureName: '', // featureName is not available at this point
+            extension: {
+              extensionId: extension.id,
+              extensionSlotName: name,
+              extensionSlotModuleName,
+            },
+          }}
+        >
+          <Extension state={state} />
+        </ComponentContext.Provider>
+      ))
+    : [];
+}

--- a/packages/framework/esm-react-utils/src/useRenderableExtensions.tsx
+++ b/packages/framework/esm-react-utils/src/useRenderableExtensions.tsx
@@ -12,10 +12,6 @@ import { ComponentContext, Extension, type ExtensionProps, useExtensionSlot } fr
  * returns the extensions as an array of React components that can be wired into a component
  * however makes sense.
  *
- * Note that because these do not render as normal extension slots, they will not show
- * up in the UI. This may require more documentation to explain to end-users how to use
- * your slot used in this way.
- *
  * @param name The name of the extension slot
  *
  * @example


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This adds a hook that takes an extension slot name and returns renderable versions of each extension bound to that slot. The purpose is to allow uses of the extension system for places where we need a very different DOM layout than that supported either by the `ExtensionSlot` component or by providing the `ExtensionSlot` component with a child function for a custom layout.

The use-case for this is generating tables that have columns configurable via the extension system, and a separate extension instance for each cell, but each cell does not need a custom configuration (instead, configuration can apply to all cells in a column). This enables that use-case.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-3098

## Other
<!-- Anything not covered above -->

PS @brandones and @denniskigen no documentation was generated for this, even though it's part of the public API, unless I missed something obvious?
