### PR TITLE
(fix) O3-2724: Fix workspace URL detection

### DIFF
--- a/packages/framework/esm-styleguide/jest.config.js
+++ b/packages/framework/esm-styleguide/jest.config.js
@@ -9,8 +9,10 @@ module.exports = {
     '^@carbon/charts': 'identity-obj-proxy',
     '@openmrs/esm-react-utils': '@openmrs/esm-react-utils/mock',
     '@openmrs/esm-translations': '@openmrs/esm-translations/mock',
+    'single-spa': 'single-spa',
     '^lodash-es/(.*)$': 'lodash/$1',
-    dexie: require.resolve('dexie'),
+    'lodash-es': 'lodash',
+    dexie: 'dexie',
   },
   collectCoverageFrom: [
     '**/src/**/*.component.tsx',


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

The workspace tries to check that the "context" it has been given is correct for the current page URL. However, the regex used is designed for testing against the pathname and not the full href, which may contain hashes (`#`) or query strings (`?`). This just ensures we're only running the regex against the pathname. I've also made some small adjustments, like escaping and regex metachars in th `contextKey` and using the single-spa provided types.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
