### PR TITLE
(fix) Fix invisible div bug in workspace system and add tablet animations

### DIFF
--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace.module.scss
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace.module.scss
@@ -87,9 +87,6 @@ $actionPanelOffset: 3rem;
     display: flex;
     flex-direction: column;
     z-index: 50;
-    -webkit-transition: width 0.5s ease-in-out;
-    -moz-transition: width 0.5s ease-in-out;
-    -o-transition: width 0.5s ease-in-out;
     transition:
       width 0.5s ease-in-out,
       right 0.5s ease-in-out;
@@ -170,6 +167,10 @@ $actionPanelOffset: 3rem;
     }
   }
 
+  .hiddenFixed {
+    top: 100% !important;
+  }
+
   .workspaceFixedContainer {
     position: fixed;
     top: 0;
@@ -179,6 +180,7 @@ $actionPanelOffset: 3rem;
     z-index: 8002;
     display: flex;
     flex-direction: column;
+    transition: top 0.5s ease-in-out;
   }
 
   .workspaceContainerWithActionMenu {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Fixes a bug where an invisible div from the workspace system was covering the whole patient chart in tablet view, rendering the whole thing non-interactive. I also implemented the tablet animations.

## Screenshots


https://github.com/openmrs/openmrs-esm-core/assets/1031876/b04f10c1-e1d1-4b1c-a138-3a28af6a5c7c



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
