### PR TITLE
(feat) Add support for setting custom workspace title

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -7021,13 +7021,13 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:329](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L329)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:339](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L339)
 
 ___
 
 ### launchWorkspace
 
-▸ **launchWorkspace**(`name`, `additionalProps?`): `void`
+▸ **launchWorkspace**<`T`\>(`name`, `additionalProps?`): `void`
 
 This launches a workspace by its name. The workspace must have been registered.
 Workspaces should be registered in the `routes.json` file.
@@ -7053,12 +7053,18 @@ by the components that display workspaces.
 Additional props can be passed to the workspace component being launched. Passing a
 prop named `workspaceTitle` will override the title of the workspace.
 
+#### Type parameters
+
+| Name | Type |
+| :------ | :------ |
+| `T` | extends `object` \| [`DefaultWorkspaceProps`](interfaces/DefaultWorkspaceProps.md) = [`DefaultWorkspaceProps`](interfaces/DefaultWorkspaceProps.md) & { `[key: string]`: `any`;  } |
+
 #### Parameters
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `name` | `string` | The name of the workspace to launch |
-| `additionalProps?` | `object` | Props to pass to the workspace component being launched. Passing          a prop named `workspaceTitle` will override the title of the workspace. |
+| `additionalProps?` | `Omit`<`T`, keyof [`DefaultWorkspaceProps`](interfaces/DefaultWorkspaceProps.md)\> & { `workspaceTitle?`: `string`  } | Props to pass to the workspace component being launched. Passing          a prop named `workspaceTitle` will override the title of the workspace. |
 
 #### Returns
 
@@ -7066,7 +7072,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:214](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L214)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:222](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L222)
 
 ___
 
@@ -7092,7 +7098,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:292](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L292)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:302](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L302)
 
 ___
 
@@ -7106,4 +7112,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:431](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L431)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:441](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L441)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -7021,7 +7021,7 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:339](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L339)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:327](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L327)
 
 ___
 
@@ -7072,7 +7072,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:222](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L222)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:210](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L210)
 
 ___
 
@@ -7098,7 +7098,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:302](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L302)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:290](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L290)
 
 ___
 
@@ -7112,4 +7112,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:441](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L441)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:429](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L429)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -7021,7 +7021,7 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:310](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L310)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:329](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L329)
 
 ___
 
@@ -7066,7 +7066,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:212](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L212)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:214](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L214)
 
 ___
 
@@ -7092,7 +7092,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:273](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L273)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:292](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L292)
 
 ___
 
@@ -7106,4 +7106,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:412](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L412)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:431](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L431)

--- a/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
+++ b/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
@@ -25,7 +25,7 @@ even if the `testFcn` passed to `promptBeforeClosing` returns `true`.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/types.ts:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L10)
+[packages/framework/esm-styleguide/src/workspaces/types.ts:11](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L11)
 
 ## Methods
 
@@ -45,4 +45,4 @@ void
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/types.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L17)
+[packages/framework/esm-styleguide/src/workspaces/types.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L18)

--- a/packages/framework/esm-framework/docs/interfaces/DefaultWorkspaceProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/DefaultWorkspaceProps.md
@@ -4,14 +4,20 @@
 
 The default parameters received by all workspaces
 
+## Hierarchy
+
+- **`DefaultWorkspaceProps`**
+
+  ↳ [`OpenWorkspace`](OpenWorkspace.md)
+
 ## Table of contents
 
 ### Methods
 
 - [closeWorkspace](DefaultWorkspaceProps.md#closeworkspace)
 - [closeWorkspaceWithSavedChanges](DefaultWorkspaceProps.md#closeworkspacewithsavedchanges)
-- [handlePostResponse](DefaultWorkspaceProps.md#handlepostresponse)
 - [promptBeforeClosing](DefaultWorkspaceProps.md#promptbeforeclosing)
+- [setTitle](DefaultWorkspaceProps.md#settitle)
 
 ## Methods
 
@@ -37,7 +43,7 @@ closed, given the user forcefully closes the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/types.ts:29](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L29)
+[packages/framework/esm-styleguide/src/workspaces/types.ts:30](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L30)
 
 ___
 
@@ -53,20 +59,6 @@ will directly close the workspace without any prompt
 | Name | Type |
 | :------ | :------ |
 | `closeWorkspaceOptions?` | [`CloseWorkspaceOptions`](CloseWorkspaceOptions.md) |
-
-#### Returns
-
-`void`
-
-#### Defined in
-
-[packages/framework/esm-styleguide/src/workspaces/types.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L39)
-
-___
-
-### handlePostResponse
-
-▸ `Optional` **handlePostResponse**(): `void`
 
 #### Returns
 
@@ -97,4 +89,32 @@ this workspace is closed; e.g. if there is unsaved data.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/types.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L34)
+[packages/framework/esm-styleguide/src/workspaces/types.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L35)
+
+___
+
+### setTitle
+
+▸ **setTitle**(`title`, `titleNode?`): `void`
+
+Use this to set the workspace title if it needs to be set dynamically.
+
+Workspace titles generally are set in the workspace declaration in the routes.json file. They can also
+be set by the workspace launcher by passing `workspaceTitle` in the `additionalProps`
+parameter of the `launchWorkspace` function. This function is useful when the workspace
+title needs to be set dynamically.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `title` | `string` | The title to set. If using titleNode, set this to a human-readable string        which will identify the workspace in notifications and other places. |
+| `titleNode?` | `ReactNode` | A React object to put in the workspace header in place of the title. This        is useful for displaying custom elements in the header. Note that custom header        elements can also be attached to the workspace header extension slots. |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/types.ts:55](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L55)

--- a/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
@@ -6,6 +6,8 @@
 
 - [`WorkspaceRegistration`](WorkspaceRegistration.md)
 
+- [`DefaultWorkspaceProps`](DefaultWorkspaceProps.md)
+
   ↳ **`OpenWorkspace`**
 
 ## Table of contents
@@ -204,7 +206,13 @@ ___
 
 ### closeWorkspace
 
-▸ **closeWorkspace**(`closeWorkspaceOptions?`): `boolean`
+▸ **closeWorkspace**(`closeWorkspaceOptions?`): `void`
+
+Call this function to close the workspace. This function will prompt the user
+if there are any unsaved changes to workspace.
+
+You can pass `onWorkspaceClose` function to be called when the workspace is finally
+closed, given the user forcefully closes the workspace.
 
 #### Parameters
 
@@ -214,17 +222,24 @@ ___
 
 #### Returns
 
-`boolean`
+`void`
+
+#### Inherited from
+
+[DefaultWorkspaceProps](DefaultWorkspaceProps.md).[closeWorkspace](DefaultWorkspaceProps.md#closeworkspace)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L48)
+[packages/framework/esm-styleguide/src/workspaces/types.ts:30](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L30)
 
 ___
 
 ### closeWorkspaceWithSavedChanges
 
-▸ **closeWorkspaceWithSavedChanges**(`closeWorkspaceOptions?`): `boolean`
+▸ **closeWorkspaceWithSavedChanges**(`closeWorkspaceOptions?`): `void`
+
+Call this function to close the workspace after the form is saved. This function
+will directly close the workspace without any prompt
 
 #### Parameters
 
@@ -234,17 +249,24 @@ ___
 
 #### Returns
 
-`boolean`
+`void`
+
+#### Inherited from
+
+[DefaultWorkspaceProps](DefaultWorkspaceProps.md).[closeWorkspaceWithSavedChanges](DefaultWorkspaceProps.md#closeworkspacewithsavedchanges)
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L49)
+[packages/framework/esm-styleguide/src/workspaces/types.ts:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L40)
 
 ___
 
 ### promptBeforeClosing
 
 ▸ **promptBeforeClosing**(`testFcn`): `void`
+
+Call this with a no-args function that returns true if the user should be prompted before
+this workspace is closed; e.g. if there is unsaved data.
 
 #### Parameters
 
@@ -256,9 +278,13 @@ ___
 
 `void`
 
+#### Inherited from
+
+[DefaultWorkspaceProps](DefaultWorkspaceProps.md).[promptBeforeClosing](DefaultWorkspaceProps.md#promptbeforeclosing)
+
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L50)
+[packages/framework/esm-styleguide/src/workspaces/types.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L35)
 
 ___
 
@@ -266,20 +292,31 @@ ___
 
 ▸ **setTitle**(`title`, `titleNode?`): `void`
 
+Use this to set the workspace title if it needs to be set dynamically.
+
+Workspace titles generally are set in the workspace declaration in the routes.json file. They can also
+be set by the workspace launcher by passing `workspaceTitle` in the `additionalProps`
+parameter of the `launchWorkspace` function. This function is useful when the workspace
+title needs to be set dynamically.
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `title` | `string` |
-| `titleNode?` | `ReactNode` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `title` | `string` | The title to set. If using titleNode, set this to a human-readable string        which will identify the workspace in notifications and other places. |
+| `titleNode?` | `ReactNode` | A React object to put in the workspace header in place of the title. This        is useful for displaying custom elements in the header. Note that custom header        elements can also be attached to the workspace header extension slots. |
 
 #### Returns
 
 `void`
 
+#### Inherited from
+
+[DefaultWorkspaceProps](DefaultWorkspaceProps.md).[setTitle](DefaultWorkspaceProps.md#settitle)
+
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:51](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L51)
+[packages/framework/esm-styleguide/src/workspaces/types.ts:55](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/types.ts#L55)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
@@ -21,6 +21,7 @@
 - [preferredWindowSize](OpenWorkspace.md#preferredwindowsize)
 - [sidebarFamily](OpenWorkspace.md#sidebarfamily)
 - [title](OpenWorkspace.md#title)
+- [titleNode](OpenWorkspace.md#titlenode)
 - [type](OpenWorkspace.md#type)
 - [width](OpenWorkspace.md#width)
 
@@ -29,6 +30,7 @@
 - [closeWorkspace](OpenWorkspace.md#closeworkspace)
 - [closeWorkspaceWithSavedChanges](OpenWorkspace.md#closeworkspacewithsavedchanges)
 - [promptBeforeClosing](OpenWorkspace.md#promptbeforeclosing)
+- [setTitle](OpenWorkspace.md#settitle)
 
 ### Workspace Methods
 
@@ -42,7 +44,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L46)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L47)
 
 ___
 
@@ -56,7 +58,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L35)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:36](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L36)
 
 ___
 
@@ -70,7 +72,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:36](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L36)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L37)
 
 ___
 
@@ -84,7 +86,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L38)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L39)
 
 ___
 
@@ -98,7 +100,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:42](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L42)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:43](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L43)
 
 ___
 
@@ -126,7 +128,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L40)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:41](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L41)
 
 ___
 
@@ -140,7 +142,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L39)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L40)
 
 ___
 
@@ -158,6 +160,20 @@ ___
 
 ___
 
+### titleNode
+
+• `Optional` **titleNode**: `ReactNode`
+
+#### Inherited from
+
+[WorkspaceRegistration](WorkspaceRegistration.md).[titleNode](WorkspaceRegistration.md#titlenode)
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L34)
+
+___
+
 ### type
 
 • **type**: `string`
@@ -168,7 +184,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L34)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L35)
 
 ___
 
@@ -182,7 +198,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L37)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L38)
 
 ## Other Methods
 
@@ -202,7 +218,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L47)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L48)
 
 ___
 
@@ -222,7 +238,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L48)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L49)
 
 ___
 
@@ -242,7 +258,28 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L49)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L50)
+
+___
+
+### setTitle
+
+▸ **setTitle**(`title`, `titleNode?`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `title` | `string` |
+| `titleNode?` | `ReactNode` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:51](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L51)
 
 ___
 
@@ -262,4 +299,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:41](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L41)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:42](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L42)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
@@ -22,6 +22,7 @@ See [WorkspaceDefinition](../API.md#workspacedefinition) for more information ab
 - [preferredWindowSize](WorkspaceRegistration.md#preferredwindowsize)
 - [sidebarFamily](WorkspaceRegistration.md#sidebarfamily)
 - [title](WorkspaceRegistration.md#title)
+- [titleNode](WorkspaceRegistration.md#titlenode)
 - [type](WorkspaceRegistration.md#type)
 - [width](WorkspaceRegistration.md#width)
 
@@ -37,7 +38,7 @@ See [WorkspaceDefinition](../API.md#workspacedefinition) for more information ab
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L35)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:36](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L36)
 
 ___
 
@@ -47,7 +48,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:36](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L36)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L37)
 
 ___
 
@@ -57,7 +58,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L38)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L39)
 
 ___
 
@@ -67,7 +68,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:42](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L42)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:43](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L43)
 
 ___
 
@@ -87,7 +88,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L40)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:41](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L41)
 
 ___
 
@@ -97,7 +98,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L39)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L40)
 
 ___
 
@@ -111,13 +112,23 @@ ___
 
 ___
 
+### titleNode
+
+• `Optional` **titleNode**: `ReactNode`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L34)
+
+___
+
 ### type
 
 • **type**: `string`
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L34)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L35)
 
 ___
 
@@ -127,7 +138,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L37)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L38)
 
 ## Workspace Methods
 
@@ -141,4 +152,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:41](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L41)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:42](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L42)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:435](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L435)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:423](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L423)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:436](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L436)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:424](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L424)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:437](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L437)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:425](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L425)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:438](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L438)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:426](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L426)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:406](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L406)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:425](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L425)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:407](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L407)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:426](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L426)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:408](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L408)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:427](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L427)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:409](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L409)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:428](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L428)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:425](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L425)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:435](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L435)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:426](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L426)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:436](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L436)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:427](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L427)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:437](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L437)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:428](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L428)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:438](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L438)

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
@@ -120,7 +120,7 @@ export function WorkspaceContainer({
 }
 
 interface WorkspaceProps {
-  workspaceInstance: OpenWorkspace | null;
+  workspaceInstance: OpenWorkspace;
   additionalWorkspaceProps?: object;
 }
 
@@ -137,16 +137,6 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
   const toggleWindowState = useCallback(() => {
     isMaximized ? updateWorkspaceWindowState('normal') : updateWorkspaceWindowState('maximized');
   }, [isMaximized]);
-
-  const workspaceTitle = useMemo(() => {
-    if (workspaceInstance === null) {
-      return '';
-    }
-    return (
-      workspaceInstance.additionalProps?.['workspaceTitle'] ??
-      translateFrom(workspaceInstance.moduleName, workspaceInstance.title, workspaceInstance.title)
-    );
-  }, [workspaceInstance]);
 
   const {
     canHide = false,
@@ -170,7 +160,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
           {!isDesktop(layout) && !canHide && (
             <HeaderMenuButton renderMenuIcon={<ArrowLeftIcon />} onClick={closeWorkspace} />
           )}
-          <HeaderName prefix="">{workspaceTitle}</HeaderName>
+          <HeaderName prefix="">{workspaceInstance.titleNode ?? workspaceInstance.title}</HeaderName>
           <div className={styles.overlayHeaderSpacer} />
           <HeaderGlobalBar className={styles.headerButtons}>
             <ExtensionSlot

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.test.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.test.tsx
@@ -51,7 +51,40 @@ describe('WorkspaceContainer in window mode', () => {
     });
   });
 
-  test('should override title; should reopen hidden workspace window when user relaunches the same workspace window', async () => {
+  test('should override title via additional props and via setTitle', async () => {
+    mockedIsDesktop.mockReturnValue(true);
+    renderWorkspaceWindow();
+    act(() => launchWorkspace('clinical-form', { workspaceTitle: 'COVID Admission' }));
+    const header = screen.getByRole('banner');
+    expect(within(header).getByText('COVID Admission')).toBeInTheDocument();
+    const workspaces = renderHook(() => useWorkspaces());
+    act(() => workspaces.result.current.workspaces[0].setTitle('COVID Discharge'));
+    expect(within(header).getByText('COVID Discharge')).toBeInTheDocument();
+    act(() =>
+      workspaces.result.current.workspaces[0].setTitle(
+        'Space Ghost',
+        <div data-testid="patient-name">Space Ghost</div>,
+      ),
+    );
+    expect(within(header).getByTestId('patient-name')).toBeInTheDocument();
+  });
+
+  test('re-launching workspace should update title, but only if setTitle was not used', async () => {
+    mockedIsDesktop.mockReturnValue(true);
+    renderWorkspaceWindow();
+    act(() => launchWorkspace('clinical-form', { workspaceTitle: 'COVID Admission' }));
+    const header = screen.getByRole('banner');
+    expect(within(header).getByText('COVID Admission')).toBeInTheDocument();
+    act(() => launchWorkspace('clinical-form', { workspaceTitle: 'COVID Discharge' }));
+    expect(within(header).getByText('COVID Discharge')).toBeInTheDocument();
+    const workspaces = renderHook(() => useWorkspaces());
+    act(() => workspaces.result.current.workspaces[0].setTitle('Fancy Special Title'));
+    expect(within(header).getByText('Fancy Special Title')).toBeInTheDocument();
+    act(() => launchWorkspace('clinical-form', { workspaceTitle: 'COVID Admission Again' }));
+    expect(within(header).getByText('Fancy Special Title')).toBeInTheDocument();
+  });
+
+  test('should reopen hidden workspace window when user relaunches the same workspace window', async () => {
     const user = userEvent.setup();
     const workspaces = renderHook(() => useWorkspaces());
     mockedIsDesktop.mockReturnValue(true);

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
@@ -32,6 +32,7 @@ export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: Worksp
         closeWorkspace: workspace.closeWorkspace,
         closeWorkspaceWithSavedChanges: workspace.closeWorkspaceWithSavedChanges,
         promptBeforeClosing: workspace.promptBeforeClosing,
+        setTitle: workspace.setTitle,
         ...additionalPropsFromPage,
         ...workspace.additionalProps,
       },

--- a/packages/framework/esm-styleguide/src/workspaces/types.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/types.ts
@@ -1,4 +1,5 @@
 import { type WorkspaceWindowState } from '@openmrs/esm-globals';
+import { type ReactNode } from 'react';
 
 export interface CloseWorkspaceOptions {
   /**
@@ -37,7 +38,21 @@ export interface DefaultWorkspaceProps {
    * will directly close the workspace without any prompt
    */
   closeWorkspaceWithSavedChanges(closeWorkspaceOptions?: CloseWorkspaceOptions): void;
-  handlePostResponse?(): void;
+  /**
+   * Use this to set the workspace title if it needs to be set dynamically.
+   *
+   * Workspace titles generally are set in the workspace declaration in the routes.json file. They can also
+   * be set by the workspace launcher by passing `workspaceTitle` in the `additionalProps`
+   * parameter of the `launchWorkspace` function. This function is useful when the workspace
+   * title needs to be set dynamically.
+   *
+   * @param title The title to set. If using titleNode, set this to a human-readable string
+   *        which will identify the workspace in notifications and other places.
+   * @param titleNode A React object to put in the workspace header in place of the title. This
+   *        is useful for displaying custom elements in the header. Note that custom header
+   *        elements can also be attached to the workspace header extension slots.
+   */
+  setTitle(title: string, titleNode?: ReactNode): void;
 }
 
 export interface WorkspaceWindowSize {

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -178,18 +178,6 @@ function promptBeforeLaunchingWorkspace(
   }
 }
 
-interface A {
-  foo: string;
-}
-
-interface B extends A {
-  bar: string;
-}
-
-const fib: Omit<B, keyof A> = {
-  bar: 'bar',
-};
-
 /**
  * This launches a workspace by its name. The workspace must have been registered.
  * Workspaces should be registered in the `routes.json` file.

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -8,7 +8,7 @@ import { useStore } from '@openmrs/esm-react-utils';
 import { navigate } from '@openmrs/esm-navigation';
 import { getGlobalStore, createGlobalStore } from '@openmrs/esm-state';
 import { getCoreTranslation, translateFrom } from '@openmrs/esm-translations';
-import { type CloseWorkspaceOptions } from './types';
+import { type DefaultWorkspaceProps, type CloseWorkspaceOptions } from './types';
 
 export interface Prompt {
   title: string;
@@ -43,12 +43,8 @@ export interface WorkspaceRegistration {
   moduleName: string;
 }
 
-export interface OpenWorkspace extends WorkspaceRegistration {
+export interface OpenWorkspace extends WorkspaceRegistration, DefaultWorkspaceProps {
   additionalProps: object;
-  closeWorkspace(closeWorkspaceOptions?: CloseWorkspaceOptions): boolean;
-  closeWorkspaceWithSavedChanges(closeWorkspaceOptions?: CloseWorkspaceOptions): boolean;
-  promptBeforeClosing(testFcn: () => boolean): void;
-  setTitle(title: string, titleNode?: ReactNode): void;
 }
 
 interface WorkspaceRegistrationStore {
@@ -182,6 +178,18 @@ function promptBeforeLaunchingWorkspace(
   }
 }
 
+interface A {
+  foo: string;
+}
+
+interface B extends A {
+  bar: string;
+}
+
+const fib: Omit<B, keyof A> = {
+  bar: 'bar',
+};
+
 /**
  * This launches a workspace by its name. The workspace must have been registered.
  * Workspaces should be registered in the `routes.json` file.
@@ -211,7 +219,9 @@ function promptBeforeLaunchingWorkspace(
  * @param additionalProps Props to pass to the workspace component being launched. Passing
  *          a prop named `workspaceTitle` will override the title of the workspace.
  */
-export function launchWorkspace(name: string, additionalProps?: object) {
+export function launchWorkspace<
+  T extends DefaultWorkspaceProps | object = DefaultWorkspaceProps & { [key: string]: any },
+>(name: string, additionalProps?: Omit<T, keyof DefaultWorkspaceProps> & { workspaceTitle?: string }) {
   const store = getWorkspaceStore();
   const workspace = getWorkspaceRegistration(name);
   const newWorkspace = {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This allows workspaces to set their own title dynamically, including setting custom React components as the title.

## Screenshots

https://github.com/openmrs/openmrs-esm-core/assets/1031876/b4235c3d-d077-41f4-9193-9e555bff2b94


## Related Issue

Needed for https://openmrs.atlassian.net/browse/O3-3246

## Other
<!-- Anything not covered above -->
