### PR TITLE
(fix) Config system and Implementer Tools both crash when 'null' passed for Array value

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/array-editor.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/array-editor.tsx
@@ -22,11 +22,12 @@ interface ArrayEditorProps {
 
 export function ArrayEditor({ element, valueArray, setValue }: ArrayEditorProps) {
   const arrayKey = useMemo(() => uniqueId('array-editor-'), []);
+  const currentValueArray = valueArray ?? [];
   return (
     <Tile className={styles.arrayEditor}>
       <StructuredListWrapper>
         <StructuredListBody>
-          {valueArray.map((value, i) => (
+          {currentValueArray.map((value, i) => (
             <StructuredListRow key={`${arrayKey}-${i}`}>
               <StructuredListCell>
                 <ValueEditorField
@@ -38,7 +39,7 @@ export function ArrayEditor({ element, valueArray, setValue }: ArrayEditorProps)
                   valueType={(element._elements?._type as Type) ?? Type.Object}
                   value={value}
                   onChange={(newValue) => {
-                    const newValueArray = cloneDeep(valueArray);
+                    const newValueArray = cloneDeep(currentValueArray);
                     newValueArray[i] = newValue;
                     setValue(newValueArray);
                   }}
@@ -52,7 +53,7 @@ export function ArrayEditor({ element, valueArray, setValue }: ArrayEditorProps)
                   iconDescription="Remove"
                   hasIconOnly
                   onClick={() => {
-                    const newValueArray = cloneDeep(valueArray);
+                    const newValueArray = cloneDeep(currentValueArray);
                     newValueArray.splice(i, 1);
                     setValue(newValueArray);
                   }}
@@ -68,7 +69,7 @@ export function ArrayEditor({ element, valueArray, setValue }: ArrayEditorProps)
                 iconDescription="Add"
                 hasIconOnly
                 onClick={() => {
-                  const newValueArray = cloneDeep(valueArray);
+                  const newValueArray = cloneDeep(currentValueArray);
                   const newValue = (element._elements?._type ?? Type.Object) == Type.Object ? {} : null;
                   newValueArray.push(newValue);
                   setValue(newValueArray);

--- a/packages/apps/esm-implementer-tools-app/src/implementer-tools.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/implementer-tools.component.tsx
@@ -57,9 +57,5 @@ function PopupHandler() {
 }
 
 export default function ImplementerTools() {
-  return (
-    <UserHasAccess privilege="coreapps.systemAdministration">
-      <PopupHandler />
-    </UserHasAccess>
-  );
+  return <PopupHandler />;
 }

--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -406,6 +406,23 @@ describe('getConfig', () => {
     expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/0.*foo-module.*baz.*must be an object/i));
   });
 
+  it('does not crash when null is passed as a freeform object config value', async () => {
+    Config.defineConfigSchema('object-null-module', {
+      objnu: {
+        _type: Type.Object,
+        _default: {},
+      },
+    });
+    const testConfig = {
+      'object-null-module': {
+        objnu: null,
+      },
+    };
+    Config.provide(testConfig);
+    await Config.getConfig('object-null-module');
+    expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/.*object-null-module.*obj.*must be an object/i));
+  });
+
   it('supports freeform object elements validations', async () => {
     Config.defineConfigSchema('foo-module', {
       foo: {
@@ -666,6 +683,23 @@ describe('getConfig', () => {
     Config.provide(goodConfig);
     const result = await Config.getConfig('foo-module');
     expect(result.bar[0].a.b).toBe(2);
+  });
+
+  it('does not crash when null is passed as an array config value', async () => {
+    Config.defineConfigSchema('array-null-module', {
+      arnu: {
+        _type: Type.Array,
+        _default: [1, 2, 3],
+      },
+    });
+    const testConfig = {
+      'array-null-module': {
+        arnu: null,
+      },
+    };
+    Config.provide(testConfig);
+    await Config.getConfig('array-null-module');
+    expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/.*array-null-module.*arnu.*must be an array/i));
   });
 
   it('fills array element object elements with defaults', async () => {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Passing 'null' for a config value which is supposed to be an Array causes both the Implementer Tools and the config system to crash. This fixes the problem, making them issue the 'wrong type' warning as expected.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
