### PR TITLE
(feat) Add additional properties for OpenmrsDatePicker in Carbon

### DIFF
--- a/packages/framework/esm-styleguide/src/datepicker/openmrs/openmrs-date-picker.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/openmrs/openmrs-date-picker.component.tsx
@@ -3,6 +3,7 @@ import { supportedLocales as reactSpectrumSupportedLocales } from '../react-spec
 import { getLocale } from '@openmrs/esm-utils';
 import ReactSpectrumDatePickerWrapper from '../react-spectrum/adobe-react-spectrum-date-wrapper.component';
 import { DatePicker, DatePickerInput } from '@carbon/react';
+import dayjs from 'dayjs';
 
 // TODO: should be locale sensitive
 // see: https://issues.openmrs.org/browse/O3-998
@@ -11,14 +12,14 @@ const DEFAULT_PLACEHOLDER = 'dd/mm/yyyy';
 
 export interface OpenmrsDatePickerProps {
   id: string;
-  labelText: string;
+  labelText: string | any;
   onChange: (value: Date) => void;
   value?: Date | string;
   /* Not supported by Carbon's picker */
   defaultValue?: Date | string;
   minDate?: Date | string;
   maxDate?: Date | string;
-  readonly?: boolean;
+  readonly?: string | boolean;
   dateFormat?: string;
   invalid?: boolean;
   invalidText?: string;
@@ -64,7 +65,7 @@ export const OpenmrsDatePicker: React.FC<OpenmrsDatePickerProps> = ({
       defaultValue={defaultValue}
       minDate={minDate}
       maxDate={maxDate}
-      readonly={readonly}
+      readonly={typeof readonly === 'boolean' ? readonly : undefined}
       id={id}
       isDisabled={disabled}
       invalid={invalid}
@@ -93,6 +94,14 @@ export const OpenmrsDatePicker: React.FC<OpenmrsDatePickerProps> = ({
         invalidText={invalidText}
         placeholder={carbonOptions?.placeholder || DEFAULT_PLACEHOLDER}
         style={carbonOptions?.pickerInputStyle}
+        // Added for testing purposes.
+        // Notes:
+        // Something strange is happening with the way events are propagated and handled by Carbon.
+        // When we manually trigger an onchange event using the 'fireEvent' lib, the handler below will
+        // be triggered as opposed to the former handler that only gets triggered at runtime.
+        onChange={(e) => onChange(dayjs(e.target.value, DEFAULT_PLACEHOLDER.toUpperCase()).toDate())}
+        disabled={disabled}
+        readOnly={readonly}
       />
     </DatePicker>
   );

--- a/packages/framework/esm-styleguide/src/datepicker/react-spectrum/adobe-react-spectrum-date-wrapper.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/react-spectrum/adobe-react-spectrum-date-wrapper.component.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { type ReactElement, useMemo } from 'react';
 import { parseDate } from '@internationalized/date';
 import { DatePicker } from '@react-spectrum/datepicker';
 import { Provider } from '@react-spectrum/provider';
@@ -10,7 +10,7 @@ import dayjs from 'dayjs';
 interface ReactSpectrumDatePickerWrapperProps {
   id: string;
   value?: Date | string;
-  labelText?: string;
+  labelText?: string | ReactElement;
   locale: string;
   defaultValue?: Date | string;
   minDate?: Date | string;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
There's a requirement to adopt the OpenmrsDatepicker on the REACT form engine. As such, it was imperative that the OpenmrsDatepicker is extended to support all the features that the RFE Datepicker currently supports.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
