### PR TITLE
(fix) O3-3888: Tweak help menu hover state 

### DIFF
--- a/packages/apps/esm-help-menu-app/src/help-menu/help.styles.scss
+++ b/packages/apps/esm-help-menu-app/src/help-menu/help.styles.scss
@@ -1,14 +1,12 @@
-.helpMenuButton:hover {
-  background-color: #e0e0e0;
-  cursor: pointer;
-}
+@use '@carbon/colors';
+@use '@carbon/layout';
 
 .helpMenuButton {
   z-index: 7900;
   background-color: white;
   height: 2.5rem !important;
   width: 2.5rem !important;
-  bottom: 1rem;
+  bottom: layout.$spacing-05;
   position: fixed;
   display: flex;
   justify-content: center;
@@ -18,5 +16,10 @@
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.1),
     0 1px 2px -1px rgba(0, 0, 0, 0.1);
-  border-radius: 2rem;
+  border-radius: layout.$spacing-03;
+
+  &:hover {
+    background-color: colors.$gray-20;
+    cursor: pointer;
+  }
 }

--- a/packages/apps/esm-help-menu-app/src/help-menu/help.styles.scss
+++ b/packages/apps/esm-help-menu-app/src/help-menu/help.styles.scss
@@ -1,3 +1,8 @@
+.helpMenuButton:hover {
+  background-color: #e0e0e0;
+  cursor: pointer;
+}
+
 .helpMenuButton {
   z-index: 7900;
   background-color: white;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

I have changed the cursor of the help menu to a pointer and applied a gray background on hover.

## Screenshots
https://www.loom.com/share/0812485b5b9144fdb452888c1c450fde?sid=412f01f6-a1bb-4ebf-bd43-c5bf33ae2b0a

## Related Issue
https://openmrs.atlassian.net/browse/O3-3888

## Other
<!-- Anything not covered above -->
