### PR TITLE
(fix) O3-3339 Workspace overlay contents have whitespace problems

### DIFF
--- a/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.module.scss
+++ b/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.module.scss
@@ -10,7 +10,6 @@
   min-width: 32.25rem;
   background-color: $ui-02;
   border-left: 1px solid $text-03;
-  overflow: hidden;
   display: grid;
   grid-template-rows: auto 1fr auto;
   z-index: 999;
@@ -24,7 +23,6 @@
   right: 0;
   z-index: 9999;
   background-color: $ui-02;
-  overflow: hidden;
   padding-top: spacing.$spacing-09;
   display: grid;
   grid-template-rows: 1fr auto;


### PR DESCRIPTION
# Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [X] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
For some reason the overflow:hidden property on the overlay causes the top portion to be cut off and creates a white space at the bottom.Removing that makes things work.Please see the video below.



## Related Issue
https://openmrs.atlassian.net/browse/O3-3339

## Video
[Workspace stylings.webm](https://github.com/openmrs/openmrs-esm-core/assets/115476530/b93a9a2e-1f53-4f60-a58f-c6a5b725cf14)
