### PR TITLE
(feat) O3-1991: Enhancements and fixes for OMRS date picker

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -530,7 +530,7 @@ A type for any of the acceptable date formats
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L37)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L49)
 
 ___
 
@@ -1472,7 +1472,7 @@ A date picker component to select a single date. Based on React Aria, but styled
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:172](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L172)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:230](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L230)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1472,7 +1472,7 @@ A date picker component to select a single date. Based on React Aria, but styled
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:177](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L177)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:172](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L172)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -395,6 +395,7 @@ ___
 | `mode` | [`FormatDateMode`](API.md#formatdatemode) | - `standard`: "03 Feb 2022" - `wide`:     "03 — Feb — 2022" |
 | `month` | `boolean` | Whether to include the month number |
 | `noToday` | `boolean` | Disables the special handling of dates that are today. If false (the default), then dates that are today will be formatted as "Today" in the locale language. If true, then dates that are today will be formatted the same as all other dates. |
+| `numberingSystem?` | `string` | The unicode numbering system to use |
 | `time` | `boolean` \| ``"for today"`` | Whether the time should be included in the output always (`true`), never (`false`), or only when the input date is today (`for today`). |
 | `year` | `boolean` | Whether to include the year |
 
@@ -530,7 +531,7 @@ A type for any of the acceptable date formats
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L49)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L48)
 
 ___
 
@@ -1472,7 +1473,7 @@ A date picker component to select a single date. Based on React Aria, but styled
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:230](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L230)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:260](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L260)
 
 ___
 
@@ -3251,7 +3252,7 @@ CalendarDate
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:395](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L395)
+[packages/framework/esm-utils/src/omrs-dates.ts:398](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L398)
 
 ___
 
@@ -3290,7 +3291,7 @@ locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:270](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L270)
+[packages/framework/esm-utils/src/omrs-dates.ts:272](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L272)
 
 ___
 
@@ -3319,7 +3320,7 @@ output of `Date.prototype.toLocaleString` for *most* locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:372](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L372)
+[packages/framework/esm-utils/src/omrs-dates.ts:375](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L375)
 
 ___
 
@@ -3342,7 +3343,7 @@ Formats the input as a time, according to the current locale.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:356](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L356)
+[packages/framework/esm-utils/src/omrs-dates.ts:359](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L359)
 
 ___
 
@@ -3364,7 +3365,7 @@ Retrieves the default calendar for the specified locale if any.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:244](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L244)
+[packages/framework/esm-utils/src/omrs-dates.ts:246](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L246)
 
 ___
 
@@ -3382,7 +3383,7 @@ string
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:380](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L380)
+[packages/framework/esm-utils/src/omrs-dates.ts:383](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L383)
 
 ___
 
@@ -3476,7 +3477,7 @@ registerDefaultCalendar('en', 'buddhist') // sets the default calendar for the '
 
 #### Defined in
 
-[packages/framework/esm-utils/src/omrs-dates.ts:235](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L235)
+[packages/framework/esm-utils/src/omrs-dates.ts:237](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/omrs-dates.ts#L237)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
@@ -33,6 +33,7 @@ Properties for the OpenmrsDatePicker
 - [isReadOnly](OpenmrsDatePickerProps.md#isreadonly)
 - [isRequired](OpenmrsDatePickerProps.md#isrequired)
 - [label](OpenmrsDatePickerProps.md#label)
+- [labelText](OpenmrsDatePickerProps.md#labeltext)
 - [light](OpenmrsDatePickerProps.md#light)
 - [maxDate](OpenmrsDatePickerProps.md#maxdate)
 - [maxValue](OpenmrsDatePickerProps.md#maxvalue)
@@ -168,7 +169,7 @@ Any CSS classes to add to the outer div of the date picker
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L69)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:68](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L68)
 
 ___
 
@@ -196,7 +197,7 @@ The default value (uncontrolled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:73](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L73)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:72](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L72)
 
 ___
 
@@ -348,13 +349,27 @@ ___
 
 ### label
 
-• `Optional` **label**: `string`
+• `Optional` **label**: `string` \| `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>
+
+The label for this DatePicker element
+
+**`deprecated`** Use labelText instead
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:77](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L77)
+
+___
+
+### labelText
+
+• `Optional` **labelText**: `string` \| `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>
 
 The label for this DatePicker element
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:77](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L77)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L81)
 
 ___
 
@@ -366,7 +381,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L81)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:85](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L85)
 
 ___
 
@@ -378,7 +393,7 @@ The latest date it is possible to select
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:85](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L85)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L89)
 
 ___
 
@@ -406,7 +421,7 @@ The earliest date it is possible to select
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L89)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L93)
 
 ___
 
@@ -484,7 +499,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:97](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L97)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:101](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L101)
 
 ___
 
@@ -531,7 +546,7 @@ Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` a
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L93)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:97](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L97)
 
 ___
 
@@ -596,7 +611,7 @@ The value (controlled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:101](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L101)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:105](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L105)
 
 ## Methods
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
@@ -2,26 +2,163 @@
 
 # Interface: OpenmrsDatePickerProps
 
+Properties for the OpenmrsDatePicker
+
+## Hierarchy
+
+- `Omit`<`DatePickerProps`<`CalendarDate`\>, ``"className"`` \| ``"defaultValue"`` \| ``"value"``\>
+
+  ↳ **`OpenmrsDatePickerProps`**
+
 ## Table of contents
 
 ### Properties
 
+- [aria-describedby](OpenmrsDatePickerProps.md#aria-describedby)
+- [aria-details](OpenmrsDatePickerProps.md#aria-details)
+- [aria-label](OpenmrsDatePickerProps.md#aria-label)
+- [aria-labelledby](OpenmrsDatePickerProps.md#aria-labelledby)
+- [autoFocus](OpenmrsDatePickerProps.md#autofocus)
+- [children](OpenmrsDatePickerProps.md#children)
 - [className](OpenmrsDatePickerProps.md#classname)
+- [defaultOpen](OpenmrsDatePickerProps.md#defaultopen)
 - [defaultValue](OpenmrsDatePickerProps.md#defaultvalue)
+- [granularity](OpenmrsDatePickerProps.md#granularity)
+- [hideTimeZone](OpenmrsDatePickerProps.md#hidetimezone)
+- [hourCycle](OpenmrsDatePickerProps.md#hourcycle)
+- [id](OpenmrsDatePickerProps.md#id)
+- [isDisabled](OpenmrsDatePickerProps.md#isdisabled)
+- [isInvalid](OpenmrsDatePickerProps.md#isinvalid)
+- [isOpen](OpenmrsDatePickerProps.md#isopen)
+- [isReadOnly](OpenmrsDatePickerProps.md#isreadonly)
+- [isRequired](OpenmrsDatePickerProps.md#isrequired)
 - [label](OpenmrsDatePickerProps.md#label)
 - [light](OpenmrsDatePickerProps.md#light)
 - [maxDate](OpenmrsDatePickerProps.md#maxdate)
+- [maxValue](OpenmrsDatePickerProps.md#maxvalue)
 - [minDate](OpenmrsDatePickerProps.md#mindate)
+- [minValue](OpenmrsDatePickerProps.md#minvalue)
+- [name](OpenmrsDatePickerProps.md#name)
+- [pageBehavior](OpenmrsDatePickerProps.md#pagebehavior)
+- [placeholderValue](OpenmrsDatePickerProps.md#placeholdervalue)
 - [short](OpenmrsDatePickerProps.md#short)
+- [shouldCloseOnSelect](OpenmrsDatePickerProps.md#shouldcloseonselect)
+- [shouldForceLeadingZeros](OpenmrsDatePickerProps.md#shouldforceleadingzeros)
 - [size](OpenmrsDatePickerProps.md#size)
+- [slot](OpenmrsDatePickerProps.md#slot)
+- [style](OpenmrsDatePickerProps.md#style)
+- [validationBehavior](OpenmrsDatePickerProps.md#validationbehavior)
 - [value](OpenmrsDatePickerProps.md#value)
 
 ### Methods
 
 - [isDateUnavailable](OpenmrsDatePickerProps.md#isdateunavailable)
+- [onBlur](OpenmrsDatePickerProps.md#onblur)
 - [onChange](OpenmrsDatePickerProps.md#onchange)
+- [onFocus](OpenmrsDatePickerProps.md#onfocus)
+- [onFocusChange](OpenmrsDatePickerProps.md#onfocuschange)
+- [onKeyDown](OpenmrsDatePickerProps.md#onkeydown)
+- [onKeyUp](OpenmrsDatePickerProps.md#onkeyup)
+- [onOpenChange](OpenmrsDatePickerProps.md#onopenchange)
+- [validate](OpenmrsDatePickerProps.md#validate)
 
 ## Properties
+
+### aria-describedby
+
+• `Optional` **aria-describedby**: `string`
+
+Identifies the element (or elements) that describes the object.
+
+#### Inherited from
+
+Omit.aria-describedby
+
+#### Defined in
+
+node_modules/@react-types/shared/src/dom.d.ts:40
+
+___
+
+### aria-details
+
+• `Optional` **aria-details**: `string`
+
+Identifies the element (or elements) that provide a detailed, extended description for the object.
+
+#### Inherited from
+
+Omit.aria-details
+
+#### Defined in
+
+node_modules/@react-types/shared/src/dom.d.ts:45
+
+___
+
+### aria-label
+
+• `Optional` **aria-label**: `string`
+
+Defines a string value that labels the current element.
+
+#### Inherited from
+
+Omit.aria-label
+
+#### Defined in
+
+node_modules/@react-types/shared/src/dom.d.ts:30
+
+___
+
+### aria-labelledby
+
+• `Optional` **aria-labelledby**: `string`
+
+Identifies the element (or elements) that labels the current element.
+
+#### Inherited from
+
+Omit.aria-labelledby
+
+#### Defined in
+
+node_modules/@react-types/shared/src/dom.d.ts:35
+
+___
+
+### autoFocus
+
+• `Optional` **autoFocus**: `boolean`
+
+Whether the element should receive focus on render.
+
+#### Inherited from
+
+Omit.autoFocus
+
+#### Defined in
+
+node_modules/@react-types/shared/src/events.d.ts:116
+
+___
+
+### children
+
+• `Optional` **children**: `ReactNode` \| (`values`: `DatePickerRenderProps` & { `defaultChildren`: `ReactNode`  }) => `ReactNode`
+
+The children of the component. A function may be provided to alter the children based on component state.
+
+#### Inherited from
+
+Omit.children
+
+#### Defined in
+
+node_modules/react-aria-components/dist/types.d.ts:54
+
+___
 
 ### className
 
@@ -31,7 +168,23 @@ Any CSS classes to add to the outer div of the date picker
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:52](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L52)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:57](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L57)
+
+___
+
+### defaultOpen
+
+• `Optional` **defaultOpen**: `boolean`
+
+Whether the overlay is open by default (uncontrolled).
+
+#### Inherited from
+
+Omit.defaultOpen
+
+#### Defined in
+
+node_modules/@react-types/overlays/src/index.d.ts:112
 
 ___
 
@@ -43,7 +196,153 @@ The default value (uncontrolled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:56](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L56)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:61](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L61)
+
+___
+
+### granularity
+
+• `Optional` **granularity**: `Granularity`
+
+Determines the smallest unit that is displayed in the date picker. By default, this is `"day"` for dates, and `"minute"` for times.
+
+#### Inherited from
+
+Omit.granularity
+
+#### Defined in
+
+node_modules/@react-types/datepicker/src/index.d.ts:52
+
+___
+
+### hideTimeZone
+
+• `Optional` **hideTimeZone**: `boolean`
+
+Whether to hide the time zone abbreviation.
+
+**`default`** false
+
+#### Inherited from
+
+Omit.hideTimeZone
+
+#### Defined in
+
+node_modules/@react-types/datepicker/src/index.d.ts:57
+
+___
+
+### hourCycle
+
+• `Optional` **hourCycle**: ``12`` \| ``24``
+
+Whether to display the time in 12 or 24 hour format. By default, this is determined by the user's locale.
+
+#### Inherited from
+
+Omit.hourCycle
+
+#### Defined in
+
+node_modules/@react-types/datepicker/src/index.d.ts:50
+
+___
+
+### id
+
+• `Optional` **id**: `string`
+
+The element's unique identifier. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id).
+
+#### Inherited from
+
+Omit.id
+
+#### Defined in
+
+node_modules/@react-types/shared/src/dom.d.ts:62
+
+___
+
+### isDisabled
+
+• `Optional` **isDisabled**: `boolean`
+
+Whether the input is disabled.
+
+#### Inherited from
+
+Omit.isDisabled
+
+#### Defined in
+
+node_modules/@react-types/shared/src/inputs.d.ts:60
+
+___
+
+### isInvalid
+
+• `Optional` **isInvalid**: `boolean`
+
+Whether the input value is invalid.
+
+#### Inherited from
+
+Omit.isInvalid
+
+#### Defined in
+
+node_modules/@react-types/shared/src/inputs.d.ts:25
+
+___
+
+### isOpen
+
+• `Optional` **isOpen**: `boolean`
+
+Whether the overlay is open by default (controlled).
+
+#### Inherited from
+
+Omit.isOpen
+
+#### Defined in
+
+node_modules/@react-types/overlays/src/index.d.ts:110
+
+___
+
+### isReadOnly
+
+• `Optional` **isReadOnly**: `boolean`
+
+Whether the input can be selected but not changed by the user.
+
+#### Inherited from
+
+Omit.isReadOnly
+
+#### Defined in
+
+node_modules/@react-types/shared/src/inputs.d.ts:62
+
+___
+
+### isRequired
+
+• `Optional` **isRequired**: `boolean`
+
+Whether user input is required on the input before form submission.
+
+#### Inherited from
+
+Omit.isRequired
+
+#### Defined in
+
+node_modules/@react-types/shared/src/inputs.d.ts:23
 
 ___
 
@@ -83,6 +382,22 @@ The latest date it is possible to select
 
 ___
 
+### maxValue
+
+• `Optional` **maxValue**: `DateValue`
+
+The maximum allowed date that a user may select.
+
+#### Inherited from
+
+Omit.maxValue
+
+#### Defined in
+
+node_modules/@react-types/datepicker/src/index.d.ts:44
+
+___
+
 ### minDate
 
 • `Optional` **minDate**: [`DateInputValue`](../API.md#dateinputvalue)
@@ -95,6 +410,72 @@ The earliest date it is possible to select
 
 ___
 
+### minValue
+
+• `Optional` **minValue**: `DateValue`
+
+The minimum allowed date that a user may select.
+
+#### Inherited from
+
+Omit.minValue
+
+#### Defined in
+
+node_modules/@react-types/datepicker/src/index.d.ts:42
+
+___
+
+### name
+
+• `Optional` **name**: `string`
+
+The name of the input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
+
+#### Inherited from
+
+Omit.name
+
+#### Defined in
+
+node_modules/@react-types/shared/src/dom.d.ts:130
+
+___
+
+### pageBehavior
+
+• `Optional` **pageBehavior**: `PageBehavior`
+
+Controls the behavior of paging. Pagination either works by advancing the visible page by visibleDuration (default) or one unit of visibleDuration.
+
+**`default`** visible
+
+#### Inherited from
+
+Omit.pageBehavior
+
+#### Defined in
+
+node_modules/@react-types/datepicker/src/index.d.ts:74
+
+___
+
+### placeholderValue
+
+• `Optional` **placeholderValue**: `CalendarDate`
+
+A placeholder date that influences the format of the placeholder shown when no value is selected. Defaults to today's date at midnight.
+
+#### Inherited from
+
+Omit.placeholderValue
+
+#### Defined in
+
+node_modules/@react-types/datepicker/src/index.d.ts:48
+
+___
+
 ### short
 
 • `Optional` **short**: `boolean`
@@ -103,7 +484,42 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L89)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:85](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L85)
+
+___
+
+### shouldCloseOnSelect
+
+• `Optional` **shouldCloseOnSelect**: `boolean` \| () => `boolean`
+
+Determines whether the date picker popover should close automatically when a date is selected.
+
+**`default`** true
+
+#### Inherited from
+
+Omit.shouldCloseOnSelect
+
+#### Defined in
+
+node_modules/@react-stately/datepicker/dist/types.d.ts:12
+
+___
+
+### shouldForceLeadingZeros
+
+• `Optional` **shouldForceLeadingZeros**: `boolean`
+
+Whether to always show leading zeros in the month, day, and hour fields.
+By default, this is determined by the user's locale.
+
+#### Inherited from
+
+Omit.shouldForceLeadingZeros
+
+#### Defined in
+
+node_modules/@react-types/datepicker/src/index.d.ts:62
 
 ___
 
@@ -115,7 +531,60 @@ Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` a
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:85](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L85)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L81)
+
+___
+
+### slot
+
+• `Optional` **slot**: ``null`` \| `string`
+
+A slot name for the component. Slots allow the component to receive props from a parent component.
+An explicit `null` value indicates that the local props completely override all props received from a parent.
+
+#### Inherited from
+
+Omit.slot
+
+#### Defined in
+
+node_modules/react-aria-components/dist/types.d.ts:71
+
+___
+
+### style
+
+• `Optional` **style**: `CSSProperties` \| (`values`: `DatePickerRenderProps` & { `defaultStyle`: `CSSProperties`  }) => `CSSProperties`
+
+The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the element. A function may be provided to compute the style based on component state.
+
+#### Inherited from
+
+Omit.style
+
+#### Defined in
+
+node_modules/react-aria-components/dist/types.d.ts:48
+
+___
+
+### validationBehavior
+
+• `Optional` **validationBehavior**: ``"native"`` \| ``"aria"``
+
+Whether to use native HTML form validation to prevent form submission
+when the value is missing or invalid, or mark the field as required
+or invalid via ARIA.
+
+**`default`** 'native'
+
+#### Inherited from
+
+Omit.validationBehavior
+
+#### Defined in
+
+node_modules/react-aria-components/dist/types.d.ts:82
 
 ___
 
@@ -127,7 +596,7 @@ The value (controlled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L93)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L89)
 
 ## Methods
 
@@ -135,8 +604,7 @@ The value (controlled)
 
 ▸ `Optional` **isDateUnavailable**(`date`): `boolean`
 
-A callback that can be used to implement arbitrary logic to mark certain dates as
-unavailable to be selected.
+Callback that is called for each date of the calendar. If it returns true, then the date is unavailable.
 
 #### Parameters
 
@@ -148,28 +616,221 @@ unavailable to be selected.
 
 `boolean`
 
+#### Inherited from
+
+Omit.isDateUnavailable
+
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:61](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L61)
+node_modules/@react-types/datepicker/src/index.d.ts:46
 
 ___
 
-### onChange
+### onBlur
 
-▸ `Optional` **onChange**(`date`): `void`
+▸ `Optional` **onBlur**(`e`): `void`
 
-Handler that is called when the value changes
+Handler that is called when the element loses focus.
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `date` | `DateValue` |
+| `e` | `FocusEvent`<`Target`, `Element`\> |
 
 #### Returns
 
 `void`
 
+#### Inherited from
+
+Omit.onBlur
+
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L81)
+node_modules/@react-types/shared/src/events.d.ts:81
+
+___
+
+### onChange
+
+▸ `Optional` **onChange**(`value`): `void`
+
+Handler that is called when the value changes.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `C` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Omit.onChange
+
+#### Defined in
+
+node_modules/@react-types/shared/src/inputs.d.ts:71
+
+___
+
+### onFocus
+
+▸ `Optional` **onFocus**(`e`): `void`
+
+Handler that is called when the element receives focus.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `e` | `FocusEvent`<`Target`, `Element`\> |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Omit.onFocus
+
+#### Defined in
+
+node_modules/@react-types/shared/src/events.d.ts:79
+
+___
+
+### onFocusChange
+
+▸ `Optional` **onFocusChange**(`isFocused`): `void`
+
+Handler that is called when the element's focus status changes.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `isFocused` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Omit.onFocusChange
+
+#### Defined in
+
+node_modules/@react-types/shared/src/events.d.ts:83
+
+___
+
+### onKeyDown
+
+▸ `Optional` **onKeyDown**(`e`): `void`
+
+Handler that is called when a key is pressed.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `e` | `KeyboardEvent` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Omit.onKeyDown
+
+#### Defined in
+
+node_modules/@react-types/shared/src/events.d.ts:72
+
+___
+
+### onKeyUp
+
+▸ `Optional` **onKeyUp**(`e`): `void`
+
+Handler that is called when a key is released.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `e` | `KeyboardEvent` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Omit.onKeyUp
+
+#### Defined in
+
+node_modules/@react-types/shared/src/events.d.ts:74
+
+___
+
+### onOpenChange
+
+▸ `Optional` **onOpenChange**(`isOpen`): `void`
+
+Handler that is called when the overlay's open state changes.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `isOpen` | `boolean` |
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+Omit.onOpenChange
+
+#### Defined in
+
+node_modules/@react-types/overlays/src/index.d.ts:114
+
+___
+
+### validate
+
+▸ `Optional` **validate**(`value`): `undefined` \| ``null`` \| ``true`` \| `ValidationError`
+
+A function that returns an error message if a given value is invalid.
+Validation errors are displayed to the user when the form is submitted
+if `validationBehavior="native"`. For realtime validation, use the `isInvalid`
+prop instead.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `value` | `T` |
+
+#### Returns
+
+`undefined` \| ``null`` \| ``true`` \| `ValidationError`
+
+#### Inherited from
+
+Omit.validate
+
+#### Defined in
+
+node_modules/@react-types/shared/src/inputs.d.ts:41

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
@@ -168,7 +168,7 @@ Any CSS classes to add to the outer div of the date picker
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:57](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L57)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:58](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L58)
 
 ___
 
@@ -196,7 +196,7 @@ The default value (uncontrolled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:61](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L61)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:62](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L62)
 
 ___
 
@@ -354,7 +354,7 @@ The label for this DatePicker element
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:65](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L65)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:66](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L66)
 
 ___
 
@@ -366,7 +366,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L69)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:70](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L70)
 
 ___
 
@@ -378,7 +378,7 @@ The latest date it is possible to select
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:73](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L73)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:74](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L74)
 
 ___
 
@@ -406,7 +406,7 @@ The earliest date it is possible to select
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:77](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L77)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:78](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L78)
 
 ___
 
@@ -484,7 +484,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:85](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L85)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:86](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L86)
 
 ___
 
@@ -531,7 +531,7 @@ Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` a
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L81)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:82](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L82)
 
 ___
 
@@ -596,7 +596,7 @@ The value (controlled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L89)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:90](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L90)
 
 ## Methods
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
@@ -168,7 +168,7 @@ Any CSS classes to add to the outer div of the date picker
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:58](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L58)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L69)
 
 ___
 
@@ -196,7 +196,7 @@ The default value (uncontrolled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:62](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L62)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:73](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L73)
 
 ___
 
@@ -354,7 +354,7 @@ The label for this DatePicker element
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:66](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L66)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:77](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L77)
 
 ___
 
@@ -366,7 +366,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:70](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L70)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L81)
 
 ___
 
@@ -378,7 +378,7 @@ The latest date it is possible to select
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:74](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L74)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:85](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L85)
 
 ___
 
@@ -406,7 +406,7 @@ The earliest date it is possible to select
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:78](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L78)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L89)
 
 ___
 
@@ -484,7 +484,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:86](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L86)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:97](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L97)
 
 ___
 
@@ -531,7 +531,7 @@ Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` a
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:82](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L82)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L93)
 
 ___
 
@@ -596,7 +596,7 @@ The value (controlled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:90](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L90)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:101](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L101)
 
 ## Methods
 

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "@carbon/charts": "^1.12.0",
     "@carbon/react": "~1.37.0",
-    "@internationalized/date": "^3.5.0",
+    "@internationalized/date": "^3.5.4",
     "core-js-pure": "^3.36.0",
     "d3": "^7.8.0",
     "geopattern": "^1.2.3",

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -684,3 +684,7 @@ html[dir='rtl'] {
   border: 1px solid #0f62fe;
   color: #0f62fe;
 }
+
+svg.omrs-icon {
+  fill: var(--omrs-icon-fill, 'currentColor');
+}

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -94,6 +94,11 @@
   &.cds--focused {
     @include focus.focus-outline('outline');
   }
+
+  &[data-invalid] {
+    @include focus.focus-outline('invalid');
+    color: theme.$support-error;
+  }
 }
 
 .inputWrapper {
@@ -162,6 +167,10 @@
 
       &:focus {
         @include focus.focus-outline('border');
+      }
+
+      &[data-invalid] {
+        @include focus.focus-outline('invalid');
       }
 
       &[data-disabled],

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -10,27 +10,27 @@
 .calendarGrid {
   width: 17rem;
 
-  & tr,
-  & tr > th,
-  & tr > td {
+  tr,
+  tr > th,
+  tr > td {
     height: 2.428rem;
     width: 2.428rem;
   }
 
-  & > thead > tr > th {
+  > thead > tr > th {
     @include type.type-style('body-compact-01');
     cursor: default;
     text-align: center;
     vertical-align: middle;
   }
 
-  & > tbody > tr > td {
+  > tbody > tr > td {
     @include type.type-style('body-compact-01');
     cursor: pointer;
     text-align: center;
     vertical-align: middle;
 
-    & > div {
+    > div {
       outline: unset;
     }
 
@@ -38,7 +38,7 @@
       background-color: theme.$layer-hover;
     }
 
-    & [aria-disabled='true'] {
+    [aria-disabled] {
       color: theme.$text-disabled;
       cursor: default;
     }
@@ -61,7 +61,7 @@
     background-color: theme.$layer-hover;
   }
 
-  & > svg {
+  > svg {
     display: block;
     margin: auto;
     text-align: center;
@@ -143,15 +143,15 @@
   margin-block-end: spacing.$spacing-01;
   text-align: center;
 
-  & > span {
+  > span {
     margin-left: spacing.$spacing-02;
     margin-right: spacing.$spacing-02;
   }
 
-  & div:has(input[inputmode='numeric']) {
+  div:has(input[inputmode='numeric']) {
     display: inline;
 
-    & > input[inputmode='numeric'] {
+    > input[inputmode='numeric'] {
       @include component-reset.reset;
       @include type.type-style('heading-compact-01');
       background-color: var(--cds-field);
@@ -190,7 +190,7 @@
       }
     }
 
-    & div[role='group'] {
+    div[role='group'] {
       @include component-reset.reset;
       display: inline;
       position: relative;
@@ -200,7 +200,7 @@
       opacity: 1;
     }
 
-    & button {
+    button {
       @include component-reset.reset;
       position: absolute;
       padding: 0 spacing.$spacing-02 0 spacing.$spacing-01;
@@ -270,13 +270,13 @@
   }
 
   .monthYear {
-    & div:has(input[inputmode='numeric']) {
-      & > input[inputmode='numeric'] {
+    div:has(input[inputmode='numeric']) {
+      > input[inputmode='numeric'] {
         padding-right: spacing.$spacing-02;
       }
     }
 
-    & button {
+    button {
       &[slot='increment'] {
         top: 0;
         left: unset;

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -127,6 +127,19 @@ function dateToInternationalizedDate(date: DateInputValue): DateValue | undefine
   }
 }
 
+function getYearAsNumber(date: Date, intlLocale: Intl.Locale) {
+  return parseInt(
+    formatDate(date, {
+      calendar: intlLocale.calendar,
+      locale: intlLocale.baseName,
+      day: false,
+      month: false,
+      noToday: true,
+      numberingSystem: 'latn',
+    }),
+  );
+}
+
 const MonthYear = forwardRef<Element, PropsWithChildren<HTMLAttributes<HTMLSpanElement>>>(
   function MonthYear(props, ref) {
     const { className } = props;
@@ -147,9 +160,10 @@ const MonthYear = forwardRef<Element, PropsWithChildren<HTMLAttributes<HTMLSpanE
       noToday: true,
     });
 
-    const year = state.visibleRange.start.toDate(tz).getFullYear();
-    const maxYear = state.maxValue ? state.maxValue.toDate(tz).getFullYear() : undefined;
-    const minYear = state.minValue ? state.minValue.toDate(tz).getFullYear() : undefined;
+    const year = getYearAsNumber(state.visibleRange.start.toDate(tz), intlLocale);
+
+    const maxYear = state.maxValue ? getYearAsNumber(state.maxValue.toDate(tz), intlLocale) : undefined;
+    const minYear = state.minValue ? getYearAsNumber(state.minValue.toDate(tz), intlLocale) : undefined;
 
     const changeHandler = useCallback((value: number) => {
       state.setFocusedDate(state.focusedDate.cycle('year', value - state.focusedDate.year));

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -1,14 +1,14 @@
 import React, {
+  cloneElement,
   forwardRef,
   type HTMLAttributes,
   type PropsWithChildren,
-  useMemo,
   type RefObject,
+  type ReactElement,
+  useMemo,
   useContext,
   useCallback,
   useRef,
-  cloneElement,
-  Children,
 } from 'react';
 import classNames, { type Argument } from 'classnames';
 import { createCalendar, CalendarDate, CalendarDateTime, ZonedDateTime } from '@internationalized/date';
@@ -21,7 +21,6 @@ import {
   CalendarCell,
   CalendarStateContext,
   DateFieldContext,
-  DateInput,
   type DateInputProps,
   DatePicker,
   type DatePickerProps,
@@ -73,8 +72,13 @@ export interface OpenmrsDatePickerProps
   defaultValue?: DateInputValue;
   /**
    * The label for this DatePicker element
+   * @deprecated Use labelText instead
    */
-  label?: string;
+  label?: string | ReactElement;
+  /**
+   * The label for this DatePicker element
+   */
+  labelText?: string | ReactElement;
   /**
    * 'true' to use the light version.
    */
@@ -224,6 +228,18 @@ const DatePickerInput = forwardRef<HTMLDivElement, DateInputProps>(function Date
   );
 });
 
+function DatePickerLabel({ labelText }: Pick<OpenmrsDatePickerProps, 'labelText'>) {
+  if (labelText === null || typeof labelText === 'undefined' || typeof labelText === 'boolean') {
+    return null;
+  }
+
+  if (typeof labelText === 'string' || typeof labelText === 'number') {
+    return <Label className="cds--label">{labelText}</Label>;
+  }
+
+  return cloneElement(labelText, { className: classNames(labelText.props?.className, 'cds--label') });
+}
+
 /**
  * A date picker component to select a single date. Based on React Aria, but styled to look like Carbon.
  */
@@ -233,6 +249,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
       className,
       defaultValue: rawDefaultValue,
       label,
+      labelText,
       light,
       maxDate: rawMaxDate,
       minDate: rawMinDate,
@@ -273,7 +290,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
             {...datePickerProps}
           >
             <div className="cds--date-picker-container">
-              {label && <Label className="cds--label">{label}</Label>}
+              <DatePickerLabel labelText={labelText ?? label} />
               <Group className={styles.inputGroup}>
                 <DatePickerInput
                   ref={ref}

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -199,9 +199,9 @@ const MonthYear = forwardRef<Element, PropsWithChildren<HTMLAttributes<HTMLSpanE
 const DatePickerIcon = forwardRef<Element>(function DatePickerIcon(props, ref) {
   const state = useContext(DatePickerStateContext);
   return state.isInvalid ? (
-    <WarningIcon className="cds--date-picker__icon cds--date-picker__icon--invalid" size={16} />
+    <WarningIcon className="cds--date-picker__icon--invalid" size={16} />
   ) : (
-    <CalendarIcon className="cds--date-picker__icon" size={16} />
+    <CalendarIcon size={16} />
   );
 });
 

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -19,6 +19,7 @@ import {
   DateInput,
   DatePicker,
   type DatePickerProps,
+  DatePickerStateContext,
   DateSegment,
   Dialog,
   Group,
@@ -31,7 +32,7 @@ import {
 import dayjs, { type Dayjs } from 'dayjs';
 import { formatDate, getDefaultCalendar, getLocale } from '@openmrs/esm-utils';
 import styles from './datepicker.module.scss';
-import { CalendarIcon, CaretDownIcon, CaretUpIcon, ChevronLeftIcon, ChevronRightIcon } from '../icons';
+import { CalendarIcon, CaretDownIcon, CaretUpIcon, ChevronLeftIcon, ChevronRightIcon, WarningIcon } from '../icons';
 
 /** A type for any of the acceptable date formats */
 export type DateInputValue =
@@ -166,6 +167,15 @@ const MonthYear = forwardRef<Element, PropsWithChildren<HTMLAttributes<HTMLSpanE
   },
 );
 
+const DatePickerIcon = forwardRef<Element>(function DatePickerIcon(props, ref) {
+  const state = useContext(DatePickerStateContext);
+  return state.isInvalid ? (
+    <WarningIcon className="cds--date-picker__icon cds--date-picker__icon--invalid" size={16} />
+  ) : (
+    <CalendarIcon className="cds--date-picker__icon" size={16} />
+  );
+});
+
 /**
  * A date picker component to select a single date. Based on React Aria, but styled to look like Carbon.
  */
@@ -232,7 +242,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
                   }}
                 </DateInput>
                 <Button className={classNames(styles.flatButton, styles.flatButtonMd)}>
-                  <CalendarIcon size={16} />
+                  <DatePickerIcon />
                 </Button>
               </Group>
             </div>

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -9,24 +9,24 @@ import React, {
 } from 'react';
 import classNames, { type Argument } from 'classnames';
 import { CalendarDate, CalendarDateTime, ZonedDateTime } from '@internationalized/date';
-import { I18nProvider, useLocale } from 'react-aria';
+import { I18nProvider, type DateValue, useLocale } from 'react-aria';
 import {
+  Button,
   Calendar,
   CalendarGrid,
   CalendarCell,
   CalendarStateContext,
   DateInput,
   DatePicker,
-  type DateValue,
+  type DatePickerProps,
   DateSegment,
   Dialog,
   Group,
+  Input,
   Label,
+  NumberField,
   Popover,
   RangeCalendarStateContext,
-  NumberField,
-  Input,
-  Button,
 } from 'react-aria-components';
 import dayjs, { type Dayjs } from 'dayjs';
 import { formatDate, getDefaultCalendar, getLocale } from '@openmrs/esm-utils';
@@ -45,7 +45,12 @@ export type DateInputValue =
   | null
   | undefined;
 
-export interface OpenmrsDatePickerProps {
+/**
+ * Properties for the OpenmrsDatePicker
+ */
+export interface OpenmrsDatePickerProps
+  // omits here for features we have custom implementations of
+  extends Omit<DatePickerProps<CalendarDate>, 'className' | 'defaultValue' | 'value'> {
   /**
    * Any CSS classes to add to the outer div of the date picker
    */
@@ -54,11 +59,6 @@ export interface OpenmrsDatePickerProps {
    * The default value (uncontrolled)
    */
   defaultValue?: DateInputValue;
-  /**
-   * A callback that can be used to implement arbitrary logic to mark certain dates as
-   * unavailable to be selected.
-   */
-  isDateUnavailable?: (date: DateValue) => boolean;
   /**
    * The label for this DatePicker element
    */
@@ -75,10 +75,6 @@ export interface OpenmrsDatePickerProps {
    * The earliest date it is possible to select
    */
   minDate?: DateInputValue;
-  /**
-   * Handler that is called when the value changes
-   */
-  onChange?: (date: DateValue) => void;
   /**
    * Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option.
    */
@@ -108,11 +104,10 @@ function dateToInternationalizedDate(date: DateInputValue): DateValue | undefine
   }
 
   if (date instanceof CalendarDate || date instanceof CalendarDateTime || date instanceof ZonedDateTime) {
-    // TODO need this casting because DateValue doesn't seem to work as-is'
-    return date as unknown as DateValue;
+    return date;
   } else {
     const date_ = dayjs(date).toDate();
-    return new CalendarDate(date_.getFullYear(), date_.getMonth() + 1, date_.getDate()) as unknown as DateValue;
+    return new CalendarDate(date_.getFullYear(), date_.getMonth() + 1, date_.getDate());
   }
 }
 
@@ -179,15 +174,14 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
     const {
       className,
       defaultValue: rawDefaultValue,
-      isDateUnavailable,
       label,
       light,
       maxDate: rawMaxDate,
       minDate: rawMinDate,
-      onChange,
       short,
       size,
       value: rawValue,
+      ...datePickerProps
     } = Object.assign({}, defaultProps, props);
 
     const defaultValue = useMemo(() => dateToInternationalizedDate(rawDefaultValue), [rawDefaultValue]);
@@ -215,11 +209,10 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
               ['cds--date-picker--light']: light,
             })}
             defaultValue={defaultValue}
-            isDateUnavailable={isDateUnavailable}
             maxValue={maxDate}
             minValue={minDate}
-            onChange={onChange}
             value={value}
+            {...datePickerProps}
           >
             <div className="cds--date-picker-container">
               {label && <Label className="cds--label">{label}</Label>}

--- a/packages/framework/esm-styleguide/src/icons/icons.module.scss
+++ b/packages/framework/esm-styleguide/src/icons/icons.module.scss
@@ -1,9 +1,3 @@
-.icon {
-  // fill must be marked !important or else it will be overridden by default Carbon selectors
-  // like '.btn__icon svg' that are interpretted as "more specific" than this class.
-  fill: var(--omrs-icon-fill, 'currentColor') !important;
-}
-
 :global([dir='rtl']) {
   .icon {
     transform: scaleX(-1);

--- a/packages/framework/esm-styleguide/src/icons/icons.tsx
+++ b/packages/framework/esm-styleguide/src/icons/icons.tsx
@@ -415,7 +415,13 @@ export const Icon = memo(
     }, []);
 
     return (
-      <svg ref={iconRef} className={classNames('omrs-icon', className)} height={size} width={size} viewBox="0 0 16 16">
+      <svg
+        ref={iconRef}
+        className={classNames('omrs-icon', style.icon, className)}
+        height={size}
+        width={size}
+        viewBox="0 0 16 16"
+      >
         <use xlinkHref={`#${icon}`} />
       </svg>
     );

--- a/packages/framework/esm-styleguide/src/icons/icons.tsx
+++ b/packages/framework/esm-styleguide/src/icons/icons.tsx
@@ -415,7 +415,7 @@ export const Icon = memo(
     }, []);
 
     return (
-      <svg ref={iconRef} className={classNames(style.icon, className)} height={size} width={size} viewBox="0 0 16 16">
+      <svg ref={iconRef} className={classNames('omrs-icon', className)} height={size} width={size} viewBox="0 0 16 16">
         <use xlinkHref={`#${icon}`} />
       </svg>
     );

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -51,7 +51,7 @@
     "rxjs": "6.x"
   },
   "dependencies": {
-    "@internationalized/date": "^3.5.0",
+    "@internationalized/date": "^3.5.4",
     "semver": "7.3.2"
   }
 }

--- a/packages/framework/esm-utils/src/omrs-dates.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.ts
@@ -158,6 +158,8 @@ export type FormatDateOptions = {
   month: boolean;
   /** Whether to include the year */
   year: boolean;
+  /** The unicode numbering system to use */
+  numberingSystem?: string;
   /**
    * Disables the special handling of dates that are today. If false
    * (the default), then dates that are today will be formatted as "Today"
@@ -271,7 +273,7 @@ export function formatDate(date: Date, options?: Partial<FormatDateOptions>) {
   let locale = options?.locale ?? getLocale();
   const _locale = new Intl.Locale(locale);
 
-  const { calendar, mode, time, day, month, year, noToday }: FormatDateOptions = {
+  const { calendar, mode, time, day, month, year, noToday, numberingSystem }: FormatDateOptions = {
     ...defaultOptions,
     ...{ noToday: _locale.language === 'am' ? true : false },
     ...options,
@@ -284,6 +286,7 @@ export function formatDate(date: Date, options?: Partial<FormatDateOptions>) {
     year: year ? 'numeric' : undefined,
     month: month ? 'short' : undefined,
     day: day ? '2-digit' : undefined,
+    numberingSystem,
   };
 
   let localeString: string;

--- a/packages/framework/esm-utils/src/omrs-dates.ts
+++ b/packages/framework/esm-utils/src/omrs-dates.ts
@@ -397,7 +397,7 @@ export function getLocale() {
  */
 export function convertToLocaleCalendar(date: CalendarDate, locale: string | Intl.Locale) {
   let locale_ = typeof locale === 'string' ? new Intl.Locale(locale) : locale;
-  const localCalendarName = getDefaultCalendar(locale);
+  const localCalendarName = getDefaultCalendar(locale_);
 
   return localCalendarName ? toCalendar(date, createCalendar(localCalendarName)) : date;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1951,15 +1951,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@internationalized/date@npm:^3.5.0":
-  version: 3.5.0
-  resolution: "@internationalized/date@npm:3.5.0"
-  dependencies:
-    "@swc/helpers": "npm:^0.5.0"
-  checksum: 10/16dfbc20b2f2b2275cb0752ba3d4e3dc967119c1041f40d61e7aced754e3473388f33759d299ad8864bc39a1aba63f119df4d3e2e1e0a3b43e58179e3ab167ea
-  languageName: node
-  linkType: hard
-
 "@internationalized/date@npm:^3.5.4":
   version: 3.5.4
   resolution: "@internationalized/date@npm:3.5.4"
@@ -3396,7 +3387,7 @@ __metadata:
   dependencies:
     "@carbon/charts": "npm:^1.12.0"
     "@carbon/react": "npm:~1.37.0"
-    "@internationalized/date": "npm:^3.5.0"
+    "@internationalized/date": "npm:^3.5.4"
     "@openmrs/esm-error-handling": "workspace:*"
     "@openmrs/esm-extensions": "workspace:*"
     "@openmrs/esm-navigation": "workspace:*"
@@ -3451,7 +3442,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-utils@workspace:packages/framework/esm-utils"
   dependencies:
-    "@internationalized/date": "npm:^3.5.0"
+    "@internationalized/date": "npm:^3.5.4"
     "@openmrs/esm-globals": "workspace:*"
     "@types/semver": "npm:^7.3.4"
     dayjs: "npm:^1.10.4"


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This addresses a number of issues with the current version of the datepicker:

* Allows additional props, specifically, most of the DOM-related properties, etc.
* Basic support for validation styles
* Now can click anywhere in the field to launch the pop-over
* Label can support arbitrary React elements
* Years are now correct for non-Gregorian calendars (to the best of my ability to test)

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

Outstanding: `minDate` and `maxDate` are currently values that only control which dates display as available. They are not (currently) part of the validation, so manually entering a date outside this range is allowed. That'll be for the next PR along with whatever else comes up.
