### PR TITLE
(feat) O3-3266: Optional deps can set feature flags

### DIFF
--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -165,11 +165,11 @@ export function defineConfigSchema(moduleName: string, schema: ConfigSchema) {
   validateConfigSchema(moduleName, schema);
   const enhancedSchema = mergeDeepRight(schema, implicitConfigSchema) as ConfigSchema;
 
-  const state = configInternalStore.getState();
-  configInternalStore.setState({
+  configInternalStore.setState((state) => ({
+    ...state,
     schemas: { ...state.schemas, [moduleName]: enhancedSchema },
     moduleLoaded: { ...state.moduleLoaded, [moduleName]: true },
-  });
+  }));
 }
 
 /**
@@ -239,10 +239,10 @@ export function defineExtensionConfigSchema(extensionName: string, schema: Confi
 }
 
 export function provide(config: Config, sourceName = 'provided') {
-  const state = configInternalStore.getState();
-  configInternalStore.setState({
+  configInternalStore.setState((state) => ({
+    ...state,
     providedConfigs: [...state.providedConfigs, { source: sourceName, config }],
-  });
+  }));
 }
 
 /**

--- a/packages/framework/esm-globals/src/types.ts
+++ b/packages/framework/esm-globals/src/types.ts
@@ -343,7 +343,7 @@ export interface OpenmrsAppRoutes {
           /**
            * The feature flag to enable if this backend dependency is present
            */
-          feature?: string;
+          feature?: FeatureFlagDefinition;
         };
   };
   /**
@@ -362,6 +362,12 @@ export interface OpenmrsAppRoutes {
    * An array of all workspaces supported by this frontend module. Workspaces can be launched by name.
    */
   workspaces?: Array<WorkspaceDefinition>;
+}
+
+export interface FeatureFlagDefinition {
+  flagName: string;
+  label: string;
+  description: string;
 }
 
 /**

--- a/packages/shell/esm-app-shell/src/optionaldeps.ts
+++ b/packages/shell/esm-app-shell/src/optionaldeps.ts
@@ -4,6 +4,7 @@ import {
   registerFeatureFlag,
   setFeatureFlag,
   getCurrentUser,
+  restBaseUrl,
 } from '@openmrs/esm-framework/src/internal';
 import { satisfies } from 'semver';
 
@@ -50,7 +51,7 @@ function setupOptionalDependencies() {
   }, new Map());
 
   if (optionalDependencyFlags.size > 0) {
-    openmrsFetch<{ results: { uuid: string; version: string }[] }>('/ws/rest/v1/module?v=custom:(uuid,version)')
+    openmrsFetch<{ results: { uuid: string; version: string }[] }>(`${restBaseUrl}/module?v=custom:(uuid,version)`)
       .then((response) => {
         (response.data.results ?? []).forEach((backendModule) => {
           if (optionalDependencyFlags.has(backendModule.uuid)) {

--- a/packages/shell/esm-app-shell/src/optionaldeps.ts
+++ b/packages/shell/esm-app-shell/src/optionaldeps.ts
@@ -1,0 +1,72 @@
+import {
+  type FeatureFlagDefinition,
+  openmrsFetch,
+  registerFeatureFlag,
+  setFeatureFlag,
+  getCurrentUser,
+} from '@openmrs/esm-framework/src/internal';
+import { satisfies } from 'semver';
+
+export function registerOptionalDependencyHandler() {
+  const subscription = getCurrentUser().subscribe((session) => {
+    if (session.authenticated) {
+      subscription.unsubscribe();
+      setupOptionalDependencies();
+    }
+  });
+
+  return Promise.resolve();
+}
+
+function setupOptionalDependencies() {
+  const optionalDependencyFlags = window.installedModules.reduce<
+    Map<string, { version: string; feature: FeatureFlagDefinition }>
+  >((curr, module) => {
+    if (module[1]?.optionalBackendDependencies) {
+      Object.entries(module[1].optionalBackendDependencies).forEach((optionalDependency) => {
+        const optionalDependencyDescriptor = optionalDependency[1];
+        if (typeof optionalDependencyDescriptor !== 'string') {
+          if (
+            typeof optionalDependencyDescriptor.feature === 'object' &&
+            optionalDependencyDescriptor.feature &&
+            optionalDependencyDescriptor.feature.flagName?.length > 0 &&
+            optionalDependencyDescriptor.feature.label?.length > 0 &&
+            optionalDependencyDescriptor.feature.description?.length > 0
+          ) {
+            curr.set(optionalDependency[0], {
+              version: optionalDependencyDescriptor.version,
+              feature: optionalDependencyDescriptor.feature,
+            });
+          } else {
+            console.warn(
+              `Feature flag descriptor for ${module[0]} does not match expected type. Feature flags must define a 'flagName', 'label', and 'description'`,
+            );
+          }
+        }
+      });
+    }
+
+    return curr;
+  }, new Map());
+
+  if (optionalDependencyFlags.size > 0) {
+    openmrsFetch<{ results: { uuid: string; version: string }[] }>('/ws/rest/v1/module?v=custom:(uuid,version)')
+      .then((response) => {
+        (response.data.results ?? []).forEach((backendModule) => {
+          if (optionalDependencyFlags.has(backendModule.uuid)) {
+            const optionalDependency = optionalDependencyFlags.get(backendModule.uuid);
+            if (optionalDependency && satisfies(backendModule.version, optionalDependency.version)) {
+              registerFeatureFlag(
+                optionalDependency.feature.flagName,
+                optionalDependency.feature.label,
+                optionalDependency.feature.description,
+              );
+
+              setFeatureFlag(optionalDependency.feature.flagName, true);
+            }
+          }
+        });
+      })
+      .catch(() => {}); // swallow any issues fetching
+  }
+}

--- a/packages/shell/esm-app-shell/src/run.ts
+++ b/packages/shell/esm-app-shell/src/run.ts
@@ -39,6 +39,7 @@ import {
 } from '@openmrs/esm-framework/src/internal';
 import { finishRegisteringAllApps, registerApp, tryRegisterExtension } from './apps';
 import { setupI18n } from './locale';
+import { registerOptionalDependencyHandler } from './optionaldeps';
 import { appName, getCoreExtensions } from './ui';
 
 // @internal
@@ -414,5 +415,6 @@ export function run(configUrls: Array<string>) {
     .then(runShell)
     .catch(handleInitFailure)
     .then(closeLoading)
-    .then(offlineEnabled ? setupOffline : undefined);
+    .then(offlineEnabled ? setupOffline : undefined)
+    .then(registerOptionalDependencyHandler);
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

In #1015 (O3-3266) I wrote:

> I've created space for, but not implemented, a feature that would enable automatically turning a feature flag on if an optional dependency is present.

This PR implements that feature.

## Screenshots
<!-- Required if you are making UI changes. -->

![Proof of life](https://github.com/openmrs/openmrs-esm-core/assets/52504170/ba1f5d3b-b69f-46e8-b686-2286ec7dcb3b)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-3266

## Other
<!-- Anything not covered above -->
