### PR TITLE
(fix) Ensure bottom nav border shows up

### DIFF
--- a/packages/framework/esm-styleguide/src/workspaces/container/action-menu.module.scss
+++ b/packages/framework/esm-styleguide/src/workspaces/container/action-menu.module.scss
@@ -38,7 +38,6 @@ $actionPanelOffset: 3rem;
   .sideRail {
     border-top: 1px solid $color-gray-30;
     background-color: $ui-02;
-    height: var(--bottom-nav-height);
     position: fixed;
     left: 0;
     bottom: 0;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Restores the top border on the bottom nav on tablet.


## Screenshots


![image](https://github.com/openmrs/openmrs-esm-core/assets/1031876/5e8c262e-5dad-45c9-abd4-afab43825c49)

## Related Issue

Fixes issue introduced in https://github.com/openmrs/openmrs-esm-core/pull/1046

## Other
<!-- Anything not covered above -->
