### PR TITLE
(fix) O3-3139 add mock for useRenderableExtensions + fix its state ty…

### DIFF
--- a/packages/framework/esm-react-utils/mock.tsx
+++ b/packages/framework/esm-react-utils/mock.tsx
@@ -37,6 +37,8 @@ export const useSession = jest.fn(() => ({
 
 export const useLayoutType = jest.fn(() => 'desktop');
 
+export const useRenderableExtensions = jest.fn(() => []);
+
 export const useAssignedExtensions = jest.fn(() => []);
 
 export const useExtensionSlotMeta = jest.fn(() => ({}));

--- a/packages/framework/esm-react-utils/src/extensions.test.tsx
+++ b/packages/framework/esm-react-utils/src/extensions.test.tsx
@@ -281,7 +281,11 @@ describe('ExtensionSlot, Extension, and useExtensionSlotMeta', () => {
   });
 
   test('useRenderableExtensions returns registered extensions', async () => {
-    registerSimpleExtension('Spanish', 'esm-languages-app', undefined, {
+    function SpanishExtension({ suffix }) {
+      return <div>Spanish{suffix}</div>;
+    }
+
+    registerSimpleExtension('Spanish', 'esm-languages-app', SpanishExtension, {
       code: 'es',
     });
     attach('Box', 'Spanish');
@@ -292,11 +296,11 @@ describe('ExtensionSlot, Extension, and useExtensionSlotMeta', () => {
     })(() => {
       const extensions = useRenderableExtensions('Box');
       const Ext = extensions[0];
-      return <Ext />;
+      return <Ext state={{ suffix: ' hola' }} />;
     });
     render(<App />);
 
-    await waitFor(() => expect(screen.getByText('Spanish')).toBeInTheDocument());
+    await waitFor(() => expect(screen.getByText('Spanish hola')).toBeInTheDocument());
   });
 });
 

--- a/packages/framework/esm-react-utils/src/useRenderableExtensions.tsx
+++ b/packages/framework/esm-react-utils/src/useRenderableExtensions.tsx
@@ -32,7 +32,7 @@ export function useRenderableExtensions(name: string): Array<React.FC<Pick<Exten
   const { extensions, extensionSlotModuleName } = useExtensionSlot(name);
 
   return name
-    ? extensions.map((extension) => (state: Record<string, unknown>) => (
+    ? extensions.map((extension) => ({ state }: Pick<ExtensionProps, 'state'>) => (
         <ComponentContext.Provider
           value={{
             moduleName: extensionSlotModuleName, // moduleName is not used by the receiving Extension


### PR DESCRIPTION
…ping

# Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
More minor fixup for `useRenderableExtensions`:
- add a mock
- make it so we only pass `ExtensionProps.state` into the extension

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
