### PR TITLE
(feat) O3-3370: In development mode, import maps should not use absolute URLs

### DIFF
--- a/packages/tooling/openmrs/src/commands/develop.ts
+++ b/packages/tooling/openmrs/src/commands/develop.ts
@@ -47,14 +47,11 @@ export async function runDevelop(args: DevelopArgs) {
     )
     .replace(/href="\/openmrs\/spa/g, `href="${spaPath}`)
     .replace(/src="\/openmrs\/spa/g, `src="${spaPath}`)
-    .replace(
-      /https:\/\/dev3\.openmrs\.org\/openmrs\/spa\/importmap\.json/g,
-      `http://${host}:${port}${spaPath}/importmap.json`,
-    );
+    .replace(/https:\/\/dev3\.openmrs\.org\/openmrs\/spa\/importmap\.json/g, `${spaPath}/importmap.json`);
 
   const sw = resolve(source, 'service-worker.js');
   // remove any full references to dev3.openmrs.org
-  const swContent = readFileSync(sw, 'utf-8').replace(/https:\/\/dev3\.openmrs\.org\/openmrs\/spa\//g, ``);
+  const swContent = readFileSync(sw, 'utf-8').replace(/https:\/\/dev3\.openmrs\.org\/openmrs\/spa\//g, `${spaPath}`);
 
   const pageUrl = `http://${host}:${port}${spaPath}`;
 

--- a/packages/tooling/openmrs/src/utils/importmap.ts
+++ b/packages/tooling/openmrs/src/utils/importmap.ts
@@ -397,7 +397,7 @@ export function proxyImportmapAndRoutes(
   Object.keys(importmap.imports).forEach((key) => {
     const url = importmap.imports[key];
     if (url.startsWith(backend)) {
-      importmap.imports[key] = url.replace(backend, `http://${host}:${port}`);
+      importmap.imports[key] = url.replace(backend, '');
     }
   });
   importMapDecl.value = JSON.stringify(importmap);


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

When running the `openmrs develop` command, the full URL for both the import map and the scripts referenced in the map. this works if you are accessing the development server locally, but it fails with tools like GitPod, which host the development server through their own reverse proxies. This PR changes things so that we just use relative paths instead of absolute URLs, which should solve the issue without affecting local devs.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-3370

## Other
<!-- Anything not covered above -->
