### PR TITLE
(chore) Release v5.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-core",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "private": true,
   "workspaces": [
     "packages/apps/*",

--- a/packages/apps/esm-devtools-app/package.json
+++ b/packages/apps/esm-devtools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-devtools-app",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "Dev tools for frontend devs using OpenMRS",
   "browser": "dist/openmrs-esm-devtools-app.js",

--- a/packages/apps/esm-help-menu-app/package.json
+++ b/packages/apps/esm-help-menu-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-help-menu-app",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": " A microfrontend that provides a help menu for O3",
   "browser": "dist/openmrs-esm-help-menu-app.js",

--- a/packages/apps/esm-implementer-tools-app/package.json
+++ b/packages/apps/esm-implementer-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-implementer-tools-app",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "The admin interface for OpenMRS Frontend",
   "browser": "dist/openmrs-esm-implementer-tools-app.js",

--- a/packages/apps/esm-login-app/package.json
+++ b/packages/apps/esm-login-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-login-app",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "The login microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-login-app.js",

--- a/packages/apps/esm-offline-tools-app/package.json
+++ b/packages/apps/esm-offline-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline-tools-app",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "The offline tools microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-offline-tools-app.js",

--- a/packages/apps/esm-primary-navigation-app/package.json
+++ b/packages/apps/esm-primary-navigation-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-primary-navigation-app",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "Main navbar microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-primary-navigation-app.js",

--- a/packages/framework/esm-api/package.json
+++ b/packages/framework/esm-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-api",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "The javascript module for interacting with the OpenMRS API",
   "browser": "dist/openmrs-esm-api.js",

--- a/packages/framework/esm-config/package.json
+++ b/packages/framework/esm-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-config",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "A configuration library for the OpenMRS Single-Spa framework.",
   "browser": "dist/openmrs-esm-module-config.js",

--- a/packages/framework/esm-context/package.json
+++ b/packages/framework/esm-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-context",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "Utilities for managing the current execution context",
   "browser": "dist/openmrs-esm-context.js",

--- a/packages/framework/esm-dynamic-loading/package.json
+++ b/packages/framework/esm-dynamic-loading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-dynamic-loading",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "Utilities for dynamically loading code in OpenMRS",
   "browser": "dist/openmrs-esm-dynamic-loading.js",

--- a/packages/framework/esm-error-handling/package.json
+++ b/packages/framework/esm-error-handling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-error-handling",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "An ES module to help with error handling",
   "browser": "dist/openmrs-esm-error-handling.js",

--- a/packages/framework/esm-expression-evaluator/package.json
+++ b/packages/framework/esm-expression-evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-expression-evaluator",
-  "version": "5.7.2",
+  "version": "5.8.0",
   "license": "MPL-2.0",
   "description": "Utilities for evaluating user-defined expressions",
   "browser": "dist/openmrs-esm-expression-evaluator.js",

--- a/packages/framework/esm-extensions/package.json
+++ b/packages/framework/esm-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-extensions",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "Coordinates extensions and extension points in the OpenMRS Frontend",
   "browser": "dist/openmrs-esm-extensions.js",

--- a/packages/framework/esm-feature-flags/package.json
+++ b/packages/framework/esm-feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-feature-flags",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "A feature flag system for the OpenMRS Single-Spa framework.",
   "browser": "dist/openmrs-esm-feature-flags.js",

--- a/packages/framework/esm-framework/package.json
+++ b/packages/framework/esm-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-framework",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "browser": "dist/openmrs-esm-framework.js",
   "main": "src/index.ts",

--- a/packages/framework/esm-globals/package.json
+++ b/packages/framework/esm-globals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-globals",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "browser": "dist/openmrs-esm-globals.js",
   "main": "src/index.ts",

--- a/packages/framework/esm-navigation/package.json
+++ b/packages/framework/esm-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-navigation",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "OpenMRS library providing tools for breadcrumbs, navigation, and history.",
   "browser": "dist/openmrs-esm-navigation.js",

--- a/packages/framework/esm-offline/package.json
+++ b/packages/framework/esm-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "browser": "dist/openmrs-esm-offline.js",

--- a/packages/framework/esm-react-utils/package.json
+++ b/packages/framework/esm-react-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-react-utils",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "React utilities for OpenMRS.",
   "browser": "dist/openmrs-esm-react-utils.js",

--- a/packages/framework/esm-routes/package.json
+++ b/packages/framework/esm-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-routes",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "Utilities for working with the routes registry",
   "browser": "dist/openmrs-esm-routes.js",

--- a/packages/framework/esm-state/package.json
+++ b/packages/framework/esm-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-state",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "Frontend stores & state management for OpenMRS",
   "browser": "dist/openmrs-esm-state.js",

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-styleguide",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "The styleguide for OpenMRS SPA",
   "browser": "dist/openmrs-esm-styleguide.js",

--- a/packages/framework/esm-translations/package.json
+++ b/packages/framework/esm-translations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-translations",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "O3 Framework module for translation support",
   "browser": "dist/openmrs-esm-translations.js",

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-utils",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "browser": "dist/openmrs-esm-utils.js",

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-app-shell",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "main": "dist/openmrs.js",
   "scripts": {

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmrs",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "main": "dist/index.js",
   "bin": "./dist/cli.js",

--- a/packages/tooling/webpack-config/package.json
+++ b/packages/tooling/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/webpack-config",
-  "version": "5.8.0",
+  "version": "5.9.0",
   "license": "MPL-2.0",
   "main": "dist/index.js",
   "types": "src/index.ts",


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.


## Summary
This PR cuts a minor release of the OpenMRS ESM Core, which supports the following changes: 

1. Improved the workspace title translation issue with asynchronous translation resource loading.
2. New E2E workflow to use the local shell to assemble the E2E environment and run all E2E tests from other repositories.
3. Introduction of a safer expression runner

## Changelog

### Fixes
* (fix) Update dummy StoreApi to work with Zustand 4.4+ by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/1128
* (fix) Add better support for loading multiple namespaces at once by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/1132
* (refactor) Load styleguide config asynchronously in PageHeader by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1133
* (fix) remove fill attributes for baby and mother svg icons by @chibongho in https://github.com/openmrs/openmrs-esm-core/pull/1135
* (fix) O3-3902 - make age() function (and its usage) handle null birth… by @chibongho in https://github.com/openmrs/openmrs-esm-core/pull/1136
* (fix) - O3-3189 - fix server-side pagination hook to handle error con… by @chibongho in https://github.com/openmrs/openmrs-esm-core/pull/1123
* (fix) Do not generate `undefined` as a value by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/1137
* (docs) Update E2E instructions on the readme file by @jayasanka-sack in https://github.com/openmrs/openmrs-esm-core/pull/1138
* (fix) Fix the URLs to load importmap and routes registry JSON by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/1140
* (fix) Workspace title must translate in the workspace container by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/1141

* Revert "(fix) Fix the URLs to load importmap and routes registry JSON" by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/1143

### New improvements
* (feat) - add baby and mother icons by @chibongho in https://github.com/openmrs/openmrs-esm-core/pull/1131
* (feat) O3-3708: Add a safer expression runner by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/1108
* (feat) O3-3866:Allow customized message/dialog for warning when closing a workspace by @mogoodrich in https://github.com/openmrs/openmrs-esm-core/pull/1129

### Improvements to E2E test suite

A recent change in the E2E test suite runs the E2E test suites in every new PR for `@openmrs/esm-patient-chart` and `@openmrs/esm-patient-management` to verify that new changes in the `@openmrs/esm-framework` doesn't cause issues in the above-mentioned apps.

* (test) Use local shell to assemble E2E environment and run all E2E tests from other repos by @jayasanka-sack in https://github.com/openmrs/openmrs-esm-core/pull/1139

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
