### PR TITLE
(fix) O3-4080: Option of adding a key in workspace

### DIFF
--- a/packages/framework/esm-extensions/src/workspaces.ts
+++ b/packages/framework/esm-extensions/src/workspaces.ts
@@ -9,6 +9,7 @@ import { translateFrom } from '@openmrs/esm-translations';
 export interface WorkspaceRegistration {
   name: string;
   title: string;
+  key?: string;
   titleNode?: ReactNode;
   type: string;
   canHide: boolean;

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
@@ -41,7 +41,7 @@ export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: Worksp
     [workspace, additionalPropsFromPage, workspaceFamilyState],
   );
   return lifecycle ? (
-    <Parcel key={workspace.key} config={lifecycle} mountParcel={mountRootParcel} {...props} />
+    <Parcel key={workspace.key || workspace.name} config={lifecycle} mountParcel={mountRootParcel} {...props} />
   ) : (
     <InlineLoading className={styles.loader} description={`${getCoreTranslation('loading', 'Loading')} ...`} />
   );

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
@@ -11,7 +11,6 @@ interface WorkspaceRendererProps {
   workspace: OpenWorkspace;
   additionalPropsFromPage?: object;
 }
-
 export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: WorkspaceRendererProps) {
   const [lifecycle, setLifecycle] = useState<ParcelConfig | undefined>();
   const workspaceFamilyState = useWorkspaceFamilyStore(workspace.sidebarFamily);
@@ -41,9 +40,8 @@ export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: Worksp
       },
     [workspace, additionalPropsFromPage, workspaceFamilyState],
   );
-
   return lifecycle ? (
-    <Parcel key={workspace.name} config={lifecycle} mountParcel={mountRootParcel} {...props} />
+    <Parcel key={workspace.key} config={lifecycle} mountParcel={mountRootParcel} {...props} />
   ) : (
     <InlineLoading className={styles.loader} description={`${getCoreTranslation('loading', 'Loading')} ...`} />
   );

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -181,7 +181,7 @@ export function launchWorkspace<
   const workspace = getWorkspaceRegistration(name);
   const newWorkspace: OpenWorkspace = {
     ...workspace,
-    key: additionalProps?.key ?? workspace.name,
+    key: getWorkspaceKey(workspace,additionalProps),
     title: getWorkspaceTitle(workspace, additionalProps),
     closeWorkspace: (options: CloseWorkspaceOptions = {}) => closeWorkspace(name, options),
     closeWorkspaceWithSavedChanges: (options: CloseWorkspaceOptions) =>
@@ -236,7 +236,7 @@ export function launchWorkspace<
     if (openWorkspace.title === getWorkspaceTitle(openWorkspace, openWorkspace.additionalProps)) {
       openWorkspace.title = getWorkspaceTitle(newWorkspace, newWorkspace.additionalProps);
     }
-    openWorkspace.additionalProps = newWorkspace.additionalProps;
+    openWorkspace.additionalProps = Object.assign({}, openWorkspace.additionalProps, newWorkspace.additionalProps);
     const restOfTheWorkspaces = openWorkspaces.filter((w) => w.name != name);
     updateStoreWithNewWorkspace(openWorkspaces[workspaceIndexInOpenWorkspaces], restOfTheWorkspaces);
   } else if (openedWorkspaceWithSameType) {
@@ -523,6 +523,9 @@ function getWorkspaceTitle(workspace: WorkspaceRegistration, additionalProps?: o
   return additionalProps?.['workspaceTitle'] ?? workspace.title;
 }
 
+function getWorkspaceKey(workspace:WorkspaceRegistration,additionalProps?:object){
+  return additionalProps?.['key'] ?? workspace.key ?? workspace.name;
+}
 export function resetWorkspaceStore() {
   getWorkspaceStore().setState(initialState);
 }

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -176,11 +176,12 @@ function promptBeforeLaunchingWorkspace(
  */
 export function launchWorkspace<
   T extends DefaultWorkspaceProps | object = DefaultWorkspaceProps & { [key: string]: any },
->(name: string, additionalProps?: Omit<T, keyof DefaultWorkspaceProps> & { workspaceTitle?: string }) {
+>(name: string, additionalProps?: Omit<T, keyof DefaultWorkspaceProps> & { workspaceTitle?: string; key?: string }) {
   const store = getWorkspaceStore();
   const workspace = getWorkspaceRegistration(name);
   const newWorkspace: OpenWorkspace = {
     ...workspace,
+    key: additionalProps?.key ?? workspace.name,
     title: getWorkspaceTitle(workspace, additionalProps),
     closeWorkspace: (options: CloseWorkspaceOptions = {}) => closeWorkspace(name, options),
     closeWorkspaceWithSavedChanges: (options: CloseWorkspaceOptions) =>
@@ -209,7 +210,6 @@ export function launchWorkspace<
     store.setState((state) => {
       const openWorkspaces = [workspaceToBeAdded, ...(restOfTheWorkspaces ?? state.openWorkspaces)];
       let workspaceWindowState = getUpdatedWorkspaceWindowState(workspaceToBeAdded);
-
       return {
         ...state,
         openWorkspaces,
@@ -241,6 +241,7 @@ export function launchWorkspace<
     updateStoreWithNewWorkspace(openWorkspaces[workspaceIndexInOpenWorkspaces], restOfTheWorkspaces);
   } else if (openedWorkspaceWithSameType) {
     const restOfTheWorkspaces = store.getState().openWorkspaces.filter((w) => w.type != newWorkspace.type);
+
     updateStoreWithNewWorkspace(openedWorkspaceWithSameType, restOfTheWorkspaces);
     promptBeforeLaunchingWorkspace(openedWorkspaceWithSameType, {
       name,


### PR DESCRIPTION
# Requirements

- [] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
When we have workspaces where titles are set dynamically and trying to launch workspaces of same name back to back does not cause for the title to update. You can see one such use case [here](https://github.com/openmrs/openmrs-esm-patient-management/blob/de07ee466b0f30b446168677980c862f924a6354/packages/esm-ward-app/src/ward-workspace/patient-details/ward-patient.workspace.tsx#L11) . The reason is we use workspace name as the key [here](https://github.com/openmrs/openmrs-esm-core/blob/5a6bbe2d83ae675e624a1e9bf332dcda0394cb86/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx#L46) which  causes the parcel component to not unmount and to restrict calling useEffect only for the first time when workspace of a particular name is launched.This in turn does not cause the title to update . By passing unique key we make sure that the useEffect is triggered each time the workspace is called. I will paste some videos below to get some more understanding. I used implementer tools in esm core for easier debugging. I have made the key as optional in order to not break existing code.

In the video below you can see that the only the content of workspace changes when clicked on dependency name but not the title 
[OpenMRS - Personal - Microsoft_ Edge 2024-10-10 22-46-26 (1).webm](https://github.com/user-attachments/assets/3eeeb692-18a8-4635-a7f0-ec5d08c366a8)

In the below video i am adding a key prop while calling launch workspace
[backend-dependencies.component.tsx - openmrs-esm-core - Visual Studio Code 2024-10-10 22-47-22 (1).webm](https://github.com/user-attachments/assets/8d373762-477d-48c6-897d-7ef7fc513ace)

In the Video below after adding the key prop, you can see that both the title and the content are changed
[OpenMRS - Personal - Microsoft_ Edge 2024-10-10 22-48-51 (1).webm](https://github.com/user-attachments/assets/2d1fa01a-0888-4ffb-a83f-48617849bca9)

Also i think that the additional props gets overridden when calling workspace of same name second time. I have made the necessary changes to not overide additionalProps.

## Screenshots


## Related Issue
https://openmrs.atlassian.net/browse/O3-4080

## Other
<!-- Anything not covered above -->
