### PR TITLE
(Fix) DatePicker input should clear when unspecified is checked

### DIFF
--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -9,6 +9,8 @@ import React, {
   useContext,
   useCallback,
   useRef,
+  useState,
+  useEffect,
 } from 'react';
 import classNames, { type Argument } from 'classnames';
 import {
@@ -284,6 +286,13 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
     const minDate = useMemo(() => dateToInternationalizedDate(rawMinDate, calendar), [rawMinDate]);
     const isInvalid = useMemo(() => invalid ?? isInvalidRaw, [invalid, isInvalidRaw]);
     const today_ = calendar ? toCalendar(today(getLocalTimeZone()), calendar) : today(getLocalTimeZone());
+    const [internalValue, setInternalValue] = useState<
+      CalendarDate | CalendarDateTime | ZonedDateTime | null | undefined
+    >(value);
+
+    useEffect(() => {
+      setInternalValue(rawValue ? dateToInternationalizedDate(rawValue, calendar) : null);
+    }, [rawValue, calendar]);
 
     return (
       <I18nProvider locale={localeWithCalendar}>
@@ -297,7 +306,8 @@ export const OpenmrsDatePicker = forwardRef<HTMLDivElement, OpenmrsDatePickerPro
             isInvalid={isInvalid}
             maxValue={maxDate}
             minValue={minDate}
-            value={value}
+            value={internalValue}
+            onChange={setInternalValue}
             {...datePickerProps}
           >
             <div className="cds--date-picker-container">


### PR DESCRIPTION
# Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This fix ensures that the date input clears correctly when the "unspecified" option is selected, addressing the issue where state changes were not properly propagated to the `DatePickerInput` component.

## Screenshots

https://github.com/user-attachments/assets/6962ac16-1af8-4dfa-8f9d-b6851d380423

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
