### PR TITLE
(feat) Content switcher style overrides

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -1,5 +1,4 @@
 @use '@carbon/styles/scss/spacing';
-@use '@carbon/styles/scss/utilities/layout';
 @use '@carbon/colors';
 
 /* UI Shell Header */
@@ -55,8 +54,6 @@
 
 /* Content Switcher */
 .cds--content-switcher:not(.darkThemeSwitch) {
-  @include layout.use('size', $default: 'sm');
-
   & > :first-child {
     border-bottom-left-radius: 0.25rem;
     border-right: unset !important;
@@ -84,20 +81,23 @@
   border-top: 1px solid colors.$blue-30;
   border-bottom: 1px solid colors.$blue-30;
 
+  &:hover {
+    background-color: colors.$gray-10-hover !important;
+  }
+
   &::after {
     background-color: transparent !important;
   }
 
   &.cds--btn--primary {
     background-color: unset;
+  }
 
-    &:hover {
-      background-color: colors.$gray-10-hover;
-    }
+  &:focus {
+    box-shadow: none;
   }
 
   &::before {
-    background-color: colors.$blue-30;
     height: 100%;
     z-index: 0;
   }
@@ -442,9 +442,8 @@ html[dir='rtl'] {
     }
   }
 
+  /* RTL Content Switcher */
   .cds--content-switcher {
-    @include layout.use('size', $default: 'sm');
-
     & > :first-child {
       border-bottom-right-radius: 0.25rem !important;
       border-left: unset !important;
@@ -459,8 +458,6 @@ html[dir='rtl'] {
 
     & > :last-child {
       border-bottom-left-radius: 0.25rem !important;
-      border-left: unset;
-      border-right: unset;
       border-top-left-radius: 0.25rem !important;
 
       [aria-selected='false'] {
@@ -489,9 +486,12 @@ html[dir='rtl'] {
     }
 
     &::before {
-      background-color: colors.$blue-30;
       height: 100%;
       z-index: 0;
+    }
+
+    &:focus {
+      box-shadow: none;
     }
 
     &.cds--content-switcher--selected {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR applies some styling overrides to the Carbon Content Switcher component to align it with the [designs](https://zeroheight.com/23a080e38/p/55274c-content-switcher). More specifically, this change fixes an issue with the styling applied to the Content Switcher buttons when they are in their selected, hovered, and focused states. See the before and after photos below the fold. 

## Screenshots

### Before (extraneous border)

![CleanShot 2024-08-05 at 4  34 44@2x](https://github.com/user-attachments/assets/a2defeba-f288-4f6b-8fae-799711e94928)

### After 

![CleanShot 2024-08-05 at 4  35 07@2x](https://github.com/user-attachments/assets/13ab2ec9-5135-4e00-a582-0107770f1eaa)

### Before (hover state doesn't have a gray background)

![CleanShot 2024-08-05 at 4  35 31@2x](https://github.com/user-attachments/assets/22aef351-cf94-4556-9199-619aeb8bcdbc)

### After

![CleanShot 2024-08-05 at 4  35 21@2x](https://github.com/user-attachments/assets/67035b6d-59ff-4fed-b5ae-88e10e9c6ab4)

### Before (full-width screenshot)

![CleanShot 2024-08-05 at 4  36 09@2x](https://github.com/user-attachments/assets/e9e3dd4f-f8f3-46ee-b062-26413dd51e52)

### After

![CleanShot 2024-08-05 at 4  35 52@2x](https://github.com/user-attachments/assets/ecf45bb3-3137-4fad-9fe5-41df0828c187)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

We'll still need more work to fix the styling when the language is RTL. [Ticket](https://openmrs.atlassian.net/browse/O3-2751)