### PR TITLE
(fix) Rename some patient name utility functions

### DIFF
--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -100,8 +100,8 @@ export {
   formatDate,
   formatDatetime,
   formatTime,
-  displayName,
-  formattedName,
+  getPatientName,
+  formatPatientName,
   selectPreferredName,
 } from '@openmrs/esm-utils';
 

--- a/packages/framework/esm-utils/src/patient-helpers.test.ts
+++ b/packages/framework/esm-utils/src/patient-helpers.test.ts
@@ -1,4 +1,4 @@
-import { displayName, formattedName, selectPreferredName } from './patient-helpers';
+import { formatPatientName, getPatientName, selectPreferredName } from './patient-helpers';
 import {
   mockPatientWithNoName,
   mockPatientWithOfficialName,
@@ -19,7 +19,7 @@ describe('Formatted display name', () => {
     [givenNameOnly, 'given'],
     [mockPatientWithNoName, ''],
   ])('Is formatted name text if present else default name format', (name, expected) => {
-    const result = formattedName(name);
+    const result = formatPatientName(name);
     expect(result).toBe(expected);
   });
 });
@@ -30,7 +30,7 @@ describe('Patient display name', () => {
     [mockPatientWithOfficialName, 'my actual name'],
     [mockPatientWithNickAndOfficialName, 'my official name'],
   ])('Is selected from usual name or official name', (patient, expected) => {
-    const result = displayName(patient);
+    const result = getPatientName(patient);
     expect(result).toBe(expected);
   });
 });

--- a/packages/framework/esm-utils/src/patient-helpers.ts
+++ b/packages/framework/esm-utils/src/patient-helpers.ts
@@ -11,9 +11,14 @@ import { type NameUse } from '@openmrs/esm-globals';
  * @param patient The patient details in FHIR format.
  * @returns The patient's display name or an empty string if name is not present.
  */
-export function displayName(patient: fhir.Patient): string {
+export function getPatientName(patient: fhir.Patient): string {
   const name = selectPreferredName(patient, 'usual', 'official');
-  return formattedName(name);
+  return formatPatientName(name);
+}
+
+/** @deprecated Use `getPatientName` */
+export function displayName(patient: fhir.Patient): string {
+  return getPatientName(patient);
 }
 
 /**
@@ -21,9 +26,14 @@ export function displayName(patient: fhir.Patient): string {
  * @param name The name to be formatted.
  * @returns The formatted display name or an empty string if name is undefined.
  */
-export function formattedName(name: fhir.HumanName | undefined): string {
+export function formatPatientName(name: fhir.HumanName | undefined): string {
   if (name) return name.text ?? defaultFormat(name);
   return '';
+}
+
+/** @deprecated Use `formatPatientName` */
+export function formattedName(name: fhir.HumanName | undefined): string {
+  return formatPatientName(name);
 }
 
 /**


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

The current names are very generic. `displayName`, the display name of what? It would make sense in a language that supported function overloading, but not ECMAScript.

If others think that the current names are fine or preferable, feel free to close this PR. But this is just my feeling about it.

I have deprecated the original names and removed them from the mock. This is somewhat aggressive, as it will cause tests to fail until the names are updated (but the actual app will continue working).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
