### PR TITLE
(fix) Add translation override for district address field

### DIFF
--- a/packages/framework/esm-translations/src/translations.ts
+++ b/packages/framework/esm-translations/src/translations.ts
@@ -11,6 +11,7 @@ const addressFields = {
   cityVillage: 'City',
   country: 'Country',
   countyDistrict: 'District',
+  district: 'District',
   postalCode: 'Postal code',
   state: 'State',
   stateProvince: 'State',


### PR DESCRIPTION
# Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Since patient fhir object returns district for the address field, it is necessary that we add this to our translations to make it possible to override such.
![Screenshot from 2024-10-28 22-28-46](https://github.com/user-attachments/assets/3fe9f36d-d387-4b03-ba2d-50111fd7aef6)


## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
