### PR TITLE
(fix) O3-3891: Adjust Change Language Modal Size to Small

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language-link.extension.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language-link.extension.tsx
@@ -1,28 +1,31 @@
-import React, { useCallback } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, SwitcherItem } from '@carbon/react';
-import { TranslateIcon, showModal, useSession } from '@openmrs/esm-framework';
+import { TranslateIcon, useSession } from '@openmrs/esm-framework';
 import styles from './change-language-link.scss';
+import ChangeLanguageModal from './change-language.modal';
 
 /** The user menu item that shows the current language and has a button to change the language */
 export function ChangeLanguageLink() {
   const { t } = useTranslation();
   const session = useSession();
-
-  const launchChangeLanguageModal = useCallback(() => showModal('change-language-modal'), []);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const languageNames = new Intl.DisplayNames([session?.locale], { type: 'language' });
 
   return (
-    <SwitcherItem className={styles.panelItemContainer} aria-label={t('changeLanguage', 'Change language')}>
-      <div>
-        <TranslateIcon size={20} />
-        <p>{languageNames.of(session?.locale)}</p>
-      </div>
-      <Button kind="ghost" onClick={launchChangeLanguageModal}>
-        {t('change', 'Change')}
-      </Button>
-    </SwitcherItem>
+    <>
+      <SwitcherItem className={styles.panelItemContainer} aria-label={t('changeLanguage', 'Change language')}>
+        <div>
+          <TranslateIcon size={20} />
+          <p>{languageNames.of(session?.locale)}</p>
+        </div>
+        <Button kind="ghost" onClick={() => setIsModalOpen(true)}>
+          {t('change', 'Change')}
+        </Button>
+      </SwitcherItem>
+      {isModalOpen && <ChangeLanguageModal close={() => setIsModalOpen(false)} />}
+    </>
   );
 }
 

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
@@ -1,14 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import {
-  Button,
-  InlineLoading,
-  ModalBody,
-  ModalFooter,
-  ModalHeader,
-  RadioButton,
-  RadioButtonGroup,
-} from '@carbon/react';
+import { InlineLoading, Modal, ModalBody, RadioButton, RadioButtonGroup } from '@carbon/react';
 import { useConnectivity, useSession } from '@openmrs/esm-framework';
 import { postUserPropertiesOffline, postUserPropertiesOnline } from './change-language.resource';
 import styles from './change-language.scss';
@@ -53,8 +45,23 @@ export default function ChangeLanguageModal({ close }: ChangeLanguageModalProps)
   );
 
   return (
-    <>
-      <ModalHeader closeModal={close} title={t('changeLanguage', 'Change language')} />
+    <Modal
+      open={true}
+      className={styles.customModal}
+      modalHeading={t('changeLanguage', 'Change language')}
+      size="sm"
+      primaryButtonText={
+        isChangingLanguage ? (
+          <InlineLoading description={t('changingLanguage', 'Changing language') + '...'} />
+        ) : (
+          t('change', 'Change')
+        )
+      }
+      primaryButtonDisabled={isChangingLanguage || selectedLocale === session?.locale}
+      secondaryButtonText={t('cancel', 'Cancel')}
+      onRequestSubmit={handleSubmit}
+      onRequestClose={close}
+    >
       <ModalBody>
         <div className={styles.languageOptionsContainer}>
           <RadioButtonGroup
@@ -76,23 +83,6 @@ export default function ChangeLanguageModal({ close }: ChangeLanguageModalProps)
           </RadioButtonGroup>
         </div>
       </ModalBody>
-      <ModalFooter>
-        <Button kind="secondary" onClick={close}>
-          {t('cancel', 'Cancel')}
-        </Button>
-        <Button
-          className={styles.submitButton}
-          disabled={isChangingLanguage || selectedLocale === session?.locale}
-          type="submit"
-          onClick={handleSubmit}
-        >
-          {isChangingLanguage ? (
-            <InlineLoading description={t('changingLanguage', 'Changing language') + '...'} />
-          ) : (
-            <span>{t('change', 'Change')}</span>
-          )}
-        </Button>
-      </ModalFooter>
-    </>
+    </Modal>
   );
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR adjusts the size of the change-language pop-up modal to small.

## Screenshots
Find attached the screenshot with the changes.
<img width="1440" alt="Screenshot 2024-09-02 at 11 26 40" src="https://github.com/user-attachments/assets/00e4e217-347c-4086-af8b-5f3e767adecc">


## Related Issue
https://openmrs.atlassian.net/browse/O3-3891

## Other
@denniskigen @vasharma05 please review.
