### PR TITLE
(feat) O3-3249: Introduce helper function to get well-formatted patient display name.

### DIFF
--- a/packages/framework/esm-api/src/types/fhir-name-use.ts
+++ b/packages/framework/esm-api/src/types/fhir-name-use.ts
@@ -1,0 +1,4 @@
+/*
+ * Supported values for FHIR HumanName.use as defined by https://build.fhir.org/valueset-name-use.html
+ */
+export type NameUse = 'usual' | 'official' | 'temp' | 'nickname' | 'anonymous' | 'old' | 'maiden';

--- a/packages/framework/esm-api/src/types/index.ts
+++ b/packages/framework/esm-api/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from './attachments-types';
 export * from './fetch';
+export * from './fhir-name-use';
 export * from './fhir-resource';
 export * from './openmrs-resource';
 export * from './user-resource';

--- a/packages/framework/esm-utils/src/index.ts
+++ b/packages/framework/esm-utils/src/index.ts
@@ -1,6 +1,7 @@
 export * from './age-helpers';
 export * from './is-online';
 export * from './omrs-dates';
+export * from './patient-helpers';
 export * from './shallowEqual';
 export * from './storage';
 export * from './test-helpers';

--- a/packages/framework/esm-utils/src/patient-helpers.test.data.ts
+++ b/packages/framework/esm-utils/src/patient-helpers.test.data.ts
@@ -1,0 +1,54 @@
+export const mockPatient = {
+  resourceType: 'Patient',
+  id: '8673ee4f-e2ab-4077-ba55-4980f408773e',
+  extension: [
+    {
+      url: 'http://fhir-es.transcendinsights.com/stu3/StructureDefinition/resource-date-created',
+      valueDateTime: '2017-01-18T09:42:40+00:00',
+    },
+    {
+      url: 'https://purl.org/elab/fhir/StructureDefinition/Creator-crew-version1',
+      valueString: 'daemon',
+    },
+  ],
+  identifier: [
+    {
+      id: '1f0ad7a1-430f-4397-b571-59ea654a52db',
+      use: 'secondary',
+      system: 'Old Identification Number',
+      value: '100732HE',
+    },
+    {
+      id: '1f0ad7a1-430f-4397-b571-59ea654a52db',
+      use: 'usual',
+      system: 'OpenMRS ID',
+      value: '100GEJ',
+    },
+  ],
+  active: true,
+  name: [
+    {
+      id: 'efdb246f-4142-4c12-a27a-9be60b9592e9',
+      use: 'usual',
+      family: 'Wilson',
+      given: ['John'],
+      text: 'Wilson, John',
+    },
+  ],
+  gender: 'male',
+  birthDate: '1972-04-04',
+  deceasedBoolean: false,
+  address: [],
+};
+
+export const mockPatientWithoutFormattedName = {
+  ...mockPatient,
+  name: [
+    {
+      id: 'efdb246f-4142-4c12-a27a-9be60b9592e9',
+      use: 'usual',
+      family: 'family name',
+      given: ['given', 'middle'],
+    },
+  ],
+};

--- a/packages/framework/esm-utils/src/patient-helpers.test.data.ts
+++ b/packages/framework/esm-utils/src/patient-helpers.test.data.ts
@@ -1,3 +1,26 @@
+export const nameWithFormat = {
+  id: 'efdb246f-4142-4c12-a27a-9be60b9592e9',
+  family: 'Wilson',
+  given: ['John'],
+  text: 'Wilson, John',
+};
+
+export const nameWithoutFormat = {
+  id: 'efdb246f-4142-4c12-a27a-9be60b9592e9',
+  family: 'family name',
+  given: ['given', 'middle'],
+};
+
+export const familyNameOnly = {
+  id: 'efdb246f-4142-4c12-a27a-9be60b9592e9',
+  family: 'family name',
+};
+
+export const givenNameOnly = {
+  id: 'efdb246f-4142-4c12-a27a-9be60b9592e9',
+  given: ['given'],
+};
+
 export const mockPatient = {
   resourceType: 'Patient',
   id: '8673ee4f-e2ab-4077-ba55-4980f408773e',
@@ -26,29 +49,98 @@ export const mockPatient = {
     },
   ],
   active: true,
-  name: [
-    {
-      id: 'efdb246f-4142-4c12-a27a-9be60b9592e9',
-      use: 'usual',
-      family: 'Wilson',
-      given: ['John'],
-      text: 'Wilson, John',
-    },
-  ],
+  name: [nameWithFormat],
   gender: 'male',
   birthDate: '1972-04-04',
   deceasedBoolean: false,
   address: [],
 };
 
-export const mockPatientWithoutFormattedName = {
+export const mockPatientWithNoName = {
+  ...mockPatient,
+  name: [],
+};
+
+export const mockPatientWithMultipleNames = {
+  // name usage may be: usual | official | temp | nickname | anonymous | old | maiden
   ...mockPatient,
   name: [
     {
       id: 'efdb246f-4142-4c12-a27a-9be60b9592e9',
-      use: 'usual',
-      family: 'family name',
-      given: ['given', 'middle'],
+      use: 'nickname',
+      given: ['nick', 'name'],
+    },
+    {
+      id: 'efdb246f-4142-4c12-a27a-9be60b9592ff',
+      use: 'nickname',
+      given: ['nick', 'name'],
+    },
+    {
+      id: 'efdb246f-4142-4c12-a27a-9be60b9561ee',
+      use: 'anonymous',
+      given: ['john', 'doe'],
+    },
+    {
+      id: 'efdb246f-4142-4c12-a27a-9be60b9561dd',
+      use: 'old',
+      given: ['previous'],
+      family: 'name',
+    },
+    {
+      id: 'efdb246f-4142-4c12-a27a-9be60b2261cc',
+      use: 'maiden',
+      family: 'maiden name',
+    },
+    {
+      // this is the actual display name
+      id: 'efdb246f-4142-4c12-a27a-9be60b2261bb',
+      given: ['John', 'Murray'],
+      family: 'Smith',
+      text: 'Smith, John Murray',
+    },
+    {
+      // this is usable as a display name, but the usual name will take precedence.
+      id: 'efdb246f-4142-4c12-a27a-9be60b2261aa',
+      use: 'official',
+      given: ['my', 'official'],
+      family: 'name',
+    },
+  ],
+};
+
+export const mockPatientWithOfficialName = {
+  ...mockPatient,
+  name: [
+    {
+      // this is usable as a display name, but the usual name should be preferred
+      id: 'efdb246f-4142-4c12-a27a-9be60b226123',
+      use: 'official',
+      given: ['my', 'official'],
+      family: 'name',
+    },
+    {
+      // this is the preferred display name, even though it comes after the official name
+      id: 'efdb246f-4142-4c12-a27a-9be60b226111',
+      use: 'usual', // explicitly marked as usual name
+      given: ['my', 'actual'],
+      family: 'name',
+    },
+  ],
+};
+
+export const mockPatientWithNickAndOfficialName = {
+  ...mockPatient,
+  name: [
+    {
+      id: 'efdb246f-4142-4c12-a27a-9be60b226111',
+      use: 'nickname',
+      given: ['nick', 'name'],
+    },
+    {
+      id: 'efdb246f-4142-4c12-a27a-9be60b226123',
+      use: 'official',
+      given: ['my', 'official'],
+      family: 'name',
     },
   ],
 };

--- a/packages/framework/esm-utils/src/patient-helpers.test.data.ts
+++ b/packages/framework/esm-utils/src/patient-helpers.test.data.ts
@@ -66,41 +66,41 @@ export const mockPatientWithMultipleNames = {
   ...mockPatient,
   name: [
     {
-      id: 'efdb246f-4142-4c12-a27a-9be60b9592e9',
+      id: 'id-of-nickname-1',
       use: 'nickname',
       given: ['nick', 'name'],
     },
     {
-      id: 'efdb246f-4142-4c12-a27a-9be60b9592ff',
+      id: 'id-of-nickname-2',
       use: 'nickname',
       given: ['nick', 'name'],
     },
     {
-      id: 'efdb246f-4142-4c12-a27a-9be60b9561ee',
+      id: 'id-of-anonymous-name-1',
       use: 'anonymous',
       given: ['john', 'doe'],
     },
     {
-      id: 'efdb246f-4142-4c12-a27a-9be60b9561dd',
+      id: 'id-of-old-name-1',
       use: 'old',
       given: ['previous'],
       family: 'name',
     },
     {
-      id: 'efdb246f-4142-4c12-a27a-9be60b2261cc',
+      id: 'id-of-maiden-name-1',
       use: 'maiden',
       family: 'maiden name',
     },
     {
       // this is the actual display name
-      id: 'efdb246f-4142-4c12-a27a-9be60b2261bb',
+      id: 'id-of-usual-name-1',
       given: ['John', 'Murray'],
       family: 'Smith',
       text: 'Smith, John Murray',
     },
     {
       // this is usable as a display name, but the usual name will take precedence.
-      id: 'efdb246f-4142-4c12-a27a-9be60b2261aa',
+      id: 'id-of-official-name-1',
       use: 'official',
       given: ['my', 'official'],
       family: 'name',
@@ -113,14 +113,14 @@ export const mockPatientWithOfficialName = {
   name: [
     {
       // this is usable as a display name, but the usual name should be preferred
-      id: 'efdb246f-4142-4c12-a27a-9be60b226123',
+      id: 'id-of-official-name-1',
       use: 'official',
       given: ['my', 'official'],
       family: 'name',
     },
     {
       // this is the preferred display name, even though it comes after the official name
-      id: 'efdb246f-4142-4c12-a27a-9be60b226111',
+      id: 'id-of-usual-name-1',
       use: 'usual', // explicitly marked as usual name
       given: ['my', 'actual'],
       family: 'name',
@@ -132,12 +132,12 @@ export const mockPatientWithNickAndOfficialName = {
   ...mockPatient,
   name: [
     {
-      id: 'efdb246f-4142-4c12-a27a-9be60b226111',
+      id: 'id-of-nickname-1',
       use: 'nickname',
       given: ['nick', 'name'],
     },
     {
-      id: 'efdb246f-4142-4c12-a27a-9be60b226123',
+      id: 'id-of-official-name-1',
       use: 'official',
       given: ['my', 'official'],
       family: 'name',

--- a/packages/framework/esm-utils/src/patient-helpers.test.ts
+++ b/packages/framework/esm-utils/src/patient-helpers.test.ts
@@ -43,14 +43,14 @@ const temp: NameUse = 'temp';
 
 describe('Preferred patient name', () => {
   it.each([
-    [mockPatientWithMultipleNames, [], 'efdb246f-4142-4c12-a27a-9be60b2261bb'],
-    [mockPatientWithMultipleNames, [usual], 'efdb246f-4142-4c12-a27a-9be60b2261bb'],
-    [mockPatientWithMultipleNames, [usual, official], 'efdb246f-4142-4c12-a27a-9be60b2261bb'],
-    [mockPatientWithMultipleNames, [official, usual], 'efdb246f-4142-4c12-a27a-9be60b2261aa'],
-    [mockPatientWithMultipleNames, [official, usual], 'efdb246f-4142-4c12-a27a-9be60b2261aa'],
-    [mockPatientWithMultipleNames, [maiden, usual, official], 'efdb246f-4142-4c12-a27a-9be60b2261cc'],
-    [mockPatientWithOfficialName, [usual, official], 'efdb246f-4142-4c12-a27a-9be60b226111'],
-    [mockPatientWithNickAndOfficialName, [nickname, official], 'efdb246f-4142-4c12-a27a-9be60b226111'],
+    [mockPatientWithMultipleNames, [], 'id-of-usual-name-1'],
+    [mockPatientWithMultipleNames, [usual], 'id-of-usual-name-1'],
+    [mockPatientWithMultipleNames, [usual, official], 'id-of-usual-name-1'],
+    [mockPatientWithMultipleNames, [official], 'id-of-official-name-1'],
+    [mockPatientWithMultipleNames, [official, usual], 'id-of-official-name-1'],
+    [mockPatientWithMultipleNames, [maiden, usual, official], 'id-of-maiden-name-1'],
+    [mockPatientWithOfficialName, [usual, official], 'id-of-usual-name-1'],
+    [mockPatientWithNickAndOfficialName, [nickname, official], 'id-of-nickname-1'],
   ])('Is selected according to preferred usage', (patient, preferredUsage, expectedNameId) => {
     const result = selectPreferredName(patient, ...preferredUsage);
     expect(result?.id).toBe(expectedNameId);

--- a/packages/framework/esm-utils/src/patient-helpers.test.ts
+++ b/packages/framework/esm-utils/src/patient-helpers.test.ts
@@ -1,0 +1,12 @@
+import { displayName } from './patient-helpers';
+import { mockPatient, mockPatientWithoutFormattedName } from './patient-helpers.test.data';
+
+describe('Patient display name', () => {
+  it.each([
+    [mockPatient, 'Wilson, John'],
+    [mockPatientWithoutFormattedName, 'given middle family name'],
+  ])('Is formatted display name if present else default display name', (patient, expected) => {
+    const result = displayName(patient);
+    expect(result).toBe(expected);
+  });
+});

--- a/packages/framework/esm-utils/src/patient-helpers.test.ts
+++ b/packages/framework/esm-utils/src/patient-helpers.test.ts
@@ -1,12 +1,69 @@
-import { displayName } from './patient-helpers';
-import { mockPatient, mockPatientWithoutFormattedName } from './patient-helpers.test.data';
+import { displayName, formattedName, selectPreferredName } from './patient-helpers';
+import {
+  mockPatientWithNoName,
+  mockPatientWithOfficialName,
+  nameWithFormat,
+  nameWithoutFormat,
+  familyNameOnly,
+  givenNameOnly,
+  mockPatientWithMultipleNames,
+  mockPatientWithNickAndOfficialName,
+} from './patient-helpers.test.data';
+import { type NameUse } from '../../esm-api';
+
+describe('Formatted display name', () => {
+  it.each([
+    [nameWithFormat, 'Wilson, John'],
+    [nameWithoutFormat, 'given middle family name'],
+    [familyNameOnly, 'family name'],
+    [givenNameOnly, 'given'],
+    [mockPatientWithNoName, ''],
+  ])('Is formatted name text if present else default name format', (name, expected) => {
+    const result = formattedName(name);
+    expect(result).toBe(expected);
+  });
+});
 
 describe('Patient display name', () => {
   it.each([
-    [mockPatient, 'Wilson, John'],
-    [mockPatientWithoutFormattedName, 'given middle family name'],
-  ])('Is formatted display name if present else default display name', (patient, expected) => {
+    [mockPatientWithMultipleNames, 'Smith, John Murray'],
+    [mockPatientWithOfficialName, 'my actual name'],
+    [mockPatientWithNickAndOfficialName, 'my official name'],
+  ])('Is selected from usual name or official name', (patient, expected) => {
     const result = displayName(patient);
     expect(result).toBe(expected);
+  });
+});
+
+const usual: NameUse = 'usual';
+const official: NameUse = 'official';
+const maiden: NameUse = 'maiden';
+const nickname: NameUse = 'nickname';
+const temp: NameUse = 'temp';
+
+describe('Preferred patient name', () => {
+  it.each([
+    [mockPatientWithMultipleNames, [], 'efdb246f-4142-4c12-a27a-9be60b2261bb'],
+    [mockPatientWithMultipleNames, [usual], 'efdb246f-4142-4c12-a27a-9be60b2261bb'],
+    [mockPatientWithMultipleNames, [usual, official], 'efdb246f-4142-4c12-a27a-9be60b2261bb'],
+    [mockPatientWithMultipleNames, [official, usual], 'efdb246f-4142-4c12-a27a-9be60b2261aa'],
+    [mockPatientWithMultipleNames, [official, usual], 'efdb246f-4142-4c12-a27a-9be60b2261aa'],
+    [mockPatientWithMultipleNames, [maiden, usual, official], 'efdb246f-4142-4c12-a27a-9be60b2261cc'],
+    [mockPatientWithOfficialName, [usual, official], 'efdb246f-4142-4c12-a27a-9be60b226111'],
+    [mockPatientWithNickAndOfficialName, [nickname, official], 'efdb246f-4142-4c12-a27a-9be60b226111'],
+  ])('Is selected according to preferred usage', (patient, preferredUsage, expectedNameId) => {
+    const result = selectPreferredName(patient, ...preferredUsage);
+    expect(result?.id).toBe(expectedNameId);
+  });
+});
+
+describe('Preferred patient name', () => {
+  it.each([
+    [mockPatientWithMultipleNames, [temp]],
+    [mockPatientWithNoName, [usual]],
+    [mockPatientWithNoName, []],
+  ])('Is empty if preferred name is not present.', (patient, preferredUsage) => {
+    const result = selectPreferredName(patient, ...preferredUsage);
+    expect(result).toBeUndefined();
   });
 });

--- a/packages/framework/esm-utils/src/patient-helpers.ts
+++ b/packages/framework/esm-utils/src/patient-helpers.ts
@@ -1,0 +1,12 @@
+/**
+ * Gets the display name for a patient.
+ * @param fhirPatient The patient details in FHIR format.
+ * @returns The patient's display name.
+ */
+export function displayName(fhirPatient): string {
+  return fhirPatient.name?.[0]?.text ?? fallbackDisplayName(fhirPatient);
+}
+
+function fallbackDisplayName(fhirPatient): string {
+  return `${fhirPatient.name?.[0].given?.join(' ')} ${fhirPatient?.name?.[0].family}`;
+}

--- a/packages/framework/esm-utils/src/patient-helpers.ts
+++ b/packages/framework/esm-utils/src/patient-helpers.ts
@@ -64,7 +64,7 @@ export function selectPreferredName(patient: fhir.Patient, ...preferredNames: Na
  */
 function defaultFormat(name: fhir.HumanName): string {
   const forenames: string[] = name.given ?? [];
-  let names: string[] = name.family ? forenames.concat(name.family) : forenames;
+  const names: string[] = name.family ? forenames.concat(name.family) : forenames;
   return names.join(' ');
 }
 

--- a/packages/framework/esm-utils/src/patient-helpers.ts
+++ b/packages/framework/esm-utils/src/patient-helpers.ts
@@ -1,12 +1,85 @@
+/** @module @category Utility */
+
+import type { NameUse } from '../../esm-api';
+
 /**
- * Gets the display name for a patient.
- * @param fhirPatient The patient details in FHIR format.
- * @returns The patient's display name.
+ * Gets the formatted display name for a patient.
+ *
+ * The display name will be taken from the patient's 'usual' name,
+ * or may fall back to the patient's 'official' name.
+ *
+ * @param patient The patient details in FHIR format.
+ * @returns The patient's display name or an empty string if name is not present.
  */
-export function displayName(fhirPatient): string {
-  return fhirPatient.name?.[0]?.text ?? fallbackDisplayName(fhirPatient);
+export function displayName(patient: fhir.Patient): string {
+  const name = selectPreferredName(patient, 'usual', 'official');
+  return formattedName(name);
 }
 
-function fallbackDisplayName(fhirPatient): string {
-  return `${fhirPatient.name?.[0].given?.join(' ')} ${fhirPatient?.name?.[0].family}`;
+/**
+ * Get a formatted display string for an FHIR name.
+ * @param name The name to be formatted.
+ * @returns The formatted display name or an empty string if name is undefined.
+ */
+export function formattedName(name: fhir.HumanName | undefined): string {
+  if (name) return name.text ?? defaultFormat(name);
+  return '';
+}
+
+/**
+ * Select the preferred name from the collection of names associated with a patient.
+ *
+ * Names may be specified with a usage such as 'usual', 'official', 'nickname', 'maiden', etc.
+ * A name with no usage specified is treated as the 'usual' name.
+ *
+ * The chosen name will be selected according to the priority order of `preferredNames`,
+ * @example
+ * // normal use case; prefer usual name, fallback to official name
+ * displayNameByUsage(patient, 'usual', 'official')
+ * @example
+ * // prefer usual name over nickname, fallback to official name
+ * displayNameByUsage(patient, 'usual', 'nickname', 'official')
+ *
+ * @param patient The patient from whom a name will be selected.
+ * @param preferredNames Optional ordered sequence of preferred name usages; defaults to 'usual' if not specified.
+ * @return the preferred name for the patient, or undefined if no acceptable name could be found.
+ */
+export function selectPreferredName(patient: fhir.Patient, ...preferredNames: NameUse[]): fhir.HumanName | undefined {
+  if (preferredNames.length == 0) {
+    preferredNames = ['usual'];
+  }
+  for (const usage of preferredNames) {
+    const name = patient.name?.find((name) => nameUsageMatches(name, usage));
+    if (name) {
+      return name;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Generate a display name by concatenating forenames and surname.
+ * @param name the person's name.
+ * @returns the person's name as a string.
+ */
+function defaultFormat(name: fhir.HumanName): string {
+  const forenames: string[] = name.given ?? [];
+  let names: string[] = name.family ? forenames.concat(name.family) : forenames;
+  return names.join(' ');
+}
+
+/**
+ * Determine whether the usage of a given name matches the given NameUse.
+ *
+ * A name with no usage is treated as the 'usual' name.
+ *
+ * @param name the name to test.
+ * @param usage the NameUse to test for.
+ */
+function nameUsageMatches(name: fhir.HumanName, usage: NameUse): boolean {
+  if (!name.use)
+    // a name with no usage is treated as 'usual'
+    return usage == 'usual';
+
+  return name.use == usage;
 }

--- a/packages/framework/esm-utils/src/patient-helpers.ts
+++ b/packages/framework/esm-utils/src/patient-helpers.ts
@@ -79,7 +79,7 @@ function defaultFormat(name: fhir.HumanName): string {
 function nameUsageMatches(name: fhir.HumanName, usage: NameUse): boolean {
   if (!name.use)
     // a name with no usage is treated as 'usual'
-    return usage == 'usual';
+    return usage === 'usual';
 
-  return name.use == usage;
+  return name.use === usage;
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.  
(No API changes made)

## Summary
FHIR patient responses may now include a well-formatted display name as per [FM2-631](https://openmrs.atlassian.net/browse/FM2-631).

Despite this, there are many locations in the O3 frontend where a patient name is displayed explicitly as `${givenName} ${familyName}`.

In going through the codebase to fix this, it becomes apparent that there is value in adopting a consistent approach to getting the patient display name. 

## Screenshots
N/A

## Related Issue
https://openmrs.atlassian.net/browse/O3-3249
https://openmrs.atlassian.net/browse/O3-2115

## Other
I already have open pull requests on openmrs-esm-patient-management:
- [openmrs-esm-patient-management 1141](https://github.com/openmrs/openmrs-esm-patient-management/pull/1141)
- [openmrs-esm-patient-management 1142](https://github.com/openmrs/openmrs-esm-patient-management/pull/1142)
- [openmrs-esm-patient-management 1143](https://github.com/openmrs/openmrs-esm-patient-management/pull/1143)

I will pause those changes until this pull request is completed.

[FM2-631]: https://openmrs.atlassian.net/browse/FM2-631?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ