### PR TITLE
(fix) Add better support for loading multiple namespaces at once

### DIFF
--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -1259,11 +1259,13 @@ describe('translation overrides', () => {
     });
     Config.registerModuleWithConfigSystem('corge-module');
     const translationOverrides = await Config.getTranslationOverrides('corge-module');
-    expect(translationOverrides).toStrictEqual({
-      en: {
-        'foo.bar': 'baz',
+    expect(translationOverrides).toStrictEqual([
+      {
+        en: {
+          'foo.bar': 'baz',
+        },
       },
-    });
+    ]);
     Config.defineConfigSchema('corge-module', {
       corges: { _default: false, _type: Type.Boolean },
     });

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -276,7 +276,7 @@ export function getTranslationOverrides(
   moduleName: string,
   slotName?: string,
   extensionId?: string,
-): Promise<Record<string, Record<string, string>>> {
+): Promise<Array<Record<string, Record<string, string>>>> {
   const promises = [
     new Promise<Record<string, Record<string, string>>>((resolve) => {
       const configStore = getConfigStore(moduleName);
@@ -309,7 +309,7 @@ export function getTranslationOverrides(
     );
   }
 
-  return Promise.all(promises).then((results) => results.reduce((prev, current) => mergeDeepRight(prev, current), {}));
+  return Promise.all(promises);
 }
 
 /**

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -839,7 +839,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-translations/src/index.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-translations/src/index.ts#L47)
+[packages/framework/esm-translations/src/index.ts:53](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-translations/src/index.ts#L53)
 
 ___
 
@@ -6065,7 +6065,7 @@ invalid key to this function will result in a type error.
 | :------ | :------ | :------ |
 | `key` | ``"error"`` \| ``"change"`` \| ``"close"`` \| ``"other"`` \| ``"actions"`` \| ``"address"`` \| ``"age"`` \| ``"cancel"`` \| ``"confirm"`` \| ``"contactAdministratorIfIssuePersists"`` \| ``"contactDetails"`` \| ``"errorCopy"`` \| ``"female"`` \| ``"hideDetails"`` \| ``"loading"`` \| ``"male"`` \| ``"patientIdentifierSticker"`` \| ``"patientLists"`` \| ``"print"`` \| ``"printError"`` \| ``"printErrorExplainer"`` \| ``"printIdentifierSticker"`` \| ``"printing"`` \| ``"relationships"`` \| ``"resetOverrides"`` \| ``"scriptLoadingFailed"`` \| ``"scriptLoadingError"`` \| ``"seeMoreLists"`` \| ``"sex"`` \| ``"showDetails"`` \| ``"unknown"`` \| ``"closeAllOpenedWorkspaces"`` \| ``"closingAllWorkspacesPromptBody"`` \| ``"closingAllWorkspacesPromptTitle"`` \| ``"discard"`` \| ``"hide"`` \| ``"maximize"`` \| ``"minimize"`` \| ``"openAnyway"`` \| ``"unsavedChangesInOpenedWorkspace"`` \| ``"unsavedChangesInWorkspace"`` \| ``"unsavedChangesTitleText"`` \| ``"workspaceHeader"`` \| ``"address1"`` \| ``"address2"`` \| ``"address3"`` \| ``"address4"`` \| ``"address5"`` \| ``"address6"`` \| ``"city"`` \| ``"cityVillage"`` \| ``"country"`` \| ``"countyDistrict"`` \| ``"postalCode"`` \| ``"state"`` \| ``"stateProvince"`` | - |
 | `defaultText?` | `string` | - |
-| `options?` | `object` | Object passed to the i18next `t` function. See https://www.i18next.com/translation-function/essentials#overview-options           for more information. `ns` and `defaultValue` are already set and may not be used. |
+| `options?` | `Omit`<`TOptions`<`StringMap`\>, ``"defaultValue"`` \| ``"ns"``\> | Object passed to the i18next `t` function. See https://www.i18next.com/translation-function/essentials#overview-options           for more information. `ns` and `defaultValue` are already set and may not be used. |
 
 #### Returns
 
@@ -6073,7 +6073,7 @@ invalid key to this function will result in a type error.
 
 #### Defined in
 
-[packages/framework/esm-translations/src/index.ts:60](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-translations/src/index.ts#L60)
+[packages/framework/esm-translations/src/index.ts:66](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-translations/src/index.ts#L66)
 
 ___
 
@@ -6092,7 +6092,8 @@ Translations within the current app should be accessed with the i18next API, usi
 
 IMPORTANT: This function creates a hidden dependency on the module. Worse yet, it creates
 a dependency specifically on that module's translation keys, which are often regarded as
-"implementation details" and therefore may be volatile.
+"implementation details" and therefore may be volatile. Also note that this function DOES NOT
+load the module's translations if they have not already been loaded via `useTranslation`.
 **This function should therefore be avoided when possible.**
 
 #### Parameters
@@ -6102,7 +6103,7 @@ a dependency specifically on that module's translation keys, which are often reg
 | `moduleName` | `string` | The module to get the translation from, e.g. '@openmrs/esm-login-app' |
 | `key` | `string` | The i18next translation key |
 | `fallback?` | `string` | Fallback text for if the lookup fails |
-| `options?` | `object` | Options object passed to the i18next `t` function. See https://www.i18next.com/translation-function/essentials#overview-options            for more information. `ns` and `defaultValue` are already set and may not be used. |
+| `options?` | `Omit`<`TOptions`<`StringMap`\>, ``"defaultValue"`` \| ``"ns"``\> | Options object passed to the i18next `t` function. See https://www.i18next.com/translation-function/essentials#overview-options            for more information. `ns` and `defaultValue` are already set and may not be used. |
 
 #### Returns
 
@@ -6112,7 +6113,7 @@ The translated text as a string
 
 #### Defined in
 
-[packages/framework/esm-translations/src/index.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-translations/src/index.ts#L39)
+[packages/framework/esm-translations/src/index.ts:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-translations/src/index.ts#L40)
 
 ___
 

--- a/packages/framework/esm-translations/src/index.ts
+++ b/packages/framework/esm-translations/src/index.ts
@@ -1,6 +1,6 @@
 /** @module @category Translation */
 import { coreTranslations } from './translations';
-import _i18n, { i18n } from 'i18next';
+import _i18n, { i18n, type TOptions } from 'i18next';
 
 const i18n: typeof _i18n = (_i18n as unknown as { default: typeof _i18n }).default || _i18n;
 
@@ -26,7 +26,8 @@ i18n.on('initialized', function () {
  *
  * IMPORTANT: This function creates a hidden dependency on the module. Worse yet, it creates
  * a dependency specifically on that module's translation keys, which are often regarded as
- * "implementation details" and therefore may be volatile.
+ * "implementation details" and therefore may be volatile. Also note that this function DOES NOT
+ * load the module's translations if they have not already been loaded via `useTranslation`.
  * **This function should therefore be avoided when possible.**
  *
  * @param moduleName The module to get the translation from, e.g. '@openmrs/esm-login-app'
@@ -36,7 +37,12 @@ i18n.on('initialized', function () {
  *            for more information. `ns` and `defaultValue` are already set and may not be used.
  * @returns The translated text as a string
  */
-export function translateFrom(moduleName: string, key: string, fallback?: string, options?: object) {
+export function translateFrom(
+  moduleName: string,
+  key: string,
+  fallback?: string,
+  options?: Omit<TOptions, 'ns' | 'defaultValue'>,
+) {
   return i18n.t(key, {
     ns: moduleName,
     defaultValue: fallback,
@@ -57,7 +63,11 @@ export type CoreTranslationKey = keyof typeof coreTranslations;
  * @param options Object passed to the i18next `t` function. See https://www.i18next.com/translation-function/essentials#overview-options
  *           for more information. `ns` and `defaultValue` are already set and may not be used.
  */
-export function getCoreTranslation(key: CoreTranslationKey, defaultText?: string, options?: object): string {
+export function getCoreTranslation(
+  key: CoreTranslationKey,
+  defaultText?: string,
+  options?: Omit<TOptions, 'ns' | 'defaultValue'>,
+): string {
   if (!coreTranslations[key]) {
     console.error(`O3 Core Translations does not provide key '${key}'. The key itself is being rendered as text.`);
     return key;

--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -63,9 +63,27 @@ export function setupI18n() {
             .then(([json, overrides]) => {
               let translations = json ?? {};
 
-              if (language in overrides) {
-                translations = merge(translations, overrides[language]);
+              // if we have a slotName and extensionId, it means that we're only loading the namespace for that extension
+              // in that slot, but we _also_ process the base translations for the namespace and any top-level config overrides
+              // so here we also provide the translations for just the namespace before merging everything together
+              if (slotName && extensionId) {
+                if (overrides.length >= 1 && language in overrides[0]) {
+                  window.i18next.addResourceBundle(
+                    language,
+                    ns,
+                    merge(translations, overrides[0][language]),
+                    true,
+                    false,
+                  );
+                } else {
+                  window.i18next.addResourceBundle(language, ns, translations, true, false);
+                }
               }
+
+              translations = merge(
+                translations,
+                overrides.filter((o) => language in o),
+              );
 
               callback(null, translations);
             })


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This is a follow-up for #1119 that addresses a very narrow issue. Specifically, with #1119, when we loaded a namespace for an extension instance in a slot, this resulted in the namespace for the app itself not yet being populated. Basically, we would populate a namespace like `@openmrs/esm-login-app___location-picker___location-picker` correctly, but leave the `@openmrs/esm-login-app` namespace unpopulated. Since we _generally_ rely on the `useTranslation()` to actually load the namespace, this meant there were some circumstances (like using the `translateFrom()` function) where the namespace for a specific extension instance was loaded but the namespace for the module was not currently registered, and `i18next` had no idea that it should try the longer namespace name.

This addresses this issue by ensuring that when we populate the namespace for an extension instance, we also populate the namespace for the app itself.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

Unsolved by this PR is the issue where `translateFrom()` cannot guarantee that a namespace is actually loaded, and so it may not correctly translate given translation keys under circumstances where the module hasn't otherwise been loaded first. While this sounds narrow, it remains a live possibility. I have added a note about this to the docs for `translateFrom()`.
