### PR TITLE
(fix) Restore PasswordInput value prop

### DIFF
--- a/packages/apps/esm-login-app/src/login/login.component.tsx
+++ b/packages/apps/esm-login-app/src/login/login.component.tsx
@@ -233,7 +233,8 @@ const Login: React.FC = () => {
                   onChange={changePassword}
                   ref={passwordInputRef}
                   required
-                  showPasswordLabel="Show password"
+                  showPasswordLabel={t('showPassword', 'Show password')}
+                  value={password}
                 />
                 {/* For password managers */}
                 {showPasswordOnSeparateScreen && (
@@ -282,7 +283,11 @@ const Login: React.FC = () => {
 const Logo: React.FC<{ t: TFunction }> = ({ t }) => {
   const { logo } = useConfig<ConfigSchema>();
   return logo.src ? (
-    <img alt={logo.alt ? t(logo.alt) :  t('openmrsLogo', 'OpenMRS logo')} className={styles.logoImg} src={interpolateUrl(logo.src)} />
+    <img
+      alt={logo.alt ? t(logo.alt) : t('openmrsLogo', 'OpenMRS logo')}
+      className={styles.logoImg}
+      src={interpolateUrl(logo.src)}
+    />
   ) : (
     <svg role="img" className={styles.logo}>
       <title>{t('openmrsLogo', 'OpenMRS logo')}</title>

--- a/packages/apps/esm-login-app/translations/en.json
+++ b/packages/apps/esm-login-app/translations/en.json
@@ -21,6 +21,7 @@
   "rememberLocationForFutureLogins": "Remember my location for future logins",
   "searchForLocation": "Search for a location",
   "selectYourLocation": "Select your location from the list below. Use the search bar to find your location.",
+  "showPassword": "Show password",
   "submitting": "Submitting",
   "tryAgain": "Try again",
   "username": "Username",


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Restores the `value` prop of the `PasswordInput` component in the `Login` page to fix an issue @brandones reported [here](https://github.com/openmrs/openmrs-esm-core/pull/1036#issuecomment-2160934389).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
