### PR TITLE
(fix) Pass patient object to the banner action buttons

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -6655,7 +6655,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx#L20)
+[packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx#L21)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/PatientBannerActionsMenuProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/PatientBannerActionsMenuProps.md
@@ -9,6 +9,7 @@
 - [actionsSlotName](PatientBannerActionsMenuProps.md#actionsslotname)
 - [additionalActionsSlotState](PatientBannerActionsMenuProps.md#additionalactionsslotstate)
 - [isDeceased](PatientBannerActionsMenuProps.md#isdeceased)
+- [patient](PatientBannerActionsMenuProps.md#patient)
 - [patientUuid](PatientBannerActionsMenuProps.md#patientuuid)
 
 ## UI Properties
@@ -19,7 +20,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx:12](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx#L12)
+[packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx:13](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx#L13)
 
 ___
 
@@ -32,7 +33,7 @@ so as to keep the PatientBannerActionsMenu API clean.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx#L17)
+[packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx#L18)
 
 ___
 
@@ -42,7 +43,17 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx:11](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx#L11)
+[packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx:12](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx#L12)
+
+___
+
+### patient
+
+• **patient**: `Patient`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx#L10)
 
 ___
 
@@ -52,4 +63,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx#L10)
+[packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx:11](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx#L11)

--- a/packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx
+++ b/packages/framework/esm-styleguide/src/patient-banner/actions-menu/patient-banner-actions-menu.component.tsx
@@ -1,12 +1,13 @@
 /** @module @category UI */
 import React, { useMemo } from 'react';
 import { OverflowMenuVertical } from '@carbon/react/icons';
-import { ExtensionSlot, useConnectedExtensions } from '@openmrs/esm-react-utils';
+import { ExtensionSlot, useConnectedExtensions, usePatient } from '@openmrs/esm-react-utils';
 import { getCoreTranslation } from '@openmrs/esm-translations';
 import { CustomOverflowMenu } from '../../custom-overflow-menu/custom-overflow-menu.component';
 import styles from './patient-banner-actions-menu.module.scss';
 
 export interface PatientBannerActionsMenuProps {
+  patient: fhir.Patient;
   patientUuid: string;
   isDeceased: boolean;
   actionsSlotName: string;
@@ -18,6 +19,7 @@ export interface PatientBannerActionsMenuProps {
 }
 
 export function PatientBannerActionsMenu({
+  patient,
   patientUuid,
   actionsSlotName,
   isDeceased,
@@ -25,7 +27,7 @@ export function PatientBannerActionsMenu({
 }: PatientBannerActionsMenuProps) {
   const patientActions = useConnectedExtensions(actionsSlotName);
   const patientActionsSlotState = useMemo(
-    () => ({ patientUuid, ...additionalActionsSlotState }),
+    () => ({ patientUuid, patient, ...additionalActionsSlotState }),
     [patientUuid, additionalActionsSlotState],
   );
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This is a follow-up on https://github.com/openmrs/openmrs-esm-patient-chart/pull/2015, where the patient banner action buttons were updated to accept the `patient` object, but weren't passed from the ExtensionSlot at the Patient Banner Action Menu. This takes the `patient` object from the patient banner and passes it down to the Action buttons. 

A follow-up PR in https://github.com/openmrs/openmrs-esm-patient-chart will be created to pass down the `patient` object from the patient banner to the Action Menu.

## Screenshots
None

## Related Issue
None

## Other
<!-- Anything not covered above -->
