### PR TITLE
(fix) O3-3760: Action Menu (Siderail) inside workspace hovering over the content

### DIFF
--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
@@ -236,11 +236,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
             additionalPropsFromPage={additionalWorkspaceProps}
           />
         </div>
-        {hasOwnSidebar && (
-          <div className={styles.workspaceActionMenu}>
-            <ActionMenu isWithinWorkspace name={workspaceInstance.sidebarFamily} />
-          </div>
-        )}
+        {hasOwnSidebar && <ActionMenu isWithinWorkspace name={workspaceInstance.sidebarFamily} />}
       </>
     )
   );

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
@@ -225,14 +225,22 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
             )}
           </HeaderGlobalBar>
         </Header>
-        <div className={styles.workspaceContent}>
+        <div
+          className={classNames(styles.workspaceContent, {
+            [styles.marginWorkspaceContent]: hasOwnSidebar,
+          })}
+        >
           <WorkspaceRenderer
             key={workspaceInstance.name}
             workspace={workspaceInstance}
             additionalPropsFromPage={additionalWorkspaceProps}
           />
         </div>
-        {hasOwnSidebar && <ActionMenu isWithinWorkspace name={workspaceInstance.sidebarFamily} />}
+        {hasOwnSidebar && (
+          <div className={styles.workspaceActionMenu}>
+            <ActionMenu isWithinWorkspace name={workspaceInstance.sidebarFamily} />
+          </div>
+        )}
       </>
     )
   );

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace.module.scss
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace.module.scss
@@ -4,6 +4,12 @@
 @import '@openmrs/esm-styleguide/src/vars';
 
 $actionPanelOffset: 3rem;
+$narrowWorkspaceWidth: 26.25rem;
+$widerWorkspaceWidth: 32.25rem;
+$extraWideWorkspaceWidth: 48.25rem;
+$narrowWorkspaceWithSiderailWidth: 29.25rem;
+$widerWorkspaceWithSiderailWidth: 35.25rem;
+$extraWideWorkspaceWithSiderailWidth: 51.25rem;
 
 .loader {
   display: flex;
@@ -103,50 +109,98 @@ $actionPanelOffset: 3rem;
   }
 
   .extraWideWorkspace {
-    width: 48.25rem;
+    width: $extraWideWorkspaceWidth;
 
     .workspaceFixedContainer {
-      width: 48.25rem;
+      width: $extraWideWorkspaceWidth;
     }
 
     &.hiddenRelative {
-      margin-right: -48.25rem !important;
+      margin-right: -$extraWideWorkspaceWidth !important;
     }
 
     .hiddenFixed {
-      right: -48.25rem !important;
+      right: -$extraWideWorkspaceWidth !important;
+    }
+  }
+
+  .extraWideWorkspace:has(.workspaceActionMenu) {
+    width: $extraWideWorkspaceWidth;
+
+    .workspaceFixedContainer {
+      width: $extraWideWorkspaceWidth;
+    }
+
+    &.hiddenRelative {
+      margin-right: -$extraWideWorkspaceWidth !important;
+    }
+
+    .hiddenFixed {
+      right: -$extraWideWorkspaceWidth !important;
     }
   }
 
   .widerWorkspace {
-    width: 32.25rem;
+    width: $widerWorkspaceWidth;
 
     .workspaceFixedContainer {
-      width: 32.25rem;
+      width: $widerWorkspaceWidth;
     }
 
     &.hiddenRelative {
-      margin-right: -32.25rem !important;
+      margin-right: -$widerWorkspaceWidth !important;
     }
 
     .hiddenFixed {
-      right: -32.25rem !important;
+      right: -$widerWorkspaceWidth !important;
+    }
+  }
+
+  .widerWorkspace:has(.workspaceActionMenu) {
+    width: $widerWorkspaceWithSiderailWidth;
+
+    .workspaceFixedContainer {
+      width: $widerWorkspaceWithSiderailWidth;
+    }
+
+    &.hiddenRelative {
+      margin-right: -$widerWorkspaceWithSiderailWidth !important;
+    }
+
+    .hiddenFixed {
+      right: -$widerWorkspaceWithSiderailWidth !important;
     }
   }
 
   .narrowWorkspace {
-    width: 26.25rem;
+    width: $narrowWorkspaceWidth;
 
     .workspaceFixedContainer {
-      width: 26.25rem;
+      width: $narrowWorkspaceWidth;
     }
 
     &.hiddenRelative {
-      margin-right: -26.25rem !important;
+      margin-right: -$narrowWorkspaceWidth !important;
     }
 
     .hiddenFixed {
-      right: -26.25rem !important;
+      right: -$narrowWorkspaceWidth !important;
+    }
+  }
+
+  .narrowWorkspace:has(.workspaceActionMenu) {
+    width: $narrowWorkspaceWithSiderailWidth;
+
+    .workspaceFixedContainer {
+      width: $narrowWorkspaceWithSiderailWidth;
+    }
+
+    &.hiddenRelative {
+      margin-right: -$narrowWorkspaceWithSiderailWidth !important;
+    }
+
+    .hiddenFixed {
+      right: -$narrowWorkspaceWithSiderailWidth !important;
     }
   }
 
@@ -154,6 +208,10 @@ $actionPanelOffset: 3rem;
     background-color: $ui-02;
     overflow-y: auto;
     flex-grow: 1;
+  }
+
+  .marginWorkspaceContent {
+    margin-right: 3rem;
   }
 
   // The parcel makes a div, between the workspace container and the workspace itself

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace.module.scss
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace.module.scss
@@ -4,12 +4,10 @@
 @import '@openmrs/esm-styleguide/src/vars';
 
 $actionPanelOffset: 3rem;
+
 $narrowWorkspaceWidth: 26.25rem;
 $widerWorkspaceWidth: 32.25rem;
 $extraWideWorkspaceWidth: 48.25rem;
-$narrowWorkspaceWithSiderailWidth: 29.25rem;
-$widerWorkspaceWithSiderailWidth: 35.25rem;
-$extraWideWorkspaceWithSiderailWidth: 51.25rem;
 
 .loader {
   display: flex;
@@ -124,22 +122,6 @@ $extraWideWorkspaceWithSiderailWidth: 51.25rem;
     }
   }
 
-  .extraWideWorkspace:has(.workspaceActionMenu) {
-    width: $extraWideWorkspaceWidth;
-
-    .workspaceFixedContainer {
-      width: $extraWideWorkspaceWidth;
-    }
-
-    &.hiddenRelative {
-      margin-right: -$extraWideWorkspaceWidth !important;
-    }
-
-    .hiddenFixed {
-      right: -$extraWideWorkspaceWidth !important;
-    }
-  }
-
   .widerWorkspace {
     width: $widerWorkspaceWidth;
 
@@ -153,22 +135,6 @@ $extraWideWorkspaceWithSiderailWidth: 51.25rem;
 
     .hiddenFixed {
       right: -$widerWorkspaceWidth !important;
-    }
-  }
-
-  .widerWorkspace:has(.workspaceActionMenu) {
-    width: $widerWorkspaceWithSiderailWidth;
-
-    .workspaceFixedContainer {
-      width: $widerWorkspaceWithSiderailWidth;
-    }
-
-    &.hiddenRelative {
-      margin-right: -$widerWorkspaceWithSiderailWidth !important;
-    }
-
-    .hiddenFixed {
-      right: -$widerWorkspaceWithSiderailWidth !important;
     }
   }
 
@@ -188,22 +154,6 @@ $extraWideWorkspaceWithSiderailWidth: 51.25rem;
     }
   }
 
-  .narrowWorkspace:has(.workspaceActionMenu) {
-    width: $narrowWorkspaceWithSiderailWidth;
-
-    .workspaceFixedContainer {
-      width: $narrowWorkspaceWithSiderailWidth;
-    }
-
-    &.hiddenRelative {
-      margin-right: -$narrowWorkspaceWithSiderailWidth !important;
-    }
-
-    .hiddenFixed {
-      right: -$narrowWorkspaceWithSiderailWidth !important;
-    }
-  }
-
   .workspaceContent {
     background-color: $ui-02;
     overflow-y: auto;
@@ -211,7 +161,7 @@ $extraWideWorkspaceWithSiderailWidth: 51.25rem;
   }
 
   .marginWorkspaceContent {
-    margin-right: 3rem;
+    margin-right: $actionPanelOffset;
   }
 
   // The parcel makes a div, between the workspace container and the workspace itself


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR fixes the following issue with workspaces having siderail inside the workspace.
![image](https://github.com/user-attachments/assets/b938c8fd-802b-426b-967f-ea0143e0f728)


## Screenshots
![image](https://github.com/user-attachments/assets/0adf7683-391b-4402-958e-5dc802213003)


## Related Issue
https://issues.openmrs.org/browse/O3-3760

## Other
<!-- Anything not covered above -->
