### PR TITLE
(fix) O3-3627: Preserve original filename when saving an attachment

### DIFF
--- a/packages/framework/esm-api/src/attachments.ts
+++ b/packages/framework/esm-api/src/attachments.ts
@@ -23,7 +23,7 @@ export async function createAttachment(patientUuid: string, fileToUpload: Upload
   formData.append('patient', patientUuid);
 
   if (fileToUpload.file) {
-    formData.append('file', fileToUpload.file);
+    formData.append('file', fileToUpload.file, fileToUpload.fileName);
   } else {
     formData.append('file', new File([''], fileToUpload.fileName), fileToUpload.fileName);
     formData.append('base64Content', fileToUpload.base64Content);


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR amends the logic that uploads a file to the server, ensuring that when a File object is provided, the original `filename` is saved. Presently, if the user manually edits the filename, the existing logic will save the original filename from the `File` object (typically the user's selection from the file dialog). This change makes it so that the filename is saved as the user edits it, rather than the original filename.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
[<!-- https://issues.openmrs.org/browse/O3- -->](https://openmrs.atlassian.net/browse/O3-3627)

## Other
<!-- Anything not covered above -->
