### PR TITLE
(fix)  O3-4327:  Fix openmrsFetchAll calling url twice when more than 1 page is fetched

### DIFF
--- a/packages/framework/esm-react-utils/src/useOpenmrsFetchAll.ts
+++ b/packages/framework/esm-react-utils/src/useOpenmrsFetchAll.ts
@@ -50,13 +50,13 @@ export function useServerFetchAll<T, R>(
   options: UseServerFetchAllOptions<R> = {},
 ): UseServerInfiniteReturnObject<T, R> {
   const response = useServerInfinite<T, R>(url, serverPaginationHandlers, options);
-  const { hasMore, error, data, loadMore, isLoading } = response;
+  const { hasMore, error, data, loadMore, isLoading, nextUri } = response;
 
   useEffect(() => {
     if (hasMore && !error) {
       loadMore();
     }
-  }, [hasMore, data]);
+  }, [hasMore, nextUri]);
 
   if (options.partialData) {
     return response;

--- a/packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts
+++ b/packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts
@@ -70,6 +70,10 @@ export interface UseServerInfiniteReturnObject<T, R> {
    * from useSWRInfinite
    */
   isLoading: boolean;
+  /**
+   * from useSWRInfinite
+   */
+  nextUri: string | null;
 }
 
 /**
@@ -147,6 +151,7 @@ export function useServerInfinite<T, R>(
     totalCount,
     hasMore,
     loadMore,
+    nextUri,
     ...rest,
   };
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
When using `useOpenmrsFetchAll` hook, i observed that there were two requests being fetched for the same url when the pages are more than 1. 
I think the issue is because every time we are sending a new array of data like below every time the component is rendered   https://github.com/openmrs/openmrs-esm-core/blob/fb69d2dce21c94fcb2bff75d25f68caa3cd87ad4/packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts#L146 

We have two options here

#### Option 1 -> To use React Memo
We can wrap the data in react memo and return that one from `useServerInfinite` Hook. This will avoid an extra api call.
` const responseData=useMemo(()=>{
    return  data?.flatMap((d) => getData(d.data) as T[]);
   },[data])`

`  return {
    data: responseData,
    totalCount,
    hasMore,
    nextUri,
    loadMore,
    ...rest,
  };`

#### Option 2 -> To replace the depency in `useServerFetchAll` Hook

I think we can have nextUri as dependency instead of whole data array.if the nextUri is changed it means there is more data and we load more, on the flip side if the nextUri does not change, there is no more data and we reached the end 


I chose option2 here, because i feel its more performant than option1  where we compare the whole data array.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/75059dc5-872b-483a-bfe0-6058fa9951cf


## Related Issue
https://openmrs.atlassian.net/browse/O3-4237

## Other
<!-- Anything not covered above -->
