### PR TITLE
(fix) O3-3249 Add missed dependency on @types/fhir for esm-utils.

### DIFF
--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -52,6 +52,7 @@
   },
   "dependencies": {
     "@internationalized/date": "^3.5.0",
+    "@types/fhir": "0.0.31",
     "semver": "7.3.2"
   }
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).  
  N/A

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Commit 27ab80e1485ad6f7017979cafa29914a165f00c4 introduced a dependency on @types/fhir for module @openmrs/esm-utils, but the dependency was not captured in `package.json`


## Related Issue
follow-on from PR for https://openmrs.atlassian.net/browse/O3-3249

