### PR TITLE
(fix) O3-3353 Workspaces shouldn't lose information when hidden

### DIFF
--- a/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx
@@ -46,13 +46,15 @@ export interface WorkspaceWindowProps {
  * @param props.contextKey The context key (explained above)
  */
 export function WorkspaceWindow({ contextKey, additionalWorkspaceProps }: WorkspaceWindowProps) {
-  const { active, workspaces, workspaceWindowState } = useWorkspaces();
-  const hidden = workspaceWindowState === 'hidden';
+  const { workspaces } = useWorkspaces();
   return (
     <>
-      {workspaces.length && active && !hidden ? (
-        <Workspace workspaceInstance={workspaces[0]} additionalWorkspaceProps={additionalWorkspaceProps} />
-      ) : null}
+      {/* Hide all workspaces but the first one */}
+      {workspaces.map((workspace, i) => (
+        <div key={workspace.name} className={classNames({ [styles.hidden]: i !== 0 })}>
+          <Workspace workspaceInstance={workspace} additionalWorkspaceProps={additionalWorkspaceProps} />
+        </div>
+      ))}
       <WorkspaceNotification contextKey={contextKey} />
     </>
   );
@@ -67,13 +69,14 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
   const layout = useLayoutType();
   const { workspaceWindowState } = useWorkspaces();
   const maximized = workspaceWindowState === 'maximized';
+  const hidden = workspaceWindowState === 'hidden';
 
   // We use the feature name of the app containing the workspace in order to set the extension
   // slot name. We can't use contextKey for this because we don't want the slot name to be
   // different for different patients, but we do want it to be different for different apps.
   const { featureName } = useContext(ComponentContext);
 
-  useBodyScrollLock(!isDesktop(layout));
+  useBodyScrollLock(!hidden && !isDesktop(layout));
 
   const toggleWindowState = useCallback(() => {
     maximized ? updateWorkspaceWindowState('normal') : updateWorkspaceWindowState('maximized');
@@ -97,6 +100,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
     <aside
       className={classNames(styles.container, width === 'narrow' ? styles.narrowWorkspace : styles.widerWorkspace, {
         [styles.maximized]: maximized,
+        [styles.hidden]: hidden,
       })}
     >
       <Header

--- a/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.module.scss
+++ b/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.module.scss
@@ -42,6 +42,10 @@ $container-width: calc(100% - 3rem);
   width: $container-width;
 }
 
+.hidden {
+  display: none;
+}
+
 .loader {
   display: flex;
   background-color: $openmrs-background-grey;

--- a/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.test.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.test.tsx
@@ -59,10 +59,11 @@ describe('WorkspaceWindow', () => {
 
     const hideButton = screen.getByRole('button', { name: 'Hide' });
     await user.click(hideButton);
-    expect(screen.queryByRole('complementary')).not.toBeInTheDocument();
+    expect(screen.queryByRole('complementary')).toHaveClass('hidden');
 
     act(() => launchWorkspace('Clinical Form', { workspaceTitle: 'POC Triage' }));
     expect(await screen.findByRole('complementary')).toBeInTheDocument();
+    expect(screen.queryByRole('complementary')).not.toHaveClass('hidden');
     expect(workspaces.result.current.workspaces.length).toBe(1);
   });
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

In [O3-1421](https://openmrs.atlassian.net/browse/O3-1421), the big workspace refactor, I changed the behavior of workspaces so that they would not be rendered at all when hidden. This was a mistake. Unmounting the workspaces means they lose whatever information was entered. This change makes it so all workspaces are always rendered.

Note that this does not fix [O3-3363 Workspace windows un-hiding themselves](https://openmrs.atlassian.net/browse/O3-3363).


## Screenshots

https://github.com/openmrs/openmrs-esm-core/assets/1031876/a6be0086-9b2e-4077-bbd1-883ac72aac7f



## Related Issue
https://openmrs.atlassian.net/browse/O3-3353

## Other
<!-- Anything not covered above -->


[O3-1421]: https://openmrs.atlassian.net/browse/O3-1421?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ