### PR TITLE
(feat) Make it possible to change modal container size

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -6831,7 +6831,7 @@ body might not vertical-scroll properly.
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `modalName` | `string` | The name of the modal to show. |
-| `props` | `Record`<`string`, `any`\> | The optional props to provide to the modal. |
+| `props` | `ModalProps` | The optional props to provide to the modal. |
 | `onClose` | () => `void` | The optional callback to call when the modal is closed. |
 
 #### Returns
@@ -6848,7 +6848,7 @@ The dispose function to force closing the modal dialog.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/modals/index.tsx:207](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/modals/index.tsx#L207)
+[packages/framework/esm-styleguide/src/modals/index.tsx:216](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/modals/index.tsx#L216)
 
 ___
 

--- a/packages/framework/esm-styleguide/src/modals/index.tsx
+++ b/packages/framework/esm-styleguide/src/modals/index.tsx
@@ -3,6 +3,7 @@ import { mountRootParcel, type Parcel } from 'single-spa';
 import { createGlobalStore } from '@openmrs/esm-state';
 import { getModalRegistration } from '@openmrs/esm-extensions';
 import { reportError } from '@openmrs/esm-error-handling';
+import { getCoreTranslation } from '@openmrs/esm-translations';
 
 type ModalInstanceState = 'NEW' | 'MOUNTED' | 'TO_BE_DELETED';
 type ModalSize = 'xs' | 'sm' | 'md' | 'lg';
@@ -38,18 +39,14 @@ function htmlToElement(html: string) {
 }
 
 function createModalFrame({ size }: { size: ModalSize }) {
+  const closeTextTranslated = getCoreTranslation('close', 'Close');
   const closeButton = htmlToElement(
-    `<button class="cds--modal-close" title="Close" aria-label="Close" type="button"><svg focusable="false" preserveAspectRatio="xMidYMid meet" fill="currentColor" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true" class="cds--modal-close__icon" xmlns="http://www.w3.org/2000/svg"><path d="M17.4141 16L24 9.4141 22.5859 8 16 14.5859 9.4143 8 8 9.4141 14.5859 16 8 22.5859 9.4143 24 16 17.4141 22.5859 24 24 22.5859 17.4141 16z"></path></svg></button>`.trim(),
+    `<button class="cds--modal-close" aria-label="${closeTextTranslated}" title="${closeTextTranslated}" type="button"><svg focusable="false" preserveAspectRatio="xMidYMid meet" fill="currentColor" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true" class="cds--modal-close__icon" xmlns="http://www.w3.org/2000/svg"><path d="M17.4141 16L24 9.4141 22.5859 8 16 14.5859 9.4143 8 8 9.4141 14.5859 16 8 22.5859 9.4143 24 16 17.4141 22.5859 24 24 22.5859 17.4141 16z"></path></svg></button>`.trim(),
   ) as HTMLButtonElement;
 
   closeButton.addEventListener('click', closeHighestInstance);
   const modalFrame = document.createElement('div');
-  modalFrame.className = 'cds--modal-container';
-
-  if (size) {
-    modalFrame.classList.add(`cds--modal-container--${size as ModalSize}`);
-  }
-
+  modalFrame.className = `cds--modal-container cds--modal-container--${size}`;
   // we also need to pass the aria label along to the modal container
   modalFrame.setAttribute('role', 'dialog');
   modalFrame.setAttribute('tabindex', '-1');

--- a/packages/framework/esm-styleguide/src/modals/index.tsx
+++ b/packages/framework/esm-styleguide/src/modals/index.tsx
@@ -5,6 +5,12 @@ import { getModalRegistration } from '@openmrs/esm-extensions';
 import { reportError } from '@openmrs/esm-error-handling';
 
 type ModalInstanceState = 'NEW' | 'MOUNTED' | 'TO_BE_DELETED';
+type ModalSize = 'xs' | 'sm' | 'md' | 'lg';
+
+interface ModalProps {
+  size?: ModalSize;
+  [key: string]: unknown;
+}
 
 interface ModalInstance {
   container?: HTMLElement;
@@ -12,7 +18,7 @@ interface ModalInstance {
   onClose: () => void;
   parcel?: Parcel | null;
   modalName: string;
-  props: Record<string, any>;
+  props: ModalProps;
 }
 
 interface ModalState {
@@ -31,20 +37,23 @@ function htmlToElement(html: string) {
   return template.content.firstChild as ChildNode;
 }
 
-function createModalFrame() {
+function createModalFrame({ size }: { size: ModalSize }) {
   const closeButton = htmlToElement(
-    `
-  <button
-    class="cds--modal-close"
-    type="button">
-    <svg id="icon" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><defs><style>.cls-1{fill:#000000;}.cls-2{fill:none;}</style></defs><title>close</title><polygon class="cls-1" points="24 9.4 22.6 8 16 14.6 9.4 8 8 9.4 14.6 16 8 22.6 9.4 24 16 17.4 22.6 24 24 22.6 17.4 16 24 9.4"/><rect class="cls-2" width="32" height="32"/></svg>
-  </button>`.trim(),
+    `<button class="cds--modal-close" title="Close" aria-label="Close" type="button"><svg focusable="false" preserveAspectRatio="xMidYMid meet" fill="currentColor" width="20" height="20" viewBox="0 0 32 32" aria-hidden="true" class="cds--modal-close__icon" xmlns="http://www.w3.org/2000/svg"><path d="M17.4141 16L24 9.4141 22.5859 8 16 14.5859 9.4143 8 8 9.4141 14.5859 16 8 22.5859 9.4143 24 16 17.4141 22.5859 24 24 22.5859 17.4141 16z"></path></svg></button>`.trim(),
   ) as HTMLButtonElement;
 
   closeButton.addEventListener('click', closeHighestInstance);
   const modalFrame = document.createElement('div');
   modalFrame.className = 'cds--modal-container';
 
+  if (size) {
+    modalFrame.classList.add(`cds--modal-container--${size as ModalSize}`);
+  }
+
+  // we also need to pass the aria label along to the modal container
+  modalFrame.setAttribute('role', 'dialog');
+  modalFrame.setAttribute('tabindex', '-1');
+  modalFrame.setAttribute('aria-modal', 'true');
   modalFrame.append(closeButton);
 
   return modalFrame;
@@ -58,7 +67,7 @@ let parcelCount = 0;
 async function renderModalIntoDOM(
   domElement: HTMLElement,
   modalName: string,
-  additionalProps: Record<string, any> = {},
+  additionalProps: Record<string, unknown> = {},
 ): Promise<Parcel | null> {
   const modalRegistration = getModalRegistration(modalName);
   let parcel: Parcel | null = null;
@@ -105,7 +114,7 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
     modalStack.forEach((instance, index) => {
       switch (instance.state) {
         case 'NEW': {
-          const modalFrame = createModalFrame();
+          const modalFrame = createModalFrame({ size: instance.props?.size ?? 'md' });
           instance.container = modalFrame;
           renderModalIntoDOM(modalFrame, instance.modalName, instance.props).then((parcel) => {
             instance.parcel = parcel;
@@ -204,7 +213,7 @@ export function setupModals(modalContainer: HTMLElement | null) {
  * @param onClose The optional callback to call when the modal is closed.
  * @returns The dispose function to force closing the modal dialog.
  */
-export function showModal(modalName: string, props: Record<string, any> = {}, onClose: () => void = () => {}) {
+export function showModal(modalName: string, props: ModalProps = {}, onClose: () => void = () => {}) {
   const close = () => {
     const state = modalStore.getState();
     const item = state.modalStack.find((m) => m.onClose === onClose);

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import { Header, HeaderGlobalAction, HeaderGlobalBar, HeaderMenuButton, HeaderName } from '@carbon/react';
 import { DownToBottom, Maximize, Minimize } from '@carbon/react/icons';
 import { ComponentContext, ExtensionSlot, isDesktop, useBodyScrollLock, useLayoutType } from '@openmrs/esm-react-utils';
-import { getCoreTranslation, translateFrom } from '@openmrs/esm-translations';
+import { getCoreTranslation } from '@openmrs/esm-translations';
 
 import { ArrowLeftIcon, ArrowRightIcon, CloseIcon } from '../../icons';
 import { WorkspaceNotification } from '../notification/workspace-notification.component';


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR introduces an optional `size` to the `ModalInstance.props` API that enables changing the size of the modal container dynamically. When a value is provided in a modal registration that conforms to the `ModalSize` interface, the corresponding modal size classname gets applied to the modalFrame. With this you can specify a modal size prop in your modal registration like so:

```tsx
  const handleLaunchModal = useCallback(() => {
    const dispose = showModal('cancel-visit-dialog', {
      closeModal: () => dispose(),
      patientUuid,
      size: 'xs',
    });
  }, [patientUuid]);
```

And get the `xs` variant of the modal rendered in the UI:

![CleanShot 2024-09-17 at 10  05 58@2x](https://github.com/user-attachments/assets/8d68ab36-da55-491c-ac81-09ba405e9b5a)

## Screenshots

https://github.com/user-attachments/assets/b25168bd-a790-429a-b558-82b10b4eaea2

## Related Issue
https://openmrs.atlassian.net/browse/O3-3891

## Other
<!-- Anything not covered above -->
