### PR TITLE
(fix) Correct Typo in Openmrs Component Decorator For Strict Mode

### DIFF
--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.test.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.test.tsx
@@ -36,7 +36,7 @@ describe('openmrs-component-decorator', () => {
     render(<DecoratedComp />);
   });
 
-  it("rendering a unsafe component is strict mode should log error in console",()=>{
+  it("rendering a unsafe component in strict mode should log error in console",()=>{
     const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
       const UnsafeDecoratedCompnent = openmrsComponentDecorator(opts)(UnsafeComponent);
       render(<UnsafeDecoratedCompnent/>);

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.test.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.test.tsx
@@ -70,10 +70,9 @@ function CompWithConfig() {
 class UnsafeComponent extends Component<any,any> {
   
   UNSAFE_componentWillMount() { 
-  
-  } 
+   } 
 
  render() { 
    return <h1>This is Unsafe Component</h1>; 
  } 
-};
+}

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.test.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import React, { Component } from 'react';
+import { render, screen, waitFor} from '@testing-library/react';
 import { openmrsComponentDecorator } from './openmrsComponentDecorator';
 import { ComponentContext } from './ComponentContext';
 
@@ -35,6 +35,22 @@ describe('openmrs-component-decorator', () => {
     const DecoratedComp = openmrsComponentDecorator(opts)(CompWithConfig);
     render(<DecoratedComp />);
   });
+
+  it("rendering a unsafe component is strict mode should log error in console",()=>{
+    const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      const UnsafeDecoratedCompnent = openmrsComponentDecorator(opts)(UnsafeComponent);
+      render(<UnsafeDecoratedCompnent/>);
+      expect(consoleError.mock.calls[0][0]).toContain('Warning: Using UNSAFE_componentWillMount');
+      consoleError.mockRestore();
+  })
+
+  it("rendering an unsafe component without strict mode should not log an error in console",()=>{
+      const spy = jest.spyOn(console, "error");
+      const unsafeComponentOptions=Object.assign(opts,{strictMode:false})
+      const UnsafeDecoratedCompnent = openmrsComponentDecorator(unsafeComponentOptions)(UnsafeComponent);
+      render(<UnsafeDecoratedCompnent/>);
+      expect(spy).not.toHaveBeenCalled();
+  })
 });
 
 function CompThatWorks() {
@@ -49,3 +65,15 @@ function CompWithConfig() {
   const { moduleName } = React.useContext(ComponentContext);
   return <div>{moduleName}</div>;
 }
+
+
+class UnsafeComponent extends Component<any,any> {
+  
+  UNSAFE_componentWillMount() { 
+  
+  } 
+
+ render() { 
+   return <h1>This is Unsafe Component</h1>; 
+ } 
+};

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
@@ -120,8 +120,8 @@ export function openmrsComponentDecorator<T>(userOpts: ComponentDecoratorOptions
               </SWRConfig>
             </Suspense>
           );
-
-          if (opts.strictMode || !React.StrictMode) {
+          
+          if (!opts.strictMode || !React.StrictMode) {
             return content;
           } else {
             return <React.StrictMode>{content}</React.StrictMode>;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
 I am not sure if this is a typo, Please feel free to close the PR if its not . The default value for the strictMode is true. But in the if condition we don't render the component with the strictMode when its true. 




