### PR TITLE
(feat) O3-3509: assemble command should support merging multiple configs

### DIFF
--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -216,6 +216,7 @@ yargs.command(
         describe:
           'The path to a frontend configuration file. Can be used multiple times. The file is copied directly into the build directory.',
         type: 'array',
+        coerce: (arg: Array<string>) => arg.map((p) => resolve(process.cwd(), p)),
       })
       .option('importmap', {
         default: undefined,
@@ -237,9 +238,9 @@ yargs.command(
       }),
   async (args) =>
     runCommand('runBuild', {
-      configUrls: args['config-url'],
-      configPaths: args['config-path'].map((p) => resolve(process.cwd(), p)),
       ...args,
+      configUrls: args['config-url'],
+      configPaths: args['config-path'],
     }),
 );
 
@@ -263,14 +264,22 @@ yargs.command(
       })
       .option('config', {
         default: ['spa-build-config.json'],
-        description: 'Path to a SPA build config JSON.',
+        description: 'Path to a SPA assemble config JSON.',
         type: 'array',
         coerce: (arg: Array<string>) => arg.map((p) => resolve(process.cwd(), p)),
       })
-      .option('hash-importmap', {
+      .option('config-file', {
+        default: [],
+        describe:
+          'Reference to a frontend configuration file. Can be used multiple times. Configurations are merged in the order specified into openmrs-config.json.',
+        type: 'array',
+        coerce: (arg: Array<string>) => arg.map((p) => resolve(process.cwd(), p)),
+      })
+      .option('hash-files', {
         default: false,
+        alias: ['hasn', 'hash-importmap'],
         description:
-          'Determines whether to include a content-specific hash for the generated importmap. This is useful if you want to be able to cache the importmap.',
+          'Determines whether to include a content-specific hash for the generated JSON files. This is useful if you want to be able to cache those files.',
         type: 'boolean',
       })
       .option('fresh', {
@@ -295,7 +304,7 @@ yargs.command(
           'The source of the frontend modules to assemble. `config` uses a configuration file specified via `--config`. `survey` starts an interactive command-line survey.',
         type: 'string',
       }),
-  (args) => runCommand('runAssemble', args),
+  (args) => runCommand('runAssemble', { ...args, configFiles: args['config-file'] }),
 );
 
 yargs.command(
@@ -326,7 +335,7 @@ yargs.command(
 
 yargs
   .epilog(
-    'The SPA build config JSON is a JSON file, typically `frontend.json`, which defines parameters for the `build` and `assemble` ' +
+    'The SPA assemble config JSON is a JSON file, typically `frontend.json`, which defines parameters for the `build` and `assemble` ' +
       'commands. The keys used by `build` are:\n' +
       '  `apiUrl`, `spaPath`, `configPaths`, `configUrls`, `importmap`, `pageTitle`, and `supportOffline`;\n' +
       'each of which is equivalent to the corresponding command line argument (see `openmrs build --help`). ' +


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Allows the specification of `--config-file` arguments when calling `assemble`. The specified files will be merged into a single `openmrs-config.json` file.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-3509

## Other
<!-- Anything not covered above -->
