### PR TITLE
(chore) Add missing translations for header menu tooltips

### DIFF
--- a/packages/apps/esm-implementer-tools-app/package.json
+++ b/packages/apps/esm-implementer-tools-app/package.json
@@ -17,7 +17,7 @@
     "analyze": "webpack --mode=production --env analyze=true",
     "typescript": "tsc",
     "lint": "eslint src --ext ts,tsx",
-    "extract-translations": "i18next 'src/**/*.component.tsx' 'src/**/*.extension.tsx' 'src/**/*.modal.tsx' --config='../../../tools/i18next-parser.config.js'"
+    "extract-translations": "i18next 'src/**/*.component.tsx' 'src/**/*.button.tsx' 'src/**/*.extension.tsx' 'src/**/*.modal.tsx' --config='../../../tools/i18next-parser.config.js'"
   },
   "keywords": [
     "openmrs",

--- a/packages/apps/esm-implementer-tools-app/translations/en.json
+++ b/packages/apps/esm-implementer-tools-app/translations/en.json
@@ -14,6 +14,7 @@
   "featureFlag": "Feature flag",
   "featureFlags": "Feature flags",
   "frontendModules": "Frontend modules",
+  "implementerTools": "Implementer Tools",
   "installedVersion": "Installed version",
   "itemDescriptionSourceDefaultText": "The current value is the default.",
   "jsonEditor": "JSON editor",

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -97,7 +97,7 @@ const HeaderItems: React.FC = () => {
           )}
           {showAppMenu && (
             <HeaderGlobalAction
-              aria-label="App Menu"
+              aria-label={t('AppMenuTooltip', 'App Menu')}
               aria-labelledby="App Menu"
               className={classNames({
                 [styles.headerGlobalBarButton]: isActivePanel('appMenu'),

--- a/packages/apps/esm-primary-navigation-app/translations/en.json
+++ b/packages/apps/esm-primary-navigation-app/translations/en.json
@@ -1,4 +1,5 @@
 {
+  "AppMenuTooltip": "App Menu",
   "cancel": "Cancel",
   "change": "Change",
   "changeLanguage": "Change language",


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR adds missing translations for the `App menu` and `Implementer tools` tooltips in the global nav header.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
