### PR TITLE
(chore) Export styleguide config type from Core

### DIFF
--- a/packages/framework/esm-styleguide/src/public.ts
+++ b/packages/framework/esm-styleguide/src/public.ts
@@ -19,3 +19,4 @@ export * from './patient-photo';
 export * from './custom-overflow-menu';
 export * from './icons/icons';
 export * from './pictograms/pictograms';
+export { type StyleguideConfigObject } from './config-schema';


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This just adds an interface for the Styleguide config schema to the `esm-framework` public API.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
