### PR TITLE
(chore) Type fix for getDefaultsFromConfigSchema

### DIFF
--- a/packages/framework/esm-utils/src/test-helpers.ts
+++ b/packages/framework/esm-utils/src/test-helpers.ts
@@ -10,7 +10,7 @@
  * default from the `useConfig`/`getConfig` mock. This function is useful if you
  * need to override some of the default values.
  */
-export function getDefaultsFromConfigSchema(schema) {
+export function getDefaultsFromConfigSchema<T = Record<string, any>>(schema): T {
   let tmp = {};
   for (let k of Object.keys(schema)) {
     if (schema[k].hasOwnProperty('_default')) {
@@ -23,7 +23,7 @@ export function getDefaultsFromConfigSchema(schema) {
       tmp[k] = schema[k];
     }
   }
-  return tmp;
+  return tmp as T;
 }
 
 function isOrdinaryObject(x) {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Previously, attempts to access keys of the return object for `getDefaultsFromConfigSchema` would produce type errors, since it was typed as `{}`.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
