### PR TITLE
(fix) Remove double border from Patient Header details panel

### DIFF
--- a/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.module.scss
+++ b/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.module.scss
@@ -6,7 +6,6 @@
 .contactDetails {
   color: $text-02;
   width: 100%;
-  border-top: 1px solid $ui-03;
 }
 
 .heading {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Removes a top border affecting the details panel in the Patient Header.

## Screenshots

### Before

![CleanShot 2024-05-23 at 10  56 22@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/36edc7ab-f82a-4298-a1f6-db7f5725489a)

### After

![CleanShot 2024-05-23 at 10  56 01@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/3c27bbf7-43b5-4b47-bbc9-4943360f9377)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
