### PR TITLE
(fix) O3-1422: Fix workspace loading state

### DIFF
--- a/packages/framework/esm-framework/jest.config.js
+++ b/packages/framework/esm-framework/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     '\\.(s?css)$': 'identity-obj-proxy',
     '\\.(svg)$': '<rootDir>/__mocks__/fileMock.js',
     'lodash-es/(.*)': 'lodash/$1',
+    'lodash-es': 'lodash',
     // See https://jestjs.io/docs/upgrading-to-jest28#packagejson-exports
     // which links to https://github.com/microsoft/accessibility-insights-web/pull/5421#issuecomment-1109168149
     '^dexie$': require.resolve('dexie'),

--- a/packages/framework/esm-styleguide/src/workspaces/window/workspace-renderer.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/window/workspace-renderer.component.tsx
@@ -19,6 +19,7 @@ export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: Worksp
   const { workspaceWindowState } = useWorkspaces();
   const maximized = workspaceWindowState === 'maximized';
   const [lifecycle, setLifecycle] = useState<ParcelConfig | undefined>();
+
   useEffect(() => {
     let active = true;
     workspace.load().then(({ default: result, ...lifecycle }) => {
@@ -48,7 +49,7 @@ export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: Worksp
       {lifecycle ? (
         <Parcel key={workspace.name} config={lifecycle} mountParcel={mountRootParcel} {...props} />
       ) : (
-        <InlineLoading className={styles.loading} description={`${getCoreTranslation('loading', 'Loading')} ...`} />
+        <InlineLoading className={styles.loader} description={`${getCoreTranslation('loading', 'Loading')} ...`} />
       )}
     </div>
   );

--- a/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.module.scss
+++ b/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.module.scss
@@ -42,6 +42,13 @@ $container-width: calc(100% - 3rem);
   width: $container-width;
 }
 
+.loader {
+  display: flex;
+  background-color: $openmrs-background-grey;
+  justify-content: center;
+  min-height: spacing.$spacing-09;
+}
+
 /* Desktop */
 :global(.omrs-breakpoint-gt-tablet) {
   .maximized {
@@ -118,7 +125,7 @@ $container-width: calc(100% - 3rem);
   .fixed {
     background-color: $ui-01;
     top: 3rem;
-    max-height: var(--tablet-workspace-window-height);
+    min-height: var(--tablet-workspace-window-height);
   }
 
   .dynamicWidth {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This follow-up fix to [O3-1422](https://openmrs.atlassian.net/browse/O3-1422) fixing the loading state in the WorkspaceRenderer component so it takes up the entirety of the vertical height on the tablet viewport. These styling changes got lost in the workspace migration and this PR just restores them.

## Screenshots

### Before

https://github.com/openmrs/openmrs-esm-core/assets/8509731/2bc15ea5-111c-4d93-ba80-838012005b5e

### After

https://github.com/openmrs/openmrs-esm-core/assets/8509731/51134df2-f705-40f3-a821-4abd30fd8ff1

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->


[O3-1422]: https://openmrs.atlassian.net/browse/O3-1422?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ