### PR TITLE
(chore) Export actual ConfigurableLink implementation from mock

### DIFF
--- a/packages/framework/esm-react-utils/mock.tsx
+++ b/packages/framework/esm-react-utils/mock.tsx
@@ -4,10 +4,8 @@ import { configSchema } from '@openmrs/esm-config/mock';
 import { getExtensionStore, getExtensionInternalStore } from '@openmrs/esm-extensions/mock';
 import { createGlobalStore } from '@openmrs/esm-state/mock';
 import { usePagination as realUsePagination } from './src/index';
-export { isDesktop, useStore, useStoreWithActions, createUseStore } from './src/index';
+export { ConfigurableLink, isDesktop, useStore, useStoreWithActions, createUseStore } from './src/index';
 import * as utils from '@openmrs/esm-utils';
-
-export const ConfigurableLink = ({ to, children }) => <a href={to}>{children}</a>;
 
 export const ComponentContext = React.createContext(null);
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR fixes the react-utils mock to export the actual implementation of the `ConfigurableLink` function instead of a mocked version. This should fix failing tests in Patient Chart and Patient Management.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
