### PR TITLE
(fix) O3-4135 - Disable help icon while user is logged out

### DIFF
--- a/packages/apps/esm-help-menu-app/src/help-menu/help.component.tsx
+++ b/packages/apps/esm-help-menu-app/src/help-menu/help.component.tsx
@@ -1,10 +1,12 @@
 import React, { useState, useEffect, useRef } from 'react';
 import classNames from 'classnames';
 import { Help } from '@carbon/react/icons';
+import { useSession } from '@openmrs/esm-framework'
 import HelpMenuPopup from './help-popup.component';
 import styles from './help.styles.scss';
 
 export default function HelpMenu() {
+  const { user } = useSession();
   const [helpMenuOpen, setHelpMenuOpen] = useState(false);
   const helpMenuButtonRef = useRef(null);
   const popupRef = useRef(null);
@@ -35,15 +37,17 @@ export default function HelpMenu() {
 
   return (
     <>
-      <button
-        aria-expanded={helpMenuOpen}
-        aria-controls="help-menu-popup"
-        onClick={toggleHelpMenu}
-        ref={helpMenuButtonRef}
-        className={classNames(styles.helpMenuButton)}
-      >
-        <Help size={24} />
-      </button>
+      {user && (
+        <button
+          aria-expanded={helpMenuOpen}
+          aria-controls="help-menu-popup"
+          onClick={toggleHelpMenu}
+          ref={helpMenuButtonRef}
+          className={classNames(styles.helpMenuButton)}
+        >
+          <Help size={24} />
+        </button>
+      )}
       {helpMenuOpen && (
         <div id="help-menu-popup" ref={popupRef} className={styles.helpMenuPopup}>
           <HelpMenuPopup />


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
The help icon (menu) appears even when the user is not logged In, I have made use of the useSession to check whether the user is authenticated or not then display the help icon.
The context of why am doing this is [here](https://openmrs.slack.com/archives/CKS32D55G/p1727938916121129)

## Screenshots
[Screencast from 28-10-24 16:19:09.webm](https://github.com/user-attachments/assets/a76d6ea5-4878-41bd-8e2f-a96f5e58e53b)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
[<!-- https://issues.openmrs.org/browse/O3- -->](https://openmrs.atlassian.net/browse/O3-4135)

## Other
<!-- Anything not covered above -->
