### PR TITLE
(fix) O3-3595: Use correct per-locale calendar in OpenmrsDatepicker

### DIFF
--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -50,7 +50,7 @@ import {
   FieldError,
 } from 'react-aria-components';
 import dayjs, { type Dayjs } from 'dayjs';
-import { convertToLocaleCalendar, formatDate, getDefaultCalendar, getLocale } from '@openmrs/esm-utils';
+import { formatDate, getDefaultCalendar, getLocale } from '@openmrs/esm-utils';
 import styles from './datepicker.module.scss';
 import { CalendarIcon, CaretDownIcon, CaretUpIcon, ChevronLeftIcon, ChevronRightIcon, WarningIcon } from '../icons';
 
@@ -116,11 +116,11 @@ function dateToInternationalizedDate(date: DateInputValue, calendar: CalendarTyp
   }
 
   if (date instanceof CalendarDate || date instanceof CalendarDateTime || date instanceof ZonedDateTime) {
-    return date;
+    return calendar ? toCalendar(date, calendar) : date;
   } else {
     const date_ = dayjs(date).toDate();
     return calendar
-      ? new CalendarDate(calendar, date_.getFullYear(), date_.getMonth() + 1, date_.getDate())
+      ? toCalendar(new CalendarDate(date_.getFullYear(), date_.getMonth() + 1, date_.getDate()), calendar)
       : new CalendarDate(date_.getFullYear(), date_.getMonth() + 1, date_.getDate());
   }
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
There was an issue with the datepicker when the selected locale was amharic; It wasn't correctly resolving the maxValue and whenever a value was selected, it would resolve to a gregorian date value.

## Screenshots

https://github.com/user-attachments/assets/d1f62d29-dbd0-46be-8ba5-d8fba1ec28d2



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
