### PR TITLE
(refactor) Switch visit requests to use promises instead of observables

### DIFF
--- a/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts
@@ -1,10 +1,26 @@
 /** @module @category API */
-import type { Observable } from 'rxjs';
 import { BehaviorSubject } from 'rxjs';
-import { take, map } from 'rxjs/operators';
-import { openmrsObservableFetch, restBaseUrl } from '../openmrs-fetch';
+import { openmrsFetch, restBaseUrl } from '../openmrs-fetch';
 import type { FetchResponse, NewVisitPayload, UpdateVisitPayload, Visit } from '../types';
 import { getGlobalStore } from '@openmrs/esm-state';
+
+export interface VisitItem {
+  mode: VisitMode;
+  visitData?: Visit;
+  status: VisitStatus;
+  anythingElse?: any;
+}
+
+export enum VisitMode {
+  NEWVISIT = 'startVisit',
+  EDITVISIT = 'editVisit',
+  LOADING = 'loadingVisit',
+}
+
+export enum VisitStatus {
+  NOTSTARTED = 'notStarted',
+  ONGOING = 'ongoing',
+}
 
 export const defaultVisitCustomRepresentation =
   'custom:(uuid,display,voided,indication,startDatetime,stopDatetime,' +
@@ -27,6 +43,7 @@ const initialState = getVisitLocalStorage() || {
   patientUuid: null,
   manuallySetVisitUuid: null,
 };
+
 export function getVisitStore() {
   return getGlobalStore<VisitStoreState>('visit', initialState);
 }
@@ -55,26 +72,20 @@ export function getVisitsForPatient(
   patientUuid: string,
   abortController: AbortController,
   v?: string,
-): Observable<FetchResponse<{ results: Array<Visit> }>> {
+): Promise<FetchResponse<{ results: Array<Visit> }>> {
   const custom = v ?? defaultVisitCustomRepresentation;
 
-  return openmrsObservableFetch(`${restBaseUrl}/visit?patient=${patientUuid}&v=${custom}`, {
+  return openmrsFetch(`${restBaseUrl}/visit?patient=${patientUuid}&v=${custom}`, {
     signal: abortController.signal,
     method: 'GET',
     headers: {
       'Content-type': 'application/json',
     },
-  })
-    .pipe(take(1))
-    .pipe(
-      map((response: FetchResponse<{ results: Array<Visit> }>) => {
-        return response;
-      }),
-    );
+  });
 }
 
-export function saveVisit(payload: NewVisitPayload, abortController: AbortController): Observable<FetchResponse<any>> {
-  return openmrsObservableFetch(`${restBaseUrl}/visit`, {
+export function saveVisit(payload: NewVisitPayload, abortController: AbortController): Promise<FetchResponse<Visit>> {
+  return openmrsFetch(`${restBaseUrl}/visit`, {
     signal: abortController.signal,
     method: 'POST',
     headers: {
@@ -84,12 +95,8 @@ export function saveVisit(payload: NewVisitPayload, abortController: AbortContro
   });
 }
 
-export function updateVisit(
-  uuid: string,
-  payload: UpdateVisitPayload,
-  abortController: AbortController,
-): Observable<any> {
-  return openmrsObservableFetch(`${restBaseUrl}/visit/${uuid}`, {
+export function updateVisit(uuid: string, payload: UpdateVisitPayload, abortController: AbortController) {
+  return openmrsFetch(`${restBaseUrl}/visit/${uuid}`, {
     signal: abortController.signal,
     method: 'POST',
     headers: {
@@ -101,21 +108,3 @@ export function updateVisit(
 
 /** @deprecated */
 export const getStartedVisit = new BehaviorSubject<VisitItem | null>(null);
-
-export interface VisitItem {
-  mode: VisitMode;
-  visitData?: Visit;
-  status: VisitStatus;
-  anythingElse?: any;
-}
-
-export enum VisitMode {
-  NEWVISIT = 'startVisit',
-  EDITVISIT = 'editVisit',
-  LOADING = 'loadingVisit',
-}
-
-export enum VisitStatus {
-  NOTSTARTED = 'notStarted',
-  ONGOING = 'ongoing',
-}

--- a/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts
@@ -22,6 +22,11 @@ export enum VisitStatus {
   ONGOING = 'ongoing',
 }
 
+export interface VisitStoreState {
+  patientUuid: string | null;
+  manuallySetVisitUuid: string | null;
+}
+
 export const defaultVisitCustomRepresentation =
   'custom:(uuid,display,voided,indication,startDatetime,stopDatetime,' +
   'encounters:(uuid,display,encounterDatetime,' +
@@ -33,11 +38,6 @@ export const defaultVisitCustomRepresentation =
   'visitType:(uuid,name,display),' +
   'attributes:(uuid,display,attributeType:(name,datatypeClassname,uuid),value),' +
   'location:(uuid,name,display))';
-
-export interface VisitStoreState {
-  patientUuid: string | null;
-  manuallySetVisitUuid: string | null;
-}
 
 const initialState = getVisitLocalStorage() || {
   patientUuid: null,
@@ -68,22 +68,6 @@ function getVisitLocalStorage(): VisitStoreState | null {
   }
 }
 
-export function getVisitsForPatient(
-  patientUuid: string,
-  abortController: AbortController,
-  v?: string,
-): Promise<FetchResponse<{ results: Array<Visit> }>> {
-  const custom = v ?? defaultVisitCustomRepresentation;
-
-  return openmrsFetch(`${restBaseUrl}/visit?patient=${patientUuid}&v=${custom}`, {
-    signal: abortController.signal,
-    method: 'GET',
-    headers: {
-      'Content-type': 'application/json',
-    },
-  });
-}
-
 export function saveVisit(payload: NewVisitPayload, abortController: AbortController): Promise<FetchResponse<Visit>> {
   return openmrsFetch(`${restBaseUrl}/visit`, {
     signal: abortController.signal,
@@ -103,6 +87,25 @@ export function updateVisit(uuid: string, payload: UpdateVisitPayload, abortCont
       'Content-type': 'application/json',
     },
     body: payload,
+  });
+}
+
+/**
+ * @deprecated Use the `useVisit` hook instead.
+ */
+export function getVisitsForPatient(
+  patientUuid: string,
+  abortController: AbortController,
+  v?: string,
+): Promise<FetchResponse<{ results: Array<Visit> }>> {
+  const custom = v ?? defaultVisitCustomRepresentation;
+
+  return openmrsFetch(`${restBaseUrl}/visit?patient=${patientUuid}&v=${custom}`, {
+    signal: abortController.signal,
+    method: 'GET',
+    headers: {
+      'Content-type': 'application/json',
+    },
   });
 }
 

--- a/packages/framework/esm-api/src/types/visit-resource.ts
+++ b/packages/framework/esm-api/src/types/visit-resource.ts
@@ -13,7 +13,7 @@ export interface NewVisitPayload {
   }>;
 }
 
-export type UpdateVisitPayload = NewVisitPayload & {};
+export type UpdateVisitPayload = Partial<NewVisitPayload> & {};
 
 export interface Visit {
   uuid: string;

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1016,7 +1016,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:25](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L25)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:30](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L30)
 
 ___
 
@@ -1038,7 +1038,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:110](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L110)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:113](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L113)
 
 ___
 
@@ -2490,6 +2490,8 @@ ___
 
 ▸ **getVisitsForPatient**(`patientUuid`, `abortController`, `v?`): `Promise`<[`FetchResponse`](interfaces/FetchResponse.md)<{ `results`: [`Visit`](interfaces/Visit.md)[]  }\>\>
 
+**`deprecated`** Use the `useVisit` hook instead.
+
 #### Parameters
 
 | Name | Type |
@@ -2504,7 +2506,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L71)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:96](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L96)
 
 ___
 
@@ -2705,7 +2707,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L87)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L71)
 
 ___
 
@@ -2851,7 +2853,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:98](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L98)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:82](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L82)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -718,7 +718,7 @@ ___
 
 ### UpdateVisitPayload
 
-Ƭ **UpdateVisitPayload**: [`NewVisitPayload`](interfaces/NewVisitPayload.md) & {}
+Ƭ **UpdateVisitPayload**: `Partial`<[`NewVisitPayload`](interfaces/NewVisitPayload.md)\> & {}
 
 #### Defined in
 
@@ -1016,7 +1016,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:9](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L9)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:25](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L25)
 
 ___
 
@@ -1038,7 +1038,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:103](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L103)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:110](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L110)
 
 ___
 
@@ -2468,7 +2468,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:30](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L30)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L47)
 
 ___
 
@@ -2488,7 +2488,7 @@ ___
 
 ### getVisitsForPatient
 
-▸ **getVisitsForPatient**(`patientUuid`, `abortController`, `v?`): `Observable`<[`FetchResponse`](interfaces/FetchResponse.md)<{ `results`: [`Visit`](interfaces/Visit.md)[]  }\>\>
+▸ **getVisitsForPatient**(`patientUuid`, `abortController`, `v?`): `Promise`<[`FetchResponse`](interfaces/FetchResponse.md)<{ `results`: [`Visit`](interfaces/Visit.md)[]  }\>\>
 
 #### Parameters
 
@@ -2500,11 +2500,11 @@ ___
 
 #### Returns
 
-`Observable`<[`FetchResponse`](interfaces/FetchResponse.md)<{ `results`: [`Visit`](interfaces/Visit.md)[]  }\>\>
+`Promise`<[`FetchResponse`](interfaces/FetchResponse.md)<{ `results`: [`Visit`](interfaces/Visit.md)[]  }\>\>
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:54](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L54)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L71)
 
 ___
 
@@ -2690,7 +2690,7 @@ ___
 
 ### saveVisit
 
-▸ **saveVisit**(`payload`, `abortController`): `Observable`<[`FetchResponse`](interfaces/FetchResponse.md)<`any`\>\>
+▸ **saveVisit**(`payload`, `abortController`): `Promise`<[`FetchResponse`](interfaces/FetchResponse.md)<[`Visit`](interfaces/Visit.md)\>\>
 
 #### Parameters
 
@@ -2701,11 +2701,11 @@ ___
 
 #### Returns
 
-`Observable`<[`FetchResponse`](interfaces/FetchResponse.md)<`any`\>\>
+`Promise`<[`FetchResponse`](interfaces/FetchResponse.md)<[`Visit`](interfaces/Visit.md)\>\>
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:76](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L76)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L87)
 
 ___
 
@@ -2726,7 +2726,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L34)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:51](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L51)
 
 ___
 
@@ -2835,23 +2835,23 @@ ___
 
 ### updateVisit
 
-▸ **updateVisit**(`uuid`, `payload`, `abortController`): `Observable`<`any`\>
+▸ **updateVisit**(`uuid`, `payload`, `abortController`): `Promise`<[`FetchResponse`](interfaces/FetchResponse.md)<`any`\>\>
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
 | `uuid` | `string` |
-| `payload` | [`NewVisitPayload`](interfaces/NewVisitPayload.md) |
+| `payload` | `Partial`<[`NewVisitPayload`](interfaces/NewVisitPayload.md)\> |
 | `abortController` | `AbortController` |
 
 #### Returns
 
-`Observable`<`any`\>
+`Promise`<[`FetchResponse`](interfaces/FetchResponse.md)<`any`\>\>
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L87)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:98](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L98)
 
 ___
 

--- a/packages/framework/esm-framework/docs/enums/VisitMode.md
+++ b/packages/framework/esm-framework/docs/enums/VisitMode.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:114](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L114)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L16)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:115](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L115)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L17)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:113](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L113)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L15)

--- a/packages/framework/esm-framework/docs/enums/VisitStatus.md
+++ b/packages/framework/esm-framework/docs/enums/VisitStatus.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:119](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L119)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L21)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:120](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L120)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L22)

--- a/packages/framework/esm-framework/docs/interfaces/ConfigurableLinkProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/ConfigurableLinkProps.md
@@ -496,7 +496,7 @@ ___
 
 ### aria-current
 
-• `Optional` **aria-current**: `boolean` \| ``"true"`` \| ``"false"`` \| ``"page"`` \| ``"step"`` \| ``"location"`` \| ``"date"`` \| ``"time"``
+• `Optional` **aria-current**: `boolean` \| ``"location"`` \| ``"true"`` \| ``"false"`` \| ``"page"`` \| ``"step"`` \| ``"date"`` \| ``"time"``
 
 Indicates the element that represents the current item within a container or set of related elements.
 

--- a/packages/framework/esm-framework/docs/interfaces/VisitItem.md
+++ b/packages/framework/esm-framework/docs/interfaces/VisitItem.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:109](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L109)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:11](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L11)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:106](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L106)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L8)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:108](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L108)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L10)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:107](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L107)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:9](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L9)

--- a/packages/framework/esm-framework/docs/interfaces/VisitStoreState.md
+++ b/packages/framework/esm-framework/docs/interfaces/VisitStoreState.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:23](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L23)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L39)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L22)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L38)

--- a/packages/framework/esm-framework/docs/interfaces/VisitStoreState.md
+++ b/packages/framework/esm-framework/docs/interfaces/VisitStoreState.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L39)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:27](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L27)
 
 ___
 
@@ -27,4 +27,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L38)
+[packages/framework/esm-api/src/shared-api-objects/visit-utils.ts:26](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/visit-utils.ts#L26)


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Ports over requests to the Visit API to use promise-based fetch requests instead of observables. Promises are generally simpler to work with than observables, and this should make the code easier to understand. This change also makes the code more consistent with other requests the frontend makes to the REST API.

I've also amended the `UpdateVisitPayload` type annotation to a partial of `NewVisitPayload`, as not all fields are required when updating a visit. We should only really need to provide the stop datetime when ending a visit, for example.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
