### PR TITLE
(fix) O3-3760 v2: Add margin to the bottom of workspaces with internal action menu

### DIFF
--- a/packages/framework/esm-styleguide/src/workspaces/action-menu-button/action-menu-button.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/action-menu-button/action-menu-button.component.tsx
@@ -58,6 +58,7 @@ export const ActionMenuButton: React.FC<ActionMenuButtonProps> = ({
         onClick={handler}
         role="button"
         tabIndex={0}
+        size="md"
       >
         <span className={styles.elementContainer}>
           <Tags formOpenInTheBackground={formOpenInTheBackground} getIcon={getIcon} tagContent={tagContent} />

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace.module.scss
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace.module.scss
@@ -249,6 +249,10 @@ $extraWideWorkspaceWidth: 48.25rem;
   .dynamicWidth {
     width: 100%;
   }
+
+  .marginWorkspaceContent {
+    margin-bottom: var(--bottom-nav-height);
+  }
 }
 
 // Overriding styles for RTL support


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR adds the margin to the workspaces having internal action menu in the tablet layout.

## Screenshots
<img width="693" alt="image" src="https://github.com/user-attachments/assets/07569380-74a1-4b49-929a-41a7d28ddbeb">


## Related Issue
https://issues.openmrs.org/browse/O3-3760

## Other
<!-- Anything not covered above -->
