### PR TITLE
(feat) O3-3266: Add support for specifying optional backend dependencies

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/types.ts
+++ b/packages/apps/esm-implementer-tools-app/src/types.ts
@@ -1,5 +1,5 @@
 import type { OpenmrsAppRoutes } from '@openmrs/esm-framework';
 
-export type FrontendModule = OpenmrsAppRoutes & {
+export interface FrontendModule extends OpenmrsAppRoutes {
   name: string;
-};
+}

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -565,7 +565,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:362](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L362)
+[packages/framework/esm-globals/src/types.ts:380](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L380)
 
 ___
 
@@ -578,7 +578,7 @@ Basically, this is the same as the app routes, with each routes definition keyed
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:353](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L353)
+[packages/framework/esm-globals/src/types.ts:371](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L371)
 
 ___
 
@@ -5600,7 +5600,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx:171](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx#L171)
+[packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx:175](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx#L175)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
@@ -11,6 +11,7 @@ This interface describes the format of the routes provided by an app
 - [backendDependencies](OpenmrsAppRoutes.md#backenddependencies)
 - [extensions](OpenmrsAppRoutes.md#extensions)
 - [modals](OpenmrsAppRoutes.md#modals)
+- [optionalBackendDependencies](OpenmrsAppRoutes.md#optionalbackenddependencies)
 - [pages](OpenmrsAppRoutes.md#pages)
 - [version](OpenmrsAppRoutes.md#version)
 - [workspaces](OpenmrsAppRoutes.md#workspaces)
@@ -37,7 +38,7 @@ An array of all extensions supported by this frontend module. Extensions can be 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:338](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L338)
+[packages/framework/esm-globals/src/types.ts:356](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L356)
 
 ___
 
@@ -49,7 +50,25 @@ An array of all modals supported by this frontend module. Modals can be launched
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:342](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L342)
+[packages/framework/esm-globals/src/types.ts:360](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L360)
+
+___
+
+### optionalBackendDependencies
+
+• `Optional` **optionalBackendDependencies**: `Object`
+
+A list of backend modules that may enable optional functionality in this frontend module if available and the corresponding required versions.
+
+#### Index signature
+
+▪ [key: `string`]: `string` \| { `feature?`: `string` ; `version`: `string`  }
+
+The name of the backend dependency and either the required version or an object describing the required version
+
+#### Defined in
+
+[packages/framework/esm-globals/src/types.ts:334](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L334)
 
 ___
 
@@ -61,7 +80,7 @@ An array of all pages supported by this frontend module. Pages are automatically
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:334](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L334)
+[packages/framework/esm-globals/src/types.ts:352](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L352)
 
 ___
 
@@ -85,4 +104,4 @@ An array of all workspaces supported by this frontend module. Workspaces can be 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:346](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L346)
+[packages/framework/esm-globals/src/types.ts:364](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L364)

--- a/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
+++ b/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
@@ -20,4 +20,4 @@
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:356](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L356)
+[packages/framework/esm-globals/src/types.ts:374](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L374)

--- a/packages/framework/esm-globals/src/types.ts
+++ b/packages/framework/esm-globals/src/types.ts
@@ -329,6 +329,24 @@ export interface OpenmrsAppRoutes {
    */
   backendDependencies?: Record<string, string>;
   /**
+   * A list of backend modules that may enable optional functionality in this frontend module if available and the corresponding required versions.
+   */
+  optionalBackendDependencies?: {
+    /** The name of the backend dependency and either the required version or an object describing the required version */
+    [key: string]:
+      | string
+      | {
+          /**
+           * The minimum version of this optional dependency that must be present.
+           */
+          version: string;
+          /**
+           * The feature flag to enable if this backend dependency is present
+           */
+          feature?: string;
+        };
+  };
+  /**
    * An array of all pages supported by this frontend module. Pages are automatically mounted based on a route.
    */
   pages?: Array<PageDefinition>;

--- a/packages/framework/esm-routes/src/routes.test.ts
+++ b/packages/framework/esm-routes/src/routes.test.ts
@@ -1,4 +1,4 @@
-import fetchMock, { enableFetchMocks } from 'jest-fetch-mock';
+import { enableFetchMocks } from 'jest-fetch-mock';
 enableFetchMocks();
 
 import { addRoutesOverride, isOpenmrsAppRoutes } from './routes';
@@ -100,6 +100,18 @@ describe('Openmrs Routes Utilities', () => {
               component: 'customExtension',
             },
           ],
+          modals: [
+            {
+              name: 'custom modal',
+              component: 'customModal',
+            },
+          ],
+          workspaces: [
+            {
+              name: 'custom workspace',
+              component: 'customWorkspace',
+            },
+          ],
         }),
       ).toBe(true);
     });
@@ -124,6 +136,32 @@ describe('Openmrs Routes Utilities', () => {
             {
               name: 'custom extension',
               component: 'customExtension',
+            },
+          ],
+        }),
+      ).toBe(true);
+    });
+
+    it('should accept an object with only modals', () => {
+      expect(
+        isOpenmrsAppRoutes({
+          modals: [
+            {
+              name: 'custom modal',
+              component: 'customModal',
+            },
+          ],
+        }),
+      ).toBe(true);
+    });
+
+    it('should accept an object with only workspaces', () => {
+      expect(
+        isOpenmrsAppRoutes({
+          workspaces: [
+            {
+              name: 'custom workspace',
+              component: 'customWorkspace',
             },
           ],
         }),

--- a/packages/framework/esm-routes/src/routes.ts
+++ b/packages/framework/esm-routes/src/routes.ts
@@ -115,6 +115,18 @@ export function isOpenmrsAppRoutes(routes: OpenmrsAppRoutes | unknown): routes i
       }
     }
 
+    if (hasOwnProperty.call(routes, 'workspaces')) {
+      if (!Boolean(maybeRoutes.workspaces) || !Array.isArray(maybeRoutes.workspaces)) {
+        return false;
+      }
+    }
+
+    if (hasOwnProperty.call(routes, 'modals')) {
+      if (!Boolean(maybeRoutes.modals) || !Array.isArray(maybeRoutes.modals)) {
+        return false;
+      }
+    }
+
     // Notice that we're essentially testing for things that cannot be treated as an OpenmrsAppRoutes
     // object. This is because a completely empty object is a valid OpenmrsAppRoutes object.
     return true;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This adds the concept of an optional backend dependency. If an app declares an optional dependency and that backend dependency is present, it's version is checked against the requested version. If the optional dependency is not present, it is not reported as missing.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-3266

## Other
<!-- Anything not covered above -->

Related PR to update the schema: https://github.com/openmrs/openmrs-contrib-json-schemas/pull/12

I've created space for, but not implemented, a feature that would enable automatically turning a feature flag on if an optional dependency is present. The goal of this feature is to reduce the amount of configuration that's necessary to enable optional features in an application.
