### PR TITLE
(fix) Expression evaluator should use typeof not instanceof to detect functions

### DIFF
--- a/packages/framework/esm-expression-evaluator/src/evaluator.test.ts
+++ b/packages/framework/esm-expression-evaluator/src/evaluator.test.ts
@@ -172,6 +172,12 @@ describe('OpenMRS Expression Evaluator', () => {
     ).resolves.toBe(2);
   });
 
+  it('Should support mock functions', () => {
+    expect(evaluate('api.getValue()', { api: { getValue: jest.fn().mockImplementation(() => 'value') } })).toBe(
+      'value',
+    );
+  });
+
   it('Should support real-world use-cases', () => {
     expect(
       evaluate('!isEmpty(array)', {

--- a/packages/framework/esm-expression-evaluator/src/evaluator.ts
+++ b/packages/framework/esm-expression-evaluator/src/evaluator.ts
@@ -468,7 +468,7 @@ function visitCallExpression(expression: jsep.CallExpression, context: Evaluatio
 
   if (!callee) {
     throw `No function named ${expression.callee} is defined in this context`;
-  } else if (!(callee instanceof Function)) {
+  } else if (!(typeof callee === 'function')) {
     throw `${expression.callee} is not a function`;
   }
 


### PR DESCRIPTION
# Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [X] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
### Problem
Mocked functions were not recognized as valid instances of `Function` when using `instanceof Function`. 

<img width="1053" alt="Screenshot 2024-10-08 at 14 23 22" src="https://github.com/user-attachments/assets/f46e4ab4-c506-4fa0-a081-e934d4312784">


### Solution
To fix this, the code has been refactored to use `typeof callee === 'function'` instead of `callee instanceof Function`. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
