### PR TITLE
(fix) O3-4134: Translation overrides not being overridden correctly

### DIFF
--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -42,7 +42,7 @@ export function setupI18n() {
             import(/* webpackMode: "lazy" */ `@openmrs/esm-translations/translations/${language}.json`),
             getTranslationOverrides(namespace),
           ])
-            .then(([json, overrides]) => {
+            .then(([json, [overrides]]) => {
               let translations = json?.default ?? {};
 
               if (language in overrides) {
@@ -80,10 +80,7 @@ export function setupI18n() {
                 }
               }
 
-              translations = merge(
-                translations,
-                overrides.filter((o) => language in o).map((o) => o[language]),
-              );
+              translations = merge(translations, ...overrides.filter((o) => language in o).map((o) => o[language]));
 
               callback(null, translations);
             })


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This fixes an issue inadvertently introduced with #1119, where the results from `getTranslationOverrides()` are not properly handled (the results are always arrays of at least one empty object).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
 https://issues.openmrs.org/browse/O3-4134

## Other
<!-- Anything not covered above -->
Not sure how I missed this. Adding tests for the locale system is on the TODO list.
