### PR TITLE
(fix) Apply geopattern styles to patient avatar conditionally

### DIFF
--- a/packages/framework/esm-styleguide/src/patient-photo/patient-photo.component.tsx
+++ b/packages/framework/esm-styleguide/src/patient-photo/patient-photo.component.tsx
@@ -27,10 +27,14 @@ export function PatientPhoto({ patientUuid, patientName, size }: PatientPhotoPro
       src={photo?.imageSrc}
       size={size === 'small' ? '48' : '80'}
       textSizeRatio={size === 'small' ? 1 : 2}
-      style={{
-        backgroundImage: `url(${patternUrl})`,
-        backgroundRepeat: 'round',
-      }}
+      style={
+        !photo
+          ? {
+              backgroundImage: `url(${patternUrl})`,
+              backgroundRepeat: 'round',
+            }
+          : undefined
+      }
     />
   );
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Follow up to #1029.

This makes it so that the styling for the [Patient Avatar](https://zeroheight.com/23a080e38/p/6663f3-patient-header/t/1911f7) using the [GeoPattern library ](https://btmills.github.io/geopattern/) is only applied when a valid patient photo doesn't exist in the backend.

## Screenshots

> So you won't see the green background behind the avatar:

![CleanShot 2024-06-05 at 12  03 45@2x (1)](https://github.com/openmrs/openmrs-esm-core/assets/8509731/b9c60ddc-f640-4c79-afdc-88da5d6dae3b)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

I'll file a subsequent ticket that implements the various variants of the Patient avatar as described in the design docs [here](https://zeroheight.com/23a080e38/p/6663f3-patient-header/t/1911f7).
