### PR TITLE
(chore) Fix styleguide config access

### DIFF
--- a/packages/framework/esm-styleguide/src/patient-photo/usePatientPhoto.ts
+++ b/packages/framework/esm-styleguide/src/patient-photo/usePatientPhoto.ts
@@ -28,7 +28,10 @@ interface PhotoObs {
 }
 
 export function usePatientPhoto(patientUuid: string): UsePatientPhotoResult {
-  const { patientPhotoConceptUuid } = useConfig<StyleguideConfigObject>();
+  const { patientPhotoConceptUuid } = useConfig<StyleguideConfigObject>({
+    externalModuleName: '@openmrs/esm-styleguide',
+  });
+
   const url = patientPhotoConceptUuid
     ? `${restBaseUrl}/obs?patient=${patientUuid}&concept=${patientPhotoConceptUuid}&v=full`
     : null;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This fixes an issue where the destructured properties in the styleguide config were showing up as `undefined`. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
