### PR TITLE
(feat) O3-4215: Enable Environment Specification for Shell Builds

### DIFF
--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -234,6 +234,11 @@ yargs.command(
         describe:
           "The locale to use as a default for this build of the app shell. Should be a value that's valid to use in an HTML lang attribute, e.g., en or en_GB.",
         type: 'string',
+      })
+      .option('env', {
+        default: 'production',
+        describe: 'The environment to build for. e.g., development, production.',
+        type: 'string',
       }),
   async (args) =>
     runCommand('runBuild', {

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -21,6 +21,7 @@ export interface BuildArgs {
   configUrls: Array<string>;
   configPaths: Array<string>;
   buildConfig?: string;
+  env: string;
 }
 
 export type BuildConfig = Partial<{
@@ -108,7 +109,7 @@ export async function runBuild(args: BuildArgs) {
   const config = loadWebpackConfig({
     importmap: importMap,
     routes,
-    env: 'production',
+    env: args.env,
     apiUrl: buildConfig.apiUrl || args.apiUrl,
     configUrls: configUrls,
     defaultLocale: args.defaultLocale || buildConfig.defaultLocale,

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -34,6 +34,7 @@ export type BuildConfig = Partial<{
   importmap: string;
   routes: string;
   spaPath: string;
+  env: string;
 }>;
 
 function loadBuildConfig(buildConfigPath?: string): BuildConfig {
@@ -109,7 +110,7 @@ export async function runBuild(args: BuildArgs) {
   const config = loadWebpackConfig({
     importmap: importMap,
     routes,
-    env: args.env,
+    env: buildConfig.env || args.env,
     apiUrl: buildConfig.apiUrl || args.apiUrl,
     configUrls: configUrls,
     defaultLocale: args.defaultLocale || buildConfig.defaultLocale,


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR introduces the ability to specify the build environment using the --env argument. By default, the environment is set to production if no argument is provided.

Motivation:
The esm-tutorials app requires tutorials to be enabled by default in the development environment while remaining disabled (or enabled by config) in production. This change makes it easier to handle such environment-specific configurations.


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-4215
