### PR TITLE
(fix) Fix change password modal

### DIFF
--- a/packages/apps/esm-login-app/src/change-password/change-password.component.tsx
+++ b/packages/apps/esm-login-app/src/change-password/change-password.component.tsx
@@ -44,29 +44,32 @@ const ChangePassword: React.FC = () => {
     resolver: zodResolver(changePasswordFormSchema),
   });
 
-  const onSubmit: SubmitHandler<z.infer<typeof changePasswordFormSchema>> = useCallback((data) => {
-    setIsChangingPassword(true);
+  const onSubmit: SubmitHandler<z.infer<typeof changePasswordFormSchema>> = useCallback(
+    (data) => {
+      setIsChangingPassword(true);
 
-    const { oldPassword, newPassword } = data;
+      const { oldPassword, newPassword } = data;
 
-    changeUserPassword(oldPassword, newPassword)
-      .then(() => {
-        showSnackbar({
-          title: t('passwordChangedSuccessfully', 'Password changed successfully'),
-          kind: 'success',
+      changeUserPassword(oldPassword, newPassword)
+        .then(() => {
+          showSnackbar({
+            title: t('passwordChangedSuccessfully', 'Password changed successfully'),
+            kind: 'success',
+          });
+        })
+        .catch((error) => {
+          showSnackbar({
+            kind: 'error',
+            subtitle: error?.message,
+            title: t('errorChangingPassword', 'Error changing password'),
+          });
+        })
+        .finally(() => {
+          setIsChangingPassword(false);
         });
-      })
-      .catch((error) => {
-        showSnackbar({
-          kind: 'error',
-          subtitle: error?.message,
-          title: t('errorChangingPassword', 'Error changing password'),
-        });
-      })
-      .finally(() => {
-        setIsChangingPassword(false);
-      });
-  }, []);
+    },
+    [t],
+  );
 
   const onError = useCallback(() => setIsChangingPassword(false), []);
 
@@ -121,7 +124,7 @@ const ChangePassword: React.FC = () => {
           />
           <Button className={styles.submitButton} disabled={isChangingPassword} type="submit">
             {isChangingPassword ? (
-              <InlineLoading description={t('changingLanguage', 'Changing password') + '...'} />
+              <InlineLoading description={t('changingPassword', 'Changing password') + '...'} />
             ) : (
               <span>{t('change', 'Change Password')}</span>
             )}

--- a/packages/apps/esm-login-app/src/change-password/change-password.test.tsx
+++ b/packages/apps/esm-login-app/src/change-password/change-password.test.tsx
@@ -1,50 +1,51 @@
 import React from 'react';
 import userEvent from '@testing-library/user-event';
 import { render, screen } from '@testing-library/react';
-import ChangePasswordModal from './change-password.modal';
 import { changeUserPassword } from './change-password.resource';
+import ChangePasswordModal from './change-password.modal';
+
+const mockClose = jest.fn();
+const mockChangeUserPassword = jest.mocked(changeUserPassword);
 
 jest.mock('./change-password.resource', () => ({
   changeUserPassword: jest.fn().mockResolvedValue({}),
 }));
 
-const mockClose = jest.fn();
-const mockChangeUserPassword = changeUserPassword as jest.Mock;
-
 describe('ChangePasswordModal', () => {
-  beforeEach(() => {
-    render(<ChangePasswordModal close={mockClose} />);
-  });
-
   it('validates the form before submitting', async () => {
+    const user = userEvent.setup();
+
+    render(<ChangePasswordModal close={mockClose} />);
+
     const submitButton = screen.getByRole('button', {
       name: /change/i,
     });
+
     const oldPasswordInput = screen.getByLabelText(/old password/i);
     const newPasswordInput = screen.getByLabelText(/^new password$/i);
     const confirmPasswordInput = screen.getByLabelText(/confirm new password/i);
 
-    expect(screen.getByRole('heading', { name: /Change password/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /change password/i })).toBeInTheDocument();
     expect(oldPasswordInput).toBeInTheDocument();
     expect(newPasswordInput).toBeInTheDocument();
     expect(confirmPasswordInput).toBeInTheDocument();
 
-    await userEvent.click(submitButton);
+    await user.click(submitButton);
 
     expect(screen.getByText(/old password is required/i)).toBeInTheDocument();
     expect(screen.getByText(/new password is required/i)).toBeInTheDocument();
     expect(screen.getByText(/password confirmation is required/i)).toBeInTheDocument();
 
-    await userEvent.type(oldPasswordInput, 'P@ssw0rd123!');
-    await userEvent.type(newPasswordInput, 'N3wP@ssw0rd456!');
-    await userEvent.type(confirmPasswordInput, 'N3wP@ssw0rd456');
+    await user.type(oldPasswordInput, 'P@ssw0rd123!');
+    await user.type(newPasswordInput, 'N3wP@ssw0rd456!');
+    await user.type(confirmPasswordInput, 'N3wP@ssw0rd456');
 
     expect(screen.getByText(/passwords do not match/i)).toBeInTheDocument();
 
-    await userEvent.clear(confirmPasswordInput);
-    await userEvent.type(confirmPasswordInput, 'N3wP@ssw0rd456!');
+    await user.clear(confirmPasswordInput);
+    await user.type(confirmPasswordInput, 'N3wP@ssw0rd456!');
 
-    await userEvent.click(submitButton);
+    await user.click(submitButton);
 
     expect(mockChangeUserPassword).toHaveBeenCalledTimes(1);
     expect(mockChangeUserPassword).toHaveBeenCalledWith('P@ssw0rd123!', 'N3wP@ssw0rd456!');

--- a/packages/apps/esm-login-app/translations/en.json
+++ b/packages/apps/esm-login-app/translations/en.json
@@ -4,7 +4,7 @@
   "cancel": "Cancel",
   "change": "Change",
   "changePassword": "Change password",
-  "changingLanguage": "Changing password",
+  "changingPassword": "Changing password",
   "confirmPassword": "Confirm new password",
   "continue": "Continue",
   "errorChangingPassword": "Error changing password",


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR fixes the change password modal as follows:

- Adds default values to the change password form schema - this is to prevent the form from being empty when the user clicks on the change password button.
- Adds min validation to the old password, new password and password confirmation fields to ensure that the user has entered a value.
- Adds the appropriate dependencies to the submit handler useCallback hook.
- Surfaces the error message returned from the change password API.
- Showing an inline error notification in the modal instead of a snackbar.
- Fixes a translation key/value pair.

## Screenshots

### Surfacing error messages from the Password resource

![CleanShot 2024-11-20 at 4  10 10@2x](https://github.com/user-attachments/assets/1bb145ec-f2b9-4170-b3b8-038dfbbf2a68)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
