### PR TITLE
(fix) O3-3265: Tweak Patient Header UI

### DIFF
--- a/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx
+++ b/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx
@@ -59,36 +59,30 @@ const PatientLists: React.FC<{ patientUuid: string }> = ({ patientUuid }) => {
 };
 
 const Address: React.FC<{ patientId: string }> = ({ patientId }) => {
-  const { isLoading, patient } = usePatient(patientId);
+  const { patient } = usePatient(patientId);
   const address = patient?.address?.find((a) => a.use === 'home');
   const getAddressKey = (url) => url.split('#')[1];
 
-  return isLoading ? (
-    <InlineLoading description={`${getCoreTranslation('loading', 'Loading')} ...`} role="progressbar" />
-  ) : (
+  return (
     <>
       <p className={styles.heading}>{getCoreTranslation('address', 'Address')}</p>
       <ul>
         {address ? (
-          <React.Fragment>
-            {Object.entries(address)
-              .filter(([key]) => !['use', 'id'].includes(key))
-              .map(([key, value]) =>
-                key === 'extension' ? (
-                  address?.extension?.[0]?.extension?.map((add, i) => {
-                    return (
-                      <li key={`address-${key}-${i}`}>
-                        {getCoreTranslation(getAddressKey(add.url), getAddressKey(add.url))}: {add.valueString}
-                      </li>
-                    );
-                  })
-                ) : (
-                  <li key={`address-${key}`}>
-                    {getCoreTranslation(key as CoreTranslationKey, key)}: {value}
+          Object.entries(address)
+            .filter(([key]) => key !== 'id')
+            .map(([key, value]) =>
+              key === 'extension' ? (
+                address.extension?.[0]?.extension?.map((add, i) => (
+                  <li key={`address-${key}-${i}`}>
+                    {getCoreTranslation(getAddressKey(add.url), getAddressKey(add.url))}: {add.valueString}
                   </li>
-                ),
-              )}
-          </React.Fragment>
+                ))
+              ) : (
+                <li key={`address-${key}`}>
+                  {getCoreTranslation(key as CoreTranslationKey, key)}: {value}
+                </li>
+              ),
+            )
         ) : (
           <li>--</li>
         )}

--- a/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.module.scss
+++ b/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.module.scss
@@ -69,7 +69,7 @@
 .demographics {
   @include type.type-style('body-compact-02');
   color: $text-02;
-  margin-top: 0.375rem;
+  margin-top: 0.25rem;
 }
 
 .row {
@@ -77,6 +77,7 @@
   flex-direction: row;
   justify-content: space-between;
   align-items: baseline;
+  margin-top: 0.25rem;
 }
 
 .patientNameRow {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR tweaks the following aspects of the [Patient header](https://zeroheight.com/23a080e38/p/6663f3-patient-header) UI:

- There ought to be the same amount of top margin between the rows of the Patient header.
- The label for the Address section in the Details panel isn’t shown when the address data is loading (or more specifically, when fetching the patient object). The label should be shown whether the corresponding data is available or not.

## Screenshots

### Before

https://github.com/openmrs/openmrs-esm-core/assets/8509731/3d088840-cb3f-47a0-b75e-115aac85c490

### After

(Ignore the font change - that's owing to the default font failing to load)

![CleanShot 2024-05-22 at 11  51 10@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/33730b00-0743-479b-928f-38ef9b864969)

## Related Issue
https://openmrs.atlassian.net/browse/O3-3265

## Other
<!-- Anything not covered above -->
