### PR TITLE
(fix) Replace deprecated substr() with slice() for string operations

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -180,6 +180,7 @@
 
 ### Other Functions
 
+- [WorkspaceContainer](API.md#workspacecontainer)
 - [isOnline](API.md#isonline)
 
 ### Store Functions
@@ -5295,6 +5296,64 @@ ___
 
 ## Other Functions
 
+### WorkspaceContainer
+
+▸ **WorkspaceContainer**(`__namedParameters`): `Element`
+
+Use this component to render the [workspace window](https://zeroheight.com/23a080e38/p/483a22-workspace)
+in an app such as the patient chart, or a workspace overlay in an app such as the clinic dashboard.
+This allows workspaces to be opened on the page where this component is mounted. This component
+must not be mounted multiple times on the same page. If there are multiple apps on a page, only
+one of those apps should use this component—it "hosts" the workspaces.
+
+Workspaces may be opened with the [launchWorkspace](API.md#launchworkspace) function from `@openmrs/esm-framework`
+(among other options).
+
+The `overlay` prop determines whether the workspace is rendered as an overlay or a window.
+When a workspace window is opened, the other content on the screen will be pushed to the left.
+When an overlay is opened, it will cover other content on the screen.
+
+The context key is a string that appears in the URL, which defines the pages on which workspaces
+are valid. If the URL changes in a way such that it no longer contains the context key, then
+all workspaces will be closed. This ensures that, for example, workspaces on the home page do
+not stay open when the user transitions to the patient dashboard; and also that workspaces do
+not stay open when the user navigates to a different patient. The context key must be a valid
+sub-path of the URL, with no initial or trailing slash. So if the URL is
+`https://example.com/patient/123/foo`, then `patient` and `patient/123` and `123/foo` are valid
+context keys, but `patient/12` and `pati` are not.
+
+An extension slot is provided in the workspace header. Its name is derived from the `featureName` of
+the top-level component in which it is defined (feature names are generally provided in the lifecycle
+functions in an app's `index.ts` file). The slot is named `workspace-header-${featureName}-slot`.
+For the patient chart, this is `workspace-header-patient-chart-slot`.
+
+This component also provides the [Siderail and Bottom Nav](https://zeroheight.com/23a080e38/p/948cf1-siderail-and-bottom-nav/b/86907e).
+To use this, pass the `showSiderailAndBottomNav` prop. The Siderail is rendered on the right side of the screen
+on desktop, and the Bottom Nav is rendered at the bottom of the screen on tablet or mobile. The sidebar/bottom-nav
+menu provides an extension slot, to which buttons are attached as extensions. The slot
+derives its name from the `featureName` of the top-level component in which this `WorkspaceContainer`
+appears (feature names are generally provided in the lifecycle functions in an app's `index.ts` file).
+The slot is named `action-menu-${featureName}-items-slot`. For the patient chart, this is
+`action-menu-patient-chart-items-slot`.
+
+This component also provides everything needed for workspace notifications to be rendered.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `__namedParameters` | [`WorkspaceContainerProps`](interfaces/WorkspaceContainerProps.md) |
+
+#### Returns
+
+`Element`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:59](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L59)
+
+___
+
 ### isOnline
 
 ▸ **isOnline**(`online?`): `boolean`
@@ -6716,25 +6775,17 @@ ___
 
 ### ActionMenu
 
-▸ **ActionMenu**(): ``null`` \| `Element`
+▸ **ActionMenu**(): `Element`
 
-This renders the [Siderail and Bottom Nav](https://zeroheight.com/23a080e38/p/948cf1-siderail-and-bottom-nav/b/86907e),
-collectively known as the Action Menu. The Siderail is rendered on the right side of the screen
-on desktop, and the Bottom Nav is rendered at the bottom of the screen on tablet or mobile.
-
-The action menu provides an extension slot, to which buttons are attached as extensions. The slot
-derives its name from the `featureName` of the top-level component in which this `ActionMenu`
-appears (feature names are generally provided in the lifecycle functions in an app's `index.ts` file).
-The slot is named `action-menu-${featureName}-items-slot`. For the patient chart, this is
-`action-menu-patient-chart-items-slot`.
+**`deprecated`** Use `WorkspaceContainer` instead
 
 #### Returns
 
-``null`` \| `Element`
+`Element`
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/action-menu/action-menu.component.tsx:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/action-menu/action-menu.component.tsx#L19)
+[packages/framework/esm-styleguide/src/workspaces/container/action-menu.component.tsx:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/action-menu.component.tsx#L10)
 
 ___
 
@@ -6742,28 +6793,7 @@ ___
 
 ▸ **WorkspaceOverlay**(`__namedParameters`): `Element`
 
-Use this component to render the workspace window as an overlay in an app. An overlay is
-a way of rendering workspaces that will cover other content on the screen, rather than
-pushing it to the left (as with [WorkspaceWindow](API.md#workspacewindow)). As described in the
-[ZeroHeight](https://zeroheight.com/23a080e38/p/483a22-workspace/t/34e1a1) documentation,
-this should be used on "app pages" such as the Clinic Dashboard.
-
-The context key is a string that appears in the URL, which defines the pages on which workspaces
-are valid. If the URL changes in a way such that it no longer contains the context key, then
-all workspaces will be closed. This ensures that, for example, workspaces on the home page do
-not stay open when the user transitions to the patient dashboard; and also that workspaces do
-not stay open when the user navigates to a different patient. The context key must be a valid
-sub-path of the URL, with no initial or trailing slash. So if the URL is
-`https://example.com/patient/123/foo`, then `patient` and `patient/123` and `123/foo` are valid
-context keys, but `patient/12` and `pati` are not.
-
-Workspaces may be opened with the [launchWorkspace](API.md#launchworkspace) function from `@openmrs/esm-framework`
-(among other options).
-
-This component also provides everything needed for workspace notifications to be rendered.
-
-This component does not include the action menu (the right siderail). The [ActionMenu](API.md#actionmenu) component
-is provided separately.
+**`deprecated`** Use `WorkspaceContainer` instead
 
 #### Parameters
 
@@ -6777,7 +6807,7 @@ is provided separately.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx#L45)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-overlay.component.tsx:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-overlay.component.tsx#L21)
 
 ___
 
@@ -6785,31 +6815,7 @@ ___
 
 ▸ **WorkspaceWindow**(`__namedParameters`): `Element`
 
-Use this component to render the [workspace window](https://zeroheight.com/23a080e38/p/483a22-workspace)
-in an app such as the patient chart.
-When a workspace is opened, the other content on the screen will be pushed to the left.
-
-The context key is a string that appears in the URL, which defines the pages on which workspaces
-are valid. If the URL changes in a way such that it no longer contains the context key, then
-all workspaces will be closed. This ensures that, for example, workspaces on the home page do
-not stay open when the user transitions to the patient dashboard; and also that workspaces do
-not stay open when the user navigates to a different patient. The context key must be a valid
-sub-path of the URL, with no initial or trailing slash. So if the URL is
-`https://example.com/patient/123/foo`, then `patient` and `patient/123` and `123/foo` are valid
-context keys, but `patient/12` and `pati` are not.
-
-Workspaces may be opened with the [launchWorkspace](API.md#launchworkspace) function from `@openmrs/esm-framework`
-(among other options).
-
-This component also provides everything needed for workspace notifications to be rendered.
-
-This component does not include the action menu (the right siderail). The [ActionMenu](API.md#actionmenu) component
-is provided separately.
-
-An extension slot is provided in the workspace header. Its name is derived from the `featureName` of
-the top-level component in which it is defined (feature names are generally provided in the lifecycle
-functions in an app's `index.ts` file). The slot is named `workspace-header-${featureName}-slot`.
-For the patient chart, this is `workspace-header-patient-chart-slot`.
+**`deprecated`** Use `WorkspaceContainer` instead
 
 #### Parameters
 
@@ -6823,7 +6829,7 @@ For the patient chart, this is `workspace-header-patient-chart-slot`.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx#L48)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-window.component.tsx:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-window.component.tsx#L22)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceContainerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceContainerProps.md
@@ -1,0 +1,52 @@
+[@openmrs/esm-framework](../API.md) / WorkspaceContainerProps
+
+# Interface: WorkspaceContainerProps
+
+## Table of contents
+
+### Properties
+
+- [additionalWorkspaceProps](WorkspaceContainerProps.md#additionalworkspaceprops)
+- [contextKey](WorkspaceContainerProps.md#contextkey)
+- [overlay](WorkspaceContainerProps.md#overlay)
+- [showSiderailAndBottomNav](WorkspaceContainerProps.md#showsiderailandbottomnav)
+
+## Properties
+
+### additionalWorkspaceProps
+
+• `Optional` **additionalWorkspaceProps**: `object`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:11](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L11)
+
+___
+
+### contextKey
+
+• **contextKey**: `string`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L8)
+
+___
+
+### overlay
+
+• `Optional` **overlay**: `boolean`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:9](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L9)
+
+___
+
+### showSiderailAndBottomNav
+
+• `Optional` **showSiderailAndBottomNav**: `boolean`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L10)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceOverlayProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceOverlayProps.md
@@ -6,9 +6,20 @@
 
 ### Workspace Properties
 
+- [additionalWorkspaceProps](WorkspaceOverlayProps.md#additionalworkspaceprops)
 - [contextKey](WorkspaceOverlayProps.md#contextkey)
 
 ## Workspace Properties
+
+### additionalWorkspaceProps
+
+• `Optional` **additionalWorkspaceProps**: `object`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-overlay.component.tsx:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-overlay.component.tsx#L15)
+
+___
 
 ### contextKey
 
@@ -16,4 +27,4 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/overlay/workspace-overlay.component.tsx#L16)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-overlay.component.tsx:14](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-overlay.component.tsx#L14)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceWindowProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceWindowProps.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx#L16)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-window.component.tsx:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-window.component.tsx#L16)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/window/workspace-window.component.tsx#L15)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-window.component.tsx:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-window.component.tsx#L15)

--- a/packages/shell/esm-app-shell/tools/helpers.js
+++ b/packages/shell/esm-app-shell/tools/helpers.js
@@ -6,7 +6,7 @@
  */
 exports.removeTrailingSlash = (path) => {
   const i = path.length - 1;
-  return path[i] === '/' ? exports.removeTrailingSlash(path.substr(0, i)) : path;
+  return path[i] === '/' ? exports.removeTrailingSlash(path.slice(0, i)) : path;
 };
 
 /**

--- a/packages/tooling/openmrs/src/utils/helpers.ts
+++ b/packages/tooling/openmrs/src/utils/helpers.ts
@@ -1,19 +1,19 @@
-import { createHash } from 'crypto';
+import { util } from 'webpack';
 
-export function trimEnd(text: string, chr: string): string {
+export function trimEnd(text: string, chr: string) {
   while (text.endsWith(chr)) {
     text = text.slice(0, text.length - chr.length);
   }
   return text;
 }
 
-export function removeTrailingSlash(path: string): string {
+export function removeTrailingSlash(path: string) {
   const i = path.length - 1;
   return path[i] === '/' ? removeTrailingSlash(path.slice(0, i)) : path;
 }
 
-export function contentHash(obj: object): string {
-  const hash = createHash('xxhash64');
-  hash.update(JSON.stringify(obj), 'utf-8');
-  return hash.digest('hex');
+export function contentHash(obj: object) {
+  const hash = util.createHash('xxhash64');
+  hash.update(JSON.stringify(obj), 'UTF-8');
+  return hash.digest().toString('hex');
 }

--- a/packages/tooling/openmrs/src/utils/helpers.ts
+++ b/packages/tooling/openmrs/src/utils/helpers.ts
@@ -1,20 +1,19 @@
-import { util } from 'webpack';
+import { createHash } from 'crypto';
 
-export function trimEnd(text: string, chr: string) {
+export function trimEnd(text: string, chr: string): string {
   while (text.endsWith(chr)) {
-    text = text.substr(0, text.length - chr.length);
+    text = text.slice(0, text.length - chr.length);
   }
-
   return text;
 }
 
-export function removeTrailingSlash(path: string) {
+export function removeTrailingSlash(path: string): string {
   const i = path.length - 1;
-  return path[i] === '/' ? removeTrailingSlash(path.substr(0, i)) : path;
+  return path[i] === '/' ? removeTrailingSlash(path.slice(0, i)) : path;
 }
 
-export function contentHash(obj: object) {
-  const hash = util.createHash('xxhash64');
-  hash.update(JSON.stringify(obj), 'UTF-8');
-  return hash.digest().toString('hex');
+export function contentHash(obj: object): string {
+  const hash = createHash('xxhash64');
+  hash.update(JSON.stringify(obj), 'utf-8');
+  return hash.digest('hex');
 }

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -336,7 +336,6 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
       alias: {
         '@openmrs/esm-framework': '@openmrs/esm-framework/src/internal',
         'lodash.findlast': 'lodash-es/findLast',
-        'react-dom$': 'react-dom/profiling',
       },
     },
     ...overrides,

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -36,23 +36,23 @@
  * Telling Webpack to use `/a/b/c`? If the Webpack config is symlinked
  * from `/d/e/`, then it *might* in *some cases* try to import `/d/e/c`.
  */
-import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
-import { resolve, dirname, basename } from 'path';
+import { existsSync, statSync } from 'fs';
+import { basename, dirname, resolve } from 'path';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
+import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
+// eslint-disable-next-line no-restricted-imports
+import { isArray, merge, mergeWith } from 'lodash';
+import { inc } from 'semver';
 import {
-  DefinePlugin,
   container,
+  DefinePlugin,
   type ModuleOptions,
-  type WebpackOptionsNormalized as WebpackConfiguration,
   type RuleSetRule,
+  type WebpackOptionsNormalized as WebpackConfiguration,
 } from 'webpack';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import { StatsWriterPlugin } from 'webpack-stats-plugin';
-// eslint-disable-next-line no-restricted-imports
-import { merge, mergeWith, isArray } from 'lodash';
-import { existsSync, statSync } from 'fs';
-import { inc } from 'semver';
 
 type OpenmrsWebpackConfig = Omit<Partial<WebpackConfiguration>, 'module'> & {
   module: ModuleOptions;
@@ -70,15 +70,13 @@ function getFrameworkVersion() {
   }
 }
 
-function makeIdent(name: string) {
-  if (name.indexOf('/') !== -1) {
-    name = name.substr(name.indexOf('/'));
+function makeIdent(name: string): string {
+  if (name.includes('/')) {
+    name = name.slice(name.indexOf('/'));
   }
-
   if (name.endsWith('-app')) {
-    name = name.substr(0, name.length - 4);
+    name = name.slice(0, -4);
   }
-
   return name;
 }
 
@@ -338,6 +336,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
       alias: {
         '@openmrs/esm-framework': '@openmrs/esm-framework/src/internal',
         'lodash.findlast': 'lodash-es/findLast',
+        'react-dom$': 'react-dom/profiling',
       },
     },
     ...overrides,


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR replaces usages of the deprecated [String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) method with [String.prototype.slice](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice). 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
