### PR TITLE
(chore) O3-4011 - refactor patient banner to have patient identifiers…

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -213,6 +213,7 @@
 - [CustomOverflowMenu](API.md#customoverflowmenu)
 - [PatientBannerActionsMenu](API.md#patientbanneractionsmenu)
 - [PatientBannerContactDetails](API.md#patientbannercontactdetails)
+- [PatientBannerPatientIdentifier](API.md#patientbannerpatientidentifier)
 - [PatientBannerPatientInfo](API.md#patientbannerpatientinfo)
 - [PatientBannerToggleContactDetailsButton](API.md#patientbannertogglecontactdetailsbutton)
 - [PatientPhoto](API.md#patientphoto)
@@ -6676,6 +6677,26 @@ ___
 #### Defined in
 
 [packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx:183](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.component.tsx#L183)
+
+___
+
+### PatientBannerPatientIdentifier
+
+▸ **PatientBannerPatientIdentifier**(`__namedParameters`): `Element`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `__namedParameters` | `PatientBannerPatientIdentifierProps` |
+
+#### Returns
+
+`Element`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-identifiers.component.tsx:13](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-identifiers.component.tsx#L13)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/StyleguideConfigObject.md
+++ b/packages/framework/esm-framework/docs/interfaces/StyleguideConfigObject.md
@@ -9,6 +9,7 @@
 - [Brand color #1](StyleguideConfigObject.md#brand color #1)
 - [Brand color #2](StyleguideConfigObject.md#brand color #2)
 - [Brand color #3](StyleguideConfigObject.md#brand color #3)
+- [excludePatientIdentifierCodeTypes](StyleguideConfigObject.md#excludepatientidentifiercodetypes)
 - [implementationName](StyleguideConfigObject.md#implementationname)
 - [patientPhotoConceptUuid](StyleguideConfigObject.md#patientphotoconceptuuid)
 - [preferredCalendar](StyleguideConfigObject.md#preferredcalendar)
@@ -45,13 +46,29 @@ ___
 
 ___
 
+### excludePatientIdentifierCodeTypes
+
+• **excludePatientIdentifierCodeTypes**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `uuids` | `string`[] |
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/config-schema.ts:7](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/config-schema.ts#L7)
+
+___
+
 ### implementationName
 
 • **implementationName**: `string`
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/config-schema.ts:7](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/config-schema.ts#L7)
+[packages/framework/esm-styleguide/src/config-schema.ts:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/config-schema.ts#L10)
 
 ___
 
@@ -61,7 +78,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/config-schema.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/config-schema.ts#L8)
+[packages/framework/esm-styleguide/src/config-schema.ts:11](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/config-schema.ts#L11)
 
 ___
 
@@ -75,4 +92,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/config-schema.ts:9](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/config-schema.ts#L9)
+[packages/framework/esm-styleguide/src/config-schema.ts:12](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/config-schema.ts#L12)

--- a/packages/framework/esm-styleguide/src/config-schema.ts
+++ b/packages/framework/esm-styleguide/src/config-schema.ts
@@ -4,6 +4,9 @@ export interface StyleguideConfigObject {
   'Brand color #1': string;
   'Brand color #2': string;
   'Brand color #3': string;
+  excludePatientIdentifierCodeTypes: {
+    uuids: Array<string>;
+  };
   implementationName: string;
   patientPhotoConceptUuid: string;
   preferredCalendar: {
@@ -23,6 +26,16 @@ export const esmStyleGuideSchema = {
   'Brand color #3': {
     _default: '#007d79',
     _type: Type.String,
+  },
+  excludePatientIdentifierCodeTypes: {
+    uuids: {
+      _type: Type.Array,
+      _description: 'List of UUIDs of patient identifier types to exclude from rendering in the patient banner',
+      _default: [],
+      _elements: {
+        _type: Type.UUID,
+      },
+    },
   },
   implementationName: {
     _type: Type.String,

--- a/packages/framework/esm-styleguide/src/patient-banner/index.ts
+++ b/packages/framework/esm-styleguide/src/patient-banner/index.ts
@@ -1,4 +1,5 @@
 export * from './patient-info/patient-banner-patient-info.component';
+export * from './patient-info/patient-banner-patient-identifiers.component';
 export * from './actions-menu/patient-banner-actions-menu.component';
 export * from './contact-details/patient-banner-toggle-contact-details-button.component';
 export * from './contact-details/patient-banner-contact-details.component';

--- a/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-identifiers.component.tsx
+++ b/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-identifiers.component.tsx
@@ -1,0 +1,55 @@
+/** @module @category UI */
+import { Tag } from '@carbon/react';
+import { useConfig, usePrimaryIdentifierCode } from '@openmrs/esm-react-utils';
+import React from 'react';
+import styles from './patient-banner-patient-info.module.scss';
+import { type StyleguideConfigObject } from '../../config-schema';
+
+interface PatientBannerPatientIdentifierProps {
+  identifier: fhir.Identifier[] | undefined;
+  showIdentifierLabel: boolean;
+}
+
+export function PatientBannerPatientIdentifier({
+  identifier,
+  showIdentifierLabel,
+}: PatientBannerPatientIdentifierProps) {
+  const { excludePatientIdentifierCodeTypes } = useConfig<StyleguideConfigObject>();
+  const { primaryIdentifierCode } = usePrimaryIdentifierCode();
+  const filteredIdentifiers =
+    identifier?.filter((identifier) => {
+      const code = identifier.type?.coding?.[0]?.code;
+      return code && !excludePatientIdentifierCodeTypes?.uuids.includes(code);
+    }) ?? [];
+
+  return (
+    <div className={styles.identifiers}>
+      {filteredIdentifiers?.length
+        ? filteredIdentifiers.map(({ value, type }, index) => (
+            <span key={value} className={styles.identifierTag}>
+              <div>{index > 0 && <span className={styles.separator}>&middot;</span>}</div>
+              {type?.coding?.[0]?.code === primaryIdentifierCode ? (
+                <div className={styles.primaryIdentifier}>
+                  {showIdentifierLabel && (
+                    <Tag type="gray" title={type?.text}>
+                      {type?.text}:
+                    </Tag>
+                  )}
+                  <span>{value}</span>
+                </div>
+              ) : (
+                <label htmlFor="identifier" className={styles.secondaryIdentifier}>
+                  {showIdentifierLabel && <span className={styles.label}>{type?.text}: </span>}
+                  <span id="identifier" className={styles.identifier}>
+                    {value}
+                  </span>
+                </label>
+              )}
+            </span>
+          ))
+        : ''}
+    </div>
+  );
+}
+
+export default PatientBannerPatientIdentifier;

--- a/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.component.tsx
+++ b/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.component.tsx
@@ -1,10 +1,10 @@
 /** @module @category UI */
-import React from 'react';
-import classNames from 'classnames';
-import { Tag } from '@carbon/react';
-import { age, formatDate, parseDate } from '@openmrs/esm-utils';
+import { ExtensionSlot } from '@openmrs/esm-react-utils';
 import { getCoreTranslation } from '@openmrs/esm-translations';
-import { ExtensionSlot, useConfig, usePrimaryIdentifierCode } from '@openmrs/esm-react-utils';
+import { age, formatDate, parseDate } from '@openmrs/esm-utils';
+import classNames from 'classnames';
+import React from 'react';
+import PatientBannerPatientIdentifier from './patient-banner-patient-identifiers.component';
 import styles from './patient-banner-patient-info.module.scss';
 
 export interface PatientBannerPatientInfoProps {
@@ -12,16 +12,8 @@ export interface PatientBannerPatientInfoProps {
 }
 
 export function PatientBannerPatientInfo({ patient }: PatientBannerPatientInfoProps) {
-  const { excludePatientIdentifierCodeTypes } = useConfig();
-  const { primaryIdentifierCode } = usePrimaryIdentifierCode();
-
   const name = `${patient?.name?.[0]?.given?.join(' ')} ${patient?.name?.[0].family}`;
   const gender = patient?.gender && getGender(patient.gender);
-
-  const filteredIdentifiers =
-    patient?.identifier?.filter(
-      (identifier) => !excludePatientIdentifierCodeTypes?.uuids.includes(identifier.type?.coding?.[0]?.code),
-    ) ?? [];
 
   return (
     <div className={styles.patientInfo}>
@@ -47,30 +39,7 @@ export function PatientBannerPatientInfo({ patient }: PatientBannerPatientInfoPr
         )}
       </div>
       <div className={styles.row}>
-        <div className={styles.identifiers}>
-          {filteredIdentifiers?.length
-            ? filteredIdentifiers.map(({ value, type }, index) => (
-                <span key={value} className={styles.identifierTag}>
-                  <div>{index > 0 && <span className={styles.separator}>&middot;</span>}</div>
-                  {type?.coding?.[0]?.code === primaryIdentifierCode ? (
-                    <div className={styles.primaryIdentifier}>
-                      <Tag type="gray" title={type?.text}>
-                        {type?.text}:
-                      </Tag>
-                      <span>{value}</span>
-                    </div>
-                  ) : (
-                    <label htmlFor="identifier" className={styles.secondaryIdentifier}>
-                      <span className={styles.label}>{type?.text}: </span>
-                      <span id="identifier" className={styles.identifier}>
-                        {value}
-                      </span>
-                    </label>
-                  )}
-                </span>
-              ))
-            : ''}
-        </div>
+        <PatientBannerPatientIdentifier identifier={patient.identifier} showIdentifierLabel={true} />
       </div>
     </div>
   );


### PR DESCRIPTION
… component be reuseable

# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This is motivated from a [discussion](https://openmrs.slack.com/archives/C06P2GVUGEP/p1726780219518729) on how the patient identifiers should show in the patient card in the ward app:

>  The identifier AND the number should appear in a tag, with the number bolded. This happens only when there are multiple patient identifiers and one identifier has been configured to the be the primary identifier

The above was said in regards to the patient banner, but should also apply to the ward patient card. This PR refactors the Patient Identifiers as a separate re-useable component, so we can reuse the same logic and configurations for patient banner and have them applied in the ward patient card (and elsewhere).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4011

## Other
<!-- Anything not covered above -->
- Right now, we do not follow the logic quoted above for the patient banner (having the primary identifier label and number appear in a tag only when there are multiple identifiers present). We can fix it in a separate PR.
- The patient banner was moved from `patient-chart` to `esm-styleguide` a while ago, but there are some remnants of the `excludePatientIdentifierCodeTypes` config value still present in `patient-chart`, mostly used when the patient chart needs to display the patient identifiers outside of the patient banner. This change should help to with completely removing the `excludePatientIdentifierCodeTypes` from the patient-chart.