### PR TITLE
(chore) Add remote caching to E2E workflow using turborepo-gh-artifacts

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
 
+env:
+  TURBO_API: 'http://127.0.0.1:9080'
+  TURBO_TOKEN: ${{ secrets.TURBO_SERVER_TOKEN }}
+  TURBO_TEAM: ${{ github.repository_owner }}
+
 jobs:
   changes:
     runs-on: ubuntu-latest
@@ -72,6 +77,12 @@ jobs:
       - name: Install Playwright Browsers
         run: yarn playwright install chromium --with-deps
 
+      - name: Setup local cache server for Turborepo
+        uses: felixmosh/turborepo-gh-artifacts@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          server-token: ${{ env.TURBO_TOKEN }}
+
       - name: Build apps
         run: yarn turbo run build --color --concurrency=5
 
@@ -85,7 +96,7 @@ jobs:
         run: yarn playwright test
 
       - name: Stop dev server
-        if: "!cancelled()"
+        if: '!cancelled()'
         run: docker stop $(docker ps -a -q)
 
       - name: Upload report


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR integrates [remote caching](https://turbo.build/repo/docs/core-concepts/remote-caching) into the E2E workflow using the [turborepo-gh-artifacts](https://github.com/felixmosh/turborepo-gh-artifacts/tree/v3/) GitHub Action. Presently, the build job takes approximately [4 minutes](https://github.com/openmrs/openmrs-esm-patient-chart/actions/workflows/e2e.yml) to run. With this addition, subsequent build jobs will be faster as GitHub Actions can cache and reuse artifacts from previous runs. 

This update brings the E2E workflow in line with our other [workflows](https://github.com/openmrs/openmrs-esm-core/tree/main/.github/workflows) that already utilize remote caching for incrementally faster builds.

## Screenshots

First run with remote caching enabled (took 12 seconds)

![CleanShot 2024-07-02 at 3  57 36@2x](https://github.com/openmrs/openmrs-esm-core/assets/8509731/f983f59c-ff53-4e4b-abe3-7b6252151ee8)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
