### PR TITLE
(fix) Allow immutable arguments to config validators

### DIFF
--- a/packages/framework/esm-config/src/validators/validators.ts
+++ b/packages/framework/esm-config/src/validators/validators.ts
@@ -18,7 +18,7 @@ export const inRange = (min: number, max: number) => {
  * @param allowedTemplateParameters To be added to `openmrsBase` and `openmrsSpaBase`
  * @category Navigation
  */
-export const isUrlWithTemplateParameters = (allowedTemplateParameters: string[]) => {
+export const isUrlWithTemplateParameters = (allowedTemplateParameters: Array<string> | readonly string[]) => {
   const allowedParams = allowedTemplateParameters.concat(['openmrsBase', 'openmrsSpaBase']);
   return validator(
     (val) => {
@@ -55,7 +55,7 @@ export const isUrl = isUrlWithTemplateParameters([]);
  * Verifies that the value is one of the allowed options.
  * @param allowedValues The list of allowable values
  */
-export const oneOf = (allowedValues: Array<any>) => {
+export const oneOf = (allowedValues: Array<any> | readonly any[]) => {
   return validator(
     (val) => allowedValues.includes(val),
     `Must be one of the following: '${allowedValues.join("', '")}'.`,


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Trivial change; this just allows you to pass a `readonly` type to validators.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
