### PR TITLE
(fix) O3-3902 - make age() function (and its usage) handle null birth…

### DIFF
--- a/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.component.tsx
+++ b/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.component.tsx
@@ -36,8 +36,13 @@ export function PatientBannerPatientInfo({ patient }: PatientBannerPatientInfoPr
         </div>
       </div>
       <div className={styles.demographics}>
-        <span>{gender}</span> &middot; <span>{patient?.birthDate && age(patient.birthDate)}</span> &middot;{' '}
-        <span>{patient?.birthDate && formatDate(parseDate(patient.birthDate), { mode: 'wide', time: false })}</span>
+        <span>{gender}</span>
+        {patient.birthDate && (
+          <>
+            &middot; <span>{age(patient.birthDate)}</span>
+            &middot; <span>{formatDate(parseDate(patient.birthDate), { mode: 'wide', time: false })}</span>
+          </>
+        )}
       </div>
       <div className={styles.row}>
         <div className={styles.identifiers}>

--- a/packages/framework/esm-utils/src/age-helpers.ts
+++ b/packages/framework/esm-utils/src/age-helpers.ts
@@ -10,11 +10,15 @@ import { type DurationInput } from '@formatjs/intl-durationformat/src/types';
  * https://webarchive.nationalarchives.gov.uk/ukgwa/20160921162509mp_/http://systems.digital.nhs.uk/data/cui/uig/patben.pdf
  * (See Tables 7 and 8)
  *
- * @param birthDate The birthDate.
+ * @param birthDate The birthDate. If birthDate is null, returns null.
  * @param currentDate Optional. If provided, calculates the age of the person at the provided currentDate (instead of now).
  * @returns A human-readable string version of the age.
  */
-export function age(birthDate: dayjs.ConfigType, currentDate: dayjs.ConfigType = dayjs()): string {
+export function age(birthDate: dayjs.ConfigType, currentDate: dayjs.ConfigType = dayjs()): string | null {
+  if (birthDate == null) {
+    return null;
+  }
+
   const to = dayjs(currentDate);
   const from = dayjs(birthDate);
 


### PR DESCRIPTION
…dates

# Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Add a null check to prevent NPE in the `age()` function when a patient's birthdate is null. There are also places, in core and patient-management, where this is insufficient, when UI elements should just not render in that case. This PR adds null check in those places too.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-3902

## Other
<!-- Anything not covered above -->
