### PR TITLE
(feat) Allow passing action menu state to the workspace container

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -5832,7 +5832,7 @@ This component also provides everything needed for workspace notifications to be
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:67](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L67)
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:68](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L68)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceContainerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceContainerProps.md
@@ -6,12 +6,23 @@
 
 ### Properties
 
+- [actionMenuProps](WorkspaceContainerProps.md#actionmenuprops)
 - [additionalWorkspaceProps](WorkspaceContainerProps.md#additionalworkspaceprops)
 - [contextKey](WorkspaceContainerProps.md#contextkey)
 - [overlay](WorkspaceContainerProps.md#overlay)
 - [showSiderailAndBottomNav](WorkspaceContainerProps.md#showsiderailandbottomnav)
 
 ## Properties
+
+### actionMenuProps
+
+• `Optional` **actionMenuProps**: `Record`<`string`, `unknown`\>
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx#L20)
+
+___
 
 ### additionalWorkspaceProps
 

--- a/packages/framework/esm-styleguide/src/workspaces/container/action-menu.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/action-menu.component.tsx
@@ -7,9 +7,10 @@ import styles from './action-menu.module.scss';
 export interface ActionMenuProps {
   isWithinWorkspace?: boolean;
   name?: string;
+  actionMenuProps?: Record<string, unknown>;
 }
 
-export function ActionMenu({ isWithinWorkspace, name }: ActionMenuProps) {
+export function ActionMenu({ isWithinWorkspace, name, actionMenuProps = {} }: ActionMenuProps) {
   const [keyboardVisible, setKeyboardVisible] = useState(false);
   const initialHeight = useRef(window.innerHeight);
   const { featureName } = useContext(ComponentContext);
@@ -37,7 +38,7 @@ export function ActionMenu({ isWithinWorkspace, name }: ActionMenuProps) {
       })}
     >
       <div className={styles.container}>
-        <ExtensionSlot className={styles.chartExtensions} name={extensionSlotName} />
+        <ExtensionSlot className={styles.chartExtensions} name={extensionSlotName} state={actionMenuProps} />
       </div>
     </aside>
   );

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
@@ -17,6 +17,7 @@ export interface WorkspaceContainerProps {
   overlay?: boolean;
   showSiderailAndBottomNav?: boolean;
   additionalWorkspaceProps?: object;
+  actionMenuProps?: Record<string, unknown>;
 }
 
 /**
@@ -69,6 +70,7 @@ export function WorkspaceContainer({
   overlay,
   showSiderailAndBottomNav,
   additionalWorkspaceProps,
+  actionMenuProps,
 }: WorkspaceContainerProps) {
   const layout = useLayoutType();
   const { workspaces, workspaceWindowState } = useWorkspaces();
@@ -118,7 +120,7 @@ export function WorkspaceContainer({
         </aside>
         <WorkspaceNotification contextKey={contextKey} />
       </div>
-      {showSiderailAndBottomNav && <ActionMenu />}
+      {showSiderailAndBottomNav && <ActionMenu actionMenuProps={actionMenuProps} />}
     </>
   );
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR will allow passing the state into the Workspace Action menu buttons via the workspace container, mainly to be used inside the Patient Chart to pass the `patientUuid` via the root component in the patient chart.

This PR is required for https://github.com/openmrs/openmrs-esm-patient-chart/pull/2080

## Screenshots
None

## Related Issue
None

## Other
<!-- Anything not covered above -->
