### PR TITLE
(fix) Ensure Confirm button in login location picker takes full width

### DIFF
--- a/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
@@ -139,7 +139,7 @@ const LocationPickerView: React.FC<LocationPickerProps> = ({ hideWelcomeMessage,
             locationTag={chooseLocation.useLoginLocationTag && 'Login Location'}
             onChange={(locationUuid) => setActiveLocation(locationUuid)}
           />
-          <div className={styles.confirmButton}>
+          <div className={styles.footerContainer}>
             <Checkbox
               id="checkbox"
               className={styles.savePreferenceCheckbox}
@@ -147,7 +147,12 @@ const LocationPickerView: React.FC<LocationPickerProps> = ({ hideWelcomeMessage,
               checked={savePreference}
               onChange={(_, { checked }) => setSavePreference(checked)}
             />
-            <Button kind="primary" type="submit" disabled={!activeLocation || !isLoginEnabled || isSubmitting}>
+            <Button
+              className={styles.confirmButton}
+              kind="primary"
+              type="submit"
+              disabled={!activeLocation || !isLoginEnabled || isSubmitting}
+            >
               {isSubmitting ? (
                 <InlineLoading className={styles.loader} description={t('submitting', 'Submitting')} />
               ) : (

--- a/packages/apps/esm-login-app/src/location-picker/location-picker.scss
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.scss
@@ -35,20 +35,15 @@
   color: $color-gray-70;
 }
 
-.confirmButton {
-  padding: spacing.$spacing-06;
+.footerContainer {
+  padding: spacing.$spacing-05 spacing.$spacing-06 spacing.$spacing-06;
 
   .savePreferenceCheckbox {
     padding-bottom: spacing.$spacing-05 !important;
   }
 
-  .actionButtons {
-    display: inline-flex;
+  .confirmButton {
     width: 100%;
-
-    button {
-      flex-grow: 1;
-    }
   }
 }
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
The Confirm button on the Change Location page was not taking the full width. This PR fix it by adjusting the CSS to ensure the Confirm button spans the full width of its container.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
<img width="763" alt="image" src="https://github.com/user-attachments/assets/181dfb2d-67a6-430d-81e3-6e460a67c386">

After:
<img width="763" alt="image" src="https://github.com/user-attachments/assets/818ee538-4ace-4316-8eb6-6b66700afffc">



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
