### PR TITLE
(fix) minor fixup to have useRenderableExtensions not be a default ex…

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -108,6 +108,7 @@
 - [useConnectedExtensions](API.md#useconnectedextensions)
 - [useExtensionSlotMeta](API.md#useextensionslotmeta)
 - [useExtensionStore](API.md#useextensionstore)
+- [useRenderableExtensions](API.md#userenderableextensions)
 
 ### Feature Flags Functions
 
@@ -3117,6 +3118,49 @@ ___
 #### Defined in
 
 [packages/framework/esm-react-utils/src/useExtensionStore.ts:6](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useExtensionStore.ts#L6)
+
+___
+
+### useRenderableExtensions
+
+▸ **useRenderableExtensions**(`name`): `React.FC`<`Pick`<[`ExtensionProps`](API.md#extensionprops), ``"state"``\>\>[]
+
+This is an advanced hook for use-cases where its useful to use the extension system,
+but not the `ExtensionSlot` component's rendering of extensions. Use of this hook
+should be avoided if possible.
+
+Functionally, this hook is very similar to the `ExtensionSlot` component, but whereas
+an `ExtensionSlot` renders a DOM tree of extensions bound to the slot, this hook simply
+returns the extensions as an array of React components that can be wired into a component
+however makes sense.
+
+**`example`**
+```ts
+const extensions = useRenderableExtensions('my-extension-slot');
+return (
+ <>
+   {extensions.map((Ext, index) => (
+     <React.Fragment key={index}>
+       <Ext state={{key: 'value'}} />
+     </React.Fragment>
+   ))}
+ </>
+)
+```
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `name` | `string` | The name of the extension slot |
+
+#### Returns
+
+`React.FC`<`Pick`<[`ExtensionProps`](API.md#extensionprops), ``"state"``\>\>[]
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/useRenderableExtensions.tsx:31](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useRenderableExtensions.tsx#L31)
 
 ___
 

--- a/packages/framework/esm-react-utils/src/extensions.test.tsx
+++ b/packages/framework/esm-react-utils/src/extensions.test.tsx
@@ -15,10 +15,10 @@ import {
   openmrsComponentDecorator,
   useExtensionSlotMeta,
   type ExtensionData,
+  useRenderableExtensions,
 } from '.';
 import userEvent from '@testing-library/user-event';
 import { registerFeatureFlag, setFeatureFlag } from '@openmrs/esm-feature-flags';
-import useRenderableExtensions from './useRenderableExtensions';
 
 // For some reason in the test context `isEqual` always returns true
 // when using the import substitution in jest.config.js. Here's a custom

--- a/packages/framework/esm-react-utils/src/useRenderableExtensions.tsx
+++ b/packages/framework/esm-react-utils/src/useRenderableExtensions.tsx
@@ -28,7 +28,7 @@ import { ComponentContext, Extension, type ExtensionProps, useExtensionSlot } fr
  * )
  * ```
  */
-export default function useRenderableExtensions(name: string): Array<React.FC<Pick<ExtensionProps, 'state'>>> {
+export function useRenderableExtensions(name: string): Array<React.FC<Pick<ExtensionProps, 'state'>>> {
   const { extensions, extensionSlotModuleName } = useExtensionSlot(name);
 
   return name


### PR DESCRIPTION
…port

# Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
I couldn't get `useRenderableExtensions` to import in `patient-management`. Changing it to not be a default import seems to fix it.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
