### PR TITLE
(feat) O3-3168: O3 should work without requiring a network connection

### DIFF
--- a/packages/framework/esm-extensions/package.json
+++ b/packages/framework/esm-extensions/package.json
@@ -42,6 +42,7 @@
     "@openmrs/esm-config": "5.x",
     "@openmrs/esm-feature-flags": "5.x",
     "@openmrs/esm-state": "5.x",
+    "@openmrs/esm-utils": "5.x",
     "single-spa": "5.x"
   },
   "devDependencies": {
@@ -49,6 +50,7 @@
     "@openmrs/esm-config": "workspace:*",
     "@openmrs/esm-feature-flags": "workspace:*",
     "@openmrs/esm-state": "workspace:*",
+    "@openmrs/esm-utils": "workspace:*",
     "single-spa": "^6.0.1"
   },
   "dependencies": {

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -19,6 +19,7 @@ import {
   getExtensionSlotsConfigStore,
 } from '@openmrs/esm-config';
 import { featureFlagsStore } from '@openmrs/esm-feature-flags';
+import { isOnline as isOnlineFn } from '@openmrs/esm-utils';
 import isEqual from 'lodash-es/isEqual';
 import isUndefined from 'lodash-es/isUndefined';
 import type { ExtensionSlotState, AssignedExtension, ConnectedExtension } from '.';
@@ -261,14 +262,15 @@ export function getConnectedExtensions(
   online: boolean | null = null,
   enabledFeatureFlags: Array<string> | null = null,
 ): Array<ConnectedExtension> {
-  const isOnline = online ?? navigator.onLine;
+  const isOnline = isOnlineFn(online ?? undefined);
   const featureFlags =
     enabledFeatureFlags ??
     Object.entries(featureFlagsStore.getState().flags)
       .filter(([, { enabled }]) => enabled)
       .map(([name]) => name);
+
   return assignedExtensions
-    .filter((e) => checkStatusFor(isOnline, e.online, e.offline))
+    .filter((e) => (window.offlineEnabled ? checkStatusFor(isOnline, e.online, e.offline) : true))
     .filter((e) => e.featureFlag === undefined || featureFlags?.includes(e.featureFlag));
 }
 

--- a/packages/framework/esm-extensions/src/helpers.ts
+++ b/packages/framework/esm-extensions/src/helpers.ts
@@ -1,6 +1,7 @@
+import { isOnline } from '@openmrs/esm-utils';
+
 export function checkStatus(online: boolean | object = true, offline: boolean | object = false) {
-  const status = navigator.onLine;
-  return checkStatusFor(status, online, offline);
+  return checkStatusFor(isOnline(), online, offline);
 }
 
 export function checkStatusFor(status: boolean, online: boolean | object = true, offline: boolean | object = false) {

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -19,7 +19,7 @@ export function setupPaths(config: any) {
   window.openmrsBase = config.apiUrl;
   window.spaBase = config.spaPath;
   window.spaEnv = config.env || 'production';
-  window.spaVersion = process.env.BUILD_VERSION;
+  window.spaVersion = process.env.BUILD_VERSION ?? 'local';
   window.getOpenmrsSpaBase = () => `${window.spaBase}/`;
 }
 

--- a/packages/framework/esm-globals/src/events.ts
+++ b/packages/framework/esm-globals/src/events.ts
@@ -10,6 +10,10 @@ export function dispatchConnectivityChanged(online: boolean) {
 
 /** @category Offline */
 export function subscribeConnectivityChanged(cb: (ev: ConnectivityChangedEvent) => void) {
+  if (!window.offlineEnabled) {
+    return () => {};
+  }
+
   const handler = (ev: CustomEvent) => cb(ev.detail);
   window.addEventListener(connectivityChangedEventName, handler);
   return () => window.removeEventListener(connectivityChangedEventName, handler);
@@ -17,7 +21,7 @@ export function subscribeConnectivityChanged(cb: (ev: ConnectivityChangedEvent) 
 
 /** @category Offline */
 export function subscribeConnectivity(cb: (ev: ConnectivityChangedEvent) => void) {
-  cb({ online: navigator.onLine });
+  cb({ online: window.offlineEnabled ? navigator.onLine : true });
   return subscribeConnectivityChanged(cb);
 }
 

--- a/packages/framework/esm-globals/src/types.ts
+++ b/packages/framework/esm-globals/src/types.ts
@@ -26,6 +26,11 @@ declare global {
      */
     initializeSpa(config: SpaConfig): void;
     /**
+     * Indicates whether offline mode is enabled in this install or not.
+     * This is used to determine whether offline functionality is present or not.
+     */
+    offlineEnabled: boolean;
+    /**
      * Gets the API base path, e.g. /openmrs
      */
     openmrsBase: string;
@@ -40,7 +45,7 @@ declare global {
     /**
      * The build number of the app shell. Set when the app shell is built by webpack.
      */
-    spaVersion?: string;
+    spaVersion: string;
     /**
      * Gets a set of options from the import-map-overrides package.
      */

--- a/packages/framework/esm-react-utils/src/useConnectivity.ts
+++ b/packages/framework/esm-react-utils/src/useConnectivity.ts
@@ -1,9 +1,10 @@
 /** @module @category Offline */
 import { subscribeConnectivityChanged } from '@openmrs/esm-globals';
+import { isOnline as isOnlineFn } from '@openmrs/esm-utils';
 import { useEffect, useState } from 'react';
 
 export function useConnectivity() {
-  let [isOnline, setIsOnline] = useState(window.navigator.onLine);
+  let [isOnline, setIsOnline] = useState(isOnlineFn());
 
   useEffect(() => subscribeConnectivityChanged(({ online }) => setIsOnline(online)), []);
 

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -39,11 +39,13 @@
     "access": "public"
   },
   "devDependencies": {
+    "@openmrs/esm-globals": "workspace:*",
     "@types/semver": "^7.3.4",
     "dayjs": "^1.10.4",
     "rxjs": "^6.5.3"
   },
   "peerDependencies": {
+    "@openmrs/esm-globals": "5.x",
     "dayjs": "1.x",
     "i18next": "21.x",
     "rxjs": "6.x"

--- a/packages/framework/esm-utils/src/index.ts
+++ b/packages/framework/esm-utils/src/index.ts
@@ -1,4 +1,5 @@
 export * from './age-helpers';
+export * from './is-online';
 export * from './omrs-dates';
 export * from './shallowEqual';
 export * from './storage';

--- a/packages/framework/esm-utils/src/is-online.ts
+++ b/packages/framework/esm-utils/src/is-online.ts
@@ -1,0 +1,5 @@
+import type {} from '@openmrs/esm-globals';
+
+export function isOnline(online?: boolean) {
+  return window.offlineEnabled ? online ?? navigator.onLine : true;
+}

--- a/packages/shell/esm-app-shell/src/apps.ts
+++ b/packages/shell/esm-app-shell/src/apps.ts
@@ -54,16 +54,20 @@ function getActivityFn(route: RouteDefinition | Array<RouteDefinition>): Activit
  * @returns An activityFn suitable to use for a single-spa application
  */
 function wrapPageActivityFn(activityFn: ActivityFn, { online, offline }: RegisteredPageDefinition) {
-  return (location: Location) => {
-    // basically, if the page should only work online and we're offline or if the
-    // page should only work offline and we're online, defaulting to always rendering
-    // the page
-    if (!((navigator.onLine && (online ?? true)) || (!navigator.onLine && (offline ?? false)))) {
-      return false;
-    }
+  if (window.offlineEnabled) {
+    return (location: Location) => {
+      // basically, if the page should only work online and we're offline or if the
+      // page should only work offline and we're online, defaulting to always rendering
+      // the page
+      if (!((navigator.onLine && (online ?? true)) || (!navigator.onLine && (offline ?? false)))) {
+        return false;
+      }
 
-    return activityFn(location);
-  };
+      return activityFn(location);
+    };
+  } else {
+    return activityFn;
+  }
 }
 
 const STARTUP_FUNCTION = 'startupApp';

--- a/packages/shell/esm-app-shell/src/index.ts
+++ b/packages/shell/esm-app-shell/src/index.ts
@@ -69,9 +69,11 @@ function initializeSpa(config: SpaConfig) {
   setupPaths(config);
   wireSpaPaths();
   return Promise.resolve(__webpack_init_sharing__('default')).then(async () => {
-    const { configUrls = [], offline = true } = config;
+    const { configUrls = [], offline = false } = config;
+    window.offlineEnabled = offline;
+
     const { run } = await import(/* webpackPreload: true */ './run');
-    return run(configUrls, offline);
+    return run(configUrls);
   });
 }
 

--- a/packages/shell/esm-app-shell/src/index.ts
+++ b/packages/shell/esm-app-shell/src/index.ts
@@ -32,7 +32,7 @@ function setupPaths(config: SpaConfig) {
   window.openmrsBase = config.apiUrl;
   window.spaBase = config.spaPath;
   window.spaEnv = config.env || 'production';
-  window.spaVersion = process.env.BUILD_VERSION;
+  window.spaVersion = process.env.BUILD_VERSION ?? 'local';
   const spaBaseWithSlash = window.spaBase.endsWith('/') ? window.spaBase : window.spaBase + '/';
   window.getOpenmrsSpaBase = _createSpaBase(spaBaseWithSlash);
 }

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -168,6 +168,10 @@ async function loadConfigs(configs: Array<{ name: string; value: Config }>) {
  * Invoked when the connectivity is changed.
  */
 function connectivityChanged() {
+  if (!window.offlineEnabled) {
+    return;
+  }
+
   const online = navigator.onLine;
   // NB We do not wait for this to be done; it is simply scheduled
   triggerAppChange();
@@ -382,7 +386,8 @@ function setupOfflineCssClasses() {
   });
 }
 
-export function run(configUrls: Array<string>, offline: boolean) {
+export function run(configUrls: Array<string>) {
+  const offlineEnabled = window.offlineEnabled;
   const closeLoading = showLoadingSpinner();
   const provideConfigs = createConfigLoader(configUrls);
 
@@ -403,11 +408,11 @@ export function run(configUrls: Array<string>, offline: boolean) {
 
   return setupApps()
     .then(finishRegisteringAllApps)
-    .then(offline ? setupOfflineCssClasses : undefined)
-    .then(offline ? registerOfflineHandlers : undefined)
+    .then(offlineEnabled ? setupOfflineCssClasses : undefined)
+    .then(offlineEnabled ? registerOfflineHandlers : undefined)
     .then(provideConfigs)
     .then(runShell)
     .catch(handleInitFailure)
     .then(closeLoading)
-    .then(offline ? setupOffline : undefined);
+    .then(offlineEnabled ? setupOffline : undefined);
 }

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -27,7 +27,7 @@ const openmrsProxyTarget = process.env.OMRS_PROXY_TARGET || 'https://dev3.openmr
 const openmrsPageTitle = process.env.OMRS_PAGE_TITLE || 'OpenMRS';
 const openmrsFavicon = process.env.OMRS_FAVICON || `${openmrsPublicPath}/favicon.ico`;
 const openmrsEnvironment = process.env.OMRS_ENV || process.env.NODE_ENV || '';
-const openmrsOffline = process.env.OMRS_OFFLINE !== 'disable';
+const openmrsOffline = process.env.OMRS_OFFLINE === 'enable';
 const openmrsDefaultLocale = process.env.OMRS_ESM_DEFAULT_LOCALE || 'en';
 const openmrsImportmapDef = process.env.OMRS_ESM_IMPORTMAP;
 const openmrsImportmapUrl = process.env.OMRS_ESM_IMPORTMAP_URL || `${openmrsPublicPath}/importmap.json`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -3105,6 +3105,7 @@ __metadata:
     "@openmrs/esm-config": "workspace:*"
     "@openmrs/esm-feature-flags": "workspace:*"
     "@openmrs/esm-state": "workspace:*"
+    "@openmrs/esm-utils": "workspace:*"
     lodash-es: "npm:^4.17.21"
     single-spa: "npm:^6.0.1"
   peerDependencies:
@@ -3112,6 +3113,7 @@ __metadata:
     "@openmrs/esm-config": 5.x
     "@openmrs/esm-feature-flags": 5.x
     "@openmrs/esm-state": 5.x
+    "@openmrs/esm-utils": 5.x
     single-spa: 5.x
   languageName: unknown
   linkType: soft
@@ -3445,11 +3447,13 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-utils@workspace:packages/framework/esm-utils"
   dependencies:
+    "@openmrs/esm-globals": "workspace:*"
     "@types/semver": "npm:^7.3.4"
     dayjs: "npm:^1.10.4"
     rxjs: "npm:^6.5.3"
     semver: "npm:7.3.2"
   peerDependencies:
+    "@openmrs/esm-globals": 5.x
     dayjs: 1.x
     i18next: 21.x
     rxjs: 6.x


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This adds a new global `offlineEnabled` which just records whether or not the app was setup with offline mode enabled or disabled. This global is now used everywhere in the framework that we check the online / offline status. If `offlineEnabled` is `false` (which is now the default), offline mode will never be triggered and every extension should function as though it were in online mode.

The underlying assumption here is that any distro built for a no-network use-case has no reason to enable offline mode. This may entail supporting something like our reference envsubst usage to be able to maintain a single build that can support both offline mode and no-network use cases. I'll be updating the RefApp so that offline mode is controlled by an environment variable.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
