### PR TITLE
(feat) Add ability to navigate to patient chart on clicking related person name

### DIFF
--- a/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx
+++ b/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx
@@ -149,7 +149,11 @@ const Relationships: React.FC<{ patientId: string }> = ({ patientId }) => {
             <>
               {relationships.map((r) => (
                 <li key={r.uuid} className={styles.relationship}>
-                  <div>{r.display}</div>
+                  <div>
+                    <ConfigurableLink to={`${window.spaBase}/patient/${r.relativeUuid}/chart`}>
+                      {r.display}
+                    </ConfigurableLink>
+                  </div>
                   <div>{r.relationshipType}</div>
                   <div>
                     {`${r.relativeAge ? r.relativeAge : '--'} ${

--- a/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.test.tsx
+++ b/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.test.tsx
@@ -137,6 +137,12 @@ describe('ContactDetails', () => {
     expect(screen.getByText(/List three/)).toBeInTheDocument();
   });
 
+  it('patient related name should be a link', async () => {
+    renderWithSwr(<PatientBannerContactDetails patientId={'some-uuid'} deceased={false} />);
+    const relationShip = screen.getByRole('link', { name: /Amanda Robinson/ });
+    expect(relationShip).toHaveAttribute('href', `/spa/patient/${mockRelationships[0].relativeUuid}/chart`);
+  });
+
   it('renders an empty state view when contact details, relations, patient lists and addresses are not available', async () => {
     mockedUsePatient.mockReturnValue({
       isLoading: false,


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR implements this feature that wasn't moved when migrating patient banner to esm-core. [03-2642](https://openmrs.atlassian.net/browse/O3-2642). I haven't included the config to turn this feature on and off, intending to making this the default.

## Screenshots
https://github.com/openmrs/openmrs-esm-core/assets/28008754/f8169988-5a12-46bc-b920-bbf5ad2a5640

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
