### PR TITLE
(fix) Styleguide should not depend on framework

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -5169,7 +5169,9 @@ ___
 Shows a modal dialog.
 
 The modal must have been registered by name. This should be done in the `routes.json` file of the
-app that defines the modal.
+app that defines the modal. Note that both the `<ModelHeader>` and `<ModalBody>` should be at the
+top level of the modal component (wrapped in a React.Fragment), or else the content of the modal
+body might not vertical-scroll properly.
 
 #### Parameters
 
@@ -5938,7 +5940,7 @@ is provided separately.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx:43](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx#L43)
+[packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx#L45)
 
 ___
 
@@ -5984,7 +5986,7 @@ For the patient chart, this is `workspace-header-patient-chart-slot`.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx:55](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx#L55)
+[packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx#L47)
 
 ___
 
@@ -6007,7 +6009,7 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:303](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L303)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:298](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L298)
 
 ___
 
@@ -6049,7 +6051,7 @@ by the components that display workspaces.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:205](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L205)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:200](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L200)
 
 ___
 
@@ -6075,7 +6077,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:266](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L266)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:261](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L261)
 
 ___
 
@@ -6089,4 +6091,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:405](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L405)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:400](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L400)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -5169,7 +5169,7 @@ ___
 Shows a modal dialog.
 
 The modal must have been registered by name. This should be done in the `routes.json` file of the
-app that defines the modal. Note that both the `<ModelHeader>` and `<ModalBody>` should be at the
+app that defines the modal. Note that both the `<ModalHeader>` and `<ModalBody>` should be at the
 top level of the modal component (wrapped in a React.Fragment), or else the content of the modal
 body might not vertical-scroll properly.
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
@@ -40,7 +40,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L49)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L44)
 
 ___
 
@@ -54,7 +54,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L40)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L35)
 
 ___
 
@@ -68,7 +68,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:41](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L41)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:36](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L36)
 
 ___
 
@@ -82,7 +82,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L45)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L40)
 
 ___
 
@@ -96,7 +96,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L37)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:32](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L32)
 
 ___
 
@@ -110,7 +110,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:43](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L43)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L38)
 
 ___
 
@@ -124,7 +124,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L38)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:33](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L33)
 
 ___
 
@@ -138,7 +138,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L39)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L34)
 
 ___
 
@@ -152,7 +152,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:42](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L42)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L37)
 
 ## Other Methods
 
@@ -172,7 +172,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L50)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L45)
 
 ___
 
@@ -192,7 +192,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:51](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L51)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L46)
 
 ___
 
@@ -212,7 +212,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:52](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L52)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L47)
 
 ___
 
@@ -232,4 +232,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L44)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L39)

--- a/packages/framework/esm-framework/docs/interfaces/Prompt.md
+++ b/packages/framework/esm-framework/docs/interfaces/Prompt.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L20)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L15)
 
 ___
 
@@ -35,7 +35,7 @@ Defaults to "Cancel"
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:25](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L25)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L20)
 
 ___
 
@@ -47,7 +47,7 @@ Defaults to "Confirm"
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L22)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L17)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L19)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L14)
 
 ## Methods
 
@@ -71,4 +71,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:23](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L23)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L18)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceOverlayProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceOverlayProps.md
@@ -16,4 +16,4 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx:14](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx#L14)
+[packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx#L16)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
@@ -35,7 +35,7 @@ See [WorkspaceDefinition](../API.md#workspacedefinition) for more information ab
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L40)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L35)
 
 ___
 
@@ -45,7 +45,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:41](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L41)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:36](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L36)
 
 ___
 
@@ -55,7 +55,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L45)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L40)
 
 ___
 
@@ -65,7 +65,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L37)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:32](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L32)
 
 ___
 
@@ -75,7 +75,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:43](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L43)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L38)
 
 ___
 
@@ -85,7 +85,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L38)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:33](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L33)
 
 ___
 
@@ -95,7 +95,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L39)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L34)
 
 ___
 
@@ -105,7 +105,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:42](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L42)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L37)
 
 ## Workspace Methods
 
@@ -119,4 +119,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L44)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L39)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceWindowProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceWindowProps.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx:23](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx#L23)
+[packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx#L15)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx#L22)
+[packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx:14](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx#L14)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:399](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L399)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:394](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L394)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:400](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L400)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:395](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L395)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:401](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L401)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:396](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L396)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:402](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L402)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:397](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L397)

--- a/packages/framework/esm-offline/package.json
+++ b/packages/framework/esm-offline/package.json
@@ -41,7 +41,6 @@
     "@openmrs/esm-api": "5.x",
     "@openmrs/esm-globals": "5.x",
     "@openmrs/esm-state": "5.x",
-    "@openmrs/esm-styleguide": "5.x",
     "rxjs": "6.x"
   },
   "dependencies": {
@@ -54,7 +53,6 @@
     "@openmrs/esm-api": "workspace:*",
     "@openmrs/esm-globals": "workspace:*",
     "@openmrs/esm-state": "workspace:*",
-    "@openmrs/esm-styleguide": "workspace:*",
     "@types/uuid": "^9.0.1",
     "rxjs": "^6.5.3"
   }

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -53,7 +53,9 @@
     "react-avatar": "^5.0.3"
   },
   "peerDependencies": {
+    "@openmrs/esm-error-handling": "5.x",
     "@openmrs/esm-extensions": "5.x",
+    "@openmrs/esm-navigation": "5.x",
     "@openmrs/esm-react-utils": "5.x",
     "@openmrs/esm-state": "5.x",
     "@openmrs/esm-translations": "5.x",
@@ -64,7 +66,9 @@
     "rxjs": "6.x"
   },
   "devDependencies": {
+    "@openmrs/esm-error-handling": "workspace:*",
     "@openmrs/esm-extensions": "workspace:*",
+    "@openmrs/esm-navigation": "workspace:*",
     "@openmrs/esm-react-utils": "workspace:*",
     "@openmrs/esm-state": "workspace:*",
     "@openmrs/esm-translations": "workspace:*",

--- a/packages/framework/esm-styleguide/src/modals/index.tsx
+++ b/packages/framework/esm-styleguide/src/modals/index.tsx
@@ -196,7 +196,7 @@ export function setupModals(modalContainer: HTMLElement | null) {
  * Shows a modal dialog.
  *
  * The modal must have been registered by name. This should be done in the `routes.json` file of the
- * app that defines the modal. Note that both the `<ModelHeader>` and `<ModalBody>` should be at the
+ * app that defines the modal. Note that both the `<ModalHeader>` and `<ModalBody>` should be at the
  * top level of the modal component (wrapped in a React.Fragment), or else the content of the modal
  * body might not vertical-scroll properly.
  *

--- a/packages/framework/esm-styleguide/src/workspaces/action-menu-button/action-menu-button.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/action-menu-button/action-menu-button.component.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import classNames from 'classnames';
 import { Button, IconButton } from '@carbon/react';
 import { useLayoutType } from '@openmrs/esm-react-utils';
-import styles from './action-menu-button.module.scss';
 import { useWorkspaces } from '../workspaces';
+import styles from './action-menu-button.module.scss';
 
 interface TagsProps {
   getIcon: (props: object) => JSX.Element;

--- a/packages/framework/esm-styleguide/src/workspaces/action-menu-button/action-menu-button.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/action-menu-button/action-menu-button.component.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import classNames from 'classnames';
 import { Button, IconButton } from '@carbon/react';
-import { useLayoutType } from '@openmrs/esm-framework';
+import { useLayoutType } from '@openmrs/esm-react-utils';
 import styles from './action-menu-button.module.scss';
 import { useWorkspaces } from '../workspaces';
 

--- a/packages/framework/esm-styleguide/src/workspaces/action-menu-button/action-menu-button.test.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/action-menu-button/action-menu-button.test.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { screen, render, cleanup } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { useLayoutType } from '@openmrs/esm-framework';
-import { ActionMenuButton } from './action-menu-button.component';
+import { useLayoutType } from '@openmrs/esm-react-utils';
 import { Pen } from '@carbon/react/icons';
+import { ActionMenuButton } from './action-menu-button.component';
 import { useWorkspaces } from '../workspaces';
 
 const mockedUseLayoutType = useLayoutType as jest.Mock;
@@ -13,8 +13,8 @@ jest.mock('@carbon/react/icons', () => ({
   Pen: jest.fn(({ size }) => <div data-testid="pen-icon">size: {size}</div>),
 }));
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
+jest.mock('@openmrs/esm-react-utils', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-react-utils');
 
   return {
     ...originalModule,

--- a/packages/framework/esm-styleguide/src/workspaces/action-menu/action-menu.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/action-menu/action-menu.component.tsx
@@ -1,9 +1,9 @@
 /** @module @category Workspace */
 import React, { useContext, useEffect, useRef, useState } from 'react';
 import classNames from 'classnames';
-import { ExtensionSlot, useLayoutType, useWorkspaces } from '@openmrs/esm-framework';
+import { ComponentContext, ExtensionSlot, useLayoutType } from '@openmrs/esm-react-utils';
+import { useWorkspaces } from '../workspaces';
 import styles from './action-menu.module.scss';
-import { ComponentContext } from '@openmrs/esm-react-utils';
 
 /**
  * This renders the [Siderail and Bottom Nav](https://zeroheight.com/23a080e38/p/948cf1-siderail-and-bottom-nav/b/86907e),

--- a/packages/framework/esm-styleguide/src/workspaces/notification/workspace-notification.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/notification/workspace-notification.component.tsx
@@ -1,5 +1,10 @@
 /** @module @category Workspace */
 import React, { useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Button, ComposedModal, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
+import styles from './workspace-notification.module.scss';
+import { navigate } from '@openmrs/esm-navigation';
+import { reportError } from '@openmrs/esm-error-handling';
 import {
   canCloseWorkspaceWithoutPrompting,
   cancelPrompt,
@@ -9,10 +14,6 @@ import {
   resetWorkspaceStore,
   useWorkspaces,
 } from '../workspaces';
-import { Button, ComposedModal, ModalBody, ModalFooter, ModalHeader } from '@carbon/react';
-import { useTranslation } from 'react-i18next';
-import styles from './workspace-notification.module.scss';
-import { navigate, reportError } from '@openmrs/esm-framework';
 
 export interface WorkspaceNotificationProps {
   contextKey: string;

--- a/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx
@@ -1,11 +1,13 @@
 /** @module @category Workspace */
 import React, { useEffect, useMemo, useRef, useState } from 'react';
+import classNames from 'classnames';
+// @ts-ignore
 import { Button, Header, InlineLoading } from '@carbon/react';
 import { ArrowLeft, Close } from '@carbon/react/icons';
-import { useLayoutType, isDesktop, getCoreTranslation, translateFrom } from '@openmrs/esm-framework';
 import { mountRootParcel, type ParcelConfig } from 'single-spa';
 import Parcel from 'single-spa-react/parcel';
-import classNames from 'classnames';
+import { useLayoutType, isDesktop } from '@openmrs/esm-react-utils';
+import { getCoreTranslation, translateFrom } from '@openmrs/esm-translations';
 import { type OpenWorkspace, useWorkspaces } from '../workspaces';
 import { WorkspaceNotification } from '../notification/workspace-notification.component';
 import styles from './workspace-overlay.module.scss';

--- a/packages/framework/esm-styleguide/src/workspaces/window/workspace-renderer.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/window/workspace-renderer.component.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState, useMemo } from 'react';
 import classNames from 'classnames';
 import { mountRootParcel, type ParcelConfig } from 'single-spa';
-import { InlineLoading } from '@carbon/react';
-import { getCoreTranslation, useLayoutType } from '@openmrs/esm-framework';
-import { type OpenWorkspace, useWorkspaces } from '../workspaces';
 import Parcel from 'single-spa-react/parcel';
+import { InlineLoading } from '@carbon/react';
+import { useLayoutType } from '@openmrs/esm-react-utils';
+import { getCoreTranslation } from '@openmrs/esm-translations';
+import { type OpenWorkspace, useWorkspaces } from '../workspaces';
 import styles from './workspace-window.module.scss';
 
 interface WorkspaceRendererProps {

--- a/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx
@@ -1,22 +1,14 @@
 /** @module @category Workspace */
 import React, { useContext, useMemo } from 'react';
 import classNames from 'classnames';
-import {
-  ExtensionSlot,
-  useBodyScrollLock,
-  useLayoutType,
-  isDesktop,
-  translateFrom,
-  getCoreTranslation,
-} from '@openmrs/esm-framework';
-import { type OpenWorkspace, useWorkspaces, updateWorkspaceWindowState } from '../workspaces';
 import { Header, HeaderGlobalBar, HeaderName, HeaderMenuButton, HeaderGlobalAction } from '@carbon/react';
 import { ArrowLeft, ArrowRight, Close, DownToBottom, Maximize, Minimize } from '@carbon/react/icons';
-import { useTranslation } from 'react-i18next';
+import { ComponentContext, ExtensionSlot, useBodyScrollLock, useLayoutType, isDesktop } from '@openmrs/esm-react-utils';
+import { translateFrom, getCoreTranslation } from '@openmrs/esm-translations';
+import { type OpenWorkspace, useWorkspaces, updateWorkspaceWindowState } from '../workspaces';
 import { WorkspaceRenderer } from './workspace-renderer.component';
-import styles from './workspace-window.module.scss';
 import { WorkspaceNotification } from '../notification/workspace-notification.component';
-import { ComponentContext } from '@openmrs/esm-react-utils';
+import styles from './workspace-window.module.scss';
 
 export interface WorkspaceWindowProps {
   contextKey: string;

--- a/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.test.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { screen, render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { isDesktop } from '@openmrs/esm-framework';
+import { isDesktop } from '@openmrs/esm-react-utils';
 import { WorkspaceWindow } from './workspace-window.component';
 import { launchWorkspace, registerWorkspace } from '..';
 
@@ -12,14 +12,22 @@ jest.mock('./workspace-renderer.component', () => ({
   WorkspaceRenderer: jest.fn().mockImplementation(() => <div>Workspace-Renderer</div>),
 }));
 
-jest.mock('@openmrs/esm-framework', () => {
-  const originalModule = jest.requireActual('@openmrs/esm-framework');
+jest.mock('@openmrs/esm-react-utils', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-react-utils');
 
   return {
     ...originalModule,
     isDesktop: jest.fn(),
-    translateFrom: (module, key, defaultValue, options) => defaultValue,
     useBodyScrollLock: jest.fn(),
+  };
+});
+
+jest.mock('@openmrs/esm-translations', () => {
+  const originalModule = jest.requireActual('@openmrs/esm-translations');
+
+  return {
+    ...originalModule,
+    translateFrom: (module, key, defaultValue, options) => defaultValue,
   };
 });
 

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -6,8 +6,8 @@ import {
   registerWorkspace,
   resetWorkspaceStore,
 } from './workspaces';
+import { registerExtension } from '@openmrs/esm-extensions';
 import { clearMockExtensionRegistry } from '@openmrs/esm-framework/mock';
-import { registerExtension } from '@openmrs/esm-framework';
 
 describe('workspace system', () => {
   beforeEach(() => {

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -1,18 +1,13 @@
 /** @module @category Workspace */
 import { useMemo } from 'react';
-import type { LifeCycles } from 'single-spa';
+import { type LifeCycles } from 'single-spa';
 import _i18n from 'i18next';
-import {
-  type ExtensionRegistration,
-  getGlobalStore,
-  navigate,
-  translateFrom,
-  createGlobalStore,
-  useStore,
-  getCoreTranslation,
-  type WorkspaceWindowState,
-} from '@openmrs/esm-framework';
-import { getExtensionRegistration } from '@openmrs/esm-extensions';
+import { type ExtensionRegistration, getExtensionRegistration } from '@openmrs/esm-extensions';
+import { type WorkspaceWindowState } from '@openmrs/esm-globals';
+import { useStore } from '@openmrs/esm-react-utils';
+import { navigate } from '@openmrs/esm-navigation';
+import { getGlobalStore, createGlobalStore } from '@openmrs/esm-state';
+import { getCoreTranslation, translateFrom } from '@openmrs/esm-translations';
 import { type CloseWorkspaceOptions } from './types';
 
 export interface Prompt {

--- a/turbo.json
+++ b/turbo.json
@@ -10,6 +10,7 @@
       "outputs": ["dist/**"]
     },
     "document": {
+      "inputs": ["packages/framework/**/src/**/*.{ts,tsx}", "!packages/framework/**/src/**/*.test.{ts,tsx}"],
       "outputs": ["packages/framework/esm-framework/docs/**"]
     },
     "test": {},

--- a/yarn.lock
+++ b/yarn.lock
@@ -3277,7 +3277,6 @@ __metadata:
     "@openmrs/esm-api": "workspace:*"
     "@openmrs/esm-globals": "workspace:*"
     "@openmrs/esm-state": "workspace:*"
-    "@openmrs/esm-styleguide": "workspace:*"
     "@types/uuid": "npm:^9.0.1"
     dexie: "npm:^3.0.3"
     lodash-es: "npm:^4.17.21"
@@ -3288,7 +3287,6 @@ __metadata:
     "@openmrs/esm-api": 5.x
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
-    "@openmrs/esm-styleguide": 5.x
     rxjs: 6.x
   languageName: unknown
   linkType: soft
@@ -3393,7 +3391,9 @@ __metadata:
     "@carbon/charts": "npm:^1.12.0"
     "@carbon/react": "npm:~1.37.0"
     "@internationalized/date": "npm:^3.5.0"
+    "@openmrs/esm-error-handling": "workspace:*"
     "@openmrs/esm-extensions": "workspace:*"
+    "@openmrs/esm-navigation": "workspace:*"
     "@openmrs/esm-react-utils": "workspace:*"
     "@openmrs/esm-state": "workspace:*"
     "@openmrs/esm-translations": "workspace:*"
@@ -3416,7 +3416,9 @@ __metadata:
     rxjs: "npm:^6.5.3"
     webpack: "npm:^5.88.0"
   peerDependencies:
+    "@openmrs/esm-error-handling": 5.x
     "@openmrs/esm-extensions": 5.x
+    "@openmrs/esm-navigation": 5.x
     "@openmrs/esm-react-utils": 5.x
     "@openmrs/esm-state": 5.x
     "@openmrs/esm-translations": 5.x


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
So the slowness I was experiencing building core was, I think, an accidental side-effect of the commit that moved the workspace into core. The issue is that the files implementing the workspace directly referenced `@openmrs/esm-framework` inside the styleguide; this is an issue because the styleguide is a dependency of the framework. Basically, what was happening was that a "fresh" build (with no `dist`) would take a reasonable time (about 8 seconds for the styleguide and framework each on my machine), but subsequent builds with the now existing `dist` folder would begin to grow in length following an exponential curve (12 seconds, then 24 seconds, up to, at one point 30 minutes).

Removing this dependency cycle doesn't seem to harm the workspace behaviour and resolves the growing build time.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
