### PR TITLE
(fix) Suppress most version mismatch warnings

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -337,6 +337,7 @@ module.exports = (env, argv = {}) => {
             // See: https://github.com/webpack/webpack/issues/16125 and https://github.com/vercel/swr/issues/2356
             obj['swr/'] = {
               requiredVersion: version,
+              strictVersion: false,
               singleton: true,
               eager: true,
               import: 'swr/',
@@ -347,6 +348,7 @@ module.exports = (env, argv = {}) => {
           } else {
             obj[depName] = {
               requiredVersion: version ?? false,
+              strictVersion: false,
               singleton: true,
               eager: true,
               import: depName,

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -288,6 +288,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
             // See: https://github.com/webpack/webpack/issues/16125 and https://github.com/vercel/swr/issues/2356
             obj['swr/'] = {
               requiredVersion: peerDependencies['swr'] ?? false,
+              strictVersion: false,
               singleton: true,
               import: 'swr/',
               shareKey: 'swr/',
@@ -297,6 +298,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
           } else {
             obj[depName] = {
               requiredVersion: peerDependencies[depName] ?? false,
+              strictVersion: false,
               singleton: true,
               import: depName,
               shareKey: depName,


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This just ensures that `strictVersion` is set to `false`. This should suppress warnings like:

```
Unsatisfied version 5.5.1-pre.1726 from openmrs of shared singleton module @openmrs/esm-framework (required ^5)
```

However, warnings like:

```
Unsatisfied version 6.1.1-pre.3580 from @openmrs/esm-appointments-app of shared singleton module @openmrs/esm-patient-common-lib (required ^7)
```

Will persist, because they indicate an actual issue.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

This will require updating the `openmrs` library in dependencies for this change to take effect.
