### PR TITLE
(feat) Disable i18next namespace separator

### DIFF
--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -81,6 +81,7 @@ export function setupI18n() {
         lookupQuerystring: 'lang',
       },
       fallbackLng: 'en',
+      nsSeparator: false,
     });
 }
 


### PR DESCRIPTION
# Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR disables the i18next namespace separator in the parser because it introduces a conflict with form field labels containing special characters such as ":". Since we are not using this feature, it is safe to globally disable it. Checkout [this](https://openmrs.slack.com/archives/C04QZ5DDVMG/p1715770746120849) slack thread for more context. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
