### PR TITLE
(fix) subscribeToContext should send the current value of the context on subscribe

### DIFF
--- a/packages/framework/esm-context/src/context.ts
+++ b/packages/framework/esm-context/src/context.ts
@@ -99,6 +99,9 @@ export type ContextCallback<T extends {} = {}> = (state: Readonly<T> | null | un
 export function subscribeToContext<T extends {} = {}>(namespace: string, callback: ContextCallback<T>) {
   let previous = getContext<T>(namespace);
 
+  // set initial value
+  callback(Object.freeze(Object.assign({}, previous)));
+
   return contextStore.subscribe((state) => {
     let current: Readonly<T> | null | undefined = namespace in state ? (state[namespace] as T) : null;
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Basically, when calling `subscribeToContext()`, we ensure the context is called with the current value. Not having this functionality was causing `useAppContext` not to work until the context was updated.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
