### PR TITLE
(chore) Increase default test timeout in framework

### DIFF
--- a/packages/apps/esm-login-app/jest.config.js
+++ b/packages/apps/esm-login-app/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
     '@openmrs/esm-framework': '@openmrs/esm-framework/mock',
     '\\.(s?css)$': 'identity-obj-proxy',
     '^lodash-es/(.*)$': 'lodash/$1',
+    'lodash-es': 'lodash',
     dexie: require.resolve('dexie'),
   },
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],

--- a/packages/framework/esm-framework/jest.config.js
+++ b/packages/framework/esm-framework/jest.config.js
@@ -17,4 +17,5 @@ module.exports = {
   testEnvironmentOptions: {
     url: 'http://localhost/',
   },
+  testTimeout: 10000,
 };


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR increases the default test timeout for tests in the `esm/framework` package to account for some long-running async processes by setting a global `testTimeout` property in the Jest config. It also adds a `lodash-es` moduleNameMapper entry in the login app's jest config to fix some broken imports that use the syntax `import { add } from lodash-es`. Check out this [failing action run](https://github.com/openmrs/openmrs-esm-core/actions/runs/9148923958) for more context on the test failures. 

## Screenshots

### Test failures on `main`

![CleanShot 2024-05-20 at 11  14 16@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/90a54185-6748-415c-8dd8-bf0a5365db23)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
