### PR TITLE
(feat) O3-3889: Update Change Password modal to the `sm` variant

### DIFF
--- a/packages/apps/esm-login-app/src/change-password/change-password-link.extension.tsx
+++ b/packages/apps/esm-login-app/src/change-password/change-password-link.extension.tsx
@@ -7,7 +7,12 @@ import styles from './change-password.scss';
 const ChangePasswordLink: React.FC = () => {
   const { t } = useTranslation();
 
-  const launchChangePasswordModal = useCallback(() => showModal('change-password-modal'), []);
+  const launchChangePasswordModal = useCallback(() => {
+    const dispose = showModal('change-password-modal', {
+      closeModal: () => dispose(),
+      size: 'sm',
+    });
+  }, []);  
 
   return (
     <SwitcherItem aria-label={t('changePassword', 'ChangePassword')} className={styles.panelItemContainer}>

--- a/packages/apps/esm-login-app/src/change-password/change-password-link.test.tsx
+++ b/packages/apps/esm-login-app/src/change-password/change-password-link.test.tsx
@@ -19,6 +19,9 @@ describe('<ChangePasswordLink/>', () => {
     await user.click(changePasswordLink);
 
     expect(mockShowModal).toHaveBeenCalledTimes(1);
-    expect(mockShowModal).toHaveBeenCalledWith('change-password-modal');
+    expect(mockShowModal).toHaveBeenCalledWith('change-password-modal', {
+      size: 'sm',
+      closeModal: expect.any(Function),
+    });
   });
 });


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Update 'Change password' modal to use the small modal component. 

## Screenshots

![CleanShot 2024-09-20 at 11  53 05@2x](https://github.com/user-attachments/assets/ba65fee7-7b98-4367-875e-bad39f00d54f)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-3889

## Other
<!-- Anything not covered above -->
