### PR TITLE
(fix) - O3-3684 - improve performance of age() function

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -6644,7 +6644,7 @@ ___
 
 Most REST endpoints that return a list of objects, such as getAll or search, are server-side paginated.
 The server limits the max number of results being returned, and multiple requests are needed to get the full data set
-if its size exceed this limit.
+if its size exceeds this limit.
 The max number of results per request is configurable server-side
 with the key "webservices.rest.maxResultsDefault". See: https://openmrs.atlassian.net/wiki/spaces/docs/pages/25469882/REST+Module
 
@@ -6682,7 +6682,7 @@ a UseServerInfiniteReturnObject object
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useServerInfinite.ts:77](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L77)
+[packages/framework/esm-react-utils/src/useServerInfinite.ts:78](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L78)
 
 ___
 
@@ -6692,7 +6692,7 @@ ___
 
 Most REST endpoints that return a list of objects, such as getAll or search, are server-side paginated.
 The server limits the max number of results being returned, and multiple requests are needed to get the full data set
-if its size exceed this limit.
+if its size exceeds this limit.
 The max number of results per request is configurable server-side
 with the key "webservices.rest.maxResultsDefault". See: https://openmrs.atlassian.net/wiki/spaces/docs/pages/25469882/REST+Module
 
@@ -6776,7 +6776,7 @@ A human-readable string version of the age.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/age-helpers.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/age-helpers.ts#L17)
+[packages/framework/esm-utils/src/age-helpers.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/age-helpers.ts#L18)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/UseServerInfiniteReturnObject.md
+++ b/packages/framework/esm-framework/docs/interfaces/UseServerInfiniteReturnObject.md
@@ -36,7 +36,7 @@ this array does not contain the complete data set.
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useServerInfinite.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L13)
+[packages/framework/esm-react-utils/src/useServerInfinite.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L14)
 
 ___
 
@@ -48,7 +48,7 @@ from useSWRInfinite
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useServerInfinite.ts:33](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L33)
+[packages/framework/esm-react-utils/src/useServerInfinite.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L34)
 
 ___
 
@@ -60,7 +60,7 @@ Whether there are more results in the data set that have not been fetched yet.
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useServerInfinite.ts:23](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L23)
+[packages/framework/esm-react-utils/src/useServerInfinite.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L24)
 
 ___
 
@@ -72,7 +72,7 @@ from useSWRInfinite
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useServerInfinite.ts:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L48)
+[packages/framework/esm-react-utils/src/useServerInfinite.ts:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L49)
 
 ___
 
@@ -84,7 +84,7 @@ from useSWRInfinite
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useServerInfinite.ts:43](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L43)
+[packages/framework/esm-react-utils/src/useServerInfinite.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L44)
 
 ___
 
@@ -96,7 +96,7 @@ from useSWRInfinite
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useServerInfinite.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L38)
+[packages/framework/esm-react-utils/src/useServerInfinite.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L39)
 
 ___
 
@@ -108,7 +108,7 @@ The total number of rows in the data set.
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useServerInfinite.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L18)
+[packages/framework/esm-react-utils/src/useServerInfinite.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L19)
 
 ## UI Methods
 
@@ -124,4 +124,4 @@ callback function to make another fetch of next page's data set.
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useServerInfinite.ts:28](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L28)
+[packages/framework/esm-react-utils/src/useServerInfinite.ts:29](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useServerInfinite.ts#L29)

--- a/packages/framework/esm-utils/src/age-helpers.ts
+++ b/packages/framework/esm-utils/src/age-helpers.ts
@@ -4,6 +4,7 @@ import { getLocale } from './omrs-dates';
 import { DurationFormat } from '@formatjs/intl-durationformat';
 import { type DurationInput } from '@formatjs/intl-durationformat/src/types';
 
+let durationFormat: DurationFormat | null = null;
 /**
  * Gets a human readable and locale supported representation of a person's age, given their birthDate,
  * The representation logic follows the guideline here:
@@ -51,5 +52,8 @@ export function age(birthDate: dayjs.ConfigType, currentDate: dayjs.ConfigType =
     duration['years'] = yearDiff;
   }
 
-  return new DurationFormat(locale, { style: 'short' }).format(duration);
+  // the DurationFormat constructor is a really expensive operation (~100ms). Cache it
+  // so it gets reused
+  durationFormat ??= new DurationFormat(locale, { style: 'short' });
+  return durationFormat.format(duration);
 }

--- a/packages/framework/esm-utils/src/age-helpers.ts
+++ b/packages/framework/esm-utils/src/age-helpers.ts
@@ -4,7 +4,6 @@ import { getLocale } from './omrs-dates';
 import { DurationFormat } from '@formatjs/intl-durationformat';
 import { type DurationInput } from '@formatjs/intl-durationformat/src/types';
 
-let durationFormat: DurationFormat | null = null;
 /**
  * Gets a human readable and locale supported representation of a person's age, given their birthDate,
  * The representation logic follows the guideline here:
@@ -52,8 +51,5 @@ export function age(birthDate: dayjs.ConfigType, currentDate: dayjs.ConfigType =
     duration['years'] = yearDiff;
   }
 
-  // the DurationFormat constructor is a really expensive operation (~100ms). Cache it
-  // so it gets reused
-  durationFormat ??= new DurationFormat(locale, { style: 'short' });
-  return durationFormat.format(duration);
+  return new DurationFormat(locale, { style: 'short', localeMatcher: 'lookup' }).format(duration);
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
The `age()` function refactored in this [PR](https://github.com/openmrs/openmrs-esm-core/pull/1100) uses a [`DurationFormat`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DurationFormat) polyfill that is a really expensive object to create (takes 66 - 100ms on my laptop depending on whether it's plugged in). We rely on it in the `esm-ward-app` to render the age, time since admission and time on ward for each patient card. That's about 200ms per patient on those 3 elements. On a ward with ~5 patients, the rendering is cripplingly slow.

This PR just adds caching to the `DurationFormat` object so we only get the performance penalty on the first `age()` call.

## Screenshots
<!-- Required if you are making UI changes. -->
Profiling before this change. Those 3 elements take 200ms to render:
![image](https://github.com/user-attachments/assets/2b0861f3-9913-4e89-b106-6566a9f0797a)

Profiling after this change. PatientAge element takes 100ms on first render, but is reasonable faster afterwards. The other 2 time elements aren't even showing in the waterfall (probably because their render times are insignificant).
![withformatjs](https://github.com/user-attachments/assets/5404dc2e-fb5d-49b6-aa3e-20a205a3d057)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
I initially tried a solution that does away with the polyfill altogether. It eliminates the first call penalty, but is a bit iffy with the i18n stuff. I checked it in [here](https://github.com/openmrs/openmrs-esm-core/commit/2b531bde02bd556bb45cd3bd7c4986be80e4c6e5) in case we want to not use the polyfill.