### PR TITLE
(fix) Restore loading Webpack loaders via require

### DIFF
--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -173,7 +173,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
   }
 
   const cssLoader = {
-    loader: 'css-loader',
+    loader: require.resolve('css-loader'),
     options: {
       modules: {
         localIdentName: `${ident}__[name]__[local]___[hash:base64:5]`,
@@ -197,14 +197,14 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
           {
             test: /\.m?(js|ts|tsx)$/,
             exclude: /node_modules(?![\/\\]@openmrs)/,
-            use: 'swc-loader',
+            use: require.resolve('swc-loader'),
           },
           scriptRuleConfig,
         ),
         merge(
           {
             test: /\.css$/,
-            use: ['style-loader', cssLoader],
+            use: [require.resolve('style-loader'), cssLoader],
           },
           cssRuleConfig,
         ),
@@ -212,10 +212,10 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
           {
             test: /\.s[ac]ss$/i,
             use: [
-              'style-loader',
+              require.resolve('style-loader'),
               cssLoader,
               {
-                loader: 'sass-loader',
+                loader: require.resolve('sass-loader'),
                 options: { sassOptions: { quietDeps: true } },
               },
             ],


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Just a revert so we're using `require.resolve()` to resolve loaders.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
