### PR TITLE
(fix) Remove uses of externalModuleName in styleguide components

### DIFF
--- a/packages/framework/esm-styleguide/src/page-header/page-header.component.tsx
+++ b/packages/framework/esm-styleguide/src/page-header/page-header.component.tsx
@@ -87,15 +87,13 @@ export const PageHeader: React.FC<PageHeaderProps> = (props) => {
  * ```
  */
 export const PageHeaderContent: React.FC<PageHeaderContentProps> = ({ title, illustration, className }) => {
-  const { implementationName } = useConfig<StyleguideConfigObject>({
-    externalModuleName: '@openmrs/esm-styleguide',
-  });
+  const config = useConfig<StyleguideConfigObject>();
 
   return (
     <div className={classNames(styles.pageHeaderContent, className)}>
       {illustration}
       <div className={styles.pageLabels}>
-        <p>{implementationName}</p>
+        {config?.implementationName && <p>{config?.implementationName}</p>}
         <p className={styles.pageName}>{title}</p>
       </div>
     </div>

--- a/packages/framework/esm-styleguide/src/patient-photo/usePatientPhoto.ts
+++ b/packages/framework/esm-styleguide/src/patient-photo/usePatientPhoto.ts
@@ -28,12 +28,10 @@ interface PhotoObs {
 }
 
 export function usePatientPhoto(patientUuid: string): UsePatientPhotoResult {
-  const { patientPhotoConceptUuid } = useConfig<StyleguideConfigObject>({
-    externalModuleName: '@openmrs/esm-styleguide',
-  });
+  const config = useConfig<StyleguideConfigObject>();
 
-  const url = patientPhotoConceptUuid
-    ? `${restBaseUrl}/obs?patient=${patientUuid}&concept=${patientPhotoConceptUuid}&v=full`
+  const url = config?.patientPhotoConceptUuid
+    ? `${restBaseUrl}/obs?patient=${patientUuid}&concept=${config.patientPhotoConceptUuid}&v=full`
     : null;
 
   const { data, error, isLoading } = useSWR<{ data: ObsFetchResponse }, Error>(patientUuid ? url : null, openmrsFetch);


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR removes uses of `externalModuleName` from two components in the styleguide. AFAIK, `externalModuleName` is used when you want to load a config schema from a separate frontend module into another. In this case, both components are colocated within the style guide and reference the style guide config schema, so there's no need to use `externalModuleName`. Unrelatedly, this exposed an issue with the [useConfig stub](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/mock.tsx#L27) in the framework mock (which is responsible for the failing tests from [this refactor](https://github.com/openmrs/openmrs-esm-patient-management/pull/1275) in Patient Management). The stub does not correctly handle `externalModuleName` and fails silently in the test environment when the component under test leverages `externalModuleName`. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
