### PR TITLE
(fix) O3-3709 - fix useOpenmrsFetchAll not fetches more than 2 pages

### DIFF
--- a/packages/framework/esm-react-utils/src/useOpenmrsFetchAll.test.tsx
+++ b/packages/framework/esm-react-utils/src/useOpenmrsFetchAll.test.tsx
@@ -42,7 +42,7 @@ describe('useOpenmrsFetchAll', () => {
   });
 
   it('should render all rows on if number of rows > pageSize with no partialData', async () => {
-    const expectedRowCount = 75;
+    const expectedRowCount = 150;
     const { result } = renderHook(() =>
       useOpenmrsFetchAll(`http://localhost/2`, {
         fetcher: (url) => getTestData(url, expectedRowCount).then((data) => ({ data }) as any),
@@ -50,6 +50,6 @@ describe('useOpenmrsFetchAll', () => {
     );
     await waitFor(() => expect(result.current.isLoading).toBeFalsy());
     expect(result.current.totalCount).toEqual(expectedRowCount);
-    expect(result.current.data).toEqual(getIntArray(0, 75));
+    expect(result.current.data).toEqual(getIntArray(0, expectedRowCount));
   });
 });

--- a/packages/framework/esm-react-utils/src/useOpenmrsFetchAll.ts
+++ b/packages/framework/esm-react-utils/src/useOpenmrsFetchAll.ts
@@ -56,7 +56,7 @@ export function useServerFetchAll<T, R>(
     if (hasMore && !error) {
       loadMore();
     }
-  }, [hasMore]);
+  }, [hasMore, data]);
 
   if (options.partialData) {
     return response;


### PR DESCRIPTION
# Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This fixes a regression I introduced in [this PR](https://github.com/openmrs/openmrs-esm-core/pull/1146/files), which causes the `useOpenmrsFetchAll` hook to not fetch more than 2 pages worth of data.

Updated the unit tests to cover this scenario.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
