### PR TITLE
(fix) Ethiopia datepicker to resolve default, min and max values correctly

### DIFF
--- a/packages/framework/esm-styleguide/src/datepicker/react-spectrum/adobe-react-spectrum-date-wrapper.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/react-spectrum/adobe-react-spectrum-date-wrapper.component.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo } from 'react';
-import type { CalendarDate } from '@internationalized/date';
+import { CalendarDate, EthiopicCalendar, toCalendar } from '@internationalized/date';
 import { parseDate } from '@internationalized/date';
 import { DatePicker } from '@react-spectrum/datepicker';
 import { Provider } from '@react-spectrum/provider';
@@ -29,12 +29,29 @@ function toLocalDateString(dateValue: Date) {
 
   return `${year}-${month}-${date}`;
 }
+function gregToEth(gregdate: string) {
+  const ymd = gregdate.split('-');
 
-function parseToCalendarDate(date: string | Date | undefined) {
+  const year = parseInt(ymd[0], 10);
+  const month = parseInt(ymd[1], 10);
+  const day = parseInt(ymd[2], 10);
+  const gregorianDate = new CalendarDate(year, month, day);
+  const ethiopianDate = toCalendar(gregorianDate, new EthiopicCalendar());
+
+  return ethiopianDate;
+}
+
+function parseToCalendarDate(date: string | Date | undefined, locale?: string, isGregorianDateValue?: boolean) {
   if (!date) {
     return undefined;
   }
-  return parseDate(toLocalDateString(typeof date === 'string' ? parseDateString(date) : date));
+
+  const localDateString = toLocalDateString(typeof date === 'string' ? parseDateString(date) : date);
+  if (locale === 'am-u-ca-ethiopic' && isGregorianDateValue) {
+    return gregToEth(localDateString);
+  }
+
+  return parseDate(localDateString);
 }
 
 function constructValidationState(invalid: boolean | undefined) {
@@ -81,9 +98,9 @@ const ReactSpectrumDatePickerWrapper: React.FC<ReactSpectrumDatePickerWrapperPro
         onChange={(calendarDate) => {
           onChange?.(new Date(calendarDate.year, calendarDate.month - 1, calendarDate.day));
         }}
-        defaultValue={parseToCalendarDate(defaultValue)}
-        minValue={minDate ? (parseToCalendarDate(minDate) as CalendarDate) : undefined}
-        maxValue={maxDate ? (parseToCalendarDate(maxDate) as CalendarDate) : undefined}
+        defaultValue={defaultValue ? (parseToCalendarDate(defaultValue, locale, true) as CalendarDate) : undefined}
+        minValue={minDate ? (parseToCalendarDate(minDate, locale, true) as CalendarDate) : undefined}
+        maxValue={maxDate ? (parseToCalendarDate(maxDate, locale, true) as CalendarDate) : undefined}
         isReadOnly={readonly}
         isDisabled={isDisabled}
         validationState={constructValidationState(invalid)}

--- a/packages/framework/esm-styleguide/src/datepicker/react-spectrum/adobe-react-spectrum-date-wrapper.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/react-spectrum/adobe-react-spectrum-date-wrapper.component.tsx
@@ -1,12 +1,11 @@
 import React, { useMemo } from 'react';
-import { type CalendarDate } from '@internationalized/date';
 import { parseDate } from '@internationalized/date';
 import { DatePicker } from '@react-spectrum/datepicker';
 import { Provider } from '@react-spectrum/provider';
 import { theme as defaultTheme } from '@react-spectrum/theme-default';
 import { useConfig } from '@openmrs/esm-react-utils';
-import { parseDate as parseDateString } from '@openmrs/esm-utils';
-import { supportedLocales } from './locales';
+import { convertToLocaleCalendar } from '@openmrs/esm-utils';
+import dayjs from 'dayjs';
 
 interface ReactSpectrumDatePickerWrapperProps {
   id: string;
@@ -23,23 +22,14 @@ interface ReactSpectrumDatePickerWrapperProps {
   onChange?: (value: Date) => void;
 }
 
-function toLocalDateString(dateValue: Date) {
-  const year = dateValue.getFullYear();
-  const month = (dateValue.getMonth() + 1).toString().padStart(2, '0');
-  const date = dateValue.getDate().toString().padStart(2, '0');
-
-  return `${year}-${month}-${date}`;
-}
-
-function parseToCalendarDate(date: string | Date | undefined, locale?: string) {
+function parseToCalendarDate(date: string | Date | undefined, locale?: string | Intl.Locale) {
   if (!date) {
     return undefined;
   }
 
-  const parsedCalendarDate = parseDate(toLocalDateString(typeof date === 'string' ? parseDateString(date) : date));
-  if (locale && supportedLocales[locale]) {
-    const localeConvertedDate = supportedLocales[locale].convert(parsedCalendarDate);
-    return localeConvertedDate;
+  const parsedCalendarDate = parseDate(dayjs(date).format('YYYY-MM-DD'));
+  if (locale) {
+    return convertToLocaleCalendar(parsedCalendarDate, locale);
   }
 
   return parsedCalendarDate;
@@ -75,13 +65,13 @@ const ReactSpectrumDatePickerWrapper: React.FC<ReactSpectrumDatePickerWrapperPro
     if (preferredCalendar?.[currentLocale]) {
       return new Intl.Locale(currentLocale, {
         calendar: preferredCalendar[currentLocale],
-      }).toString();
+      });
     }
     return currentLocale;
   }, [currentLocale, preferredCalendar]);
 
   return (
-    <Provider locale={locale} colorScheme="light" theme={defaultTheme}>
+    <Provider locale={locale.toString()} colorScheme="light" theme={defaultTheme}>
       <DatePicker
         id={id}
         label={labelText}
@@ -89,9 +79,9 @@ const ReactSpectrumDatePickerWrapper: React.FC<ReactSpectrumDatePickerWrapperPro
         onChange={(calendarDate) => {
           onChange?.(new Date(calendarDate.year, calendarDate.month - 1, calendarDate.day));
         }}
-        defaultValue={defaultValue ? (parseToCalendarDate(defaultValue, currentLocale) as CalendarDate) : undefined}
-        minValue={minDate ? (parseToCalendarDate(minDate, currentLocale) as CalendarDate) : undefined}
-        maxValue={maxDate ? (parseToCalendarDate(maxDate, currentLocale) as CalendarDate) : undefined}
+        defaultValue={parseToCalendarDate(defaultValue, locale)}
+        minValue={parseToCalendarDate(minDate, locale)}
+        maxValue={parseToCalendarDate(maxDate, locale)}
         isReadOnly={readonly}
         isDisabled={isDisabled}
         validationState={constructValidationState(invalid)}

--- a/packages/framework/esm-styleguide/src/datepicker/react-spectrum/locales.ts
+++ b/packages/framework/esm-styleguide/src/datepicker/react-spectrum/locales.ts
@@ -1,16 +1,5 @@
-import { type CalendarDate, EthiopicCalendar, toCalendar, IndianCalendar } from '@internationalized/date';
-
-const convertToEthiopicDate = (date: CalendarDate) => {
-  return toCalendar(date, new EthiopicCalendar());
-};
-
-const convertToIndianDate = (date: CalendarDate) => {
-  return toCalendar(date, new IndianCalendar());
-};
-
 export const supportedLocales = {
-  am: { locale: 'am-AM-u-ca-ethiopic', convert: convertToEthiopicDate },
-  am_ET: { locale: 'Amharic (Ethiopia)', convert: convertToEthiopicDate },
-  ti_ET: { locale: 'Tigrinya (Ethiopia)', convert: convertToEthiopicDate },
-  in: { locale: 'hi-IN-u-ca-indian', convert: convertToIndianDate },
+  am: 'Amharic',
+  am_ET: 'Amharic (Ethiopia)',
+  ti_ET: 'Tigrinya (Ethiopia)',
 };

--- a/packages/framework/esm-styleguide/src/datepicker/react-spectrum/locales.ts
+++ b/packages/framework/esm-styleguide/src/datepicker/react-spectrum/locales.ts
@@ -1,5 +1,5 @@
 export const supportedLocales = {
-  am: 'Amharic',
+  am: 'am-AM-u-ca-ethiopic',
   am_ET: 'Amharic (Ethiopia)',
   ti_ET: 'Tigrinya (Ethiopia)',
 };

--- a/packages/framework/esm-styleguide/src/datepicker/react-spectrum/locales.ts
+++ b/packages/framework/esm-styleguide/src/datepicker/react-spectrum/locales.ts
@@ -1,5 +1,16 @@
+import { type CalendarDate, EthiopicCalendar, toCalendar, IndianCalendar } from '@internationalized/date';
+
+const convertToEthiopicDate = (date: CalendarDate) => {
+  return toCalendar(date, new EthiopicCalendar());
+};
+
+const convertToIndianDate = (date: CalendarDate) => {
+  return toCalendar(date, new IndianCalendar());
+};
+
 export const supportedLocales = {
-  am: 'am-AM-u-ca-ethiopic',
-  am_ET: 'Amharic (Ethiopia)',
-  ti_ET: 'Tigrinya (Ethiopia)',
+  am: { locale: 'am-AM-u-ca-ethiopic', convert: convertToEthiopicDate },
+  am_ET: { locale: 'Amharic (Ethiopia)', convert: convertToEthiopicDate },
+  ti_ET: { locale: 'Tigrinya (Ethiopia)', convert: convertToEthiopicDate },
+  in: { locale: 'hi-IN-u-ca-indian', convert: convertToIndianDate },
 };

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -51,6 +51,7 @@
     "rxjs": "6.x"
   },
   "dependencies": {
+    "@internationalized/date": "^3.5.0",
     "semver": "7.3.2"
   }
 }

--- a/packages/framework/esm-utils/src/omrs-dates.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.ts
@@ -386,7 +386,7 @@ export function getLocale() {
  */
 export function convertToLocaleCalendar(date: CalendarDate, locale: string | Intl.Locale) {
   let locale_ = typeof locale === 'string' ? new Intl.Locale(locale) : locale;
-  const localCalendarName = locale_.calendar;
+  const localCalendarName = getDefaultCalendar(locale);
 
   return localCalendarName ? toCalendar(date, createCalendar(localCalendarName)) : date;
 }

--- a/packages/framework/esm-utils/src/omrs-dates.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.ts
@@ -3,6 +3,7 @@
  * @category Date and Time
  */
 import type { i18n } from 'i18next';
+import { createCalendar, toCalendar, type CalendarDate } from '@internationalized/date';
 import dayjs from 'dayjs';
 import utc from 'dayjs/plugin/utc';
 import isToday from 'dayjs/plugin/isToday';
@@ -377,4 +378,15 @@ export function getLocale() {
   }
 
   return language;
+}
+
+/**
+ * Converts a calendar date to the equivalent locale calendar date.
+ * @returns CalendarDate
+ */
+export function convertToLocaleCalendar(date: CalendarDate, locale: string | Intl.Locale) {
+  let locale_ = typeof locale === 'string' ? new Intl.Locale(locale) : locale;
+  const localCalendarName = locale_.calendar;
+
+  return localCalendarName ? toCalendar(date, createCalendar(localCalendarName)) : date;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3447,6 +3447,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-utils@workspace:packages/framework/esm-utils"
   dependencies:
+    "@internationalized/date": "npm:^3.5.0"
     "@openmrs/esm-globals": "workspace:*"
     "@types/semver": "npm:^7.3.4"
     dayjs: "npm:^1.10.4"


### PR DESCRIPTION
# Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This pull request addresses an issue encountered with the locale datepicker functionality. When the locale was set to Amharic, the date picker incorrectly displayed the Ethiopian calendar with the wrong year. Specifically, when the maxValue prop was set to today's date, the calendar would display the year 2024 instead of the expected year 2016 in the Ethiopian calendar. This PR aims to rectify this issue.

## Screenshots

https://github.com/openmrs/openmrs-esm-core/assets/12844964/ead2b9b2-4216-4a29-b098-7713f6f1c6e6



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
