### PR TITLE
(feat): Enhancements to the OpenmrsDatePicker

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1571,7 +1571,7 @@ A date picker component to select a single date. Based on React Aria, but styled
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:265](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L265)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:247](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L247)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1571,7 +1571,7 @@ A date picker component to select a single date. Based on React Aria, but styled
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:275](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L275)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:272](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L272)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -529,7 +529,7 @@ A type for any of the acceptable date formats
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L49)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:56](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L56)
 
 ___
 
@@ -1571,7 +1571,7 @@ A date picker component to select a single date. Based on React Aria, but styled
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:272](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L272)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:265](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L265)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -529,7 +529,7 @@ A type for any of the acceptable date formats
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L48)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L49)
 
 ___
 
@@ -1571,7 +1571,7 @@ A date picker component to select a single date. Based on React Aria, but styled
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:270](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L270)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:275](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L275)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1571,7 +1571,7 @@ A date picker component to select a single date. Based on React Aria, but styled
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:260](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L260)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:270](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L270)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
@@ -27,6 +27,7 @@ Properties for the OpenmrsDatePicker
 - [hideTimeZone](OpenmrsDatePickerProps.md#hidetimezone)
 - [hourCycle](OpenmrsDatePickerProps.md#hourcycle)
 - [id](OpenmrsDatePickerProps.md#id)
+- [invalidText](OpenmrsDatePickerProps.md#invalidtext)
 - [isDisabled](OpenmrsDatePickerProps.md#isdisabled)
 - [isInvalid](OpenmrsDatePickerProps.md#isinvalid)
 - [isOpen](OpenmrsDatePickerProps.md#isopen)
@@ -169,7 +170,7 @@ Any CSS classes to add to the outer div of the date picker
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:68](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L68)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L69)
 
 ___
 
@@ -197,7 +198,7 @@ The default value (uncontrolled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:72](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L72)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:73](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L73)
 
 ___
 
@@ -264,6 +265,18 @@ Omit.id
 #### Defined in
 
 node_modules/@react-types/shared/src/dom.d.ts:62
+
+___
+
+### invalidText
+
+• `Optional` **invalidText**: `string`
+
+Text to show if the input is invalid e.g. an error message
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:77](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L77)
 
 ___
 
@@ -343,7 +356,7 @@ Omit.isRequired
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:109](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L109)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L81)
 
 ___
 
@@ -357,7 +370,7 @@ The label for this DatePicker element
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:77](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L77)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:86](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L86)
 
 ___
 
@@ -369,7 +382,7 @@ The label for this DatePicker element
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L81)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:90](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L90)
 
 ___
 
@@ -381,7 +394,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:85](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L85)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:94](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L94)
 
 ___
 
@@ -393,7 +406,7 @@ The latest date it is possible to select
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L89)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:98](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L98)
 
 ___
 
@@ -421,7 +434,7 @@ The earliest date it is possible to select
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L93)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:102](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L102)
 
 ___
 
@@ -499,7 +512,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:101](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L101)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:110](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L110)
 
 ___
 
@@ -546,7 +559,7 @@ Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` a
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:97](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L97)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:106](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L106)
 
 ___
 
@@ -611,7 +624,7 @@ The value (controlled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:105](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L105)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:114](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L114)
 
 ## Methods
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
@@ -378,7 +378,7 @@ ___
 
 • `Optional` **labelText**: `string` \| `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>
 
-The label for this DatePicker element
+The label for this DatePicker element. If a string is passed and the input is marked as required, an asterisk is appended to the label.
 
 #### Defined in
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
@@ -27,6 +27,7 @@ Properties for the OpenmrsDatePicker
 - [hideTimeZone](OpenmrsDatePickerProps.md#hidetimezone)
 - [hourCycle](OpenmrsDatePickerProps.md#hourcycle)
 - [id](OpenmrsDatePickerProps.md#id)
+- [invalid](OpenmrsDatePickerProps.md#invalid)
 - [invalidText](OpenmrsDatePickerProps.md#invalidtext)
 - [isDisabled](OpenmrsDatePickerProps.md#isdisabled)
 - [isInvalid](OpenmrsDatePickerProps.md#isinvalid)
@@ -170,7 +171,7 @@ Any CSS classes to add to the outer div of the date picker
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:76](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L76)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:74](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L74)
 
 ___
 
@@ -198,7 +199,7 @@ The default value (uncontrolled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:80](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L80)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:76](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L76)
 
 ___
 
@@ -268,6 +269,18 @@ node_modules/@react-types/shared/src/dom.d.ts:62
 
 ___
 
+### invalid
+
+• `Optional` **invalid**: `boolean`
+
+Whether the input value is invalid.
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:78](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L78)
+
+___
+
 ### invalidText
 
 • `Optional` **invalidText**: `string`
@@ -276,7 +289,7 @@ Text to show if the input is invalid e.g. an error message
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:84](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L84)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:80](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L80)
 
 ___
 
@@ -370,7 +383,7 @@ The label for this DatePicker element
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L89)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:85](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L85)
 
 ___
 
@@ -382,7 +395,7 @@ The label for this DatePicker element.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L93)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:87](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L87)
 
 ___
 
@@ -394,7 +407,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:97](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L97)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L89)
 
 ___
 
@@ -406,7 +419,7 @@ The latest date it is possible to select
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:101](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L101)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:91](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L91)
 
 ___
 
@@ -434,7 +447,7 @@ The earliest date it is possible to select
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:105](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L105)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L93)
 
 ___
 
@@ -512,7 +525,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:113](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L113)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:97](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L97)
 
 ___
 
@@ -555,11 +568,11 @@ ___
 
 • `Optional` **size**: ``"sm"`` \| ``"md"`` \| ``"lg"``
 
-Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option.
+Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:109](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L109)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:95](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L95)
 
 ___
 
@@ -624,7 +637,7 @@ The value (controlled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:117](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L117)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:99](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L99)
 
 ## Methods
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
@@ -335,15 +335,15 @@ ___
 
 • `Optional` **isRequired**: `boolean`
 
-Whether user input is required on the input before form submission.
+Specifies if the input is required. Used to add an asterisk to the label.
 
-#### Inherited from
+#### Overrides
 
 Omit.isRequired
 
 #### Defined in
 
-node_modules/@react-types/shared/src/inputs.d.ts:23
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:109](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L109)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
@@ -170,7 +170,7 @@ Any CSS classes to add to the outer div of the date picker
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L69)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:76](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L76)
 
 ___
 
@@ -198,7 +198,7 @@ The default value (uncontrolled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:73](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L73)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:80](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L80)
 
 ___
 
@@ -276,7 +276,7 @@ Text to show if the input is invalid e.g. an error message
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:77](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L77)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:84](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L84)
 
 ___
 
@@ -348,15 +348,15 @@ ___
 
 • `Optional` **isRequired**: `boolean`
 
-Specifies if the input is required. Used to add an asterisk to the label.
+Whether user input is required on the input before form submission.
 
-#### Overrides
+#### Inherited from
 
 Omit.isRequired
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L81)
+node_modules/@react-types/shared/src/inputs.d.ts:23
 
 ___
 
@@ -370,7 +370,7 @@ The label for this DatePicker element
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:86](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L86)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L89)
 
 ___
 
@@ -378,11 +378,11 @@ ___
 
 • `Optional` **labelText**: `string` \| `ReactElement`<`any`, `string` \| `JSXElementConstructor`<`any`\>\>
 
-The label for this DatePicker element. If a string is passed and the input is marked as required, an asterisk is appended to the label.
+The label for this DatePicker element.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:90](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L90)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L93)
 
 ___
 
@@ -394,7 +394,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:94](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L94)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:97](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L97)
 
 ___
 
@@ -406,7 +406,7 @@ The latest date it is possible to select
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:98](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L98)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:101](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L101)
 
 ___
 
@@ -434,7 +434,7 @@ The earliest date it is possible to select
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:102](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L102)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:105](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L105)
 
 ___
 
@@ -512,7 +512,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:110](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L110)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:113](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L113)
 
 ___
 
@@ -559,7 +559,7 @@ Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` a
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:106](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L106)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:109](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L109)
 
 ___
 
@@ -624,7 +624,7 @@ The value (controlled)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/datepicker/index.tsx:114](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L114)
+[packages/framework/esm-styleguide/src/datepicker/index.tsx:117](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/index.tsx#L117)
 
 ## Methods
 

--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -685,6 +685,6 @@ html[dir='rtl'] {
   color: #0f62fe;
 }
 
-svg.omrs-icon {
+.omrs-icon {
   fill: var(--omrs-icon-fill, 'currentColor');
 }

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -40,8 +40,8 @@
     }
 
     [data-selected] {
-      background-color: #0f62fe;
-      color: white;
+      background-color: $color-blue-60-2;
+      color: $ui-background;
     }
 
     [aria-disabled] {

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -35,11 +35,11 @@
       outline: unset;
     }
 
-    &:hover:not(:has([aria-disabled='true'])) {
+    &:hover:not(:has([aria-disabled], [data-selected])) {
       background-color: theme.$layer-hover;
     }
 
-    [data-selected] {
+    &:has([data-selected]) {
       background-color: $color-blue-60-2;
       color: $ui-background;
     }
@@ -72,6 +72,10 @@
     margin: auto;
     text-align: center;
   }
+}
+
+[data-invalid] > .flatButton > svg {
+  --omrs-icon-fill: #{theme.$support-error};
 }
 
 .flatButtonMd {

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -6,6 +6,7 @@
 @use '@carbon/styles/scss/utilities/box-shadow';
 @use '@carbon/styles/scss/utilities/component-reset';
 @use '@carbon/styles/scss/utilities/focus-outline' as focus;
+@import '@openmrs/esm-styleguide/src/vars';
 
 .calendarGrid {
   width: 17rem;
@@ -36,6 +37,11 @@
 
     &:hover:not(:has([aria-disabled='true'])) {
       background-color: theme.$layer-hover;
+    }
+
+    [data-selected] {
+      background-color: #0f62fe;
+      color: white;
     }
 
     [aria-disabled] {

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -2,7 +2,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/theme';
 @use '@carbon/styles/scss/type';
-@use '@carbon/styles/scss/colors';
 @use '@carbon/styles/scss/components/button';
 @use '@carbon/styles/scss/utilities/box-shadow';
 @use '@carbon/styles/scss/utilities/component-reset';
@@ -294,6 +293,6 @@
 }
 
 .isRequired {
-  color: #da1e28 !important;
-  margin-left: 0.25rem;
+  color: theme.$text-error !important;
+  margin-left: spacing.$spacing-02;
 }

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -302,11 +302,6 @@
   }
 }
 
-.isRequired {
-  color: theme.$text-error !important;
-  margin-left: spacing.$spacing-02;
-}
-
 .invalidText {
   color: theme.$text-error !important;
   font-size: 0.75rem;

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -6,7 +6,7 @@
 @use '@carbon/styles/scss/utilities/box-shadow';
 @use '@carbon/styles/scss/utilities/component-reset';
 @use '@carbon/styles/scss/utilities/focus-outline' as focus;
-@import '@openmrs/esm-styleguide/src/vars';
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .calendarGrid {
   width: 17rem;
@@ -301,4 +301,12 @@
 .isRequired {
   color: theme.$text-error !important;
   margin-left: spacing.$spacing-02;
+}
+
+.invalidText {
+  color: theme.$text-error !important;
+  font-size: 0.75rem;
+  font-weight: 400 !important;
+  margin: spacing.$spacing-02 0 0;
+  overflow: hidden;
 }

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -2,6 +2,7 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/theme';
 @use '@carbon/styles/scss/type';
+@use '@carbon/styles/scss/colors';
 @use '@carbon/styles/scss/components/button';
 @use '@carbon/styles/scss/utilities/box-shadow';
 @use '@carbon/styles/scss/utilities/component-reset';
@@ -290,4 +291,9 @@
       }
     }
   }
+}
+
+.isRequired {
+  color: #da1e28 !important;
+  margin-left: 0.25rem;
 }

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -314,3 +314,31 @@
   margin: spacing.$spacing-02 0 0;
   overflow: hidden;
 }
+
+.today:not([data-selected]) {
+  position: relative;
+  color: $color-blue-60-2;
+  font-weight: 600;
+  font-size: var(--cds-body-compact-01-font-size, 0.875rem);
+  line-height: var(--cds-body-compact-01-line-height, 1.28572);
+  letter-spacing: var(--cds-body-compact-01-letter-spacing, 0.16px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  block-size: 2.5rem;
+  cursor: pointer;
+  inline-size: 2.5rem;
+
+  &::after {
+    position: absolute;
+    display: block;
+    background-color: var(--cds-link-primary, #0f62fe);
+    block-size: 0.25rem;
+    content: '';
+    inline-size: 0.25rem;
+    inset-block-end: 0.4375rem;
+    inset-inline-start: 50%;
+    -webkit-transform: translateX(-50%);
+    transform: translateX(-50%);
+  }
+}

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -300,9 +300,6 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
       return `${locale}-u-ca-${calendar}`;
     }, [locale]);
 
-    // eslint-disable-next-line no-console
-    console.log("core's date picker is up and running =======");
-
     return (
       <I18nProvider locale={localeWithCalendar}>
         <div className={classNames('cds--form-item', className)}>

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -205,13 +205,10 @@ const MonthYear = forwardRef<Element, PropsWithChildren<HTMLAttributes<HTMLSpanE
   },
 );
 
-const DatePickerIcon = forwardRef<Element>(function DatePickerIcon(props, ref) {
+const DatePickerIcon = forwardRef<SVGSVGElement>(function DatePickerIcon(props, ref) {
   const state = useContext(DatePickerStateContext);
-  return state.isInvalid ? (
-    <WarningIcon className="cds--date-picker__icon--invalid" size={16} />
-  ) : (
-    <CalendarIcon size={16} />
-  );
+
+  return state.isInvalid ? <WarningIcon ref={ref} size={16} /> : <CalendarIcon ref={ref} size={16} />;
 });
 
 // The main reason for this component is to allow us to click inside the date field and trigger the popover
@@ -278,6 +275,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
       className,
       defaultValue: rawDefaultValue,
       invalidText,
+      isInvalid: isInvalidRaw,
       isRequired,
       label,
       labelText,
@@ -294,6 +292,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
     const value = useMemo(() => dateToInternationalizedDate(rawValue), [rawValue]);
     const maxDate = useMemo(() => dateToInternationalizedDate(rawMaxDate), [rawMaxDate]);
     const minDate = useMemo(() => dateToInternationalizedDate(rawMinDate), [rawMinDate]);
+    const isInvalid = useMemo(() => (invalidText ? true : isInvalidRaw), [invalidText, isInvalidRaw]);
 
     const locale = getLocale();
 
@@ -315,6 +314,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
               ['cds--date-picker--light']: light,
             })}
             defaultValue={defaultValue}
+            isInvalid={isInvalid}
             isRequired={isRequired}
             maxValue={maxDate}
             minValue={minDate}

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -275,7 +275,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
       className,
       defaultValue: rawDefaultValue,
       invalidText,
-      isInvalid: isInvalidRaw,
+      isInvalid,
       isRequired,
       label,
       labelText,
@@ -292,7 +292,6 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
     const value = useMemo(() => dateToInternationalizedDate(rawValue), [rawValue]);
     const maxDate = useMemo(() => dateToInternationalizedDate(rawMaxDate), [rawMaxDate]);
     const minDate = useMemo(() => dateToInternationalizedDate(rawMinDate), [rawMinDate]);
-    const isInvalid = useMemo(() => (invalidText ? true : isInvalidRaw), [invalidText, isInvalidRaw]);
 
     const locale = getLocale();
 

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -38,6 +38,7 @@ import {
   InputContext,
   Provider,
   GroupContext,
+  Text,
 } from 'react-aria-components';
 import dayjs, { type Dayjs } from 'dayjs';
 import { formatDate, getDefaultCalendar, getLocale } from '@openmrs/esm-utils';
@@ -71,6 +72,14 @@ export interface OpenmrsDatePickerProps
    */
   defaultValue?: DateInputValue;
   /**
+   * Text to show if the input is invalid e.g. an error message
+   */
+  invalidText?: string;
+  /**
+   * Specifies if the input is required. Used to add an asterisk to the label.
+   */
+  isRequired?: boolean;
+  /**
    * The label for this DatePicker element
    * @deprecated Use labelText instead
    */
@@ -103,10 +112,6 @@ export interface OpenmrsDatePickerProps
    * The value (controlled)
    */
   value?: DateInputValue;
-  /**
-   * Specifies if the input is required. Used to add an asterisk to the label.
-   */
-  isRequired?: boolean;
 }
 
 const defaultProps: OpenmrsDatePickerProps = {
@@ -272,6 +277,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
     const {
       className,
       defaultValue: rawDefaultValue,
+      invalidText,
       isRequired,
       label,
       labelText,
@@ -336,6 +342,11 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
                   <DatePickerIcon />
                 </Button>
               </Group>
+              {invalidText && (
+                <Text slot="errorMessage" className={styles.invalidText}>
+                  {invalidText}
+                </Text>
+              )}
             </div>
             <Popover className={styles.popover} placement="bottom" offset={1}>
               <Dialog className={styles.dialog}>

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -272,6 +272,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
     const {
       className,
       defaultValue: rawDefaultValue,
+      isRequired,
       label,
       labelText,
       light,
@@ -280,7 +281,6 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
       short,
       size,
       value: rawValue,
-      isRequired,
       ...datePickerProps
     } = Object.assign({}, defaultProps, props);
 
@@ -309,6 +309,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
               ['cds--date-picker--light']: light,
             })}
             defaultValue={defaultValue}
+            isRequired={isRequired}
             maxValue={maxDate}
             minValue={minDate}
             value={value}

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -83,16 +83,12 @@ export interface OpenmrsDatePickerProps
    */
   invalidText?: string;
   /**
-   * Specifies if the input is required. Used to add an asterisk to the label.
-   */
-  isRequired?: boolean;
-  /**
    * The label for this DatePicker element
    * @deprecated Use labelText instead
    */
   label?: string | ReactElement;
   /**
-   * The label for this DatePicker element. If a string is passed and the input is marked as required, an asterisk is appended to the label.
+   * The label for this DatePicker element.
    */
   labelText?: string | ReactElement;
   /**
@@ -255,22 +251,12 @@ const DatePickerInput = forwardRef<HTMLDivElement, DateInputProps>(function Date
   );
 });
 
-function DatePickerLabel({ labelText, isRequired = false }: Pick<OpenmrsDatePickerProps, 'labelText' | 'isRequired'>) {
+function DatePickerLabel({ labelText }: Pick<OpenmrsDatePickerProps, 'labelText'>) {
   if (labelText === null || typeof labelText === 'undefined' || typeof labelText === 'boolean') {
     return null;
   }
 
-  return (
-    <Label className="cds--label">
-      {typeof labelText === 'string' && isRequired ? (
-        <>
-          {labelText} <span className={styles.isRequired}>*</span>
-        </>
-      ) : (
-        labelText
-      )}
-    </Label>
-  );
+  return <Label className="cds--label">{labelText}</Label>;
 }
 
 /**
@@ -283,7 +269,6 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
       defaultValue: rawDefaultValue,
       invalidText,
       isInvalid,
-      isRequired,
       label,
       labelText,
       light,
@@ -322,14 +307,13 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
             })}
             defaultValue={defaultValue}
             isInvalid={isInvalid}
-            isRequired={isRequired}
             maxValue={maxDate}
             minValue={minDate}
             value={value}
             {...datePickerProps}
           >
             <div className="cds--date-picker-container">
-              <DatePickerLabel labelText={labelText ?? label} isRequired={isRequired} />
+              <DatePickerLabel labelText={labelText ?? label} />
               <Group className={styles.inputGroup}>
                 <DatePickerInput
                   ref={ref}

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -342,9 +342,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
                   <DatePickerIcon />
                 </Button>
               </Group>
-              {datePickerProps.isInvalid && invalidText && (
-                <FieldError className={styles.invalidText}>{invalidText}</FieldError>
-              )}
+              {isInvalid && invalidText && <FieldError className={styles.invalidText}>{invalidText}</FieldError>}
             </div>
             <Popover className={styles.popover} placement="bottom" offset={1}>
               <Dialog className={styles.dialog}>

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -103,6 +103,10 @@ export interface OpenmrsDatePickerProps
    * The value (controlled)
    */
   value?: DateInputValue;
+  /**
+   * Specifies if the input is required. Used to add an asterisk to the label.
+   */
+  isRequired?: boolean;
 }
 
 const defaultProps: OpenmrsDatePickerProps = {
@@ -242,16 +246,22 @@ const DatePickerInput = forwardRef<HTMLDivElement, DateInputProps>(function Date
   );
 });
 
-function DatePickerLabel({ labelText }: Pick<OpenmrsDatePickerProps, 'labelText'>) {
+function DatePickerLabel({ labelText, isRequired = false }: Pick<OpenmrsDatePickerProps, 'labelText' | 'isRequired'>) {
   if (labelText === null || typeof labelText === 'undefined' || typeof labelText === 'boolean') {
     return null;
   }
 
-  if (typeof labelText === 'string' || typeof labelText === 'number') {
-    return <Label className="cds--label">{labelText}</Label>;
-  }
-
-  return cloneElement(labelText, { className: classNames(labelText.props?.className, 'cds--label') });
+  return (
+    <Label className="cds--label">
+      {typeof labelText === 'string' && isRequired ? (
+        <>
+          {labelText} <span className={styles.isRequired}>*</span>
+        </>
+      ) : (
+        labelText
+      )}
+    </Label>
+  );
 }
 
 /**
@@ -270,6 +280,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
       short,
       size,
       value: rawValue,
+      isRequired,
       ...datePickerProps
     } = Object.assign({}, defaultProps, props);
 
@@ -289,6 +300,9 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
       return `${locale}-u-ca-${calendar}`;
     }, [locale]);
 
+    // eslint-disable-next-line no-console
+    console.log("core's date picker is up and running =======");
+
     return (
       <I18nProvider locale={localeWithCalendar}>
         <div className={classNames('cds--form-item', className)}>
@@ -304,7 +318,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
             {...datePickerProps}
           >
             <div className="cds--date-picker-container">
-              <DatePickerLabel labelText={labelText ?? label} />
+              <DatePickerLabel labelText={labelText ?? label} isRequired={isRequired} />
               <Group className={styles.inputGroup}>
                 <DatePickerInput
                   ref={ref}

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -342,7 +342,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
                   <DatePickerIcon />
                 </Button>
               </Group>
-              {invalidText && (
+              {datePickerProps.isInvalid && invalidText && (
                 <Text slot="errorMessage" className={styles.invalidText}>
                   {invalidText}
                 </Text>

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -85,7 +85,7 @@ export interface OpenmrsDatePickerProps
    */
   label?: string | ReactElement;
   /**
-   * The label for this DatePicker element
+   * The label for this DatePicker element. If a string is passed and the input is marked as required, an asterisk is appended to the label.
    */
   labelText?: string | ReactElement;
   /**

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -38,7 +38,7 @@ import {
   InputContext,
   Provider,
   GroupContext,
-  Text,
+  FieldError,
 } from 'react-aria-components';
 import dayjs, { type Dayjs } from 'dayjs';
 import { formatDate, getDefaultCalendar, getLocale } from '@openmrs/esm-utils';
@@ -343,9 +343,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
                 </Button>
               </Group>
               {datePickerProps.isInvalid && invalidText && (
-                <Text slot="errorMessage" className={styles.invalidText}>
-                  {invalidText}
-                </Text>
+                <FieldError className={styles.invalidText}>{invalidText}</FieldError>
               )}
             </div>
             <Popover className={styles.popover} placement="bottom" offset={1}>

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -11,7 +11,14 @@ import React, {
   useRef,
 } from 'react';
 import classNames, { type Argument } from 'classnames';
-import { createCalendar, CalendarDate, CalendarDateTime, ZonedDateTime } from '@internationalized/date';
+import {
+  createCalendar,
+  CalendarDate,
+  CalendarDateTime,
+  ZonedDateTime,
+  today,
+  getLocalTimeZone,
+} from '@internationalized/date';
 import { I18nProvider, type DateValue, useLocale, useDateField } from 'react-aria';
 import { useDateFieldState } from 'react-stately';
 import {
@@ -294,6 +301,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
     const minDate = useMemo(() => dateToInternationalizedDate(rawMinDate), [rawMinDate]);
 
     const locale = getLocale();
+    const today_ = today(getLocalTimeZone());
 
     const localeWithCalendar = useMemo(() => {
       const calendar = getDefaultCalendar(locale);
@@ -356,7 +364,14 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
                     </Button>
                   </header>
                   <CalendarGrid className={styles.calendarGrid}>
-                    {(date) => <CalendarCell className="cds--date-picker__day" date={date} />}
+                    {(date) => (
+                      <CalendarCell
+                        className={classNames('cds--date-picker__day', {
+                          [styles.today]: today_.compare(date) === 0,
+                        })}
+                        date={date}
+                      />
+                    )}
                   </CalendarGrid>
                 </Calendar>
               </Dialog>

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -70,50 +70,32 @@ export type DateInputValue =
 export interface OpenmrsDatePickerProps
   // omits here for features we have custom implementations of
   extends Omit<DatePickerProps<CalendarDate>, 'className' | 'defaultValue' | 'value'> {
-  /**
-   * Any CSS classes to add to the outer div of the date picker
-   */
+  /** Any CSS classes to add to the outer div of the date picker */
   className?: Argument;
-  /**
-   * The default value (uncontrolled)
-   */
+  /** The default value (uncontrolled) */
   defaultValue?: DateInputValue;
-  /**
-   * Text to show if the input is invalid e.g. an error message
-   */
+  /** Whether the input value is invalid. */
+  invalid?: boolean;
+  /** Text to show if the input is invalid e.g. an error message */
   invalidText?: string;
   /**
    * The label for this DatePicker element
    * @deprecated Use labelText instead
    */
   label?: string | ReactElement;
-  /**
-   * The label for this DatePicker element.
-   */
+  /** The label for this DatePicker element. */
   labelText?: string | ReactElement;
-  /**
-   * 'true' to use the light version.
-   */
+  /** 'true' to use the light version. */
   light?: boolean;
-  /**
-   * The latest date it is possible to select
-   */
+  /** The latest date it is possible to select */
   maxDate?: DateInputValue;
-  /**
-   * The earliest date it is possible to select
-   */
+  /** The earliest date it is possible to select */
   minDate?: DateInputValue;
-  /**
-   * Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option.
-   */
+  /** Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option */
   size?: 'sm' | 'md' | 'lg';
-  /**
-   * 'true' to use the short version.
-   */
+  /** 'true' to use the short version. */
   short?: boolean;
-  /**
-   * The value (controlled)
-   */
+  /** The value (controlled) */
   value?: DateInputValue;
 }
 
@@ -267,8 +249,9 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
     const {
       className,
       defaultValue: rawDefaultValue,
+      invalid,
       invalidText,
-      isInvalid,
+      isInvalid: isInvalidRaw,
       label,
       labelText,
       light,
@@ -284,6 +267,7 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
     const value = useMemo(() => dateToInternationalizedDate(rawValue), [rawValue]);
     const maxDate = useMemo(() => dateToInternationalizedDate(rawMaxDate), [rawMaxDate]);
     const minDate = useMemo(() => dateToInternationalizedDate(rawMinDate), [rawMinDate]);
+    const isInvalid = useMemo(() => invalid ?? isInvalidRaw, [invalid, isInvalidRaw]);
 
     const locale = getLocale();
     const today_ = today(getLocalTimeZone());

--- a/packages/framework/esm-styleguide/src/icons/icons.tsx
+++ b/packages/framework/esm-styleguide/src/icons/icons.tsx
@@ -601,7 +601,9 @@ export const Icon = memo(
 
     useEffect(() => {
       if (iconRef.current) {
-        iconRef.current.style.setProperty('--omrs-icon-fill', fill);
+        if (fill !== 'currentColor') {
+          iconRef.current.style.setProperty('--omrs-icon-fill', fill);
+        }
       }
     }, []);
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->
This PR adds styling enhancements to the Date Picker.
1.  Fixes an issue where the label and the asterisk of required inputs were getting broken into two lines by wrapping it up in the `<Label>` component with the className `cds-label`.
After fix:
<img width="308" alt="Screenshot 2024-07-02 at 12 46 58 AM" src="https://github.com/openmrs/openmrs-esm-core/assets/34070216/e70c420e-7d84-47a0-8989-44795dfb446e">

2. Adds styling to selected date in the calendar. 
<img width="307" alt="Screenshot 2024-07-03 at 1 33 52 AM" src="https://github.com/openmrs/openmrs-esm-core/assets/34070216/8b101499-c6ee-4e6f-b621-e51979ae6594">

3. Adds support for the prop `invalidText`. Renders the text passed in to the prop `invalidText` if the condition `isInvalid` is true, with the carbon styling for an error message applied.
<img width="307" alt="Screenshot 2024-07-02 at 9 07 33 PM" src="https://github.com/openmrs/openmrs-esm-core/assets/34070216/9a3e4bbc-f6ee-4a87-9a94-2b51968d1669">

4. Adds styling to the current date so that it is highlighted. The styling is the same as which was in the Carbon date picker.
<img width="307" alt="Screenshot 2024-07-03 at 1 33 28 AM" src="https://github.com/openmrs/openmrs-esm-core/assets/34070216/150fe3e7-4857-4521-ae0d-68cf85c60702">


5. - [ ] Add the alias `invalid` to `isInvalid`.

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
