### PR TITLE
Revert "(fix) Fix the URLs to load importmap and routes registry JSON"

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -7214,9 +7214,7 @@ with the key "webservices.rest.maxResultsDefault". See: https://openmrs.atlassia
 
 This hook fetches data from a paginated rest endpoint, initially by fetching the first page of the results.
 It provides a callback to load data from subsequent pages as needed. This hook is intended to serve UIs that
-provide infinite loading / scrolling of results. Unlike `useOpenmrsPagination`, this hook does not allow random access
-(and lazy-loading) of any arbitrary page; rather, it fetches pages sequentially starting form the initial page, and the next page
-is fetched by calling `loadMore`. See: https://swr.vercel.app/docs/pagination#useswrinfinite
+provide infinite loading / scrolling of results.
 
 **`see`** `useOpenmrsPagination`
 
@@ -7245,7 +7243,7 @@ a UseServerInfiniteReturnObject object
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts:99](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts#L99)
+[packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts:97](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts#L97)
 
 ___
 
@@ -7387,7 +7385,7 @@ ___
 
 ### age
 
-▸ **age**(`birthDate`, `currentDate?`): `string` \| ``null``
+▸ **age**(`birthDate`, `currentDate?`): `string`
 
 Gets a human readable and locale supported representation of a person's age, given their birthDate,
 The representation logic follows the guideline here:
@@ -7398,12 +7396,12 @@ https://webarchive.nationalarchives.gov.uk/ukgwa/20160921162509mp_/http://system
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `birthDate` | `undefined` \| ``null`` \| `string` \| `number` \| `Date` \| `Dayjs` | The birthDate. If birthDate is null, returns null. |
+| `birthDate` | `undefined` \| ``null`` \| `string` \| `number` \| `Date` \| `Dayjs` | The birthDate. |
 | `currentDate` | `undefined` \| ``null`` \| `string` \| `number` \| `Date` \| `Dayjs` | Optional. If provided, calculates the age of the person at the provided currentDate (instead of now). |
 
 #### Returns
 
-`string` \| ``null``
+`string`
 
 A human-readable string version of the age.
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -7214,7 +7214,9 @@ with the key "webservices.rest.maxResultsDefault". See: https://openmrs.atlassia
 
 This hook fetches data from a paginated rest endpoint, initially by fetching the first page of the results.
 It provides a callback to load data from subsequent pages as needed. This hook is intended to serve UIs that
-provide infinite loading / scrolling of results.
+provide infinite loading / scrolling of results. Unlike `useOpenmrsPagination`, this hook does not allow random access
+(and lazy-loading) of any arbitrary page; rather, it fetches pages sequentially starting form the initial page, and the next page
+is fetched by calling `loadMore`. See: https://swr.vercel.app/docs/pagination#useswrinfinite
 
 **`see`** `useOpenmrsPagination`
 
@@ -7243,7 +7245,7 @@ a UseServerInfiniteReturnObject object
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts:97](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts#L97)
+[packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts:99](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts#L99)
 
 ___
 
@@ -7385,7 +7387,7 @@ ___
 
 ### age
 
-▸ **age**(`birthDate`, `currentDate?`): `string`
+▸ **age**(`birthDate`, `currentDate?`): `string` \| ``null``
 
 Gets a human readable and locale supported representation of a person's age, given their birthDate,
 The representation logic follows the guideline here:
@@ -7396,12 +7398,12 @@ https://webarchive.nationalarchives.gov.uk/ukgwa/20160921162509mp_/http://system
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `birthDate` | `undefined` \| ``null`` \| `string` \| `number` \| `Date` \| `Dayjs` | The birthDate. |
+| `birthDate` | `undefined` \| ``null`` \| `string` \| `number` \| `Date` \| `Dayjs` | The birthDate. If birthDate is null, returns null. |
 | `currentDate` | `undefined` \| ``null`` \| `string` \| `number` \| `Date` \| `Dayjs` | Optional. If provided, calculates the age of the person at the provided currentDate (instead of now). |
 
 #### Returns
 
-`string`
+`string` \| ``null``
 
 A human-readable string version of the age.
 

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -30,17 +30,9 @@ const openmrsEnvironment = process.env.OMRS_ENV || process.env.NODE_ENV || '';
 const openmrsOffline = process.env.OMRS_OFFLINE === 'enable';
 const openmrsDefaultLocale = process.env.OMRS_ESM_DEFAULT_LOCALE || 'en';
 const openmrsImportmapDef = process.env.OMRS_ESM_IMPORTMAP;
-const openmrsImportmapUrl = process.env.OMRS_ESM_IMPORTMAP_URL
-  ? !process.env.OMRS_ESM_IMPORTMAP_URL.startsWith('/') && !process.env.OMRS_ESM_IMPORTMAP_URL.startsWith('http')
-    ? process.env.OMRS_ESM_IMPORTMAP_URL
-    : `${openmrsPublicPath}/${process.env.OMRS_ESM_IMPORTMAP_URL}`
-  : `${openmrsPublicPath}/importmap.json`;
+const openmrsImportmapUrl = process.env.OMRS_ESM_IMPORTMAP_URL || `${openmrsPublicPath}/importmap.json`;
 const openmrsRoutesDef = process.env.OMRS_ROUTES;
-const openmrsRoutesUrl = process.env.OMRS_ROUTES_URL
-  ? !process.env.OMRS_ROUTES_URL.startsWith('/') && !process.env.OMRS_ROUTES_URL.startsWith('http')
-    ? process.env.OMRS_ROUTES_URL
-    : `${openmrsPublicPath}/${process.env.OMRS_ROUTES_URL}`
-  : `${openmrsPublicPath}/routes.registry.json`;
+const openmrsRoutesUrl = process.env.OMRS_ROUTES_URL || `${openmrsPublicPath}/routes.registry.json`;
 const openmrsCoreApps = process.env.OMRS_ESM_CORE_APPS_DIR || resolve(__dirname, '../../apps');
 const openmrsConfigUrls = (process.env.OMRS_CONFIG_URLS || '')
   .split(';')


### PR DESCRIPTION
Reverts openmrs/openmrs-esm-core#1140

The path found for the `importmap.json` when running apps in other repositories is: `/openmrs/spa//openmrs/spa/importmap.json`