### PR TITLE
(fix) O3-3401: Use optional chaining to safely unsubscribe from getCurrentUser observable

### DIFF
--- a/packages/shell/esm-app-shell/src/optionaldeps.ts
+++ b/packages/shell/esm-app-shell/src/optionaldeps.ts
@@ -11,7 +11,7 @@ import { satisfies } from 'semver';
 export function registerOptionalDependencyHandler() {
   const subscription = getCurrentUser().subscribe((session) => {
     if (session.authenticated) {
-      subscription.unsubscribe();
+      subscription?.unsubscribe();
       setupOptionalDependencies();
     }
   });


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR brings the fix for the error being thrown in case the `getCurrentUser` was observable was unsubscribed more than once.

## Screenshots
None

## Related Issue

https://issues.openmrs.org/browse/O3-3401

## Other
<!-- Anything not covered above -->
