### PR TITLE
(feat) Export OpenmrsDatePickerProps interface to facilitate testing of the OpenmrsDatePicker

### DIFF
--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -58,7 +58,6 @@ export const LeftNavMenu = jest.fn(() => <div>Left Nav Menu</div>);
 export const setLeftNav = jest.fn();
 export const unsetLeftNav = jest.fn();
 export const ResponsiveWrapper = jest.fn(({ children }) => <>{children}</>);
-export const OpenmrsDatePicker = jest.fn(() => <div>OpenMRS DatePicker</div>);
 export const ErrorState = jest.fn(() => <div>Error State</div>);
 
 export const CustomOverflowMenu = jest.fn(({ menuTitle, children }) => (

--- a/packages/framework/esm-styleguide/src/datepicker/openmrs/openmrs-date-picker.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/openmrs/openmrs-date-picker.component.tsx
@@ -9,7 +9,7 @@ import { DatePicker, DatePickerInput } from '@carbon/react';
 const DEFAULT_DATE_FORMAT = 'd/m/Y';
 const DEFAULT_PLACEHOLDER = 'dd/mm/yyyy';
 
-interface OpenmrsDatePickerProps {
+export interface OpenmrsDatePickerProps {
   id: string;
   labelText: string;
   onChange: (value: Date) => void;


### PR DESCRIPTION
# Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
When writing tests for the OpenmrsDatePicker, jest was failing to recognize the component because the OpenmrsDatePickerProps interface was not being exported. This PR fixes the issue.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
