### PR TITLE
(fix) Minor improvements to workspaces and workspace tests, supporting O3-2724

### DIFF
--- a/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx
@@ -73,9 +73,11 @@ const Workspace: React.FC<WorkspaceProps> = ({ workspaceInstance }) => {
     };
   }, [workspaceInstance.load]);
 
-  const title = useMemo(
-    () => translateFrom(workspaceInstance.moduleName, workspaceInstance.title, workspaceInstance.title),
-    [workspaceInstance.moduleName, workspaceInstance.title],
+  const workspaceTitle = useMemo(
+    () =>
+      workspaceInstance.additionalProps?.['workspaceTitle'] ??
+      translateFrom(workspaceInstance.moduleName, workspaceInstance.title, workspaceInstance.title),
+    [workspaceInstance],
   );
 
   const workspaceProps = {
@@ -86,7 +88,7 @@ const Workspace: React.FC<WorkspaceProps> = ({ workspaceInstance }) => {
   };
 
   return (
-    <div
+    <aside
       className={classNames({
         [styles.desktopOverlay]: isDesktop(layout),
         [styles.tabletOverlay]: !isDesktop(layout),
@@ -94,7 +96,7 @@ const Workspace: React.FC<WorkspaceProps> = ({ workspaceInstance }) => {
     >
       {isDesktop(layout) ? (
         <div className={styles.desktopHeader}>
-          <div className={styles.headerContent}>{title}</div>
+          <div className={styles.headerContent}>{workspaceTitle}</div>
           <Button
             className={styles.closeButton}
             onClick={() => workspaceInstance?.closeWorkspace()}
@@ -118,7 +120,7 @@ const Workspace: React.FC<WorkspaceProps> = ({ workspaceInstance }) => {
             tooltipPosition="bottom"
             renderIcon={(props) => <ArrowLeftIcon size={16} onClick={close} {...props} />}
           />
-          <div className={styles.headerContent}>{title}</div>
+          <div className={styles.headerContent}>{workspaceTitle}</div>
         </Header>
       )}
       <div className={styles.workspaceContent} ref={ref}>
@@ -131,6 +133,6 @@ const Workspace: React.FC<WorkspaceProps> = ({ workspaceInstance }) => {
           />
         )}
       </div>
-    </div>
+    </aside>
   );
 };

--- a/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.test.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { screen, render, within, act } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { isDesktop, useLayoutType } from '@openmrs/esm-react-utils';
+import { WorkspaceOverlay } from './workspace-overlay.component';
+import { launchWorkspace, registerWorkspace, workspaceStore } from '..';
+import '@testing-library/jest-dom';
+
+jest.mock('single-spa-react/parcel', () => jest.fn().mockImplementation(() => <div>Parcel</div>));
+
+const mockedUseLayoutType = useLayoutType as jest.Mock;
+
+window.history.pushState({}, 'Workspace Overlay', '/workspace-overlay');
+
+describe('WorkspaceOverlay', () => {
+  beforeAll(() => {
+    registerWorkspace({
+      name: 'Patient Search',
+      title: 'Patient Search',
+      load: jest.fn().mockResolvedValue({ result: 'hey' }),
+      moduleName: '@openmrs/foo',
+    });
+  });
+
+  it('renders the desktop version of the overlay', async () => {
+    mockedUseLayoutType.mockReturnValue('small-desktop');
+    act(() => launchWorkspace('Patient Search', { workspaceTitle: 'Test Header' }));
+    renderWorkspaceOverlay();
+
+    expect(await screen.findByText('Test Header')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+    const container = screen.getByRole('complementary');
+    expect(container).toHaveClass('desktopOverlay');
+  });
+
+  it('renders the tablet version of the overlay', async () => {
+    mockedUseLayoutType.mockReturnValue('tablet');
+    act(() => launchWorkspace('Patient Search'));
+    renderWorkspaceOverlay();
+
+    expect(await screen.findByText('Patient Search')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close' })).toBeInTheDocument();
+    const container = screen.getByRole('complementary');
+    expect(container).toHaveClass('tabletOverlay');
+  });
+
+  it('opens with overridable title and closes', async () => {
+    mockedUseLayoutType.mockReturnValue('small-desktop');
+    const user = userEvent.setup();
+    act(() => launchWorkspace('Patient Search', { workspaceTitle: 'Make an appointment' }));
+    renderWorkspaceOverlay();
+
+    expect(screen.queryByRole('complementary')).toBeInTheDocument();
+    expect(screen.getByText('Make an appointment')).toBeInTheDocument();
+
+    const closeButton = screen.getByRole('button', { name: 'Close' });
+    await user.click(closeButton);
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+  });
+});
+
+function renderWorkspaceOverlay() {
+  render(<WorkspaceOverlay contextKey="workspace-overlay" />);
+}

--- a/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx
@@ -1,5 +1,5 @@
 /** @module @category Workspace */
-import React, { useContext, useMemo } from 'react';
+import React, { useCallback, useContext, useMemo } from 'react';
 import classNames from 'classnames';
 import { Header, HeaderGlobalBar, HeaderName, HeaderMenuButton, HeaderGlobalAction } from '@carbon/react';
 import { DownToBottom, Maximize, Minimize } from '@carbon/react/icons';
@@ -75,9 +75,9 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
 
   useBodyScrollLock(!isDesktop(layout));
 
-  const toggleWindowState = () => {
+  const toggleWindowState = useCallback(() => {
     maximized ? updateWorkspaceWindowState('normal') : updateWorkspaceWindowState('maximized');
-  };
+  }, [maximized]);
 
   const workspaceTitle = useMemo(
     () =>
@@ -114,6 +114,9 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
               {(canMaximize || maximized) && (
                 <HeaderGlobalAction
                   align="bottom"
+                  aria-label={
+                    maximized ? getCoreTranslation('minimize', 'Minimize') : getCoreTranslation('maximize', 'Maximize')
+                  }
                   label={
                     maximized ? getCoreTranslation('minimize', 'Minimize') : getCoreTranslation('maximize', 'Maximize')
                   }
@@ -126,6 +129,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
               {canHide ? (
                 <HeaderGlobalAction
                   align="bottom-right"
+                  aria-label={getCoreTranslation('hide', 'Hide')}
                   label={getCoreTranslation('hide', 'Hide')}
                   onClick={() => updateWorkspaceWindowState('hidden')}
                   size="lg"
@@ -135,6 +139,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
               ) : (
                 <HeaderGlobalAction
                   align="bottom-right"
+                  aria-label={getCoreTranslation('close', 'Close')}
                   label={getCoreTranslation('close', 'Close')}
                   onClick={() => closeWorkspace?.()}
                   size="lg"
@@ -147,6 +152,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
           {layout === 'tablet' && canHide && (
             <HeaderGlobalAction
               align="bottom-right"
+              aria-label={getCoreTranslation('close', 'Close')}
               label={getCoreTranslation('close', 'Close')}
               onClick={() => closeWorkspace?.()}
             >

--- a/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.test.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.test.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
-import { screen, render } from '@testing-library/react';
+import { screen, render, within, renderHook, act } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { isDesktop } from '@openmrs/esm-react-utils';
+import { ComponentContext, isDesktop } from '@openmrs/esm-react-utils';
 import { WorkspaceWindow } from './workspace-window.component';
-import { launchWorkspace, registerWorkspace } from '..';
+import { launchWorkspace, registerWorkspace, useWorkspaces } from '..';
 
-const mockExtensionRegistry = {};
 const mockedIsDesktop = isDesktop as jest.Mock;
+
+window.history.pushState({}, 'Workspace Window', '/workspace-window');
 
 jest.mock('./workspace-renderer.component', () => ({
   WorkspaceRenderer: jest.fn().mockImplementation(() => <div>Workspace-Renderer</div>),
@@ -31,51 +32,64 @@ jest.mock('@openmrs/esm-translations', () => {
   };
 });
 
-xdescribe('WorkspaceWindow', () => {
-  test('should reopen hidden workspace window when user relaunches the same workspace window', async () => {
+describe('WorkspaceWindow', () => {
+  beforeAll(() => {
+    registerWorkspace({
+      name: 'Clinical Form',
+      title: 'Clinical Form',
+      load: jest.fn(),
+      moduleName: '@openmrs/foo',
+      canHide: true,
+      canMaximize: true,
+    });
+  });
+
+  test('should override title; should reopen hidden workspace window when user relaunches the same workspace window', async () => {
     const user = userEvent.setup();
-
-    registerWorkspace({ name: 'Clinical Form', title: 'Clinical Form', load: jest.fn(), moduleName: '@openmrs/foo' });
-    launchWorkspace('Clinical Form', { workspaceTitle: 'POC Triage' });
+    const workspaces = renderHook(() => useWorkspaces());
     mockedIsDesktop.mockReturnValue(true);
-
+    expect(workspaces.result.current.workspaces.length).toBe(0);
     renderWorkspaceWindow();
 
-    expect(screen.getByRole('banner', { name: 'Workspace Title' })).toBeInTheDocument();
-    expect(screen.getByText('POC Triage')).toBeInTheDocument();
-
-    const workspaceContainer = screen.getByRole('complementary');
-    expect(workspaceContainer).toHaveClass('show');
+    act(() => launchWorkspace('Clinical Form', { workspaceTitle: 'POC Triage' }));
+    expect(workspaces.result.current.workspaces.length).toBe(1);
+    const header = screen.getByRole('banner');
+    expect(within(header).getByText('POC Triage')).toBeInTheDocument();
+    expect(screen.getByRole('complementary')).toBeInTheDocument();
 
     const hideButton = screen.getByRole('button', { name: 'Hide' });
+    await user.click(hideButton);
+    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
 
-    user.click(hideButton);
-
-    expect(workspaceContainer).toHaveClass('hide');
-
-    await launchWorkspace('Clinical Form', { workspaceTitle: 'POC Triage' });
-
-    expect(await screen.findByRole('complementary')).toHaveClass('show');
+    act(() => launchWorkspace('Clinical Form', { workspaceTitle: 'POC Triage' }));
+    expect(await screen.findByRole('complementary')).toBeInTheDocument();
+    expect(workspaces.result.current.workspaces.length).toBe(1);
   });
 
   test('should toggle between maximized and normal screen size', async () => {
     const user = userEvent.setup();
-
+    mockedIsDesktop.mockReturnValue(true);
     renderWorkspaceWindow();
 
-    const maximizeButton = await screen.findByRole('button', { name: 'Maximize' });
+    act(() => launchWorkspace('Clinical Form'));
+    const header = screen.getByRole('banner');
+    expect(within(header).getByText('Clinical Form')).toBeInTheDocument();
+    expect(screen.getByRole('complementary')).not.toHaveClass('maximized');
 
-    user.click(maximizeButton);
+    const maximizeButton = await screen.findByRole('button', { name: 'Maximize' });
+    await user.click(maximizeButton);
     expect(screen.getByRole('complementary')).toHaveClass('maximized');
 
     const minimizeButton = await screen.findByRole('button', { name: 'Minimize' });
-
-    user.click(minimizeButton);
-
+    await user.click(minimizeButton);
     expect(screen.getByRole('complementary')).not.toHaveClass('maximized');
   });
 });
 
 function renderWorkspaceWindow() {
-  render(<WorkspaceWindow contextKey="foo" />);
+  render(
+    <ComponentContext.Provider value={{ featureName: 'test', moduleName: '@openmrs/foo' }}>
+      <WorkspaceWindow contextKey="workspace-window" />
+    </ComponentContext.Provider>,
+  );
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This adds and enables tests for `WorkspaceWindow` and `WorkspaceOverlay`. This also adds support for overriding the workspace title of an overlay the same way as can be done with a workspace window—it's simple enough and I didn't see a reason one should support it and not the other. I also made the workspace overlay an `aside`, like the window. And quashed some console warnings about `aria-label`.

## Screenshots

This should not produce any change.

## Related Issue

Requested by @denniskigen [here](https://github.com/openmrs/openmrs-esm-patient-management/pull/1103#discussion_r1617889776), for ticket https://openmrs.atlassian.net/browse/O3-2724

## Other
<!-- Anything not covered above -->
