### PR TITLE
(feat) O3-3857: Support extension overrides in per-slot extension config

### DIFF
--- a/packages/framework/esm-config/package.json
+++ b/packages/framework/esm-config/package.json
@@ -43,11 +43,13 @@
   "peerDependencies": {
     "@openmrs/esm-globals": "5.x",
     "@openmrs/esm-state": "5.x",
+    "@openmrs/esm-utils": "5.x",
     "single-spa": "5.x"
   },
   "devDependencies": {
     "@openmrs/esm-globals": "workspace:*",
     "@openmrs/esm-state": "workspace:*",
+    "@openmrs/esm-utils": "workspace:*",
     "@types/ramda": "^0.26.44",
     "single-spa": "^6.0.1"
   }

--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -1108,8 +1108,13 @@ describe('extension config', () => {
     const moduleLevelConfig = { 'ext-mod': { bar: 'qux' } };
     updateConfigExtensionStore();
     Config.provide(moduleLevelConfig);
-    const result = getExtensionConfig('barSlot', 'fooExt').config;
-    expect(result).toStrictEqual({ bar: 'qux', baz: 'bazzy' });
+    const result = getExtensionConfig('barSlot', 'fooExt').getState().config;
+    expect(result).toStrictEqual({
+      bar: 'qux',
+      baz: 'bazzy',
+      'Display conditions': { privileges: [] },
+      'Translation overrides': {},
+    });
     expect(console.error).not.toHaveBeenCalled();
   });
 
@@ -1126,8 +1131,13 @@ describe('extension config', () => {
       },
     };
     Config.provide(configureConfig);
-    const result = getExtensionConfig('barSlot', 'fooExt#id0').config;
-    expect(result).toStrictEqual({ bar: 'qux', baz: 'quiz' });
+    const result = getExtensionConfig('barSlot', 'fooExt#id0').getState().config;
+    expect(result).toStrictEqual({
+      bar: 'qux',
+      baz: 'quiz',
+      'Display conditions': { privileges: [] },
+      'Translation overrides': {},
+    });
     expect(console.error).not.toHaveBeenCalled();
   });
 
@@ -1154,8 +1164,12 @@ describe('extension config', () => {
     });
     const extensionAtBaseConfig = { fooExt: { qux: 'quxolotl' } };
     Config.provide(extensionAtBaseConfig);
-    const result = getExtensionConfig('barSlot', 'fooExt').config;
-    expect(result).toStrictEqual({ qux: 'quxolotl' });
+    const result = getExtensionConfig('barSlot', 'fooExt').getState().config;
+    expect(result).toStrictEqual({
+      qux: 'quxolotl',
+      'Display conditions': { privileges: [] },
+      'Translation overrides': {},
+    });
     expect(console.error).not.toHaveBeenCalled();
   });
 
@@ -1175,8 +1189,12 @@ describe('extension config', () => {
       },
     };
     Config.provide(configureConfig);
-    const result = getExtensionConfig('barSlot', 'fooExt#id2').config;
-    expect(result).toStrictEqual({ qux: 'quxotic' });
+    const result = getExtensionConfig('barSlot', 'fooExt#id2').getState().config;
+    expect(result).toStrictEqual({
+      qux: 'quxotic',
+      'Display conditions': { privileges: [] },
+      'Translation overrides': {},
+    });
   });
 
   it('validates the extension configure config, with extension config schema', () => {

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -309,7 +309,7 @@ export function getTranslationOverrides(
     );
   }
 
-  return Promise.all(promises).then((results) => results.reduce((prev, current) => ({ ...prev, ...current }), {}));
+  return Promise.all(promises).then((results) => results.reduce((prev, current) => mergeDeepRight(prev, current), {}));
 }
 
 /**

--- a/packages/framework/esm-config/src/module-config/state.ts
+++ b/packages/framework/esm-config/src/module-config/state.ts
@@ -216,7 +216,7 @@ export function getExtensionConfig(
 /** @internal */
 export function getExtensionConfigFromStore(state: ExtensionsConfigStore, slotName: string, extensionId: string) {
   const extensionConfig = state.configs[slotName]?.[extensionId];
-  return extensionConfig ?? { loaded: false, config: null, translationOverridesLoaded: false };
+  return extensionConfig ?? { loaded: false, config: null };
 }
 
 /**

--- a/packages/framework/esm-config/src/module-config/state.ts
+++ b/packages/framework/esm-config/src/module-config/state.ts
@@ -1,6 +1,7 @@
 /** @module @category Config */
 import { createGlobalStore, getGlobalStore } from '@openmrs/esm-state';
-import { omit } from 'ramda';
+import { shallowEqual } from '@openmrs/esm-utils';
+import { type StoreApi } from 'zustand';
 import type { Config, ConfigObject, ConfigSchema, ExtensionSlotConfigObject, ProvidedConfig } from '../types';
 
 /**
@@ -166,19 +167,56 @@ export function getExtensionsConfigStore() {
 }
 
 /** @internal */
-export function getExtensionConfig(slotName: string, extensionId: string) {
-  const extensionConfig = Object.assign(
-    {},
-    getExtensionConfigFromStore(getExtensionsConfigStore().getState(), slotName, extensionId),
-  );
-  extensionConfig.config = omit(['Display conditions', 'Translation overrides'], extensionConfig.config);
-  return extensionConfig;
+export function getExtensionConfig(
+  slotName: string,
+  extensionId: string,
+): StoreApi<Omit<ConfigStore, 'translationOverridesLoaded'>> {
+  const extensionConfigStore = getExtensionsConfigStore();
+  const selector = (configStore: ExtensionsConfigStore) => configStore.configs[slotName]?.[extensionId];
+
+  return {
+    getState() {
+      return selector(extensionConfigStore.getState()) ?? { loaded: false, config: null };
+    },
+    setState(
+      partial: ConfigStore | Partial<ConfigStore> | ((state: ConfigStore) => ConfigStore | Partial<ConfigStore>),
+      replace: boolean = false,
+    ) {
+      extensionConfigStore.setState((state) => {
+        if (!state.configs[slotName]) {
+          state.configs[slotName] = {};
+        }
+
+        const newState = typeof partial === 'function' ? partial(state.configs.slotName[extensionId]) : partial;
+        if (replace) {
+          state.configs[slotName][extensionId] = Object.assign({}, newState) as ConfigStore;
+        } else {
+          state.configs[slotName][extensionId] = Object.assign({}, state.configs[slotName][extensionId], newState);
+        }
+
+        return state;
+      });
+    },
+    subscribe(listener) {
+      return extensionConfigStore.subscribe((state, prevState) => {
+        const newState = selector(state);
+        const oldState = selector(prevState);
+
+        if (!shallowEqual(newState, oldState)) {
+          listener(newState, oldState);
+        }
+      });
+    },
+    destroy() {
+      /* this is a no-op */
+    },
+  };
 }
 
 /** @internal */
 export function getExtensionConfigFromStore(state: ExtensionsConfigStore, slotName: string, extensionId: string) {
   const extensionConfig = state.configs[slotName]?.[extensionId];
-  return extensionConfig ?? { loaded: false, config: null };
+  return extensionConfig ?? { loaded: false, config: null, translationOverridesLoaded: false };
 }
 
 /**

--- a/packages/framework/esm-config/src/module-config/state.ts
+++ b/packages/framework/esm-config/src/module-config/state.ts
@@ -171,6 +171,19 @@ export function getExtensionConfig(
   slotName: string,
   extensionId: string,
 ): StoreApi<Omit<ConfigStore, 'translationOverridesLoaded'>> {
+  if (
+    typeof slotName !== 'string' ||
+    typeof extensionId !== 'string' ||
+    slotName === '__proto__' ||
+    extensionId === '__proto__' ||
+    slotName === 'constructor' ||
+    extensionId === 'constructor' ||
+    slotName === 'prototype' ||
+    extensionId === 'prototype'
+  ) {
+    throw new Error('Attempted to call `getExtensionConfig()` with invalid argument');
+  }
+
   const extensionConfigStore = getExtensionsConfigStore();
   const selector = (configStore: ExtensionsConfigStore) => configStore.configs[slotName]?.[extensionId];
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -3049,7 +3049,7 @@ for more information about defining a config schema.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:164](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L164)
+[packages/framework/esm-config/src/module-config/module-config.ts:166](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L166)
 
 ___
 
@@ -3081,7 +3081,7 @@ for more information about defining a config schema.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:225](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L225)
+[packages/framework/esm-config/src/module-config/module-config.ts:227](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L227)
 
 ___
 
@@ -3113,7 +3113,7 @@ of the execution of a function.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:257](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L257)
+[packages/framework/esm-config/src/module-config/module-config.ts:259](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L259)
 
 ___
 
@@ -3134,7 +3134,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:241](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L241)
+[packages/framework/esm-config/src/module-config/module-config.ts:243](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L243)
 
 ___
 

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
@@ -100,7 +100,14 @@ export function openmrsComponentDecorator<T>(userOpts: ComponentDecoratorOptions
                   {opts.disableTranslations ? (
                     <Comp {...this.props} />
                   ) : (
-                    <I18nextProvider i18n={window.i18next} defaultNS={opts.moduleName}>
+                    <I18nextProvider
+                      i18n={window.i18next}
+                      defaultNS={
+                        this.props._extensionContext
+                          ? `${opts.moduleName}___${this.props._extensionContext.extensionSlotName}___${this.props._extensionContext.extensionId}`
+                          : opts.moduleName
+                      }
+                    >
                       <Comp {...this.props} />
                     </I18nextProvider>
                   )}

--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -1,7 +1,7 @@
 import * as i18next from 'i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import { initReactI18next } from 'react-i18next';
-import merge from 'lodash-es/merge';
+import { merge } from 'lodash-es';
 import {
   getTranslationOverrides,
   importDynamic,
@@ -55,9 +55,10 @@ export function setupI18n() {
               callback(err, null);
             });
         } else {
-          importDynamic(namespace)
+          const [ns, slotName, extensionId] = namespace.split('___');
+          importDynamic(ns)
             .then((module) =>
-              Promise.all([getImportPromise(module, namespace, language), getTranslationOverrides(namespace)]),
+              Promise.all([getImportPromise(module, ns, language), getTranslationOverrides(ns, slotName, extensionId)]),
             )
             .then(([json, overrides]) => {
               let translations = json ?? {};

--- a/yarn.lock
+++ b/yarn.lock
@@ -3015,12 +3015,14 @@ __metadata:
   dependencies:
     "@openmrs/esm-globals": "workspace:*"
     "@openmrs/esm-state": "workspace:*"
+    "@openmrs/esm-utils": "workspace:*"
     "@types/ramda": "npm:^0.26.44"
     ramda: "npm:^0.26.1"
     single-spa: "npm:^6.0.1"
   peerDependencies:
     "@openmrs/esm-globals": 5.x
     "@openmrs/esm-state": 5.x
+    "@openmrs/esm-utils": 5.x
     single-spa: 5.x
   languageName: unknown
   linkType: soft


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

The "Translation overrides" configuration stuff only works when defined at the app level because the translation namespace does not communicate any extension-specific information.

This PR fixes that so that you can provide translation overrides at the level of specific extensions-in-slots, which is useful for some of the implementation of "Clinical views" and other scenarios using "generic extension components".

## Screenshots
<!-- Required if you are making UI changes. -->

With this configuration:

![Example Configuration](https://github.com/user-attachments/assets/1b84ecac-20e9-4812-9fad-cb3d65a5abd9)

When showing the extension in the slot, we get:

![Specific slot override](https://github.com/user-attachments/assets/8791500e-962f-40c5-b597-6429c0373042)

When showing it in a different slot we get:

![General override](https://github.com/user-attachments/assets/551414c1-7322-49e6-9d37-a72749e3c3be)

## Related Issue
https://issues.openmrs.org/browse/O3- 3857

## Other

This uses `___` as a field demarcator since other characters I thought of either have special handling in module names or in i18next itself.