### PR TITLE
(fix) O3-3691: The workspace family store shouldn't reset if workspace of same family is launched

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -6994,7 +6994,7 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:306](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L306)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:304](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L304)
 
 ___
 
@@ -7045,7 +7045,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:178](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L178)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:176](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L176)
 
 ___
 
@@ -7071,7 +7071,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:263](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L263)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:261](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L261)
 
 ___
 
@@ -7085,4 +7085,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:416](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L416)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:414](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L414)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -7085,4 +7085,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:412](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L412)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:416](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L416)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -6977,7 +6977,7 @@ ___
 
 ### closeWorkspace
 
-▸ **closeWorkspace**(`name`, `options?`): `void`
+▸ **closeWorkspace**(`name`, `options?`): `boolean`
 
 Function to close an opened workspace
 
@@ -6990,11 +6990,11 @@ Function to close an opened workspace
 
 #### Returns
 
-`void`
+`boolean`
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:306](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L306)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:305](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L305)
 
 ___
 
@@ -7045,7 +7045,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:179](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L179)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:178](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L178)
 
 ___
 
@@ -7071,7 +7071,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:264](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L264)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:263](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L263)
 
 ___
 
@@ -7085,4 +7085,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:424](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L424)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:419](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L419)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -6994,7 +6994,7 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:288](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L288)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:306](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L306)
 
 ___
 
@@ -7045,7 +7045,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:166](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L166)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:178](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L178)
 
 ___
 
@@ -7071,7 +7071,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:251](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L251)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:263](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L263)
 
 ___
 
@@ -7085,4 +7085,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:402](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L402)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:412](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L412)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -6977,7 +6977,7 @@ ___
 
 ### closeWorkspace
 
-▸ **closeWorkspace**(`name`, `options?`): `boolean`
+▸ **closeWorkspace**(`name`, `options?`): `void`
 
 Function to close an opened workspace
 
@@ -6990,11 +6990,11 @@ Function to close an opened workspace
 
 #### Returns
 
-`boolean`
+`void`
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:304](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L304)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:306](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L306)
 
 ___
 
@@ -7045,7 +7045,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:176](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L176)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:179](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L179)
 
 ___
 
@@ -7071,7 +7071,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:261](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L261)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:264](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L264)
 
 ___
 
@@ -7085,4 +7085,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:414](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L414)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:424](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L424)

--- a/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
+++ b/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
@@ -6,7 +6,6 @@
 
 ### Workspace Properties
 
-- [clearWorkspaceFamilyStore](CloseWorkspaceOptions.md#clearworkspacefamilystore)
 - [ignoreChanges](CloseWorkspaceOptions.md#ignorechanges)
 
 ### Workspace Methods
@@ -14,20 +13,6 @@
 - [onWorkspaceClose](CloseWorkspaceOptions.md#onworkspaceclose)
 
 ## Workspace Properties
-
-### clearWorkspaceFamilyStore
-
-• `Optional` **clearWorkspaceFamilyStore**: `boolean`
-
-Controls whether the workspace family store will be cleared when this workspace is closed. Defaults to true except when opening a new workspace of the same family.
-
-**`default`** true
-
-#### Defined in
-
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:32](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L32)
-
-___
 
 ### ignoreChanges
 

--- a/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
+++ b/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
@@ -19,15 +19,13 @@
 
 • `Optional` **clearWorkspaceFamilyStore**: `boolean`
 
-If set to true, the workspace family store will be cleared when the workspace is closed. Defaults to true.
-
-If set to false, the workspace family store will not be cleared when the workspace is closed. This happens when the new workspace is of the same sidebar family as the current workspace.
+Controls whether the workspace family store will be cleared when this workspace is closed. Defaults to true except when opening a new workspace of the same family.
 
 **`default`** true
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L34)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:32](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L32)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
+++ b/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
@@ -6,6 +6,7 @@
 
 ### Workspace Properties
 
+- [clearWorkspaceFamilyStore](CloseWorkspaceOptions.md#clearworkspacefamilystore)
 - [ignoreChanges](CloseWorkspaceOptions.md#ignorechanges)
 
 ### Workspace Methods
@@ -13,6 +14,22 @@
 - [onWorkspaceClose](CloseWorkspaceOptions.md#onworkspaceclose)
 
 ## Workspace Properties
+
+### clearWorkspaceFamilyStore
+
+• `Optional` **clearWorkspaceFamilyStore**: `boolean`
+
+If set to true, the workspace family store will be cleared when the workspace is closed. Defaults to true.
+
+If set to false, the workspace family store will not be cleared when the workspace is closed. This happens when the new workspace is of the same sidebar family as the current workspace.
+
+**`default`** true
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L34)
+
+___
 
 ### ignoreChanges
 

--- a/packages/framework/esm-framework/docs/interfaces/DefaultWorkspaceProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/DefaultWorkspaceProps.md
@@ -43,7 +43,7 @@ closed, given the user forcefully closes the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L46)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L44)
 
 ___
 
@@ -66,7 +66,7 @@ will directly close the workspace without any prompt
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:56](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L56)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:54](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L54)
 
 ___
 
@@ -89,7 +89,7 @@ this workspace is closed; e.g. if there is unsaved data.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:51](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L51)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L49)
 
 ___
 
@@ -117,4 +117,4 @@ title needs to be set dynamically.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L71)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L69)

--- a/packages/framework/esm-framework/docs/interfaces/DefaultWorkspaceProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/DefaultWorkspaceProps.md
@@ -43,7 +43,7 @@ closed, given the user forcefully closes the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L44)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L47)
 
 ___
 
@@ -66,7 +66,7 @@ will directly close the workspace without any prompt
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:54](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L54)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:57](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L57)
 
 ___
 
@@ -89,7 +89,7 @@ this workspace is closed; e.g. if there is unsaved data.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L49)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:52](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L52)
 
 ___
 
@@ -117,4 +117,4 @@ title needs to be set dynamically.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L69)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L72)

--- a/packages/framework/esm-framework/docs/interfaces/DefaultWorkspaceProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/DefaultWorkspaceProps.md
@@ -43,7 +43,7 @@ closed, given the user forcefully closes the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L38)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L46)
 
 ___
 
@@ -66,7 +66,7 @@ will directly close the workspace without any prompt
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L48)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:56](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L56)
 
 ___
 
@@ -89,7 +89,7 @@ this workspace is closed; e.g. if there is unsaved data.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:43](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L43)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:51](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L51)
 
 ___
 
@@ -117,4 +117,4 @@ title needs to be set dynamically.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:63](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L63)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L71)

--- a/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
@@ -202,7 +202,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:98](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L98)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:106](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L106)
 
 ## Methods
 
@@ -232,7 +232,7 @@ closed, given the user forcefully closes the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L38)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L46)
 
 ___
 
@@ -259,7 +259,7 @@ will directly close the workspace without any prompt
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L48)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:56](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L56)
 
 ___
 
@@ -304,7 +304,7 @@ this workspace is closed; e.g. if there is unsaved data.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:43](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L43)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:51](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L51)
 
 ___
 
@@ -336,4 +336,4 @@ title needs to be set dynamically.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:63](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L63)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L71)

--- a/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
@@ -202,7 +202,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:106](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L106)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:104](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L104)
 
 ## Methods
 
@@ -232,7 +232,7 @@ closed, given the user forcefully closes the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L46)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L44)
 
 ___
 
@@ -259,7 +259,7 @@ will directly close the workspace without any prompt
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:56](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L56)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:54](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L54)
 
 ___
 
@@ -304,7 +304,7 @@ this workspace is closed; e.g. if there is unsaved data.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:51](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L51)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L49)
 
 ___
 
@@ -336,4 +336,4 @@ title needs to be set dynamically.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L71)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L69)

--- a/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
@@ -202,7 +202,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:104](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L104)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:107](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L107)
 
 ## Methods
 
@@ -232,7 +232,7 @@ closed, given the user forcefully closes the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L44)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L47)
 
 ___
 
@@ -259,7 +259,7 @@ will directly close the workspace without any prompt
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:54](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L54)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:57](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L57)
 
 ___
 
@@ -304,7 +304,7 @@ this workspace is closed; e.g. if there is unsaved data.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L49)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:52](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L52)
 
 ___
 
@@ -336,4 +336,4 @@ title needs to be set dynamically.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L69)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L72)

--- a/packages/framework/esm-framework/docs/interfaces/Prompt.md
+++ b/packages/framework/esm-framework/docs/interfaces/Prompt.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:88](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L88)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:91](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L91)
 
 ___
 
@@ -35,7 +35,7 @@ Defaults to "Cancel"
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L93)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:96](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L96)
 
 ___
 
@@ -47,7 +47,7 @@ Defaults to "Confirm"
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:90](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L90)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L93)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L87)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:90](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L90)
 
 ## Methods
 
@@ -71,4 +71,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:91](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L91)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:94](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L94)

--- a/packages/framework/esm-framework/docs/interfaces/Prompt.md
+++ b/packages/framework/esm-framework/docs/interfaces/Prompt.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:90](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L90)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:88](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L88)
 
 ___
 
@@ -35,7 +35,7 @@ Defaults to "Cancel"
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:95](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L95)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L93)
 
 ___
 
@@ -47,7 +47,7 @@ Defaults to "Confirm"
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:92](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L92)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:90](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L90)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L89)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L87)
 
 ## Methods
 
@@ -71,4 +71,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L93)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:91](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L91)

--- a/packages/framework/esm-framework/docs/interfaces/Prompt.md
+++ b/packages/framework/esm-framework/docs/interfaces/Prompt.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:82](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L82)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:90](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L90)
 
 ___
 
@@ -35,7 +35,7 @@ Defaults to "Cancel"
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L87)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:95](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L95)
 
 ___
 
@@ -47,7 +47,7 @@ Defaults to "Confirm"
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:84](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L84)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:92](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L92)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L81)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L89)
 
 ## Methods
 
@@ -71,4 +71,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:85](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L85)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L93)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:396](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L396)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:406](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L406)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:397](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L397)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:407](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L407)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:398](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L398)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:408](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L408)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:399](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L399)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:409](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L409)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:418](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L418)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:413](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L413)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:419](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L419)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:414](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L414)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:420](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L420)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:415](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L415)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:421](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L421)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:416](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L416)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:406](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L406)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:410](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L410)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:407](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L407)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:411](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L411)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:408](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L408)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:412](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L412)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:409](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L409)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:413](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L413)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:410](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L410)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:408](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L408)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:411](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L411)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:409](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L409)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:412](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L412)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:410](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L410)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:413](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L413)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:411](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L411)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:408](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L408)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:418](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L418)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:409](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L409)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:419](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L419)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:410](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L410)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:420](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L420)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:411](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L411)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:421](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L421)

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
@@ -39,7 +39,7 @@ export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: Worksp
         ...workspaceFamilyState,
         ...workspace.additionalProps,
       },
-    [workspace, additionalPropsFromPage],
+    [workspace, additionalPropsFromPage, workspaceFamilyState],
   );
 
   return lifecycle ? (

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.test.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.test.tsx
@@ -27,7 +27,7 @@ describe('WorkspaceRenderer', () => {
     });
     render(
       <WorkspaceRenderer
-        // @ts-ignore
+        // @ts-ignore The workspace is of type OpenWorkspace and not all properties are required
         workspace={{
           closeWorkspace: mockedCloseWorkspace,
           name: 'workspace-name',

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.test.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.test.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { WorkspaceRenderer } from './workspace-renderer.component';
+import { getWorkspaceFamilyStore, OpenWorkspace } from '../workspaces';
+import Parcel from 'single-spa-react/parcel';
+
+const mockFn = jest.fn();
+
+jest.mock('single-spa-react/parcel', () =>
+  jest.fn((props) => {
+    mockFn(props);
+    return <div data-testid="mocked-parcel" />;
+  }),
+);
+
+describe('WorkspaceRenderer', () => {
+  it('should render workspace', async () => {
+    const mockedCloseWorkspace = jest.fn();
+    const mockedCloseWorkspaceWithSavedChanges = jest.fn();
+    const mockedPromptBeforeClosing = jest.fn();
+    const mockedSetTitle = jest.fn();
+    const mockedLoadFn = jest.fn().mockImplementation(() => Promise.resolve({ default: 'file-content' }));
+    getWorkspaceFamilyStore('test-sidebar-family')?.setState({
+      // Testing that the workspace family state should be overrided by additionalProps
+      foo: false,
+      workspaceFamilyState: {},
+    });
+    render(
+      <WorkspaceRenderer
+        // @ts-ignore
+        workspace={{
+          closeWorkspace: mockedCloseWorkspace,
+          name: 'workspace-name',
+          load: mockedLoadFn,
+          title: 'Workspace title',
+          closeWorkspaceWithSavedChanges: mockedCloseWorkspaceWithSavedChanges,
+          promptBeforeClosing: mockedPromptBeforeClosing,
+          setTitle: mockedSetTitle,
+          additionalProps: {
+            foo: 'true',
+          },
+          sidebarFamily: 'test-sidebar-family',
+        }}
+        additionalPropsFromPage={{ bar: 'true' }}
+      />,
+    );
+
+    expect(screen.getByText('Loading ...')).toBeInTheDocument();
+    expect(mockedLoadFn).toHaveBeenCalled();
+    await screen.findByTestId('mocked-parcel');
+
+    expect(mockFn).toHaveBeenCalledWith({
+      config: 'file-content',
+      mountParcel: undefined,
+      closeWorkspace: mockedCloseWorkspace,
+      closeWorkspaceWithSavedChanges: mockedCloseWorkspaceWithSavedChanges,
+      promptBeforeClosing: mockedPromptBeforeClosing,
+      setTitle: mockedSetTitle,
+      foo: 'true',
+      bar: 'true',
+      workspaceFamilyState: {},
+    });
+  });
+});

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -2,7 +2,6 @@ import {
   type Prompt,
   cancelPrompt,
   closeWorkspace,
-  closeWorkspaceInternal,
   getWorkspaceFamilyStore,
   getWorkspaceStore,
   launchWorkspace,
@@ -519,28 +518,6 @@ describe('workspace system', () => {
       closeWorkspace('ward-patient-workspace');
       expect(workspaceFamilyStore?.getState()?.['foo']).toBeUndefined();
       expect(workspaceFamilyStore?.getState()).toStrictEqual({});
-    });
-
-    it('should not clear workspace family store if the workspace is closed and `clearWorkspaceFamilyStore` option is passed false', async () => {
-      registerWorkspace({
-        name: 'ward-patient-workspace',
-        title: 'Ward Patient Workspace',
-        load: jest.fn(),
-        type: 'ward-patient',
-        moduleName: '@openmrs/esm-ward-app',
-        hasOwnSidebar: true,
-        sidebarFamily: 'ward-patient-sidebar',
-      });
-      launchWorkspace('ward-patient-workspace', {
-        foo: true,
-      });
-      const workspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
-      expect(workspaceFamilyStore).toBeTruthy();
-      expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
-      closeWorkspaceInternal('ward-patient-workspace', {
-        clearWorkspaceFamilyStore: false,
-      });
-      expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
     });
 
     it('should not clear the workspace store if the new workspace opened is of the same type as the already opened workspace', () => {

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -647,6 +647,40 @@ describe('workspace system', () => {
       expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
     });
 
+    it('should not clear the workspace if a workspace of same sidebar family is opened', () => {
+      registerWorkspace({
+        name: 'ward-patient-workspace',
+        title: 'Ward Patient Workspace',
+        load: jest.fn(),
+        type: 'ward-patient',
+        moduleName: '@openmrs/esm-ward-app',
+        hasOwnSidebar: true,
+        sidebarFamily: 'ward-patient-sidebar',
+        canHide: true,
+      });
+      registerWorkspace({
+        name: 'transfer-patient-workspace',
+        title: 'Transfer Patient Workspace',
+        load: jest.fn(),
+        type: 'transfer-patient',
+        moduleName: '@openmrs/esm-ward-app',
+        hasOwnSidebar: true,
+        sidebarFamily: 'ward-patient-sidebar',
+      });
+      const workspaceStore = getWorkspaceStore();
+      launchWorkspace('ward-patient-workspace', {
+        foo: true,
+      });
+      const wardPatientFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
+      expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
+      expect(wardPatientFamilyStore).toBeTruthy();
+      expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
+      launchWorkspace('transfer-patient-workspace', { bar: false });
+      expect(workspaceStore.getState().openWorkspaces.length).toBe(2);
+      expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
+      expect(wardPatientFamilyStore?.getState()?.['bar']).toBe(false);
+    });
+
     it('should retain default closeWorkspace options in case workspace options are passed', () => {
       registerWorkspace({
         name: 'ward-patient-workspace',

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -1,6 +1,7 @@
 import {
   type Prompt,
   cancelPrompt,
+  closeWorkspace,
   getWorkspaceFamilyStore,
   getWorkspaceStore,
   launchWorkspace,
@@ -8,7 +9,6 @@ import {
 } from './workspaces';
 import { registerExtension, registerWorkspace } from '@openmrs/esm-extensions';
 import { clearMockExtensionRegistry } from '@openmrs/esm-framework/mock';
-import { waitFor } from '@testing-library/dom';
 
 describe('workspace system', () => {
   beforeEach(() => {
@@ -499,7 +499,50 @@ describe('workspace system', () => {
       expect(workspaceFamilyStore?.getState()).toStrictEqual({});
     });
 
-    it('should share the same store with different workspaces with same sidebarFamilyName', () => {
+    it('should clear workspace family store by default if the workspace is closed, since `clearWorkspaceFamilyStore` is true by default', async () => {
+      registerWorkspace({
+        name: 'ward-patient-workspace',
+        title: 'Ward Patient Workspace',
+        load: jest.fn(),
+        type: 'ward-patient',
+        moduleName: '@openmrs/esm-ward-app',
+        hasOwnSidebar: true,
+        sidebarFamily: 'ward-patient-sidebar',
+      });
+      launchWorkspace('ward-patient-workspace', {
+        foo: true,
+      });
+      const workspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
+      expect(workspaceFamilyStore).toBeTruthy();
+      expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
+      closeWorkspace('ward-patient-workspace');
+      expect(workspaceFamilyStore?.getState()?.['foo']).toBeUndefined();
+      expect(workspaceFamilyStore?.getState()).toStrictEqual({});
+    });
+
+    it('should not clear workspace family store if the workspace is closed and `clearWorkspaceFamilyStore` option is passed false', async () => {
+      registerWorkspace({
+        name: 'ward-patient-workspace',
+        title: 'Ward Patient Workspace',
+        load: jest.fn(),
+        type: 'ward-patient',
+        moduleName: '@openmrs/esm-ward-app',
+        hasOwnSidebar: true,
+        sidebarFamily: 'ward-patient-sidebar',
+      });
+      launchWorkspace('ward-patient-workspace', {
+        foo: true,
+      });
+      const workspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
+      expect(workspaceFamilyStore).toBeTruthy();
+      expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
+      closeWorkspace('ward-patient-workspace', {
+        clearWorkspaceFamilyStore: false,
+      });
+      expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
+    });
+
+    it('should not clear the workspace store if the new workspace opened is of the same type as the already opened workspace', () => {
       const sidebarFamily = 'ward-patient-sidebar';
       registerWorkspace({
         name: 'ward-patient-workspace',
@@ -509,7 +552,6 @@ describe('workspace system', () => {
         moduleName: '@openmrs/esm-ward-app',
         hasOwnSidebar: true,
         sidebarFamily,
-        canHide: true,
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -529,19 +571,48 @@ describe('workspace system', () => {
       expect(sidebarFamilyStore).toBeTruthy();
       expect(sidebarFamilyStore?.getState()?.['foo']).toBe(true);
       launchWorkspace('transfer-patient-workspace', { bar: false });
-      expect(workspaceStore.getState().openWorkspaces.length).toBe(2);
+      expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
       const transferPatientWorkspace = workspaceStore.getState().openWorkspaces[0];
-      const wardPatientWorkspace = workspaceStore.getState().openWorkspaces[1];
-      expect(wardPatientWorkspace.name).toBe('ward-patient-workspace');
-      expect(wardPatientWorkspace).toBeTruthy();
-      expect(sidebarFamilyStore?.getState()?.['foo']).toBe(true);
-      expect(sidebarFamilyStore?.getState()?.['bar']).toBe(false);
-      expect(transferPatientWorkspace.name).toBe('transfer-patient-workspace');
       expect(sidebarFamilyStore?.getState()?.['foo']).toBe(true);
       expect(sidebarFamilyStore?.getState()?.['bar']).toBe(false);
     });
 
-    it('should clear workspace if all the workspaces of the same family is closed', async () => {
+    it('should clear the store when new workspace with different sidebar is opened, given the original workspace cannot hide', () => {
+      registerWorkspace({
+        name: 'ward-patient-workspace',
+        title: 'Ward Patient Workspace',
+        load: jest.fn(),
+        type: 'ward-patient',
+        moduleName: '@openmrs/esm-ward-app',
+        hasOwnSidebar: true,
+        sidebarFamily: 'ward-patient-sidebar',
+      });
+      registerWorkspace({
+        name: 'transfer-patient-workspace',
+        title: 'Transfer Patient Workspace',
+        load: jest.fn(),
+        type: 'transfer-patient',
+        moduleName: '@openmrs/esm-ward-app',
+        hasOwnSidebar: true,
+        sidebarFamily: 'another-sidebar-family',
+      });
+      const workspaceStore = getWorkspaceStore();
+      launchWorkspace('ward-patient-workspace', {
+        foo: true,
+      });
+      const wardPatientFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
+      expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
+      expect(wardPatientFamilyStore).toBeTruthy();
+      expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
+      launchWorkspace('transfer-patient-workspace', { bar: false });
+      const anotherSidebarFamilyStore = getWorkspaceFamilyStore('another-sidebar-family');
+      expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
+      expect(anotherSidebarFamilyStore?.getState()?.['bar']).toBe(false);
+      expect(wardPatientFamilyStore?.getState()?.['foo']).toBeUndefined();
+      expect(wardPatientFamilyStore?.getState()).toStrictEqual({});
+    });
+
+    it('should not clear the store when new workspace with different sidebar is opened, given the original workspace can hide', () => {
       registerWorkspace({
         name: 'ward-patient-workspace',
         title: 'Ward Patient Workspace',
@@ -559,25 +630,64 @@ describe('workspace system', () => {
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
         hasOwnSidebar: true,
+        sidebarFamily: 'another-sidebar-family',
+      });
+      const workspaceStore = getWorkspaceStore();
+      launchWorkspace('ward-patient-workspace', {
+        foo: true,
+      });
+      const wardPatientFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
+      expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
+      expect(wardPatientFamilyStore).toBeTruthy();
+      expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
+      launchWorkspace('transfer-patient-workspace', { bar: false });
+      const anotherSidebarFamilyStore = getWorkspaceFamilyStore('another-sidebar-family');
+      expect(workspaceStore.getState().openWorkspaces.length).toBe(2);
+      expect(anotherSidebarFamilyStore?.getState()?.['bar']).toBe(false);
+      expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
+    });
+
+    it('should retain default closeWorkspace options in case workspace options are passed', () => {
+      registerWorkspace({
+        name: 'ward-patient-workspace',
+        title: 'Ward Patient Workspace',
+        load: jest.fn(),
+        type: 'ward-patient',
+        moduleName: '@openmrs/esm-ward-app',
+        hasOwnSidebar: true,
         sidebarFamily: 'ward-patient-sidebar',
       });
       launchWorkspace('ward-patient-workspace', {
         foo: true,
       });
-      launchWorkspace('transfer-patient-workspace', { bar: false });
-      const workspaceStore = getWorkspaceStore();
-      expect(workspaceStore.getState().openWorkspaces.length).toBe(2);
-      const transferPatientWorkspace = workspaceStore.getState().openWorkspaces[0];
-      transferPatientWorkspace.closeWorkspace({ ignoreChanges: true });
-      const wardPatientWorkspace = workspaceStore.getState().openWorkspaces[0];
-      const wardPatientWorkspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
-      expect(wardPatientWorkspaceFamilyStore).toBeTruthy();
-      expect(wardPatientWorkspaceFamilyStore?.getState()?.['foo']).toBe(true);
-      expect(wardPatientWorkspaceFamilyStore?.getState()?.['bar']).toBe(false);
-      // Closing the last opened workspace of the family
-      wardPatientWorkspace.closeWorkspace({ ignoreChanges: true });
-      expect(wardPatientWorkspaceFamilyStore?.getState()?.['foo']).toBeUndefined();
-      expect(wardPatientWorkspaceFamilyStore?.getState()?.['bar']).toBeUndefined();
+      const workspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
+      expect(workspaceFamilyStore).toBeTruthy();
+      expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
+      /**
+       * This is to test the change in the closeWorkspace function
+       * function closeWorkspace(
+       *  workspaceName: string,
+       *  options?: CloseWorkspaceOptions={
+       *    ignoreChanges: false,
+       *    onWorkspaceClose: () => {},
+       *    clearWorkspaceFamilyStore: true
+       *   }
+       * ): void
+       *
+       * TO
+       *
+       * function closeWorkspace(
+       *  workspaceName: string,
+       *  options?: CloseWorkspaceOptions={}
+       * ) {
+       *  options = {...defaultOptions, ...options}
+       * }
+       *
+       */
+
+      closeWorkspace('ward-patient-workspace', { ignoreChanges: true });
+      expect(workspaceFamilyStore?.getState()?.['foo']).toBeUndefined();
+      expect(workspaceFamilyStore?.getState()).toStrictEqual({});
     });
   });
 });

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -698,28 +698,7 @@ describe('workspace system', () => {
       const workspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
       expect(workspaceFamilyStore).toBeTruthy();
       expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
-      /**
-       * This is to test the change in the closeWorkspace function
-       * function closeWorkspace(
-       *  workspaceName: string,
-       *  options?: CloseWorkspaceOptions={
-       *    ignoreChanges: false,
-       *    onWorkspaceClose: () => {},
-       *    clearWorkspaceFamilyStore: true
-       *   }
-       * ): void
-       *
-       * TO
-       *
-       * function closeWorkspace(
-       *  workspaceName: string,
-       *  options?: CloseWorkspaceOptions={}
-       * ) {
-       *  options = {...defaultOptions, ...options}
-       * }
-       *
-       */
-
+      // test that default options are interpolated when providing options to `closeWorkspace`
       closeWorkspace('ward-patient-workspace', { ignoreChanges: true });
       expect(workspaceFamilyStore?.getState()?.['foo']).toBeUndefined();
       expect(workspaceFamilyStore?.getState()).toStrictEqual({});

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -2,6 +2,7 @@ import {
   type Prompt,
   cancelPrompt,
   closeWorkspace,
+  closeWorkspaceInternal,
   getWorkspaceFamilyStore,
   getWorkspaceStore,
   launchWorkspace,
@@ -536,7 +537,7 @@ describe('workspace system', () => {
       const workspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
       expect(workspaceFamilyStore).toBeTruthy();
       expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
-      closeWorkspace('ward-patient-workspace', {
+      closeWorkspaceInternal('ward-patient-workspace', {
         clearWorkspaceFamilyStore: false,
       });
       expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -134,7 +134,6 @@ function promptBeforeLaunchingWorkspace(
       // Calling the launchWorkspace again, since one of the `if` case
       // might resolve, but we need to check all the cases before launching the form.
       onWorkspaceClose: () => launchWorkspace(name, additionalProps),
-      // This condition is added here to check if the new workspace is of the same sidebar family as the current workspace.
       // If the new workspace is of the same sidebar family, then we don't need to clear the workspace family store.
       clearWorkspaceFamilyStore: newWorkspaceRegistration.sidebarFamily !== workspace.sidebarFamily,
     });

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -313,7 +313,11 @@ export function closeWorkspace(name: string, options: CloseWorkspaceOptions = {}
     const workspaceSidebarFamilyName = workspaceToBeClosed?.sidebarFamily;
     const newOpenWorkspaces = state.openWorkspaces.filter((w) => w.name != name);
     const workspaceFamilyStore = getWorkspaceFamilyStore(workspaceSidebarFamilyName);
-    if (options.clearWorkspaceFamilyStore && workspaceFamilyStore) {
+    if (
+      options.clearWorkspaceFamilyStore &&
+      workspaceFamilyStore &&
+      !newOpenWorkspaces.some((w) => w.sidebarFamily === workspaceSidebarFamilyName)
+    ) {
       // Clearing the workspace family store if there are no more workspaces with the same sidebar family name and the new workspace is not of the same sidebar family, which is handled in the `launchWorkspace` function.
       workspaceFamilyStore.setState({}, true);
       const unsubscribe = workspaceFamilyStore.subscribe(() => {});

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -25,9 +25,7 @@ export interface CloseWorkspaceOptions {
    */
   onWorkspaceClose?: () => void;
   /**
-   * If set to true, the workspace family store will be cleared when the workspace is closed. Defaults to true.
-   *
-   * If set to false, the workspace family store will not be cleared when the workspace is closed. This happens when the new workspace is of the same sidebar family as the current workspace.
+   * Controls whether the workspace family store will be cleared when this workspace is closed. Defaults to true except when opening a new workspace of the same family.
    *
    * @default true
    */

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -303,14 +303,10 @@ const defaultOptions: CloseWorkspaceOptions = {
  * @param options Options to close workspace
  */
 export function closeWorkspace(name: string, options: CloseWorkspaceOptions = {}) {
-  closeWorkspaceInternal(name, { ...options, clearWorkspaceFamilyStore: true });
+  return closeWorkspaceInternal(name, { ...options, clearWorkspaceFamilyStore: true });
 }
 
-/**
- * Function to close an opened workspace
- * @internal Exported for testing purposes only
- */
-export function closeWorkspaceInternal(name: string, options: CloseWorkspaceInternalOptions = {}): boolean {
+function closeWorkspaceInternal(name: string, options: CloseWorkspaceInternalOptions = {}): boolean {
   options = { ...defaultOptions, ...options };
   const store = getWorkspaceStore();
 

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -24,6 +24,9 @@ export interface CloseWorkspaceOptions {
    * @returns void
    */
   onWorkspaceClose?: () => void;
+}
+
+interface CloseWorkspaceInternalOptions extends CloseWorkspaceOptions {
   /**
    * Controls whether the workspace family store will be cleared when this workspace is closed. Defaults to true except when opening a new workspace of the same family.
    *
@@ -126,7 +129,7 @@ function promptBeforeLaunchingWorkspace(
   const newWorkspaceRegistration = getWorkspaceRegistration(name);
 
   const proceed = () => {
-    workspace.closeWorkspace({
+    closeWorkspaceInternal(workspace.name, {
       ignoreChanges: true,
       // Calling the launchWorkspace again, since one of the `if` case
       // might resolve, but we need to check all the cases before launching the form.
@@ -293,7 +296,6 @@ export function cancelPrompt() {
 const defaultOptions: CloseWorkspaceOptions = {
   ignoreChanges: false,
   onWorkspaceClose: () => {},
-  clearWorkspaceFamilyStore: true,
 };
 
 /**
@@ -301,7 +303,15 @@ const defaultOptions: CloseWorkspaceOptions = {
  * @param name Workspace registration name
  * @param options Options to close workspace
  */
-export function closeWorkspace(name: string, options: CloseWorkspaceOptions = {}): boolean {
+export function closeWorkspace(name: string, options: CloseWorkspaceOptions = {}) {
+  closeWorkspaceInternal(name, { ...options, clearWorkspaceFamilyStore: true });
+}
+
+/**
+ * Function to close an opened workspace
+ * @internal Exported for testing purposes only
+ */
+export function closeWorkspaceInternal(name: string, options: CloseWorkspaceInternalOptions = {}): boolean {
   options = { ...defaultOptions, ...options };
   const store = getWorkspaceStore();
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
The issue comes from [this line](https://github.com/openmrs/openmrs-esm-core/blob/98118452809d1d8217059e24d4dc37096231d500/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L305) which does check that the workspaces remaining do have the same sidebar family name and doesn’t check the fact that the new workspace to be opened is of the same family, hence it shouldn’t clear the workspace.

The reason behind this is that when we launch 2nd workspace, it will first close the 1st workspace and as per the condition linked above, it will reset the store, which is not ideal. We need a condition that if the new workspace is opened of the same sidebar family and the previous workspace is closing, the store shouldn't clear itself.

Addition: Added tests for workspace renderer to test if the valid props are being passed into the workspace or not.

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/O3-3691

## Other
Fun fact:
This issue would've been caught earlier by my unit tests if I hadn't added [this line](https://github.com/openmrs/openmrs-esm-core/blob/98118452809d1d8217059e24d4dc37096231d500/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts#L512) in a test case in my previous PR #1094 
