### PR TITLE
(fix) O3-3188 make modal body vertical-scroll properly

### DIFF
--- a/packages/framework/esm-styleguide/src/modals/index.tsx
+++ b/packages/framework/esm-styleguide/src/modals/index.tsx
@@ -43,14 +43,12 @@ function createModalFrame() {
   ) as HTMLButtonElement;
 
   closeButton.addEventListener('click', closeHighestInstance);
-  const outer = document.createElement('div');
-  outer.className = 'cds--modal-container';
-  const contentContainer = document.createElement('div');
+  const modalFrame = document.createElement('div');
+  modalFrame.className = 'cds--modal-container';
 
-  outer.append(closeButton);
-  outer.append(contentContainer);
+  modalFrame.append(closeButton);
 
-  return { outer, contentContainer };
+  return modalFrame;
 }
 
 let parcelCount = 0;
@@ -108,13 +106,13 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
     modalStack.forEach((instance, index) => {
       switch (instance.state) {
         case 'NEW': {
-          const { outer, contentContainer } = createModalFrame();
-          instance.container = outer;
-          renderModalIntoDOM(contentContainer, instance.modalName, instance.props).then((parcel) => {
+          const modalFrame = createModalFrame();
+          instance.container = modalFrame;
+          renderModalIntoDOM(modalFrame, instance.modalName, instance.props).then((parcel) => {
             instance.parcel = parcel;
             instance.state = 'MOUNTED';
-            modalContainer.prepend(outer);
-            outer.style.visibility = 'unset';
+            modalContainer.prepend(modalFrame);
+            modalFrame.style.visibility = 'unset';
           });
           break;
         }
@@ -198,7 +196,9 @@ export function setupModals(modalContainer: HTMLElement | null) {
  * Shows a modal dialog.
  *
  * The modal must have been registered by name. This should be done in the `routes.json` file of the
- * app that defines the modal.
+ * app that defines the modal. Note that both the `<ModelHeader>` and `<ModalBody>` should be at the
+ * top level of the modal component (wrapped in a React.Fragment), or else the content of the modal
+ * body might not vertical-scroll properly.
  *
  * @param modalName The name of the modal to show.
  * @param props The optional props to provide to the modal.


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
The `showModal()` function adds an unnecessary `<div>` wrapping the `<ModalHeader>` and `<ModalBody>`. The div causes a CSS issue with `<ModalBody>` with long content unable to scroll. Removing the div fixes that.

Testing done:
- manually inspected the HTML DOM to verify that the extra `<div>` is no longer there.
- opened up a modal with long content to verify that its scrollable
- open up several modals with less content (not enough to use the modal to hit its max-height limit) to verify that it still tenders fine.
## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![modal_before](https://github.com/openmrs/openmrs-esm-core/assets/509602/6d73e701-8950-4d49-aa3b-2bdad4f0f4f3)

After:
![modal_after](https://github.com/openmrs/openmrs-esm-core/assets/509602/a2e5b4f5-151e-4983-a145-029115481c22)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
This change should only be noticeable for modals that require vertical-scrolling for its body. Also, when calling `showModal()`, the input modal component should not have a `<div>` wrapping its `<ModalHeader>` and `<ModalBody>` (rather, it should be wrapped in a `<React.Fragment>`). Unfortunately, that is done in many places in `patient-chart` and `patient-management`.