### PR TITLE
(fix) Don't generate warning from mini-css about order

### DIFF
--- a/packages/framework/esm-styleguide/src/workspaces/action-menu-button/action-menu-button.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/action-menu-button/action-menu-button.component.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import classNames from 'classnames';
 import { Button, IconButton } from '@carbon/react';
 import { useLayoutType } from '@openmrs/esm-react-utils';
-import styles from './action-menu-button.module.scss';
 import { useWorkspaces } from '../workspaces';
+import styles from './action-menu-button.module.scss';
 
 interface TagsProps {
   getIcon: (props: object) => JSX.Element;

--- a/packages/framework/esm-styleguide/src/workspaces/action-menu-button/action-menu-button.module.scss
+++ b/packages/framework/esm-styleguide/src/workspaces/action-menu-button/action-menu-button.module.scss
@@ -1,6 +1,6 @@
 @use '@carbon/styles/scss/spacing';
 @use '@carbon/styles/scss/type';
-@import '@openmrs/esm-styleguide/src/vars';
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 .container {
   margin-top: spacing.$spacing-02;
@@ -20,7 +20,7 @@
 
   & > span {
     margin-top: spacing.$spacing-02;
-    @include type.type-style("body-compact-01");
+    @include type.type-style('body-compact-01');
     color: $text-02;
   }
 
@@ -78,7 +78,6 @@
 
 /* Tablet */
 :global(.omrs-breakpoint-lt-desktop) {
-
   .container {
     margin-bottom: 0;
     margin-top: 0;
@@ -102,7 +101,7 @@
 
     & > span {
       color: $interactive-01;
-      @include type.type-style("heading-compact-01");
+      @include type.type-style('heading-compact-01');
     }
 
     svg {

--- a/packages/framework/esm-styleguide/src/workspaces/container/action-menu.module.scss
+++ b/packages/framework/esm-styleguide/src/workspaces/container/action-menu.module.scss
@@ -1,5 +1,5 @@
 @use '@carbon/styles/scss/spacing';
-@import '@openmrs/esm-styleguide/src/vars';
+@use '@openmrs/esm-styleguide/src/vars' as *;
 
 $icon-button-size: 2.5rem;
 $actionPanelOffset: 3rem;

--- a/packages/framework/esm-styleguide/src/workspaces/notification/workspace-notification.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/notification/workspace-notification.component.tsx
@@ -6,7 +6,6 @@ import { navigate } from '@openmrs/esm-navigation';
 import { reportError } from '@openmrs/esm-error-handling';
 import { escapeRegExp } from 'lodash-es';
 import { type SingleSpaCustomEventDetail } from 'single-spa';
-import styles from './workspace-notification.module.scss';
 import {
   cancelPrompt,
   canCloseWorkspaceWithoutPrompting,
@@ -16,6 +15,7 @@ import {
   resetWorkspaceStore,
   useWorkspaces,
 } from '../workspaces';
+import styles from './workspace-notification.module.scss';
 
 export interface WorkspaceNotificationProps {
   contextKey: string;

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -43,6 +43,7 @@
     "i18next-browser-languagedetector": "^6.1.8",
     "import-map-overrides": "^3.0.0",
     "lodash-es": "4.17.21",
+    "mini-css-extract-plugin": "^2.9.0",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",
     "react-i18next": "^11.18.6",

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -217,7 +217,7 @@ module.exports = (env, argv = {}) => {
           test: /openmrs-esm-styleguide\.css$/,
           use: [
             isProd
-              ? { loader: require.resolve(MiniCssExtractPlugin.loader), options: { emit: { ignoreOrder: true } } }
+              ? { loader: require.resolve(MiniCssExtractPlugin.loader) }
               : { loader: require.resolve('style-loader') },
             { loader: require.resolve('css-loader') },
           ],
@@ -377,6 +377,7 @@ module.exports = (env, argv = {}) => {
       isProd &&
         new MiniCssExtractPlugin({
           filename: 'openmrs.[contenthash].css',
+          ignoreOrder: true,
         }),
       new DefinePlugin({
         'process.env.BUILD_VERSION': JSON.stringify(`${version}-${timestamp}`),

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -217,7 +217,7 @@ module.exports = (env, argv = {}) => {
           test: /openmrs-esm-styleguide\.css$/,
           use: [
             isProd
-              ? { loader: require.resolve(MiniCssExtractPlugin.loader), options: { ignoreOrder: true } }
+              ? { loader: require.resolve(MiniCssExtractPlugin.loader), options: { emit: { ignoreOrder: true } } }
               : { loader: require.resolve('style-loader') },
             { loader: require.resolve('css-loader') },
           ],

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -217,7 +217,7 @@ module.exports = (env, argv = {}) => {
           test: /openmrs-esm-styleguide\.css$/,
           use: [
             isProd
-              ? { loader: require.resolve(MiniCssExtractPlugin.loader) }
+              ? { loader: require.resolve(MiniCssExtractPlugin.loader), options: { ignoreOrder: true } }
               : { loader: require.resolve('style-loader') },
             { loader: require.resolve('css-loader') },
           ],

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -45,7 +45,7 @@
     "html-webpack-plugin": "^5.5.0",
     "inquirer": "^7.3.3",
     "lodash-es": "^4.17.21",
-    "mini-css-extract-plugin": "^2.4.5",
+    "mini-css-extract-plugin": "^2.9.0",
     "node-watch": "^0.7.4",
     "npm-registry-fetch": "^14.0.3",
     "pacote": "^15.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2959,6 +2959,7 @@ __metadata:
     i18next-browser-languagedetector: "npm:^6.1.8"
     import-map-overrides: "npm:^3.0.0"
     lodash-es: "npm:4.17.21"
+    mini-css-extract-plugin: "npm:^2.9.0"
     react: "npm:^18.1.0"
     react-dom: "npm:^18.1.0"
     react-i18next: "npm:^11.18.6"
@@ -13498,14 +13499,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"mini-css-extract-plugin@npm:^2.4.5":
-  version: 2.6.1
-  resolution: "mini-css-extract-plugin@npm:2.6.1"
+"mini-css-extract-plugin@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "mini-css-extract-plugin@npm:2.9.0"
   dependencies:
     schema-utils: "npm:^4.0.0"
+    tapable: "npm:^2.2.1"
   peerDependencies:
     webpack: ^5.0.0
-  checksum: 10/368e104453b7631c54a9c537077a4824383892f126259fc0cc0139b356f99e9d3c082297eb933c9c301166bf93f71fdeb9a8bdaef85f71a061300d5a16234f69
+  checksum: 10/4c9ee9c0c6160a64a4884d5a92a1a5c0b68d556cd00f975cf6c8a79b51ac90e6130a37b3832b17d377d0cb1b31c0313c8c023458d4f69e95fe3424a8b43d834f
   languageName: node
   linkType: hard
 
@@ -14286,7 +14288,7 @@ __metadata:
     html-webpack-plugin: "npm:^5.5.0"
     inquirer: "npm:^7.3.3"
     lodash-es: "npm:^4.17.21"
-    mini-css-extract-plugin: "npm:^2.4.5"
+    mini-css-extract-plugin: "npm:^2.9.0"
     node-watch: "npm:^0.7.4"
     npm-registry-fetch: "npm:^14.0.3"
     pacote: "npm:^15.0.0"


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Just removes warnings from mini-css-plugin due to the [issue described here](https://github.com/webpack-contrib/mini-css-extract-plugin/issues/250#issuecomment-415345126).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
