### PR TITLE
(feat) O3-4196: Improve Optional Backend Dependencies functionality

### DIFF
--- a/packages/shell/esm-app-shell/src/optionaldeps.ts
+++ b/packages/shell/esm-app-shell/src/optionaldeps.ts
@@ -56,7 +56,10 @@ function setupOptionalDependencies() {
         (response.data.results ?? []).forEach((backendModule) => {
           if (optionalDependencyFlags.has(backendModule.uuid)) {
             const optionalDependency = optionalDependencyFlags.get(backendModule.uuid);
-            if (optionalDependency && satisfies(backendModule.version, optionalDependency.version)) {
+            if (
+              optionalDependency &&
+              satisfies(backendModule.version, optionalDependency.version, { includePrerelease: true })
+            ) {
               registerFeatureFlag(
                 optionalDependency.feature.flagName,
                 optionalDependency.feature.label,


### PR DESCRIPTION
# Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

The semvar library that we use only considers prerelease versions “in-range” within certain conditions (see [npm: semver](https://www.npmjs.com/package/semver) )… in this use case, I think we almost always want any “SNAPSHOT” versions above the dependency version to be considered within range; per the documentation above this  is easily doable via setting the “includePrerelease" flag

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://openmrs.atlassian.net/browse/O3-4196

## Other
<!-- Anything not covered above -->
