### PR TITLE
(fix) O3-3189 - Fix useOpemrsInfinite hook to correctly take in URL

### DIFF
--- a/packages/framework/esm-react-utils/src/useOpenmrsFetchAll.ts
+++ b/packages/framework/esm-react-utils/src/useOpenmrsFetchAll.ts
@@ -56,7 +56,7 @@ export function useServerFetchAll<T, R>(
     if (hasMore && !error) {
       loadMore();
     }
-  });
+  }, [hasMore]);
 
   if (options.partialData) {
     return response;

--- a/packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts
+++ b/packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts
@@ -112,9 +112,9 @@ export function useServerInfinite<T, R>(
   const { getNextUrl, getTotalCount, getData } = serverPaginationHandlers;
   const fetcher: (key: string) => Promise<FetchResponse<R>> = options.fetcher ?? openmrsFetch;
   const getKey = useCallback(
-    (pageIndex: number, previousPageData: FetchResponse<R>) => {
+    (pageIndex: number, previousPageData: FetchResponse<R>): string | null => {
       if (pageIndex == 0) {
-        return url;
+        return url?.toString() ?? null;
       } else {
         return serverPaginationHandlers.getNextUrl(previousPageData.data);
       }


### PR DESCRIPTION
… object

# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

This fixes a nasty bug with the `useOpnemrsInfinite` hook, when `url` passed in is an `URL` object instead of a `string`. The `getKey` function should return a string value for `useSWRInfinite` to do `==` value comparison on. The previous implementation has the function potentially returning a URL object as key, makes makes `==` do reference comparison, which causes key comparison to always be false, causing an infinite fetch loop.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
