### PR TITLE
(test) Fix flaky Login E2E test

### DIFF
--- a/e2e/specs/login.spec.ts
+++ b/e2e/specs/login.spec.ts
@@ -48,6 +48,6 @@ test('Login as Admin user', async ({ page }) => {
   });
 
   await test.step('And I should see the logout button', async () => {
-    await expect(userPanel.getByRole('button', { name: /logout/i })).toBeVisible();
+    await expect(page.getByRole('button', { name: /logout/i })).toBeVisible();
   });
 });

--- a/e2e/specs/login.spec.ts
+++ b/e2e/specs/login.spec.ts
@@ -6,6 +6,7 @@ test.use({ storageState: { cookies: [], origins: [] } });
 
 test('Login as Admin user', async ({ page }) => {
   const loginPage = new LoginPage(page);
+  const userPanel = page.locator('[data-extension-slot-name="user-panel-slot"]');
 
   await test.step('When I navigate to the login page', async () => {
     await loginPage.goto();
@@ -34,10 +35,19 @@ test('Login as Admin user', async ({ page }) => {
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home`);
   });
 
-  await test.step('And I should be able to see various elements on the page', async () => {
+  await test.step('When I click on the my account button', async () => {
     await page.getByRole('button', { name: /My Account/i }).click();
-    await expect(page.getByText(/super user/i)).toBeVisible();
-    await expect(page.getByText(/outpatient clinic/i)).toBeVisible();
-    await expect(page.getByRole('button', { name: /logout/i })).toBeVisible();
+  });
+
+  await test.step('Then I should see the user details', async () => {
+    await expect(userPanel.getByText(/super user/i)).toBeVisible();
+  });
+
+  await test.step('And I should see the location details', async () => {
+    await expect(userPanel.getByText(/outpatient clinic/i)).toBeVisible();
+  });
+
+  await test.step('And I should see the logout button', async () => {
+    await expect(userPanel.getByRole('button', { name: /logout/i })).toBeVisible();
   });
 });


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
The lab order often fails because the location is displayed twice on the homepage.
<img width="287" alt="image" src="https://github.com/openmrs/openmrs-esm-core/assets/33048395/1fc02445-0cbe-4f8c-834b-ae90e3bfb90b">
This PR narrows down the locator to the user panel.

Additionally, I have broken down the vague step `And I should be able to see various elements on the page` into smaller, more specific steps to improve clarity in the reports.

