### PR TITLE
(refactor) O3-4077: Improve the workspace group workflow

### DIFF
--- a/packages/framework/esm-extensions/src/workspaces.ts
+++ b/packages/framework/esm-extensions/src/workspaces.ts
@@ -17,7 +17,7 @@ export interface WorkspaceRegistration {
   preferredWindowSize: WorkspaceWindowState;
   load: () => Promise<{ default?: LifeCycles } & LifeCycles>;
   moduleName: string;
-  workspaceGroups?: Array<string>;
+  groups?: Array<string>;
 }
 
 interface WorkspaceRegistrationStore {
@@ -39,7 +39,7 @@ export interface RegisterWorkspaceOptions {
   preferredWindowSize?: WorkspaceWindowState;
   load: () => Promise<{ default?: LifeCycles } & LifeCycles>;
   moduleName: string;
-  workspaceGroups?: Array<string>;
+  groups?: Array<string>;
 }
 
 /**
@@ -58,7 +58,7 @@ export function registerWorkspace(workspace: RegisterWorkspaceOptions) {
         canHide: workspace.canHide ?? false,
         canMaximize: workspace.canMaximize ?? false,
         width: workspace.width ?? 'narrow',
-        workspaceGroups: workspace.workspaceGroups ?? [],
+        groups: workspace.groups ?? [],
       },
     },
   }));
@@ -94,7 +94,7 @@ export function getWorkspaceRegistration(name: string): WorkspaceRegistration {
         canHide: workspaceExtension.meta?.canHide ?? false,
         canMaximize: workspaceExtension.meta?.canMaximize ?? false,
         width: workspaceExtension.meta?.width ?? 'narrow',
-        workspaceGroups: workspaceExtension?.meta?.workspaceGroups ?? [],
+        groups: workspaceExtension?.meta?.groups ?? [],
       };
     } else {
       throw new Error(`No workspace named '${name}' has been registered.`);

--- a/packages/framework/esm-extensions/src/workspaces.ts
+++ b/packages/framework/esm-extensions/src/workspaces.ts
@@ -17,6 +17,7 @@ export interface WorkspaceRegistration {
   preferredWindowSize: WorkspaceWindowState;
   load: () => Promise<{ default?: LifeCycles } & LifeCycles>;
   moduleName: string;
+  workspaceGroups?: Array<string>;
 }
 
 interface WorkspaceRegistrationStore {
@@ -38,6 +39,7 @@ export interface RegisterWorkspaceOptions {
   preferredWindowSize?: WorkspaceWindowState;
   load: () => Promise<{ default?: LifeCycles } & LifeCycles>;
   moduleName: string;
+  workspaceGroups: Array<string>;
 }
 
 /**
@@ -91,6 +93,7 @@ export function getWorkspaceRegistration(name: string): WorkspaceRegistration {
         canHide: workspaceExtension.meta?.canHide ?? false,
         canMaximize: workspaceExtension.meta?.canMaximize ?? false,
         width: workspaceExtension.meta?.width ?? 'narrow',
+        workspaceGroups: workspaceExtension?.meta?.workspaceGroups ?? [],
       };
     } else {
       throw new Error(`No workspace named '${name}' has been registered.`);

--- a/packages/framework/esm-extensions/src/workspaces.ts
+++ b/packages/framework/esm-extensions/src/workspaces.ts
@@ -39,7 +39,7 @@ export interface RegisterWorkspaceOptions {
   preferredWindowSize?: WorkspaceWindowState;
   load: () => Promise<{ default?: LifeCycles } & LifeCycles>;
   moduleName: string;
-  workspaceGroups: Array<string>;
+  workspaceGroups?: Array<string>;
 }
 
 /**
@@ -58,6 +58,7 @@ export function registerWorkspace(workspace: RegisterWorkspaceOptions) {
         canHide: workspace.canHide ?? false,
         canMaximize: workspace.canMaximize ?? false,
         width: workspace.width ?? 'narrow',
+        workspaceGroups: workspace.workspaceGroups ?? [],
       },
     },
   }));

--- a/packages/framework/esm-extensions/src/workspaces.ts
+++ b/packages/framework/esm-extensions/src/workspaces.ts
@@ -14,8 +14,6 @@ export interface WorkspaceRegistration {
   canHide: boolean;
   canMaximize: boolean;
   width: 'narrow' | 'wider' | 'extra-wide';
-  hasOwnSidebar: boolean;
-  sidebarFamily: string;
   preferredWindowSize: WorkspaceWindowState;
   load: () => Promise<{ default?: LifeCycles } & LifeCycles>;
   moduleName: string;
@@ -37,8 +35,6 @@ export interface RegisterWorkspaceOptions {
   canHide?: boolean;
   canMaximize?: boolean;
   width?: 'narrow' | 'wider' | 'extra-wide';
-  hasOwnSidebar?: boolean;
-  sidebarFamily?: string;
   preferredWindowSize?: WorkspaceWindowState;
   load: () => Promise<{ default?: LifeCycles } & LifeCycles>;
   moduleName: string;
@@ -60,8 +56,6 @@ export function registerWorkspace(workspace: RegisterWorkspaceOptions) {
         canHide: workspace.canHide ?? false,
         canMaximize: workspace.canMaximize ?? false,
         width: workspace.width ?? 'narrow',
-        hasOwnSidebar: workspace.hasOwnSidebar ?? false,
-        sidebarFamily: workspace.sidebarFamily ?? 'default',
       },
     },
   }));
@@ -97,8 +91,6 @@ export function getWorkspaceRegistration(name: string): WorkspaceRegistration {
         canHide: workspaceExtension.meta?.canHide ?? false,
         canMaximize: workspaceExtension.meta?.canMaximize ?? false,
         width: workspaceExtension.meta?.width ?? 'narrow',
-        sidebarFamily: 'default',
-        hasOwnSidebar: false,
       };
     } else {
       throw new Error(`No workspace named '${name}' has been registered.`);

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -8049,7 +8049,7 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:384](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L384)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:383](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L383)
 
 ___
 
@@ -8100,18 +8100,19 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:248](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L248)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:247](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L247)
 
 ___
 
 ### launchWorkspaceGroup
 
-▸ **launchWorkspaceGroup**(`args`): `void`
+▸ **launchWorkspaceGroup**(`groupName`, `args`): `void`
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
+| `groupName` | `string` |
 | `args` | `LaunchWorkspaceGroupArg` |
 
 #### Returns
@@ -8120,7 +8121,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:167](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L167)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:166](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L166)
 
 ___
 
@@ -8146,7 +8147,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:341](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L341)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:340](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L340)
 
 ___
 
@@ -8160,4 +8161,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:500](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L500)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:499](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L499)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -262,6 +262,7 @@
 
 - [closeWorkspace](API.md#closeworkspace)
 - [launchWorkspace](API.md#launchworkspace)
+- [launchWorkspaceGroup](API.md#launchworkspacegroup)
 - [navigateAndLaunchWorkspace](API.md#navigateandlaunchworkspace)
 - [useWorkspaces](API.md#useworkspaces)
 
@@ -8048,13 +8049,13 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:320](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L320)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:315](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L315)
 
 ___
 
 ### launchWorkspace
 
-▸ **launchWorkspace**<`T`\>(`name`, `additionalProps?`, `workspaceContainerName?`): `void`
+▸ **launchWorkspace**<`T`\>(`name`, `additionalProps?`): `void`
 
 This launches a workspace by its name. The workspace must have been registered.
 Workspaces should be registered in the `routes.json` file.
@@ -8092,7 +8093,6 @@ prop named `workspaceTitle` will override the title of the workspace.
 | :------ | :------ | :------ |
 | `name` | `string` | The name of the workspace to launch |
 | `additionalProps?` | `Omit`<`T`, keyof [`DefaultWorkspaceProps`](interfaces/DefaultWorkspaceProps.md)\> & { `workspaceTitle?`: `string`  } | Props to pass to the workspace component being launched. Passing          a prop named `workspaceTitle` will override the title of the workspace. |
-| `workspaceContainerName?` | `string` | - |
 
 #### Returns
 
@@ -8100,7 +8100,28 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:179](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L179)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:192](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L192)
+
+___
+
+### launchWorkspaceGroup
+
+▸ **launchWorkspaceGroup**(`groupName`, `state`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `groupName` | `string` |
+| `state` | `object` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:125](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L125)
 
 ___
 
@@ -8126,19 +8147,13 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:278](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L278)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:273](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L273)
 
 ___
 
 ### useWorkspaces
 
-▸ **useWorkspaces**(`containerName?`): [`WorkspacesInfo`](interfaces/WorkspacesInfo.md)
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `containerName?` | `string` |
+▸ **useWorkspaces**(): [`WorkspacesInfo`](interfaces/WorkspacesInfo.md)
 
 #### Returns
 
@@ -8146,4 +8161,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:435](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L435)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:436](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L436)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -5855,7 +5855,7 @@ This component also provides everything needed for workspace notifications to be
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:68](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L68)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L69)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -610,7 +610,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:396](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L396)
+[packages/framework/esm-globals/src/types.ts:397](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L397)
 
 ___
 
@@ -623,7 +623,7 @@ Basically, this is the same as the app routes, with each routes definition keyed
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:387](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L387)
+[packages/framework/esm-globals/src/types.ts:388](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L388)
 
 ___
 
@@ -793,7 +793,7 @@ ___
 
 ### WorkspaceDefinition
 
-Ƭ **WorkspaceDefinition**: { `canHide?`: `boolean` ; `canMaximize?`: `boolean` ; `hasOwnSidebar?`: `boolean` ; `name`: `string` ; `preferredWindowSize?`: [`WorkspaceWindowState`](API.md#workspacewindowstate) ; `sidebarFamily?`: `string` ; `title`: `string` ; `type`: `string` ; `width?`: ``"narrow"`` \| ``"wider"`` \| ``"extra-wide"``  } & { `component`: `string`  } \| { `component?`: `never`  }
+Ƭ **WorkspaceDefinition**: { `canHide?`: `boolean` ; `canMaximize?`: `boolean` ; `hasOwnSidebar?`: `boolean` ; `name`: `string` ; `preferredWindowSize?`: [`WorkspaceWindowState`](API.md#workspacewindowstate) ; `sidebarFamily?`: `string` ; `title`: `string` ; `type`: `string` ; `width?`: ``"narrow"`` \| ``"wider"`` \| ``"extra-wide"`` ; `workspaceGroups`: `string`[]  } & { `component`: `string`  } \| { `component?`: `never`  }
 
 A definition of a workspace as extracted from an app's routes.json
 
@@ -8049,7 +8049,7 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:315](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L315)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:380](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L380)
 
 ___
 
@@ -8100,20 +8100,19 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:192](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L192)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:248](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L248)
 
 ___
 
 ### launchWorkspaceGroup
 
-▸ **launchWorkspaceGroup**(`groupName`, `state`): `void`
+▸ **launchWorkspaceGroup**(`args`): `void`
 
 #### Parameters
 
 | Name | Type |
 | :------ | :------ |
-| `groupName` | `string` |
-| `state` | `object` |
+| `args` | `LaunchWorkspaceGroupArg` |
 
 #### Returns
 
@@ -8121,7 +8120,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:125](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L125)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:167](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L167)
 
 ___
 
@@ -8147,7 +8146,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:273](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L273)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:337](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L337)
 
 ___
 
@@ -8161,4 +8160,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:436](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L436)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:496](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L496)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -610,7 +610,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:392](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L392)
+[packages/framework/esm-globals/src/types.ts:409](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L409)
 
 ___
 
@@ -623,7 +623,7 @@ Basically, this is the same as the app routes, with each routes definition keyed
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:383](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L383)
+[packages/framework/esm-globals/src/types.ts:400](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L400)
 
 ___
 
@@ -8049,7 +8049,7 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:423](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L423)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:425](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L425)
 
 ___
 
@@ -8100,7 +8100,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:287](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L287)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:289](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L289)
 
 ___
 
@@ -8131,7 +8131,7 @@ launchWorkspaceGroup("myGroup", {
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:203](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L203)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:205](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L205)
 
 ___
 
@@ -8157,7 +8157,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:380](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L380)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:382](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L382)
 
 ___
 
@@ -8171,4 +8171,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:535](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L535)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:536](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L536)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -793,7 +793,7 @@ ___
 
 ### WorkspaceDefinition
 
-Ƭ **WorkspaceDefinition**: { `canHide?`: `boolean` ; `canMaximize?`: `boolean` ; `name`: `string` ; `preferredWindowSize?`: [`WorkspaceWindowState`](API.md#workspacewindowstate) ; `title`: `string` ; `type`: `string` ; `width?`: ``"narrow"`` \| ``"wider"`` \| ``"extra-wide"`` ; `workspaceGroups`: `string`[]  } & { `component`: `string`  } \| { `component?`: `never`  }
+Ƭ **WorkspaceDefinition**: { `canHide?`: `boolean` ; `canMaximize?`: `boolean` ; `groups`: `string`[] ; `name`: `string` ; `preferredWindowSize?`: [`WorkspaceWindowState`](API.md#workspacewindowstate) ; `title`: `string` ; `type`: `string` ; `width?`: ``"narrow"`` \| ``"wider"`` \| ``"extra-wide"``  } & { `component`: `string`  } \| { `component?`: `never`  }
 
 A definition of a workspace as extracted from an app's routes.json
 
@@ -8049,7 +8049,7 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:416](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L416)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:423](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L423)
 
 ___
 
@@ -8100,7 +8100,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:280](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L280)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:287](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L287)
 
 ___
 
@@ -8131,7 +8131,7 @@ launchWorkspaceGroup("myGroup", {
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:199](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L199)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:203](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L203)
 
 ___
 
@@ -8157,7 +8157,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:373](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L373)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:380](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L380)
 
 ___
 
@@ -8171,4 +8171,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:528](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L528)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:535](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L535)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -8048,7 +8048,7 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:311](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L311)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:320](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L320)
 
 ___
 
@@ -8100,7 +8100,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:178](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L178)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:179](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L179)
 
 ___
 
@@ -8126,7 +8126,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:269](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L269)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:278](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L278)
 
 ___
 
@@ -8146,4 +8146,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:425](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L425)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:435](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L435)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -610,7 +610,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:397](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L397)
+[packages/framework/esm-globals/src/types.ts:392](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L392)
 
 ___
 
@@ -623,7 +623,7 @@ Basically, this is the same as the app routes, with each routes definition keyed
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:388](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L388)
+[packages/framework/esm-globals/src/types.ts:383](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L383)
 
 ___
 
@@ -793,7 +793,7 @@ ___
 
 ### WorkspaceDefinition
 
-Ƭ **WorkspaceDefinition**: { `canHide?`: `boolean` ; `canMaximize?`: `boolean` ; `hasOwnSidebar?`: `boolean` ; `name`: `string` ; `preferredWindowSize?`: [`WorkspaceWindowState`](API.md#workspacewindowstate) ; `sidebarFamily?`: `string` ; `title`: `string` ; `type`: `string` ; `width?`: ``"narrow"`` \| ``"wider"`` \| ``"extra-wide"`` ; `workspaceGroups`: `string`[]  } & { `component`: `string`  } \| { `component?`: `never`  }
+Ƭ **WorkspaceDefinition**: { `canHide?`: `boolean` ; `canMaximize?`: `boolean` ; `name`: `string` ; `preferredWindowSize?`: [`WorkspaceWindowState`](API.md#workspacewindowstate) ; `title`: `string` ; `type`: `string` ; `width?`: ``"narrow"`` \| ``"wider"`` \| ``"extra-wide"`` ; `workspaceGroups`: `string`[]  } & { `component`: `string`  } \| { `component?`: `never`  }
 
 A definition of a workspace as extracted from an app's routes.json
 
@@ -5855,7 +5855,7 @@ This component also provides everything needed for workspace notifications to be
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L69)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:68](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L68)
 
 ___
 
@@ -8049,7 +8049,7 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:383](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L383)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:416](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L416)
 
 ___
 
@@ -8100,7 +8100,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:247](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L247)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:280](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L280)
 
 ___
 
@@ -8108,12 +8108,22 @@ ___
 
 ▸ **launchWorkspaceGroup**(`groupName`, `args`): `void`
 
+Launches a workspace group with the specified name and configuration.
+If there are any open workspaces, it will first close them before launching the new workspace group.
+
+**`example`**
+launchWorkspaceGroup("myGroup", {
+  state: initialState,
+  onWorkspaceGroupLaunch: () => console.log("Workspace group launched"),
+  workspaceGroupCleanup: () => console.log("Cleaning up workspace group")
+});
+
 #### Parameters
 
-| Name | Type |
-| :------ | :------ |
-| `groupName` | `string` |
-| `args` | `LaunchWorkspaceGroupArg` |
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `groupName` | `string` | The name of the workspace group to launch |
+| `args` | `LaunchWorkspaceGroupArg` | Configuration object for launching the workspace group |
 
 #### Returns
 
@@ -8121,7 +8131,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:166](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L166)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:199](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L199)
 
 ___
 
@@ -8147,7 +8157,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:340](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L340)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:373](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L373)
 
 ___
 
@@ -8161,4 +8171,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:499](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L499)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:528](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L528)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -8049,7 +8049,7 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:380](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L380)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:384](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L384)
 
 ___
 
@@ -8146,7 +8146,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:337](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L337)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:341](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L341)
 
 ___
 
@@ -8160,4 +8160,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:496](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L496)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:500](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L500)

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -8048,13 +8048,13 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:304](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L304)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:311](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L311)
 
 ___
 
 ### launchWorkspace
 
-▸ **launchWorkspace**<`T`\>(`name`, `additionalProps?`): `void`
+▸ **launchWorkspace**<`T`\>(`name`, `additionalProps?`, `workspaceContainerName?`): `void`
 
 This launches a workspace by its name. The workspace must have been registered.
 Workspaces should be registered in the `routes.json` file.
@@ -8092,6 +8092,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 | :------ | :------ | :------ |
 | `name` | `string` | The name of the workspace to launch |
 | `additionalProps?` | `Omit`<`T`, keyof [`DefaultWorkspaceProps`](interfaces/DefaultWorkspaceProps.md)\> & { `workspaceTitle?`: `string`  } | Props to pass to the workspace component being launched. Passing          a prop named `workspaceTitle` will override the title of the workspace. |
+| `workspaceContainerName?` | `string` | - |
 
 #### Returns
 
@@ -8099,7 +8100,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:177](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L177)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:178](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L178)
 
 ___
 
@@ -8125,13 +8126,19 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:262](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L262)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:269](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L269)
 
 ___
 
 ### useWorkspaces
 
-▸ **useWorkspaces**(): [`WorkspacesInfo`](interfaces/WorkspacesInfo.md)
+▸ **useWorkspaces**(`containerName?`): [`WorkspacesInfo`](interfaces/WorkspacesInfo.md)
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `containerName?` | `string` |
 
 #### Returns
 
@@ -8139,4 +8146,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:418](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L418)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:425](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L425)

--- a/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
+++ b/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
@@ -21,7 +21,7 @@
 
 Controls whether the workspace group should be closed and store to be
 cleared when this workspace is closed.
-Defaults to true except when opening a new workspace of the same family.
+Defaults to true except when opening a new workspace of the same group.
 
 **`default`** true
 

--- a/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
+++ b/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
@@ -6,6 +6,7 @@
 
 ### Workspace Properties
 
+- [closeWorkspaceGroup](CloseWorkspaceOptions.md#closeworkspacegroup)
 - [ignoreChanges](CloseWorkspaceOptions.md#ignorechanges)
 
 ### Workspace Methods
@@ -13,6 +14,20 @@
 - [onWorkspaceClose](CloseWorkspaceOptions.md#onworkspaceclose)
 
 ## Workspace Properties
+
+### closeWorkspaceGroup
+
+• `Optional` **closeWorkspaceGroup**: `boolean`
+
+Controls whether the workspace family store will be cleared when this workspace is closed. Defaults to true except when opening a new workspace of the same family.
+
+**`default`** true
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:31](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L31)
+
+___
 
 ### ignoreChanges
 

--- a/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
+++ b/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
@@ -19,13 +19,15 @@
 
 • `Optional` **closeWorkspaceGroup**: `boolean`
 
-Controls whether the workspace family store will be cleared when this workspace is closed. Defaults to true except when opening a new workspace of the same family.
+Controls whether the workspace group should be closed and store to be
+cleared when this workspace is closed.
+Defaults to true except when opening a new workspace of the same family.
 
 **`default`** true
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:31](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L31)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:33](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L33)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/DefaultWorkspaceProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/DefaultWorkspaceProps.md
@@ -43,7 +43,7 @@ closed, given the user forcefully closes the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L46)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L45)
 
 ___
 
@@ -66,7 +66,7 @@ will directly close the workspace without any prompt
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:56](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L56)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:55](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L55)
 
 ___
 
@@ -89,7 +89,7 @@ this workspace is closed; e.g. if there is unsaved data.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:51](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L51)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L50)
 
 ___
 
@@ -117,4 +117,4 @@ title needs to be set dynamically.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L71)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L70)

--- a/packages/framework/esm-framework/docs/interfaces/FeatureFlagDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/FeatureFlagDefinition.md
@@ -22,7 +22,7 @@ An explanation of what the flag does, which will be displayed in the Implementer
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:350](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L350)
+[packages/framework/esm-globals/src/types.ts:351](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L351)
 
 ___
 
@@ -34,7 +34,7 @@ A code-friendly name for the flag, which will be used to reference it in code
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:346](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L346)
+[packages/framework/esm-globals/src/types.ts:347](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L347)
 
 ___
 
@@ -46,4 +46,4 @@ A human-friendly name which will be displayed in the Implementer Tools
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:348](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L348)
+[packages/framework/esm-globals/src/types.ts:349](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L349)

--- a/packages/framework/esm-framework/docs/interfaces/FeatureFlagDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/FeatureFlagDefinition.md
@@ -22,7 +22,7 @@ An explanation of what the flag does, which will be displayed in the Implementer
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:346](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L346)
+[packages/framework/esm-globals/src/types.ts:363](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L363)
 
 ___
 
@@ -34,7 +34,7 @@ A code-friendly name for the flag, which will be used to reference it in code
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:342](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L342)
+[packages/framework/esm-globals/src/types.ts:359](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L359)
 
 ___
 
@@ -46,4 +46,4 @@ A human-friendly name which will be displayed in the Implementer Tools
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:344](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L344)
+[packages/framework/esm-globals/src/types.ts:361](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L361)

--- a/packages/framework/esm-framework/docs/interfaces/FeatureFlagDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/FeatureFlagDefinition.md
@@ -22,7 +22,7 @@ An explanation of what the flag does, which will be displayed in the Implementer
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:351](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L351)
+[packages/framework/esm-globals/src/types.ts:346](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L346)
 
 ___
 
@@ -34,7 +34,7 @@ A code-friendly name for the flag, which will be used to reference it in code
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:347](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L347)
+[packages/framework/esm-globals/src/types.ts:342](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L342)
 
 ___
 
@@ -46,4 +46,4 @@ A human-friendly name which will be displayed in the Implementer Tools
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:349](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L349)
+[packages/framework/esm-globals/src/types.ts:344](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L344)

--- a/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
@@ -23,11 +23,12 @@
 - [titleNode](OpenWorkspace.md#titlenode)
 - [type](OpenWorkspace.md#type)
 - [width](OpenWorkspace.md#width)
+- [workspaceGroups](OpenWorkspace.md#workspacegroups)
 
 ### Workspace Properties
 
 - [additionalProps](OpenWorkspace.md#additionalprops)
-- [workspaceContainerName](OpenWorkspace.md#workspacecontainername)
+- [currentWorkspaceGroup](OpenWorkspace.md#currentworkspacegroup)
 
 ### Methods
 
@@ -165,6 +166,20 @@ ___
 
 ___
 
+### workspaceGroups
+
+• `Optional` **workspaceGroups**: `string`[]
+
+#### Inherited from
+
+[WorkspaceRegistration](WorkspaceRegistration.md).[workspaceGroups](WorkspaceRegistration.md#workspacegroups)
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L20)
+
+___
+
 ## Workspace Properties
 
 ### additionalProps
@@ -173,17 +188,17 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:107](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L107)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:109](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L109)
 
 ___
 
-### workspaceContainerName
+### currentWorkspaceGroup
 
-• `Optional` **workspaceContainerName**: `string`
+• `Optional` **currentWorkspaceGroup**: `string`
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:108](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L108)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:110](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L110)
 
 ## Methods
 
@@ -213,7 +228,7 @@ closed, given the user forcefully closes the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L46)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L45)
 
 ___
 
@@ -240,7 +255,7 @@ will directly close the workspace without any prompt
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:56](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L56)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:55](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L55)
 
 ___
 
@@ -285,7 +300,7 @@ this workspace is closed; e.g. if there is unsaved data.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:51](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L51)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L50)
 
 ___
 
@@ -317,4 +332,4 @@ title needs to be set dynamically.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L71)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L70)

--- a/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
@@ -16,11 +16,9 @@
 
 - [canHide](OpenWorkspace.md#canhide)
 - [canMaximize](OpenWorkspace.md#canmaximize)
-- [hasOwnSidebar](OpenWorkspace.md#hasownsidebar)
 - [moduleName](OpenWorkspace.md#modulename)
 - [name](OpenWorkspace.md#name)
 - [preferredWindowSize](OpenWorkspace.md#preferredwindowsize)
-- [sidebarFamily](OpenWorkspace.md#sidebarfamily)
 - [title](OpenWorkspace.md#title)
 - [titleNode](OpenWorkspace.md#titlenode)
 - [type](OpenWorkspace.md#type)
@@ -29,6 +27,7 @@
 ### Workspace Properties
 
 - [additionalProps](OpenWorkspace.md#additionalprops)
+- [workspaceContainerName](OpenWorkspace.md#workspacecontainername)
 
 ### Methods
 
@@ -68,20 +67,6 @@ ___
 
 ___
 
-### hasOwnSidebar
-
-• **hasOwnSidebar**: `boolean`
-
-#### Inherited from
-
-[WorkspaceRegistration](WorkspaceRegistration.md).[hasOwnSidebar](WorkspaceRegistration.md#hasownsidebar)
-
-#### Defined in
-
-[packages/framework/esm-extensions/src/workspaces.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L17)
-
-___
-
 ### moduleName
 
 • **moduleName**: `string`
@@ -92,7 +77,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/workspaces.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L21)
+[packages/framework/esm-extensions/src/workspaces.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L19)
 
 ___
 
@@ -120,21 +105,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/workspaces.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L19)
-
-___
-
-### sidebarFamily
-
-• **sidebarFamily**: `string`
-
-#### Inherited from
-
-[WorkspaceRegistration](WorkspaceRegistration.md).[sidebarFamily](WorkspaceRegistration.md#sidebarfamily)
-
-#### Defined in
-
-[packages/framework/esm-extensions/src/workspaces.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L18)
+[packages/framework/esm-extensions/src/workspaces.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L17)
 
 ___
 
@@ -203,6 +174,16 @@ ___
 #### Defined in
 
 [packages/framework/esm-styleguide/src/workspaces/workspaces.ts:106](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L106)
+
+___
+
+### workspaceContainerName
+
+• `Optional` **workspaceContainerName**: `string`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:107](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L107)
 
 ## Methods
 
@@ -277,7 +258,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L20)
+[packages/framework/esm-extensions/src/workspaces.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L18)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
@@ -173,7 +173,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:106](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L106)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:107](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L107)
 
 ___
 
@@ -183,7 +183,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:107](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L107)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:108](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L108)
 
 ## Methods
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
@@ -16,6 +16,7 @@
 
 - [canHide](OpenWorkspace.md#canhide)
 - [canMaximize](OpenWorkspace.md#canmaximize)
+- [groups](OpenWorkspace.md#groups)
 - [moduleName](OpenWorkspace.md#modulename)
 - [name](OpenWorkspace.md#name)
 - [preferredWindowSize](OpenWorkspace.md#preferredwindowsize)
@@ -23,7 +24,6 @@
 - [titleNode](OpenWorkspace.md#titlenode)
 - [type](OpenWorkspace.md#type)
 - [width](OpenWorkspace.md#width)
-- [workspaceGroups](OpenWorkspace.md#workspacegroups)
 
 ### Workspace Properties
 
@@ -65,6 +65,20 @@ ___
 #### Defined in
 
 [packages/framework/esm-extensions/src/workspaces.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L15)
+
+___
+
+### groups
+
+• `Optional` **groups**: `string`[]
+
+#### Inherited from
+
+[WorkspaceRegistration](WorkspaceRegistration.md).[groups](WorkspaceRegistration.md#groups)
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L20)
 
 ___
 
@@ -163,20 +177,6 @@ ___
 #### Defined in
 
 [packages/framework/esm-extensions/src/workspaces.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L16)
-
-___
-
-### workspaceGroups
-
-• `Optional` **workspaceGroups**: `string`[]
-
-#### Inherited from
-
-[WorkspaceRegistration](WorkspaceRegistration.md).[workspaceGroups](WorkspaceRegistration.md#workspacegroups)
-
-#### Defined in
-
-[packages/framework/esm-extensions/src/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L20)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
@@ -27,7 +27,7 @@ A list of backend modules necessary for this frontend module and the correspondi
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:354](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L354)
+[packages/framework/esm-globals/src/types.ts:371](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L371)
 
 ___
 
@@ -39,7 +39,7 @@ An array of all extensions supported by this frontend module. Extensions can be 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:370](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L370)
+[packages/framework/esm-globals/src/types.ts:387](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L387)
 
 ___
 
@@ -51,7 +51,7 @@ An array of all feature flags for any beta-stage features this module provides.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:372](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L372)
+[packages/framework/esm-globals/src/types.ts:389](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L389)
 
 ___
 
@@ -63,7 +63,7 @@ An array of all modals supported by this frontend module. Modals can be launched
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:374](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L374)
+[packages/framework/esm-globals/src/types.ts:391](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L391)
 
 ___
 
@@ -81,7 +81,7 @@ The name of the backend dependency and either the required version or an object 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:356](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L356)
+[packages/framework/esm-globals/src/types.ts:373](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L373)
 
 ___
 
@@ -93,7 +93,7 @@ An array of all pages supported by this frontend module. Pages are automatically
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:368](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L368)
+[packages/framework/esm-globals/src/types.ts:385](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L385)
 
 ___
 
@@ -105,7 +105,7 @@ The version of this frontend module.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:352](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L352)
+[packages/framework/esm-globals/src/types.ts:369](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L369)
 
 ___
 
@@ -117,4 +117,4 @@ An array of all workspaces supported by this frontend module. Workspaces can be 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:376](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L376)
+[packages/framework/esm-globals/src/types.ts:393](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L393)

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
@@ -27,7 +27,7 @@ A list of backend modules necessary for this frontend module and the correspondi
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:359](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L359)
+[packages/framework/esm-globals/src/types.ts:354](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L354)
 
 ___
 
@@ -39,7 +39,7 @@ An array of all extensions supported by this frontend module. Extensions can be 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:375](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L375)
+[packages/framework/esm-globals/src/types.ts:370](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L370)
 
 ___
 
@@ -51,7 +51,7 @@ An array of all feature flags for any beta-stage features this module provides.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:377](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L377)
+[packages/framework/esm-globals/src/types.ts:372](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L372)
 
 ___
 
@@ -63,7 +63,7 @@ An array of all modals supported by this frontend module. Modals can be launched
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:379](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L379)
+[packages/framework/esm-globals/src/types.ts:374](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L374)
 
 ___
 
@@ -81,7 +81,7 @@ The name of the backend dependency and either the required version or an object 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:361](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L361)
+[packages/framework/esm-globals/src/types.ts:356](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L356)
 
 ___
 
@@ -93,7 +93,7 @@ An array of all pages supported by this frontend module. Pages are automatically
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:373](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L373)
+[packages/framework/esm-globals/src/types.ts:368](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L368)
 
 ___
 
@@ -105,7 +105,7 @@ The version of this frontend module.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:357](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L357)
+[packages/framework/esm-globals/src/types.ts:352](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L352)
 
 ___
 
@@ -117,4 +117,4 @@ An array of all workspaces supported by this frontend module. Workspaces can be 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:381](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L381)
+[packages/framework/esm-globals/src/types.ts:376](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L376)

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
@@ -27,7 +27,7 @@ A list of backend modules necessary for this frontend module and the correspondi
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:358](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L358)
+[packages/framework/esm-globals/src/types.ts:359](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L359)
 
 ___
 
@@ -39,7 +39,7 @@ An array of all extensions supported by this frontend module. Extensions can be 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:374](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L374)
+[packages/framework/esm-globals/src/types.ts:375](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L375)
 
 ___
 
@@ -51,7 +51,7 @@ An array of all feature flags for any beta-stage features this module provides.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:376](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L376)
+[packages/framework/esm-globals/src/types.ts:377](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L377)
 
 ___
 
@@ -63,7 +63,7 @@ An array of all modals supported by this frontend module. Modals can be launched
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:378](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L378)
+[packages/framework/esm-globals/src/types.ts:379](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L379)
 
 ___
 
@@ -81,7 +81,7 @@ The name of the backend dependency and either the required version or an object 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:360](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L360)
+[packages/framework/esm-globals/src/types.ts:361](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L361)
 
 ___
 
@@ -93,7 +93,7 @@ An array of all pages supported by this frontend module. Pages are automatically
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:372](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L372)
+[packages/framework/esm-globals/src/types.ts:373](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L373)
 
 ___
 
@@ -105,7 +105,7 @@ The version of this frontend module.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:356](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L356)
+[packages/framework/esm-globals/src/types.ts:357](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L357)
 
 ___
 
@@ -117,4 +117,4 @@ An array of all workspaces supported by this frontend module. Workspaces can be 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:380](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L380)
+[packages/framework/esm-globals/src/types.ts:381](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L381)

--- a/packages/framework/esm-framework/docs/interfaces/Prompt.md
+++ b/packages/framework/esm-framework/docs/interfaces/Prompt.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:90](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L90)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L89)
 
 ___
 
@@ -35,7 +35,7 @@ Defaults to "Cancel"
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:95](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L95)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:94](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L94)
 
 ___
 
@@ -47,7 +47,7 @@ Defaults to "Confirm"
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:92](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L92)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:91](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L91)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L89)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:88](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L88)
 
 ## Methods
 
@@ -71,4 +71,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L93)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:92](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L92)

--- a/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
+++ b/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
@@ -20,4 +20,4 @@
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:386](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L386)
+[packages/framework/esm-globals/src/types.ts:403](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L403)

--- a/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
+++ b/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
@@ -20,4 +20,4 @@
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:391](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L391)
+[packages/framework/esm-globals/src/types.ts:386](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L386)

--- a/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
+++ b/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
@@ -20,4 +20,4 @@
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:390](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L390)
+[packages/framework/esm-globals/src/types.ts:391](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L391)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceContainerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceContainerProps.md
@@ -21,7 +21,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L20)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L21)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceContainerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceContainerProps.md
@@ -8,6 +8,7 @@
 
 - [actionMenuProps](WorkspaceContainerProps.md#actionmenuprops)
 - [additionalWorkspaceProps](WorkspaceContainerProps.md#additionalworkspaceprops)
+- [containerName](WorkspaceContainerProps.md#containername)
 - [contextKey](WorkspaceContainerProps.md#contextkey)
 - [overlay](WorkspaceContainerProps.md#overlay)
 - [showSiderailAndBottomNav](WorkspaceContainerProps.md#showsiderailandbottomnav)
@@ -30,7 +31,17 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L19)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L20)
+
+___
+
+### containerName
+
+• `Optional` **containerName**: `string`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L17)
 
 ___
 
@@ -50,7 +61,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L17)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L18)
 
 ___
 
@@ -60,4 +71,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L18)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L19)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceContainerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceContainerProps.md
@@ -8,7 +8,6 @@
 
 - [actionMenuProps](WorkspaceContainerProps.md#actionmenuprops)
 - [additionalWorkspaceProps](WorkspaceContainerProps.md#additionalworkspaceprops)
-- [containerName](WorkspaceContainerProps.md#containername)
 - [contextKey](WorkspaceContainerProps.md#contextkey)
 - [overlay](WorkspaceContainerProps.md#overlay)
 - [showSiderailAndBottomNav](WorkspaceContainerProps.md#showsiderailandbottomnav)
@@ -21,7 +20,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L21)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L20)
 
 ___
 
@@ -31,17 +30,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L20)
-
-___
-
-### containerName
-
-• `Optional` **containerName**: `string`
-
-#### Defined in
-
-[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L17)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L19)
 
 ___
 
@@ -61,7 +50,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L18)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L17)
 
 ___
 
@@ -71,4 +60,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L19)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L18)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
@@ -16,11 +16,9 @@ See [WorkspaceDefinition](../API.md#workspacedefinition) for more information ab
 
 - [canHide](WorkspaceRegistration.md#canhide)
 - [canMaximize](WorkspaceRegistration.md#canmaximize)
-- [hasOwnSidebar](WorkspaceRegistration.md#hasownsidebar)
 - [moduleName](WorkspaceRegistration.md#modulename)
 - [name](WorkspaceRegistration.md#name)
 - [preferredWindowSize](WorkspaceRegistration.md#preferredwindowsize)
-- [sidebarFamily](WorkspaceRegistration.md#sidebarfamily)
 - [title](WorkspaceRegistration.md#title)
 - [titleNode](WorkspaceRegistration.md#titlenode)
 - [type](WorkspaceRegistration.md#type)
@@ -52,23 +50,13 @@ ___
 
 ___
 
-### hasOwnSidebar
-
-• **hasOwnSidebar**: `boolean`
-
-#### Defined in
-
-[packages/framework/esm-extensions/src/workspaces.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L17)
-
-___
-
 ### moduleName
 
 • **moduleName**: `string`
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/workspaces.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L21)
+[packages/framework/esm-extensions/src/workspaces.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L19)
 
 ___
 
@@ -88,17 +76,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/workspaces.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L19)
-
-___
-
-### sidebarFamily
-
-• **sidebarFamily**: `string`
-
-#### Defined in
-
-[packages/framework/esm-extensions/src/workspaces.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L18)
+[packages/framework/esm-extensions/src/workspaces.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L17)
 
 ___
 
@@ -152,4 +130,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L20)
+[packages/framework/esm-extensions/src/workspaces.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L18)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
@@ -23,6 +23,7 @@ See [WorkspaceDefinition](../API.md#workspacedefinition) for more information ab
 - [titleNode](WorkspaceRegistration.md#titlenode)
 - [type](WorkspaceRegistration.md#type)
 - [width](WorkspaceRegistration.md#width)
+- [workspaceGroups](WorkspaceRegistration.md#workspacegroups)
 
 ### Methods
 
@@ -117,6 +118,16 @@ ___
 #### Defined in
 
 [packages/framework/esm-extensions/src/workspaces.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L16)
+
+___
+
+### workspaceGroups
+
+• `Optional` **workspaceGroups**: `string`[]
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L20)
 
 ## Methods
 

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
@@ -16,6 +16,7 @@ See [WorkspaceDefinition](../API.md#workspacedefinition) for more information ab
 
 - [canHide](WorkspaceRegistration.md#canhide)
 - [canMaximize](WorkspaceRegistration.md#canmaximize)
+- [groups](WorkspaceRegistration.md#groups)
 - [moduleName](WorkspaceRegistration.md#modulename)
 - [name](WorkspaceRegistration.md#name)
 - [preferredWindowSize](WorkspaceRegistration.md#preferredwindowsize)
@@ -23,7 +24,6 @@ See [WorkspaceDefinition](../API.md#workspacedefinition) for more information ab
 - [titleNode](WorkspaceRegistration.md#titlenode)
 - [type](WorkspaceRegistration.md#type)
 - [width](WorkspaceRegistration.md#width)
-- [workspaceGroups](WorkspaceRegistration.md#workspacegroups)
 
 ### Methods
 
@@ -48,6 +48,16 @@ ___
 #### Defined in
 
 [packages/framework/esm-extensions/src/workspaces.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L15)
+
+___
+
+### groups
+
+• `Optional` **groups**: `string`[]
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L20)
 
 ___
 
@@ -118,16 +128,6 @@ ___
 #### Defined in
 
 [packages/framework/esm-extensions/src/workspaces.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L16)
-
-___
-
-### workspaceGroups
-
-• `Optional` **workspaceGroups**: `string`[]
-
-#### Defined in
-
-[packages/framework/esm-extensions/src/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L20)
 
 ## Methods
 

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -7,6 +7,7 @@
 ### Workspace Properties
 
 - [active](WorkspacesInfo.md#active)
+- [currentGroupName](WorkspacesInfo.md#currentgroupname)
 - [prompt](WorkspacesInfo.md#prompt)
 - [workspaceWindowState](WorkspacesInfo.md#workspacewindowstate)
 - [workspaces](WorkspacesInfo.md#workspaces)
@@ -20,6 +21,16 @@
 #### Defined in
 
 [packages/framework/esm-styleguide/src/workspaces/workspaces.ts:429](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L429)
+
+___
+
+### currentGroupName
+
+• `Optional` **currentGroupName**: `string`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:433](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L433)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:492](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L492)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:521](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L521)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:493](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L493)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:522](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L522)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:496](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L496)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:525](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L525)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:494](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L494)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:523](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L523)
 
 ___
 
@@ -67,4 +67,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:495](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L495)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:524](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L524)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:493](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L493)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:492](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L492)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:494](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L494)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:493](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L493)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:497](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L497)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:496](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L496)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:495](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L495)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:494](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L494)
 
 ___
 
@@ -67,4 +67,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:496](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L496)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:495](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L495)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:528](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L528)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:529](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L529)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:529](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L529)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:530](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L530)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:532](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L532)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:533](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L533)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:530](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L530)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:531](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L531)
 
 ___
 
@@ -67,4 +67,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:531](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L531)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:532](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L532)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:419](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L419)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:429](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L429)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:420](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L420)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:430](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L430)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:421](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L421)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:431](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L431)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:422](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L422)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:432](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L432)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -7,8 +7,8 @@
 ### Workspace Properties
 
 - [active](WorkspacesInfo.md#active)
-- [currentGroupName](WorkspacesInfo.md#currentgroupname)
 - [prompt](WorkspacesInfo.md#prompt)
+- [workspaceGroup](WorkspacesInfo.md#workspacegroup)
 - [workspaceWindowState](WorkspacesInfo.md#workspacewindowstate)
 - [workspaces](WorkspacesInfo.md#workspaces)
 
@@ -20,17 +20,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:429](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L429)
-
-___
-
-### currentGroupName
-
-• `Optional` **currentGroupName**: `string`
-
-#### Defined in
-
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:433](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L433)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:489](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L489)
 
 ___
 
@@ -40,7 +30,24 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:430](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L430)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:490](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L490)
+
+___
+
+### workspaceGroup
+
+• `Optional` **workspaceGroup**: `Object`
+
+#### Type declaration
+
+| Name | Type |
+| :------ | :------ |
+| `cleanup?` | `Function` |
+| `name` | `string` |
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:493](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L493)
 
 ___
 
@@ -50,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:431](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L431)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:491](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L491)
 
 ___
 
@@ -60,4 +67,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:432](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L432)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:492](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L492)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:489](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L489)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:493](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L493)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:490](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L490)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:494](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L494)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:493](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L493)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:497](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L497)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:491](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L491)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:495](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L495)
 
 ___
 
@@ -67,4 +67,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:492](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L492)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:496](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L496)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:521](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L521)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:528](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L528)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:522](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L522)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:529](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L529)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:525](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L525)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:532](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L532)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:523](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L523)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:530](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L530)
 
 ___
 
@@ -67,4 +67,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:524](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L524)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:531](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L531)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:412](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L412)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:419](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L419)
 
 ___
 
@@ -29,7 +29,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:413](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L413)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:420](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L420)
 
 ___
 
@@ -39,7 +39,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:414](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L414)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:421](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L421)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:415](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L415)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:422](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L422)

--- a/packages/framework/esm-globals/src/types.ts
+++ b/packages/framework/esm-globals/src/types.ts
@@ -302,13 +302,30 @@ export type WorkspaceDefinition = {
    * The width "extra-wide" is for workspaces that contain their own sidebar.
    */
   width?: 'narrow' | 'wider' | 'extra-wide';
-  preferredWindowSize?: WorkspaceWindowState;
   /**
-   * Workspaces can open either individually or in a group of workspaces. The workspace groups
-   * will define the groups in which a workspace can be opened.
+   * Launches the workspace in the preferred size, it defaults to the 'narrow' width
+   */
+  preferredWindowSize?: WorkspaceWindowState;
+
+  /**
+   * Workspaces can open either independently or as part of a "workspace group". A
+   * "workspace group" groups related workspaces together, so that only one is visible
+   * at a time. For example,
    *
-   * In case the currently opened workspace is not present in the groups of a workspace,
-   * the current group will close and then the workspace will be launched.
+   * @example
+   *
+   * {
+   *  name: 'order-basket',
+   *  type: 'order',
+   *  groups: ['ward-patient']
+   * }
+   *
+   * This means that the 'order-basket' workspace can be opened independently, or only
+   * in the 'ward-patient'.
+   * If a workspace group is already open and a new workspace is launched, and the
+   * groups in the newly launched workspace do not include the currently open group’s
+   * name, the entire workspace group will close, and the new workspace will launch independently.
+   *
    */
   groups: Array<string>;
 } & (

--- a/packages/framework/esm-globals/src/types.ts
+++ b/packages/framework/esm-globals/src/types.ts
@@ -302,19 +302,14 @@ export type WorkspaceDefinition = {
    * The width "extra-wide" is for workspaces that contain their own sidebar.
    */
   width?: 'narrow' | 'wider' | 'extra-wide';
-  /**
-   * Controls whether the workspace has its own sidebar. If true, the sidebar will be displayed when the workspace is open.
-   */
-  hasOwnSidebar?: boolean;
-  /**
-   * Sidebars have icons that representing workspaces. The sidebar family is the name of the
-   * sidebar that should contain the icon for this workspace. This is generally only needed if
-   * `hasOwnSidebar` is true, in which case this is the name of that sidebar. If multiple
-   * workspaces have `hasOwnSidebar` set to true and the same family name, then the sidebar
-   * within the workspace area will have icons for each of those workspaces.
-   */
-  sidebarFamily?: string;
   preferredWindowSize?: WorkspaceWindowState;
+  /**
+   * Workspaces can open either individually or in a group of workspaces. The workspace groups
+   * will define the groups in which a workspace can be opened.
+   *
+   * In case the currently opened workspace is not present in the workspaceGroups of a workspace,
+   * the current group will close and then the workspace will be launched.
+   */
   workspaceGroups: Array<string>;
 } & (
   | {

--- a/packages/framework/esm-globals/src/types.ts
+++ b/packages/framework/esm-globals/src/types.ts
@@ -315,6 +315,7 @@ export type WorkspaceDefinition = {
    */
   sidebarFamily?: string;
   preferredWindowSize?: WorkspaceWindowState;
+  workspaceGroups: Array<string>;
 } & (
   | {
       /**

--- a/packages/framework/esm-globals/src/types.ts
+++ b/packages/framework/esm-globals/src/types.ts
@@ -307,10 +307,10 @@ export type WorkspaceDefinition = {
    * Workspaces can open either individually or in a group of workspaces. The workspace groups
    * will define the groups in which a workspace can be opened.
    *
-   * In case the currently opened workspace is not present in the workspaceGroups of a workspace,
+   * In case the currently opened workspace is not present in the groups of a workspace,
    * the current group will close and then the workspace will be launched.
    */
-  workspaceGroups: Array<string>;
+  groups: Array<string>;
 } & (
   | {
       /**

--- a/packages/framework/esm-routes/src/loaders/components.ts
+++ b/packages/framework/esm-routes/src/loaders/components.ts
@@ -194,6 +194,7 @@ supported, so the workspace will not be loaded.`,
       canMaximize: workspace.canMaximize,
       width: workspace.width,
       preferredWindowSize: workspace.preferredWindowSize,
+      workspaceGroups: workspace.workspaceGroups ?? [],
     });
   }
 }

--- a/packages/framework/esm-routes/src/loaders/components.ts
+++ b/packages/framework/esm-routes/src/loaders/components.ts
@@ -193,8 +193,6 @@ supported, so the workspace will not be loaded.`,
       canHide: workspace.canHide,
       canMaximize: workspace.canMaximize,
       width: workspace.width,
-      hasOwnSidebar: workspace.hasOwnSidebar,
-      sidebarFamily: workspace.sidebarFamily,
       preferredWindowSize: workspace.preferredWindowSize,
     });
   }

--- a/packages/framework/esm-routes/src/loaders/components.ts
+++ b/packages/framework/esm-routes/src/loaders/components.ts
@@ -194,7 +194,7 @@ supported, so the workspace will not be loaded.`,
       canMaximize: workspace.canMaximize,
       width: workspace.width,
       preferredWindowSize: workspace.preferredWindowSize,
-      workspaceGroups: workspace.workspaceGroups ?? [],
+      groups: workspace.groups ?? [],
     });
   }
 }

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
@@ -74,7 +74,8 @@ export function WorkspaceContainer({
   actionMenuProps,
 }: WorkspaceContainerProps) {
   const layout = useLayoutType();
-  const { workspaces, workspaceWindowState, currentGroupName } = useWorkspaces();
+  const { workspaces, workspaceWindowState, workspaceGroup } = useWorkspaces();
+  const currentGroupName = workspaceGroup?.name;
   const activeWorkspace = workspaces[0];
   const isHidden = workspaceWindowState === 'hidden' || activeWorkspace == null;
   const isMaximized = workspaceWindowState === 'maximized';
@@ -144,7 +145,8 @@ interface WorkspaceProps {
 function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspaceProps) {
   const { t } = useTranslation();
   const layout = useLayoutType();
-  const { workspaceWindowState, currentGroupName } = useWorkspaces();
+  const { workspaceWindowState, workspaceGroup } = useWorkspaces();
+  const currentGroupName = workspaceGroup?.name;
   const isMaximized = workspaceWindowState === 'maximized';
 
   // We use the feature name of the app containing the workspace in order to set the extension
@@ -159,7 +161,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
   const {
     canHide = false,
     canMaximize = false,
-    workspaceContainerName = '',
+    currentWorkspaceGroup = '',
     closeWorkspace,
   } = useMemo(() => workspaceInstance ?? ({} as OpenWorkspace), [workspaceInstance]);
 
@@ -182,7 +184,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
           <div className={styles.overlayHeaderSpacer} />
           <HeaderGlobalBar className={styles.headerButtons}>
             <ExtensionSlot
-              name={`workspace-header-family-${workspaceInstance.workspaceContainerName}-slot`}
+              name={`workspace-header-family-${workspaceInstance.currentWorkspaceGroup}-slot`}
               state={workspaceProps}
             />
             <ExtensionSlot name={`workspace-header-type-${workspaceInstance.type}-slot`} state={workspaceProps} />
@@ -245,7 +247,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
         </Header>
         <div
           className={classNames(styles.workspaceContent, {
-            [styles.marginWorkspaceContent]: Boolean(workspaceContainerName),
+            [styles.marginWorkspaceContent]: Boolean(currentWorkspaceGroup),
           })}
         >
           <WorkspaceRenderer

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
@@ -14,7 +14,6 @@ import styles from './workspace.module.scss';
 
 export interface WorkspaceContainerProps {
   contextKey: string;
-  containerName?: string;
   overlay?: boolean;
   showSiderailAndBottomNav?: boolean;
   additionalWorkspaceProps?: object;
@@ -256,7 +255,6 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
             additionalPropsFromPage={additionalWorkspaceProps}
           />
         </div>
-        {/* {hasOwnSidebar && <ActionMenu isWithinWorkspace name={workspaceInstance.sidebarFamily} />} */}
       </>
     )
   );

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
@@ -74,14 +74,14 @@ export function WorkspaceContainer({
   actionMenuProps,
 }: WorkspaceContainerProps) {
   const layout = useLayoutType();
-  const { workspaces, workspaceWindowState, currentContainerName } = useWorkspaces();
+  const { workspaces, workspaceWindowState, currentGroupName } = useWorkspaces();
   const activeWorkspace = workspaces[0];
   const isHidden = workspaceWindowState === 'hidden' || activeWorkspace == null;
   const isMaximized = workspaceWindowState === 'maximized';
   const width = activeWorkspace?.width ?? (overlay ? 'wider' : 'narrow');
   const showActionMenu = useMemo(
-    () => showSiderailAndBottomNav || (currentContainerName && !isHidden),
-    [currentContainerName, isHidden, showSiderailAndBottomNav],
+    () => showSiderailAndBottomNav || (currentGroupName && !isHidden),
+    [currentGroupName, isHidden, showSiderailAndBottomNav],
   );
 
   useBodyScrollLock(!isHidden && !isDesktop(layout));
@@ -127,7 +127,7 @@ export function WorkspaceContainer({
       </div>
       {showActionMenu && (
         <ActionMenu
-          name={currentContainerName}
+          name={currentGroupName}
           isWithinWorkspace={!showSiderailAndBottomNav}
           actionMenuProps={actionMenuProps}
         />
@@ -144,7 +144,7 @@ interface WorkspaceProps {
 function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspaceProps) {
   const { t } = useTranslation();
   const layout = useLayoutType();
-  const { workspaceWindowState } = useWorkspaces();
+  const { workspaceWindowState, currentGroupName } = useWorkspaces();
   const isMaximized = workspaceWindowState === 'maximized';
 
   // We use the feature name of the app containing the workspace in order to set the extension
@@ -208,7 +208,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
                     {isMaximized ? <Minimize /> : <Maximize />}
                   </HeaderGlobalAction>
                 )}
-                {canHide ? (
+                {canHide && !currentGroupName ? (
                   <HeaderGlobalAction
                     align="bottom-right"
                     aria-label={getCoreTranslation('hide', 'Hide')}

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
@@ -68,21 +68,20 @@ export interface WorkspaceContainerProps {
  */
 export function WorkspaceContainer({
   contextKey,
-  containerName,
   overlay,
   showSiderailAndBottomNav,
   additionalWorkspaceProps,
   actionMenuProps,
 }: WorkspaceContainerProps) {
   const layout = useLayoutType();
-  const { workspaces, workspaceWindowState } = useWorkspaces(containerName);
+  const { workspaces, workspaceWindowState, currentContainerName } = useWorkspaces();
   const activeWorkspace = workspaces[0];
   const isHidden = workspaceWindowState === 'hidden' || activeWorkspace == null;
   const isMaximized = workspaceWindowState === 'maximized';
   const width = activeWorkspace?.width ?? (overlay ? 'wider' : 'narrow');
   const showActionMenu = useMemo(
-    () => showSiderailAndBottomNav || (containerName && !isHidden),
-    [containerName, isHidden, showSiderailAndBottomNav],
+    () => showSiderailAndBottomNav || (currentContainerName && !isHidden),
+    [currentContainerName, isHidden, showSiderailAndBottomNav],
   );
 
   useBodyScrollLock(!isHidden && !isDesktop(layout));
@@ -128,7 +127,7 @@ export function WorkspaceContainer({
       </div>
       {showActionMenu && (
         <ActionMenu
-          name={containerName}
+          name={currentContainerName}
           isWithinWorkspace={!showSiderailAndBottomNav}
           actionMenuProps={actionMenuProps}
         />

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
@@ -183,7 +183,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
           <div className={styles.overlayHeaderSpacer} />
           <HeaderGlobalBar className={styles.headerButtons}>
             <ExtensionSlot
-              name={`workspace-header-family-${workspaceInstance.currentWorkspaceGroup}-slot`}
+              name={`workspace-header-group-${workspaceInstance.currentWorkspaceGroup}-slot`}
               state={workspaceProps}
             />
             <ExtensionSlot name={`workspace-header-type-${workspaceInstance.type}-slot`} state={workspaceProps} />

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
@@ -14,6 +14,7 @@ import styles from './workspace.module.scss';
 
 export interface WorkspaceContainerProps {
   contextKey: string;
+  containerName?: string;
   overlay?: boolean;
   showSiderailAndBottomNav?: boolean;
   additionalWorkspaceProps?: object;
@@ -67,17 +68,22 @@ export interface WorkspaceContainerProps {
  */
 export function WorkspaceContainer({
   contextKey,
+  containerName,
   overlay,
   showSiderailAndBottomNav,
   additionalWorkspaceProps,
   actionMenuProps,
 }: WorkspaceContainerProps) {
   const layout = useLayoutType();
-  const { workspaces, workspaceWindowState } = useWorkspaces();
+  const { workspaces, workspaceWindowState } = useWorkspaces(containerName);
   const activeWorkspace = workspaces[0];
   const isHidden = workspaceWindowState === 'hidden' || activeWorkspace == null;
   const isMaximized = workspaceWindowState === 'maximized';
   const width = activeWorkspace?.width ?? (overlay ? 'wider' : 'narrow');
+  const showActionMenu = useMemo(
+    () => showSiderailAndBottomNav || (containerName && !isHidden),
+    [containerName, isHidden, showSiderailAndBottomNav],
+  );
 
   useBodyScrollLock(!isHidden && !isDesktop(layout));
 
@@ -120,7 +126,13 @@ export function WorkspaceContainer({
         </aside>
         <WorkspaceNotification contextKey={contextKey} />
       </div>
-      {showSiderailAndBottomNav && <ActionMenu actionMenuProps={actionMenuProps} />}
+      {showActionMenu && (
+        <ActionMenu
+          name={containerName}
+          isWithinWorkspace={!showSiderailAndBottomNav}
+          actionMenuProps={actionMenuProps}
+        />
+      )}
     </>
   );
 }
@@ -148,7 +160,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
   const {
     canHide = false,
     canMaximize = false,
-    hasOwnSidebar = false,
+    workspaceContainerName = '',
     closeWorkspace,
   } = useMemo(() => workspaceInstance ?? ({} as OpenWorkspace), [workspaceInstance]);
 
@@ -171,7 +183,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
           <div className={styles.overlayHeaderSpacer} />
           <HeaderGlobalBar className={styles.headerButtons}>
             <ExtensionSlot
-              name={`workspace-header-family-${workspaceInstance.sidebarFamily}-slot`}
+              name={`workspace-header-family-${workspaceInstance.workspaceContainerName}-slot`}
               state={workspaceProps}
             />
             <ExtensionSlot name={`workspace-header-type-${workspaceInstance.type}-slot`} state={workspaceProps} />
@@ -234,7 +246,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
         </Header>
         <div
           className={classNames(styles.workspaceContent, {
-            [styles.marginWorkspaceContent]: hasOwnSidebar,
+            [styles.marginWorkspaceContent]: Boolean(workspaceContainerName),
           })}
         >
           <WorkspaceRenderer
@@ -243,7 +255,7 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
             additionalPropsFromPage={additionalWorkspaceProps}
           />
         </div>
-        {hasOwnSidebar && <ActionMenu isWithinWorkspace name={workspaceInstance.sidebarFamily} />}
+        {/* {hasOwnSidebar && <ActionMenu isWithinWorkspace name={workspaceInstance.sidebarFamily} />} */}
       </>
     )
   );

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
@@ -5,7 +5,7 @@ import { InlineLoading } from '@carbon/react';
 import { getCoreTranslation } from '@openmrs/esm-translations';
 import styles from './workspace.module.scss';
 import { type OpenWorkspace } from '../workspaces';
-import { useWorkspaceFamilyStore } from '../workspace-sidebar-store/useWorkspaceFamilyStore';
+import { useWorkspaceGroupStore } from '../workspace-sidebar-store/useWorkspaceGroupStore';
 
 interface WorkspaceRendererProps {
   workspace: OpenWorkspace;
@@ -14,7 +14,7 @@ interface WorkspaceRendererProps {
 
 export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: WorkspaceRendererProps) {
   const [lifecycle, setLifecycle] = useState<ParcelConfig | undefined>();
-  const workspaceFamilyState = useWorkspaceFamilyStore(workspace.currentWorkspaceGroup);
+  const workspaceFamilyState = useWorkspaceGroupStore(workspace.currentWorkspaceGroup);
 
   useEffect(() => {
     let active = true;

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
@@ -14,7 +14,7 @@ interface WorkspaceRendererProps {
 
 export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: WorkspaceRendererProps) {
   const [lifecycle, setLifecycle] = useState<ParcelConfig | undefined>();
-  const workspaceFamilyState = useWorkspaceFamilyStore(workspace.sidebarFamily);
+  const workspaceFamilyState = useWorkspaceFamilyStore(workspace.workspaceContainerName);
 
   useEffect(() => {
     let active = true;

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
@@ -14,7 +14,7 @@ interface WorkspaceRendererProps {
 
 export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: WorkspaceRendererProps) {
   const [lifecycle, setLifecycle] = useState<ParcelConfig | undefined>();
-  const workspaceFamilyState = useWorkspaceGroupStore(workspace.currentWorkspaceGroup);
+  const workspaceGroupState = useWorkspaceGroupStore(workspace.currentWorkspaceGroup);
 
   useEffect(() => {
     let active = true;
@@ -36,10 +36,10 @@ export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: Worksp
         promptBeforeClosing: workspace.promptBeforeClosing,
         setTitle: workspace.setTitle,
         ...additionalPropsFromPage,
-        ...workspaceFamilyState,
+        ...workspaceGroupState,
         ...workspace.additionalProps,
       },
-    [workspace, additionalPropsFromPage, workspaceFamilyState],
+    [workspace, additionalPropsFromPage, workspaceGroupState],
   );
 
   return lifecycle ? (

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
@@ -14,7 +14,7 @@ interface WorkspaceRendererProps {
 
 export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: WorkspaceRendererProps) {
   const [lifecycle, setLifecycle] = useState<ParcelConfig | undefined>();
-  const workspaceFamilyState = useWorkspaceFamilyStore(workspace.workspaceContainerName);
+  const workspaceFamilyState = useWorkspaceFamilyStore(workspace.currentWorkspaceGroup);
 
   useEffect(() => {
     let active = true;

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.test.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.test.tsx
@@ -58,7 +58,6 @@ describe('WorkspaceRenderer', () => {
       setTitle: mockedSetTitle,
       foo: 'true',
       bar: 'true',
-      workspaceFamilyState: {},
     });
   });
 });

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.test.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.test.tsx
@@ -20,10 +20,10 @@ describe('WorkspaceRenderer', () => {
     const mockedPromptBeforeClosing = jest.fn();
     const mockedSetTitle = jest.fn();
     const mockedLoadFn = jest.fn().mockImplementation(() => Promise.resolve({ default: 'file-content' }));
-    getWorkspaceGroupStore('test-sidebar-family')?.setState({
-      // Testing that the workspace family state should be overrided by additionalProps
+    getWorkspaceGroupStore('test-sidebar-store')?.setState({
+      // Testing that the workspace group state should be overrided by additionalProps
       foo: false,
-      workspaceFamilyState: {},
+      workspaceGroupStore: {},
     });
     render(
       <WorkspaceRenderer

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.test.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen } from '@testing-library/react';
 import { WorkspaceRenderer } from './workspace-renderer.component';
-import { getWorkspaceFamilyStore, OpenWorkspace } from '../workspaces';
+import { getWorkspaceGroupStore } from '../workspaces';
 import Parcel from 'single-spa-react/parcel';
 
 const mockFn = jest.fn();
@@ -20,7 +20,7 @@ describe('WorkspaceRenderer', () => {
     const mockedPromptBeforeClosing = jest.fn();
     const mockedSetTitle = jest.fn();
     const mockedLoadFn = jest.fn().mockImplementation(() => Promise.resolve({ default: 'file-content' }));
-    getWorkspaceFamilyStore('test-sidebar-family')?.setState({
+    getWorkspaceGroupStore('test-sidebar-family')?.setState({
       // Testing that the workspace family state should be overrided by additionalProps
       foo: false,
       workspaceFamilyState: {},
@@ -39,7 +39,6 @@ describe('WorkspaceRenderer', () => {
           additionalProps: {
             foo: 'true',
           },
-          sidebarFamily: 'test-sidebar-family',
         }}
         additionalPropsFromPage={{ bar: 'true' }}
       />,

--- a/packages/framework/esm-styleguide/src/workspaces/public.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/public.ts
@@ -1,6 +1,12 @@
 export * from './action-menu-button/action-menu-button.component';
 export * from './container/workspace-container.component';
-export { closeWorkspace, launchWorkspace, navigateAndLaunchWorkspace, useWorkspaces } from './workspaces';
+export {
+  closeWorkspace,
+  launchWorkspace,
+  navigateAndLaunchWorkspace,
+  useWorkspaces,
+  launchWorkspaceGroup,
+} from './workspaces';
 export {
   type DefaultWorkspaceProps,
   type CloseWorkspaceOptions,

--- a/packages/framework/esm-styleguide/src/workspaces/workspace-sidebar-store/useWorkspaceFamilyStore.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspace-sidebar-store/useWorkspaceFamilyStore.ts
@@ -12,7 +12,7 @@ import type { StoreApi } from 'zustand/vanilla';
  *
  * @param {string} sidebarFamilyName The sidebarFamilyName of the workspace used when registering the workspace in the module's routes.json file.
  */
-export function useWorkspaceFamilyStore(sidebarFamilyName: string) {
+export function useWorkspaceFamilyStore(sidebarFamilyName?: string) {
   const [storeState, setStoreState] = useState<object>({});
   const [currentSidebarFamilyName, setCurrentSidebarFamilyName] = useState(sidebarFamilyName);
 

--- a/packages/framework/esm-styleguide/src/workspaces/workspace-sidebar-store/useWorkspaceGroupStore.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspace-sidebar-store/useWorkspaceGroupStore.ts
@@ -2,14 +2,14 @@ import { useEffect, useState } from 'react';
 import { getWorkspaceGroupStore } from '../workspaces';
 
 /**
- * This hook is used to interact with the store of a workspace family.
- * A workspace family is defined as a group of workspaces that share the same sidebarFamilyName.
+ * This hook is used to interact with the store of a workspace store.
+ * A workspace store is defined as a group of workspaces that open in the same workspace group.
  *
- * In case a workspace doesn't have a sidebarFamilyName, it will be considered as a standalone workspace, and hence this hook will return an empty object and updateFunction as an empty function.
+ * In case a workspace group is not active, it will be considered as a standalone workspace, and hence this hook will return an empty object and updateFunction as an empty function.
  *
  * @internal
  *
- * @param {string} sidebarFamilyName The sidebarFamilyName of the workspace used when registering the workspace in the module's routes.json file.
+ * @param {string} workspaceGroupName The workspaceGroupName of the workspace used when registering the workspace in the module's routes.json file.
  */
 export function useWorkspaceGroupStore(workspaceGroupName?: string) {
   const [storeState, setStoreState] = useState<object>({});

--- a/packages/framework/esm-styleguide/src/workspaces/workspace-sidebar-store/useWorkspaceGroupStore.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspace-sidebar-store/useWorkspaceGroupStore.ts
@@ -1,6 +1,5 @@
-import { useEffect, useMemo, useState } from 'react';
-import { getWorkspaceFamilyStore } from '../workspaces';
-import type { StoreApi } from 'zustand/vanilla';
+import { useEffect, useState } from 'react';
+import { getWorkspaceGroupStore } from '../workspaces';
 
 /**
  * This hook is used to interact with the store of a workspace family.
@@ -12,18 +11,18 @@ import type { StoreApi } from 'zustand/vanilla';
  *
  * @param {string} sidebarFamilyName The sidebarFamilyName of the workspace used when registering the workspace in the module's routes.json file.
  */
-export function useWorkspaceFamilyStore(sidebarFamilyName?: string) {
+export function useWorkspaceGroupStore(workspaceGroupName?: string) {
   const [storeState, setStoreState] = useState<object>({});
-  const [currentSidebarFamilyName, setCurrentSidebarFamilyName] = useState(sidebarFamilyName);
+  const [currentWorkspaceGroupName, setCurrentWorkspaceGroupName] = useState(workspaceGroupName);
 
   useEffect(() => {
-    if (currentSidebarFamilyName !== sidebarFamilyName) {
-      setCurrentSidebarFamilyName(sidebarFamilyName);
+    if (currentWorkspaceGroupName !== workspaceGroupName) {
+      setCurrentWorkspaceGroupName(workspaceGroupName);
     }
-  }, [sidebarFamilyName]);
+  }, [workspaceGroupName]);
 
   useEffect(() => {
-    const store = getWorkspaceFamilyStore(currentSidebarFamilyName);
+    const store = getWorkspaceGroupStore(currentWorkspaceGroupName);
     let unsubscribe: () => void;
     if (store) {
       setStoreState(store.getState());
@@ -34,7 +33,7 @@ export function useWorkspaceFamilyStore(sidebarFamilyName?: string) {
         unsubscribe?.();
       }
     };
-  }, [currentSidebarFamilyName]);
+  }, [currentWorkspaceGroupName]);
 
   return storeState;
 }

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -443,36 +443,36 @@ describe('workspace system', () => {
 
   describe('Testing `getWorkspaceGroupStore` function', () => {
     it('should return undefined if no workspace sidebar name is passed', () => {
-      let workspaceFamilyStore = getWorkspaceGroupStore(undefined);
-      expect(workspaceFamilyStore).toBeUndefined();
-      workspaceFamilyStore = getWorkspaceGroupStore('default');
-      expect(workspaceFamilyStore).toBeUndefined();
+      let workspaceGroupStore = getWorkspaceGroupStore(undefined);
+      expect(workspaceGroupStore).toBeUndefined();
+      workspaceGroupStore = getWorkspaceGroupStore('default');
+      expect(workspaceGroupStore).toBeUndefined();
     });
 
     it('should return store if workspace sidebar name is passed', () => {
-      const workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store', {
+      const workspaceGroupStore = getWorkspaceGroupStore('ward-patient-store', {
         foo: true,
       });
-      expect(workspaceFamilyStore).toBeTruthy();
-      expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
+      expect(workspaceGroupStore).toBeTruthy();
+      expect(workspaceGroupStore?.getState()?.['foo']).toBe(true);
     });
 
     it('should update the store state with new additionalProps if workspaces with same workspaceGroup name calls the function', () => {
-      let workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store', {
+      let workspaceGroupStore = getWorkspaceGroupStore('ward-patient-store', {
         foo: true,
       });
-      expect(workspaceFamilyStore).toBeTruthy();
-      expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
-      workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store', {
+      expect(workspaceGroupStore).toBeTruthy();
+      expect(workspaceGroupStore?.getState()?.['foo']).toBe(true);
+      workspaceGroupStore = getWorkspaceGroupStore('ward-patient-store', {
         bar: true,
       });
-      expect(workspaceFamilyStore).toBeTruthy();
-      expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
-      expect(workspaceFamilyStore?.getState()?.['bar']).toBe(true);
+      expect(workspaceGroupStore).toBeTruthy();
+      expect(workspaceGroupStore?.getState()?.['foo']).toBe(true);
+      expect(workspaceGroupStore?.getState()?.['bar']).toBe(true);
     });
   });
 
-  describe('Testing workspace family store', () => {
+  describe('Testing workspace group store', () => {
     it('should create store for workspace groups', () => {
       registerWorkspace({
         name: 'allergies',
@@ -492,19 +492,19 @@ describe('workspace system', () => {
         state: {},
         workspaceToLaunch: { name: 'ward-patient-workspace' },
       });
-      const workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store');
+      const workspaceGroupStore = getWorkspaceGroupStore('ward-patient-store');
       const workspaceStore = getWorkspaceStore();
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
       expect(workspaceStore.getState().openWorkspaces[0].name).toBe('ward-patient-workspace');
-      expect(workspaceFamilyStore).toBeTruthy();
+      expect(workspaceGroupStore).toBeTruthy();
       workspaceStore.getState().openWorkspaces[0].closeWorkspace({ ignoreChanges: true });
       launchWorkspace('allergies');
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
       expect(workspaceStore.getState().openWorkspaces[0].name).toBe('allergies');
-      expect(workspaceFamilyStore?.getState()).toStrictEqual({});
+      expect(workspaceGroupStore?.getState()).toStrictEqual({});
     });
 
-    it('should clear workspace family store by default if the workspace is closed, since `closeWorkspaceGroup` is true by default', async () => {
+    it('should clear workspace group store by default if the workspace is closed, since `closeWorkspaceGroup` is true by default', async () => {
       registerWorkspace({
         name: 'ward-patient-workspace',
         title: 'Ward Patient Workspace',
@@ -519,12 +519,12 @@ describe('workspace system', () => {
         },
         workspaceToLaunch: { name: 'ward-patient-workspace' },
       });
-      const workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store');
-      expect(workspaceFamilyStore).toBeTruthy();
-      expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
+      const workspaceGroupStore = getWorkspaceGroupStore('ward-patient-store');
+      expect(workspaceGroupStore).toBeTruthy();
+      expect(workspaceGroupStore?.getState()?.['foo']).toBe(true);
       closeWorkspace('ward-patient-workspace');
-      expect(workspaceFamilyStore?.getState()?.['foo']).toBeUndefined();
-      expect(workspaceFamilyStore?.getState()).toStrictEqual({});
+      expect(workspaceGroupStore?.getState()?.['foo']).toBeUndefined();
+      expect(workspaceGroupStore?.getState()).toStrictEqual({});
     });
 
     it('should not clear the workspace store if the new workspace opened can open in the same group', () => {
@@ -580,7 +580,7 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        groups: ['another-sidebar-family'],
+        groups: ['another-sidebar-group'],
       });
       const workspaceStore = getWorkspaceStore();
       launchWorkspaceGroup('ward-patient-store', {
@@ -589,25 +589,25 @@ describe('workspace system', () => {
         },
         workspaceToLaunch: { name: 'ward-patient-workspace' },
       });
-      const wardPatientFamilyStore = getWorkspaceGroupStore('ward-patient-store');
+      const wardPatientGroupStore = getWorkspaceGroupStore('ward-patient-store');
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
-      expect(wardPatientFamilyStore).toBeTruthy();
-      expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
-      launchWorkspaceGroup('another-sidebar-family', {
+      expect(wardPatientGroupStore).toBeTruthy();
+      expect(wardPatientGroupStore?.getState()?.['foo']).toBe(true);
+      launchWorkspaceGroup('another-sidebar-group', {
         state: {
           bar: false,
         },
         workspaceToLaunch: { name: 'transfer-patient-workspace' },
       });
-      expect(workspaceStore.getState().workspaceGroup?.name).toBe('another-sidebar-family');
-      const anotherWorkspaceGroupStore = getWorkspaceGroupStore('another-sidebar-family');
+      expect(workspaceStore.getState().workspaceGroup?.name).toBe('another-sidebar-group');
+      const anotherWorkspaceGroupStore = getWorkspaceGroupStore('another-sidebar-group');
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
       expect(anotherWorkspaceGroupStore?.getState()?.['bar']).toBe(false);
-      expect(wardPatientFamilyStore?.getState()?.['foo']).toBeUndefined();
-      expect(wardPatientFamilyStore?.getState()).toStrictEqual({});
+      expect(wardPatientGroupStore?.getState()?.['foo']).toBeUndefined();
+      expect(wardPatientGroupStore?.getState()).toStrictEqual({});
     });
 
-    it('should not clear the workspace if a workspace of same sidebar family is opened', () => {
+    it('should not clear the workspace if a workspace of same sidebar group is opened', () => {
       registerWorkspace({
         name: 'ward-patient-workspace',
         title: 'Ward Patient Workspace',
@@ -632,14 +632,14 @@ describe('workspace system', () => {
         },
         workspaceToLaunch: { name: 'ward-patient-workspace' },
       });
-      const wardPatientFamilyStore = getWorkspaceGroupStore('ward-patient-store');
+      const wardPatientGroupStore = getWorkspaceGroupStore('ward-patient-store');
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
-      expect(wardPatientFamilyStore).toBeTruthy();
-      expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
+      expect(wardPatientGroupStore).toBeTruthy();
+      expect(wardPatientGroupStore?.getState()?.['foo']).toBe(true);
       launchWorkspace('transfer-patient-workspace', { bar: false });
       expect(workspaceStore.getState().openWorkspaces.length).toBe(2);
-      expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
-      expect(wardPatientFamilyStore?.getState()?.['bar']).toBe(false);
+      expect(wardPatientGroupStore?.getState()?.['foo']).toBe(true);
+      expect(wardPatientGroupStore?.getState()?.['bar']).toBe(false);
     });
 
     it('should retain default closeWorkspace options in case workspace options are passed', () => {
@@ -655,13 +655,13 @@ describe('workspace system', () => {
         state: { foo: true },
         workspaceToLaunch: { name: 'ward-patient-workspace' },
       });
-      const workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store');
-      expect(workspaceFamilyStore).toBeTruthy();
-      expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
+      const workspaceGroupStore = getWorkspaceGroupStore('ward-patient-store');
+      expect(workspaceGroupStore).toBeTruthy();
+      expect(workspaceGroupStore?.getState()?.['foo']).toBe(true);
       // test that default options are interpolated when providing options to `closeWorkspace`
       closeWorkspace('ward-patient-workspace', { ignoreChanges: true });
-      expect(workspaceFamilyStore?.getState()?.['foo']).toBeUndefined();
-      expect(workspaceFamilyStore?.getState()).toStrictEqual({});
+      expect(workspaceGroupStore?.getState()?.['foo']).toBeUndefined();
+      expect(workspaceGroupStore?.getState()).toStrictEqual({});
     });
   });
 });

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -485,8 +485,6 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        hasOwnSidebar: true,
-        sidebarFamily: 'ward-patient-sidebar',
       });
       launchWorkspace('ward-patient-workspace');
       const workspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
@@ -508,8 +506,8 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        hasOwnSidebar: true,
-        sidebarFamily: 'ward-patient-sidebar',
+        // hasOwnSidebar: true,
+        // sidebarFamily: 'ward-patient-sidebar',
       });
       launchWorkspace('ward-patient-workspace', {
         foo: true,
@@ -530,8 +528,8 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        hasOwnSidebar: true,
-        sidebarFamily,
+        // hasOwnSidebar: true,
+        // sidebarFamily,
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -539,8 +537,8 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        hasOwnSidebar: true,
-        sidebarFamily,
+        // hasOwnSidebar: true,
+        // sidebarFamily,
       });
       const workspaceStore = getWorkspaceStore();
       launchWorkspace('ward-patient-workspace', {
@@ -564,8 +562,8 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        hasOwnSidebar: true,
-        sidebarFamily: 'ward-patient-sidebar',
+        // hasOwnSidebar: true,
+        // sidebarFamily: 'ward-patient-sidebar',
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -573,8 +571,8 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        hasOwnSidebar: true,
-        sidebarFamily: 'another-sidebar-family',
+        // hasOwnSidebar: true,
+        // sidebarFamily: 'another-sidebar-family',
       });
       const workspaceStore = getWorkspaceStore();
       launchWorkspace('ward-patient-workspace', {
@@ -599,8 +597,8 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        hasOwnSidebar: true,
-        sidebarFamily: 'ward-patient-sidebar',
+        // hasOwnSidebar: true,
+        // sidebarFamily: 'ward-patient-sidebar',
         canHide: true,
       });
       registerWorkspace({
@@ -609,8 +607,8 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        hasOwnSidebar: true,
-        sidebarFamily: 'another-sidebar-family',
+        // hasOwnSidebar: true,
+        // sidebarFamily: 'another-sidebar-family',
       });
       const workspaceStore = getWorkspaceStore();
       launchWorkspace('ward-patient-workspace', {
@@ -634,8 +632,8 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        hasOwnSidebar: true,
-        sidebarFamily: 'ward-patient-sidebar',
+        // hasOwnSidebar: true,
+        // sidebarFamily: 'ward-patient-sidebar',
         canHide: true,
       });
       registerWorkspace({
@@ -644,8 +642,8 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        hasOwnSidebar: true,
-        sidebarFamily: 'ward-patient-sidebar',
+        // hasOwnSidebar: true,
+        // sidebarFamily: 'ward-patient-sidebar',
       });
       const workspaceStore = getWorkspaceStore();
       launchWorkspace('ward-patient-workspace', {
@@ -668,8 +666,8 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        hasOwnSidebar: true,
-        sidebarFamily: 'ward-patient-sidebar',
+        // hasOwnSidebar: true,
+        // sidebarFamily: 'ward-patient-sidebar',
       });
       launchWorkspace('ward-patient-workspace', {
         foo: true,

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -2,7 +2,7 @@ import {
   type Prompt,
   cancelPrompt,
   closeWorkspace,
-  getWorkspaceFamilyStore,
+  getWorkspaceGroupStore,
   getWorkspaceStore,
   launchWorkspace,
   launchWorkspaceGroup,
@@ -441,29 +441,29 @@ describe('workspace system', () => {
     expect(store.getState().openWorkspaces.length).toBe(0);
   });
 
-  describe('Testing `getWorkspaceFamilyStore` function', () => {
+  describe('Testing `getWorkspaceGroupStore` function', () => {
     it('should return undefined if no workspace sidebar name is passed', () => {
-      let workspaceFamilyStore = getWorkspaceFamilyStore(undefined);
+      let workspaceFamilyStore = getWorkspaceGroupStore(undefined);
       expect(workspaceFamilyStore).toBeUndefined();
-      workspaceFamilyStore = getWorkspaceFamilyStore('default');
+      workspaceFamilyStore = getWorkspaceGroupStore('default');
       expect(workspaceFamilyStore).toBeUndefined();
     });
 
     it('should return store if workspace sidebar name is passed', () => {
-      const workspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar', {
+      const workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store', {
         foo: true,
       });
       expect(workspaceFamilyStore).toBeTruthy();
       expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
     });
 
-    it('should update the store state with new additionalProps if workspaces with same sidebarFamily name calls the function', () => {
-      let workspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar', {
+    it('should update the store state with new additionalProps if workspaces with same workspaceGroup name calls the function', () => {
+      let workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store', {
         foo: true,
       });
       expect(workspaceFamilyStore).toBeTruthy();
       expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
-      workspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar', {
+      workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store', {
         bar: true,
       });
       expect(workspaceFamilyStore).toBeTruthy();
@@ -486,15 +486,15 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: ['ward-patient-sidebar'],
+        workspaceGroups: ['ward-patient-store'],
       });
-      launchWorkspaceGroup('ward-patient-sidebar', {
+      launchWorkspaceGroup('ward-patient-store', {
         state: {},
         onWorkspaceGroupLaunch: () => {
           launchWorkspace('ward-patient-workspace');
         },
       });
-      const workspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
+      const workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store');
       const workspaceStore = getWorkspaceStore();
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
       expect(workspaceStore.getState().openWorkspaces[0].name).toBe('ward-patient-workspace');
@@ -513,9 +513,9 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: ['ward-patient-sidebar'],
+        workspaceGroups: ['ward-patient-store'],
       });
-      launchWorkspaceGroup('ward-patient-sidebar', {
+      launchWorkspaceGroup('ward-patient-store', {
         state: {
           foo: true,
         },
@@ -523,7 +523,7 @@ describe('workspace system', () => {
           launchWorkspace('ward-patient-workspace');
         },
       });
-      const workspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
+      const workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store');
       expect(workspaceFamilyStore).toBeTruthy();
       expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
       closeWorkspace('ward-patient-workspace');
@@ -532,14 +532,14 @@ describe('workspace system', () => {
     });
 
     it('should not clear the workspace store if the new workspace opened can open in the same group', () => {
-      const sidebarFamily = 'ward-patient-sidebar';
+      const workspaceGroup = 'ward-patient-store';
       registerWorkspace({
         name: 'ward-patient-workspace',
         title: 'Ward Patient Workspace',
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: [sidebarFamily],
+        workspaceGroups: [workspaceGroup],
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -547,9 +547,9 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: [sidebarFamily],
+        workspaceGroups: [workspaceGroup],
       });
-      launchWorkspaceGroup(sidebarFamily, {
+      launchWorkspaceGroup(workspaceGroup, {
         state: {
           foo: true,
         },
@@ -558,17 +558,17 @@ describe('workspace system', () => {
         },
       });
       const workspaceStore = getWorkspaceStore();
-      const sidebarFamilyStore = getWorkspaceFamilyStore(sidebarFamily);
+      const workspaceGroupStore = getWorkspaceGroupStore(workspaceGroup);
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
-      expect(sidebarFamilyStore).toBeTruthy();
-      expect(sidebarFamilyStore?.getState()?.['foo']).toBe(true);
+      expect(workspaceGroupStore).toBeTruthy();
+      expect(workspaceGroupStore?.getState()?.['foo']).toBe(true);
       launchWorkspace('transfer-patient-workspace', {
         bar: false,
       });
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
       const transferPatientWorkspace = workspaceStore.getState().openWorkspaces[0];
-      expect(sidebarFamilyStore?.getState()?.['foo']).toBe(true);
-      expect(sidebarFamilyStore?.getState()?.['bar']).toBe(false);
+      expect(workspaceGroupStore?.getState()?.['foo']).toBe(true);
+      expect(workspaceGroupStore?.getState()?.['bar']).toBe(false);
     });
 
     it('should clear the store when new workspace with different sidebar is opened, given the original workspace cannot hide', () => {
@@ -578,7 +578,7 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: ['ward-patient-sidebar'],
+        workspaceGroups: ['ward-patient-store'],
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -589,7 +589,7 @@ describe('workspace system', () => {
         workspaceGroups: ['another-sidebar-family'],
       });
       const workspaceStore = getWorkspaceStore();
-      launchWorkspaceGroup('ward-patient-sidebar', {
+      launchWorkspaceGroup('ward-patient-store', {
         state: {
           foo: true,
         },
@@ -597,7 +597,7 @@ describe('workspace system', () => {
           launchWorkspace('ward-patient-workspace');
         },
       });
-      const wardPatientFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
+      const wardPatientFamilyStore = getWorkspaceGroupStore('ward-patient-store');
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
       expect(wardPatientFamilyStore).toBeTruthy();
       expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
@@ -610,43 +610,12 @@ describe('workspace system', () => {
         },
       });
       expect(workspaceStore.getState().workspaceGroup?.name).toBe('another-sidebar-family');
-      const anotherSidebarFamilyStore = getWorkspaceFamilyStore('another-sidebar-family');
+      const anotherWorkspaceGroupStore = getWorkspaceGroupStore('another-sidebar-family');
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
-      expect(anotherSidebarFamilyStore?.getState()?.['bar']).toBe(false);
+      expect(anotherWorkspaceGroupStore?.getState()?.['bar']).toBe(false);
       expect(wardPatientFamilyStore?.getState()?.['foo']).toBeUndefined();
       expect(wardPatientFamilyStore?.getState()).toStrictEqual({});
     });
-
-    // it('should not clear the store when new workspace with different sidebar is opened, given the original workspace can hide', () => {
-    //   registerWorkspace({
-    //     name: 'ward-patient-workspace',
-    //     title: 'Ward Patient Workspace',
-    //     load: jest.fn(),
-    //     type: 'ward-patient',
-    //     moduleName: '@openmrs/esm-ward-app',
-    //     canHide: true,
-    //   });
-    //   registerWorkspace({
-    //     name: 'transfer-patient-workspace',
-    //     title: 'Transfer Patient Workspace',
-    //     load: jest.fn(),
-    //     type: 'transfer-patient',
-    //     moduleName: '@openmrs/esm-ward-app',
-    //   });
-    //   const workspaceStore = getWorkspaceStore();
-    //   launchWorkspace('ward-patient-workspace', {
-    //     foo: true,
-    //   });
-    //   const wardPatientFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
-    //   expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
-    //   expect(wardPatientFamilyStore).toBeTruthy();
-    //   expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
-    //   launchWorkspace('transfer-patient-workspace', { bar: false });
-    //   const anotherSidebarFamilyStore = getWorkspaceFamilyStore('another-sidebar-family');
-    //   expect(workspaceStore.getState().openWorkspaces.length).toBe(2);
-    //   expect(anotherSidebarFamilyStore?.getState()?.['bar']).toBe(false);
-    //   expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
-    // });
 
     it('should not clear the workspace if a workspace of same sidebar family is opened', () => {
       registerWorkspace({
@@ -656,7 +625,7 @@ describe('workspace system', () => {
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
         canHide: true,
-        workspaceGroups: ['ward-patient-sidebar'],
+        workspaceGroups: ['ward-patient-store'],
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -664,10 +633,10 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: ['ward-patient-sidebar'],
+        workspaceGroups: ['ward-patient-store'],
       });
       const workspaceStore = getWorkspaceStore();
-      launchWorkspaceGroup('ward-patient-sidebar', {
+      launchWorkspaceGroup('ward-patient-store', {
         state: {
           foo: true,
         },
@@ -675,7 +644,7 @@ describe('workspace system', () => {
           launchWorkspace('ward-patient-workspace');
         },
       });
-      const wardPatientFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
+      const wardPatientFamilyStore = getWorkspaceGroupStore('ward-patient-store');
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
       expect(wardPatientFamilyStore).toBeTruthy();
       expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
@@ -692,15 +661,15 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: ['ward-patient-sidebar'],
+        workspaceGroups: ['ward-patient-store'],
       });
-      launchWorkspaceGroup('ward-patient-sidebar', {
+      launchWorkspaceGroup('ward-patient-store', {
         state: { foo: true },
         onWorkspaceGroupLaunch: () => {
           launchWorkspace('ward-patient-workspace');
         },
       });
-      const workspaceFamilyStore = getWorkspaceFamilyStore('ward-patient-sidebar');
+      const workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store');
       expect(workspaceFamilyStore).toBeTruthy();
       expect(workspaceFamilyStore?.getState()?.['foo']).toBe(true);
       // test that default options are interpolated when providing options to `closeWorkspace`

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -486,13 +486,11 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: ['ward-patient-store'],
+        groups: ['ward-patient-store'],
       });
       launchWorkspaceGroup('ward-patient-store', {
         state: {},
-        onWorkspaceGroupLaunch: () => {
-          launchWorkspace('ward-patient-workspace');
-        },
+        workspaceToLaunch: { name: 'ward-patient-workspace' },
       });
       const workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store');
       const workspaceStore = getWorkspaceStore();
@@ -513,15 +511,13 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: ['ward-patient-store'],
+        groups: ['ward-patient-store'],
       });
       launchWorkspaceGroup('ward-patient-store', {
         state: {
           foo: true,
         },
-        onWorkspaceGroupLaunch: () => {
-          launchWorkspace('ward-patient-workspace');
-        },
+        workspaceToLaunch: { name: 'ward-patient-workspace' },
       });
       const workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store');
       expect(workspaceFamilyStore).toBeTruthy();
@@ -539,7 +535,7 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: [workspaceGroup],
+        groups: [workspaceGroup],
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -547,15 +543,13 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: [workspaceGroup],
+        groups: [workspaceGroup],
       });
       launchWorkspaceGroup(workspaceGroup, {
         state: {
           foo: true,
         },
-        onWorkspaceGroupLaunch: () => {
-          launchWorkspace('ward-patient-workspace');
-        },
+        workspaceToLaunch: { name: 'ward-patient-workspace' },
       });
       const workspaceStore = getWorkspaceStore();
       const workspaceGroupStore = getWorkspaceGroupStore(workspaceGroup);
@@ -578,7 +572,7 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: ['ward-patient-store'],
+        groups: ['ward-patient-store'],
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -586,16 +580,14 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: ['another-sidebar-family'],
+        groups: ['another-sidebar-family'],
       });
       const workspaceStore = getWorkspaceStore();
       launchWorkspaceGroup('ward-patient-store', {
         state: {
           foo: true,
         },
-        onWorkspaceGroupLaunch: () => {
-          launchWorkspace('ward-patient-workspace');
-        },
+        workspaceToLaunch: { name: 'ward-patient-workspace' },
       });
       const wardPatientFamilyStore = getWorkspaceGroupStore('ward-patient-store');
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
@@ -605,9 +597,7 @@ describe('workspace system', () => {
         state: {
           bar: false,
         },
-        onWorkspaceGroupLaunch: () => {
-          launchWorkspace('transfer-patient-workspace');
-        },
+        workspaceToLaunch: { name: 'transfer-patient-workspace' },
       });
       expect(workspaceStore.getState().workspaceGroup?.name).toBe('another-sidebar-family');
       const anotherWorkspaceGroupStore = getWorkspaceGroupStore('another-sidebar-family');
@@ -625,7 +615,7 @@ describe('workspace system', () => {
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
         canHide: true,
-        workspaceGroups: ['ward-patient-store'],
+        groups: ['ward-patient-store'],
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -633,16 +623,14 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: ['ward-patient-store'],
+        groups: ['ward-patient-store'],
       });
       const workspaceStore = getWorkspaceStore();
       launchWorkspaceGroup('ward-patient-store', {
         state: {
           foo: true,
         },
-        onWorkspaceGroupLaunch: () => {
-          launchWorkspace('ward-patient-workspace');
-        },
+        workspaceToLaunch: { name: 'ward-patient-workspace' },
       });
       const wardPatientFamilyStore = getWorkspaceGroupStore('ward-patient-store');
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
@@ -661,13 +649,11 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        workspaceGroups: ['ward-patient-store'],
+        groups: ['ward-patient-store'],
       });
       launchWorkspaceGroup('ward-patient-store', {
         state: { foo: true },
-        onWorkspaceGroupLaunch: () => {
-          launchWorkspace('ward-patient-workspace');
-        },
+        workspaceToLaunch: { name: 'ward-patient-workspace' },
       });
       const workspaceFamilyStore = getWorkspaceGroupStore('ward-patient-store');
       expect(workspaceFamilyStore).toBeTruthy();

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -488,8 +488,7 @@ describe('workspace system', () => {
         moduleName: '@openmrs/esm-ward-app',
         workspaceGroups: ['ward-patient-sidebar'],
       });
-      launchWorkspaceGroup({
-        groupName: 'ward-patient-sidebar',
+      launchWorkspaceGroup('ward-patient-sidebar', {
         state: {},
         onWorkspaceGroupLaunch: () => {
           launchWorkspace('ward-patient-workspace');
@@ -516,8 +515,7 @@ describe('workspace system', () => {
         moduleName: '@openmrs/esm-ward-app',
         workspaceGroups: ['ward-patient-sidebar'],
       });
-      launchWorkspaceGroup({
-        groupName: 'ward-patient-sidebar',
+      launchWorkspaceGroup('ward-patient-sidebar', {
         state: {
           foo: true,
         },
@@ -551,8 +549,7 @@ describe('workspace system', () => {
         moduleName: '@openmrs/esm-ward-app',
         workspaceGroups: [sidebarFamily],
       });
-      launchWorkspaceGroup({
-        groupName: sidebarFamily,
+      launchWorkspaceGroup(sidebarFamily, {
         state: {
           foo: true,
         },
@@ -592,8 +589,7 @@ describe('workspace system', () => {
         workspaceGroups: ['another-sidebar-family'],
       });
       const workspaceStore = getWorkspaceStore();
-      launchWorkspaceGroup({
-        groupName: 'ward-patient-sidebar',
+      launchWorkspaceGroup('ward-patient-sidebar', {
         state: {
           foo: true,
         },
@@ -605,8 +601,7 @@ describe('workspace system', () => {
       expect(workspaceStore.getState().openWorkspaces.length).toBe(1);
       expect(wardPatientFamilyStore).toBeTruthy();
       expect(wardPatientFamilyStore?.getState()?.['foo']).toBe(true);
-      launchWorkspaceGroup({
-        groupName: 'another-sidebar-family',
+      launchWorkspaceGroup('another-sidebar-family', {
         state: {
           bar: false,
         },
@@ -672,8 +667,7 @@ describe('workspace system', () => {
         workspaceGroups: ['ward-patient-sidebar'],
       });
       const workspaceStore = getWorkspaceStore();
-      launchWorkspaceGroup({
-        groupName: 'ward-patient-sidebar',
+      launchWorkspaceGroup('ward-patient-sidebar', {
         state: {
           foo: true,
         },
@@ -700,8 +694,7 @@ describe('workspace system', () => {
         moduleName: '@openmrs/esm-ward-app',
         workspaceGroups: ['ward-patient-sidebar'],
       });
-      launchWorkspaceGroup({
-        groupName: 'ward-patient-sidebar',
+      launchWorkspaceGroup('ward-patient-sidebar', {
         state: { foo: true },
         onWorkspaceGroupLaunch: () => {
           launchWorkspace('ward-patient-workspace');

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -506,8 +506,6 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        // hasOwnSidebar: true,
-        // sidebarFamily: 'ward-patient-sidebar',
       });
       launchWorkspace('ward-patient-workspace', {
         foo: true,
@@ -528,8 +526,6 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        // hasOwnSidebar: true,
-        // sidebarFamily,
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -537,8 +533,6 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        // hasOwnSidebar: true,
-        // sidebarFamily,
       });
       const workspaceStore = getWorkspaceStore();
       launchWorkspace('ward-patient-workspace', {
@@ -562,8 +556,6 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        // hasOwnSidebar: true,
-        // sidebarFamily: 'ward-patient-sidebar',
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -571,8 +563,6 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        // hasOwnSidebar: true,
-        // sidebarFamily: 'another-sidebar-family',
       });
       const workspaceStore = getWorkspaceStore();
       launchWorkspace('ward-patient-workspace', {
@@ -597,8 +587,6 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        // hasOwnSidebar: true,
-        // sidebarFamily: 'ward-patient-sidebar',
         canHide: true,
       });
       registerWorkspace({
@@ -607,8 +595,6 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        // hasOwnSidebar: true,
-        // sidebarFamily: 'another-sidebar-family',
       });
       const workspaceStore = getWorkspaceStore();
       launchWorkspace('ward-patient-workspace', {
@@ -632,8 +618,6 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        // hasOwnSidebar: true,
-        // sidebarFamily: 'ward-patient-sidebar',
         canHide: true,
       });
       registerWorkspace({
@@ -642,8 +626,6 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        // hasOwnSidebar: true,
-        // sidebarFamily: 'ward-patient-sidebar',
       });
       const workspaceStore = getWorkspaceStore();
       launchWorkspace('ward-patient-workspace', {
@@ -666,8 +648,6 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        // hasOwnSidebar: true,
-        // sidebarFamily: 'ward-patient-sidebar',
       });
       launchWorkspace('ward-patient-workspace', {
         foo: true,

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -26,7 +26,7 @@ export interface CloseWorkspaceOptions {
   /**
    * Controls whether the workspace group should be closed and store to be
    * cleared when this workspace is closed.
-   * Defaults to true except when opening a new workspace of the same family.
+   * Defaults to true except when opening a new workspace of the same group.
    *
    * @default true
    */
@@ -177,6 +177,10 @@ interface LaunchWorkspaceGroupArg {
   state: object;
   onWorkspaceGroupLaunch?: Function;
   workspaceGroupCleanup?: Function;
+  workspaceToLaunch?: {
+    name: string;
+    additionalProps?: object;
+  };
 }
 
 /**
@@ -197,7 +201,7 @@ interface LaunchWorkspaceGroupArg {
  * });
  */
 export function launchWorkspaceGroup(groupName: string, args: LaunchWorkspaceGroupArg) {
-  const { state, onWorkspaceGroupLaunch, workspaceGroupCleanup } = args;
+  const { state, onWorkspaceGroupLaunch, workspaceGroupCleanup, workspaceToLaunch } = args;
   const store = getWorkspaceStore();
   if (store.getState().openWorkspaces.length) {
     const workspaceGroup = store.getState().workspaceGroup;
@@ -220,6 +224,9 @@ export function launchWorkspaceGroup(groupName: string, args: LaunchWorkspaceGro
     }));
     getWorkspaceGroupStore(groupName, state);
     onWorkspaceGroupLaunch?.();
+    if (workspaceToLaunch) {
+      launchWorkspace(workspaceToLaunch?.name, workspaceToLaunch?.additionalProps ?? {});
+    }
   }
 }
 
@@ -284,7 +291,7 @@ export function launchWorkspace<
   const workspace = getWorkspaceRegistration(name);
   const currentWorkspaceGroup = store.getState().workspaceGroup;
 
-  if (currentWorkspaceGroup && !workspace.workspaceGroups?.includes(currentWorkspaceGroup?.name)) {
+  if (currentWorkspaceGroup && !workspace.groups?.includes(currentWorkspaceGroup?.name)) {
     closeWorkspaceGroup(currentWorkspaceGroup?.name, () => {
       launchWorkspace(name, additionalProps);
     });

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -258,6 +258,7 @@ export function launchWorkspace<
     });
     return;
   }
+  const currentGroupName = store.getState().workspaceGroup?.name;
   const newWorkspace: OpenWorkspace = {
     ...workspace,
     title: getWorkspaceTitle(workspace, additionalProps),
@@ -276,10 +277,13 @@ export function launchWorkspace<
         };
       });
     },
-    currentWorkspaceGroup: store.getState().workspaceGroup?.name,
+    currentWorkspaceGroup: currentGroupName,
     additionalProps: additionalProps ?? {},
   };
 
+  if (currentGroupName) {
+    getWorkspaceFamilyStore(currentGroupName, additionalProps);
+  }
   function updateStoreWithNewWorkspace(workspaceToBeAdded: OpenWorkspace, restOfTheWorkspaces?: Array<OpenWorkspace>) {
     store.setState((state) => {
       const openWorkspaces = [workspaceToBeAdded, ...(restOfTheWorkspaces ?? state.openWorkspaces)];

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -153,10 +153,10 @@ function closeWorkspaceGroup(groupName: string, onWorkspaceCloseup?: Function) {
 
   closeAllWorkspaces(() => {
     // Clearing the workspace group and respective store if the new workspace is not part of the current group, which is handled in the `launchWorkspace` function.
-    const workspaceFamilyStore = getWorkspaceGroupStore(groupName);
-    if (workspaceFamilyStore) {
-      workspaceFamilyStore.setState({}, true);
-      const unsubscribe = workspaceFamilyStore.subscribe(() => {});
+    const workspaceGroupStore = getWorkspaceGroupStore(groupName);
+    if (workspaceGroupStore) {
+      workspaceGroupStore.setState({}, true);
+      const unsubscribe = workspaceGroupStore.subscribe(() => {});
       unsubscribe?.();
     }
     if (currentWorkspaceGroup && typeof currentWorkspaceGroup?.cleanup === 'function') {
@@ -243,7 +243,7 @@ function promptBeforeLaunchingWorkspace(
       // Calling the launchWorkspace again, since one of the `if` case
       // might resolve, but we need to check all the cases before launching the form.
       onWorkspaceClose: () => launchWorkspace(name, additionalProps),
-      // If the new workspace is of the same sidebar family, then we don't need to clear the workspace family store.
+      // If the new workspace is of the same sidebar group, then we don't need to clear the workspace group store.
       closeWorkspaceGroup: false,
     });
   };

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -100,6 +100,7 @@ export interface WorkspaceStoreState {
   openWorkspaces: Array<OpenWorkspace>;
   prompt: Prompt | null;
   workspaceWindowState: WorkspaceWindowState;
+  currentContainerName?: string;
 }
 
 export interface OpenWorkspace extends WorkspaceRegistration, DefaultWorkspaceProps {
@@ -183,6 +184,14 @@ export function launchWorkspace<
   workspaceContainerName?: string,
 ) {
   const store = getWorkspaceStore();
+
+  if (workspaceContainerName) {
+    store.setState((prev) => ({
+      ...prev,
+      currentContainerName: workspaceContainerName,
+    }));
+  }
+
   const workspace = getWorkspaceRegistration(name);
   const newWorkspace: OpenWorkspace = {
     ...workspace,
@@ -202,7 +211,7 @@ export function launchWorkspace<
         };
       });
     },
-    workspaceContainerName,
+    workspaceContainerName: workspaceContainerName || store.getState().currentContainerName,
     additionalProps: additionalProps ?? {},
   };
 
@@ -378,6 +387,7 @@ const initialState: WorkspaceStoreState = {
   openWorkspaces: [],
   prompt: null,
   workspaceWindowState: 'normal',
+  currentContainerName: '',
 };
 
 export const workspaceStore = createGlobalStore('workspace', initialState);

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -158,24 +158,23 @@ function closeWorkspaceGroup(groupName: string, onWorkspaceCloseup?: Function) {
 }
 
 interface LaunchWorkspaceGroupArg {
-  groupName: string;
   state: object;
   onWorkspaceGroupLaunch?: Function;
   workspaceGroupCleanup?: Function;
 }
 
-export function launchWorkspaceGroup(args: LaunchWorkspaceGroupArg) {
-  const { groupName, state, onWorkspaceGroupLaunch, workspaceGroupCleanup } = args;
+export function launchWorkspaceGroup(groupName: string, args: LaunchWorkspaceGroupArg) {
+  const { state, onWorkspaceGroupLaunch, workspaceGroupCleanup } = args;
   const store = getWorkspaceStore();
   if (store.getState().openWorkspaces.length) {
     const workspaceGroup = store.getState().workspaceGroup;
     if (workspaceGroup) {
       closeWorkspaceGroup(workspaceGroup?.name, () => {
-        launchWorkspaceGroup(args);
+        launchWorkspaceGroup(groupName, args);
       });
     } else {
       closeAllWorkspaces(() => {
-        launchWorkspaceGroup(args);
+        launchWorkspaceGroup(groupName, args);
       });
     }
   } else {

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -23,7 +23,7 @@ const { ModuleFederationPlugin } = container;
 const openmrsAddCookie = process.env.OMRS_ADD_COOKIE;
 const openmrsApiUrl = removeTrailingSlash(process.env.OMRS_API_URL || '/openmrs');
 const openmrsPublicPath = removeTrailingSlash(process.env.OMRS_PUBLIC_PATH || '/openmrs/spa');
-const openmrsProxyTarget = process.env.OMRS_PROXY_TARGET || 'https://kgh-test.pih-emr.org/';
+const openmrsProxyTarget = process.env.OMRS_PROXY_TARGET || 'https://dev3.openmrs.org/';
 const openmrsPageTitle = process.env.OMRS_PAGE_TITLE || 'OpenMRS';
 const openmrsFavicon = process.env.OMRS_FAVICON || `${openmrsPublicPath}/favicon.ico`;
 const openmrsEnvironment = process.env.OMRS_ENV || process.env.NODE_ENV || '';
@@ -34,7 +34,7 @@ const openmrsImportmapUrl = process.env.OMRS_ESM_IMPORTMAP_URL || `${openmrsPubl
 const openmrsRoutesDef = process.env.OMRS_ROUTES;
 const openmrsRoutesUrl = process.env.OMRS_ROUTES_URL || `${openmrsPublicPath}/routes.registry.json`;
 const openmrsCoreApps = process.env.OMRS_ESM_CORE_APPS_DIR || resolve(__dirname, '../../apps');
-const openmrsConfigUrls = (process.env.OMRS_CONFIG_URLS || '/openmrs/spa/site/config.json')
+const openmrsConfigUrls = (process.env.OMRS_CONFIG_URLS || '')
   .split(';')
   .filter((url) => url.length > 0)
   .map((url) => JSON.stringify(url))

--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -23,7 +23,7 @@ const { ModuleFederationPlugin } = container;
 const openmrsAddCookie = process.env.OMRS_ADD_COOKIE;
 const openmrsApiUrl = removeTrailingSlash(process.env.OMRS_API_URL || '/openmrs');
 const openmrsPublicPath = removeTrailingSlash(process.env.OMRS_PUBLIC_PATH || '/openmrs/spa');
-const openmrsProxyTarget = process.env.OMRS_PROXY_TARGET || 'https://dev3.openmrs.org/';
+const openmrsProxyTarget = process.env.OMRS_PROXY_TARGET || 'https://kgh-test.pih-emr.org/';
 const openmrsPageTitle = process.env.OMRS_PAGE_TITLE || 'OpenMRS';
 const openmrsFavicon = process.env.OMRS_FAVICON || `${openmrsPublicPath}/favicon.ico`;
 const openmrsEnvironment = process.env.OMRS_ENV || process.env.NODE_ENV || '';
@@ -34,7 +34,7 @@ const openmrsImportmapUrl = process.env.OMRS_ESM_IMPORTMAP_URL || `${openmrsPubl
 const openmrsRoutesDef = process.env.OMRS_ROUTES;
 const openmrsRoutesUrl = process.env.OMRS_ROUTES_URL || `${openmrsPublicPath}/routes.registry.json`;
 const openmrsCoreApps = process.env.OMRS_ESM_CORE_APPS_DIR || resolve(__dirname, '../../apps');
-const openmrsConfigUrls = (process.env.OMRS_CONFIG_URLS || '')
+const openmrsConfigUrls = (process.env.OMRS_CONFIG_URLS || '/openmrs/spa/site/config.json')
   .split(';')
   .filter((url) => url.length > 0)
   .map((url) => JSON.stringify(url))


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Currently, for the related workspaces (current implementation: patient dashboard workspace in the Ward View), the sidebar family (group of workspaces is termed as a family) is defined in the workspace registration using 2 properties `hasSidebar` and `sidebarFamily`.

@brandones suggests that we can move this handling to the `WorkspaceContainer`, and handling of workspace group should be independent to the workspace implementation.

## New implementation

### Workspace group (rename of the workspace family)
Workspace group refers to the workspaces with a sidebar and shares some common state among different workspaces.

### Launching workspace group
Workspace group should be launched with `launchWorkspaceGroup` and we can pass state, as well as a callback when workspace is launched and a cleanup function when the workspace group closes.

### Supported group for a workspace
A new property `workspaceGroups` is defined in the workspace registration, to validate if a workspace launched is a part of the currently opened workspace group and if not, the current workspace group will be closed and then the workspace will be launched.

### Example
```
<button
        className={styles.wardPatientCardButton}
        onClick={() => {
          launchWorkspaceGroup('ward-patient', {
            state: {
              wardPatient,
              WardPatientHeader,
            },
            onWorkspaceGroupLaunch: () => {
              const store = getPatientChartStore();
              store.setState({
                patientUuid: patient.uuid,
              });
              launchWorkspace<PatientWorkspaceAdditionalProps>('patient-transfer-swap-workspace');
            },
            workspaceGroupCleanup: () => {
              const store = getPatientChartStore();
              store.setState({
                patientUuid: undefined,
              });
            },
          });
        }}>
        {getPatientName(patient.person)}
      </button>
```

## Screenshots
None

## Related Issue
https://issues.openmrs.org/browse/O3-4077

## Other
<!-- Anything not covered above -->
