### PR TITLE
(chore) Release v6.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-core",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "private": true,
   "workspaces": [
     "packages/apps/*",

--- a/packages/apps/esm-devtools-app/package.json
+++ b/packages/apps/esm-devtools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-devtools-app",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "Dev tools for frontend devs using OpenMRS",
   "browser": "dist/openmrs-esm-devtools-app.js",

--- a/packages/apps/esm-help-menu-app/package.json
+++ b/packages/apps/esm-help-menu-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-help-menu-app",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": " A microfrontend that provides a help menu for O3",
   "browser": "dist/openmrs-esm-help-menu-app.js",

--- a/packages/apps/esm-implementer-tools-app/package.json
+++ b/packages/apps/esm-implementer-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-implementer-tools-app",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "The admin interface for OpenMRS Frontend",
   "browser": "dist/openmrs-esm-implementer-tools-app.js",

--- a/packages/apps/esm-login-app/package.json
+++ b/packages/apps/esm-login-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-login-app",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "The login microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-login-app.js",

--- a/packages/apps/esm-offline-tools-app/package.json
+++ b/packages/apps/esm-offline-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline-tools-app",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "The offline tools microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-offline-tools-app.js",

--- a/packages/apps/esm-primary-navigation-app/package.json
+++ b/packages/apps/esm-primary-navigation-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-primary-navigation-app",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "Main navbar microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-primary-navigation-app.js",

--- a/packages/framework/esm-api/package.json
+++ b/packages/framework/esm-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-api",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "The javascript module for interacting with the OpenMRS API",
   "browser": "dist/openmrs-esm-api.js",

--- a/packages/framework/esm-config/package.json
+++ b/packages/framework/esm-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-config",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "A configuration library for the OpenMRS Single-Spa framework.",
   "browser": "dist/openmrs-esm-module-config.js",

--- a/packages/framework/esm-context/package.json
+++ b/packages/framework/esm-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-context",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "Utilities for managing the current execution context",
   "browser": "dist/openmrs-esm-context.js",

--- a/packages/framework/esm-dynamic-loading/package.json
+++ b/packages/framework/esm-dynamic-loading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-dynamic-loading",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "Utilities for dynamically loading code in OpenMRS",
   "browser": "dist/openmrs-esm-dynamic-loading.js",

--- a/packages/framework/esm-error-handling/package.json
+++ b/packages/framework/esm-error-handling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-error-handling",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "An ES module to help with error handling",
   "browser": "dist/openmrs-esm-error-handling.js",

--- a/packages/framework/esm-expression-evaluator/package.json
+++ b/packages/framework/esm-expression-evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-expression-evaluator",
-  "version": "5.7.3",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "Utilities for evaluating user-defined expressions",
   "browser": "dist/openmrs-esm-expression-evaluator.js",

--- a/packages/framework/esm-extensions/package.json
+++ b/packages/framework/esm-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-extensions",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "Coordinates extensions and extension points in the OpenMRS Frontend",
   "browser": "dist/openmrs-esm-extensions.js",

--- a/packages/framework/esm-feature-flags/package.json
+++ b/packages/framework/esm-feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-feature-flags",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "A feature flag system for the OpenMRS Single-Spa framework.",
   "browser": "dist/openmrs-esm-feature-flags.js",

--- a/packages/framework/esm-framework/package.json
+++ b/packages/framework/esm-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-framework",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "browser": "dist/openmrs-esm-framework.js",
   "main": "src/index.ts",

--- a/packages/framework/esm-globals/package.json
+++ b/packages/framework/esm-globals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-globals",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "browser": "dist/openmrs-esm-globals.js",
   "main": "src/index.ts",

--- a/packages/framework/esm-navigation/package.json
+++ b/packages/framework/esm-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-navigation",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "OpenMRS library providing tools for breadcrumbs, navigation, and history.",
   "browser": "dist/openmrs-esm-navigation.js",

--- a/packages/framework/esm-offline/package.json
+++ b/packages/framework/esm-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "browser": "dist/openmrs-esm-offline.js",

--- a/packages/framework/esm-react-utils/package.json
+++ b/packages/framework/esm-react-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-react-utils",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "React utilities for OpenMRS.",
   "browser": "dist/openmrs-esm-react-utils.js",

--- a/packages/framework/esm-routes/package.json
+++ b/packages/framework/esm-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-routes",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "Utilities for working with the routes registry",
   "browser": "dist/openmrs-esm-routes.js",

--- a/packages/framework/esm-state/package.json
+++ b/packages/framework/esm-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-state",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "Frontend stores & state management for OpenMRS",
   "browser": "dist/openmrs-esm-state.js",

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-styleguide",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "The styleguide for OpenMRS SPA",
   "browser": "dist/openmrs-esm-styleguide.js",

--- a/packages/framework/esm-translations/package.json
+++ b/packages/framework/esm-translations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-translations",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "O3 Framework module for translation support",
   "browser": "dist/openmrs-esm-translations.js",

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-utils",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "browser": "dist/openmrs-esm-utils.js",

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-app-shell",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "main": "dist/openmrs.js",
   "scripts": {

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmrs",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "main": "dist/index.js",
   "bin": "./dist/cli.js",

--- a/packages/tooling/webpack-config/package.json
+++ b/packages/tooling/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/webpack-config",
-  "version": "5.8.1",
+  "version": "6.0.0",
   "license": "MPL-2.0",
   "main": "dist/index.js",
   "types": "src/index.ts",


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Cuts a new major release of Core, `v6.0.0`, with breaking changes, new features, and bug fixes. Here's the draft changelog:

### Breaking changes

* (BREAKING) Retire concept of ConnectedExtension by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/1154

### Features

* (feat) O3-4249: Add component to support rendering an icon if it exists by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/1220
* (feat) Add pharmacy pictogram by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1218
* (feat) O3-4216: Add `Programs` icon to CarbonMRS icon pack by @Munyua123 in https://github.com/openmrs/openmrs-esm-core/pull/1212
* (feat) O3-4215: Enable Environment Specification for Shell Builds by @jayasanka-sack in https://github.com/openmrs/openmrs-esm-core/pull/1211
* (feat) Use gender icons from icon framework in patient header by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1208
* (feat) O3-4168: Add gender icons to the CarbonMRS icon pack by @mccarthyaaron in https://github.com/openmrs/openmrs-esm-core/pull/1207
* (feat) Add `in-patient` pictogram by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1205
* (feat) Add translation for "Save" to core translations library by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1204
* (feat) O3-4196: Improve optional backend dependencies functionality by @mogoodrich in https://github.com/openmrs/openmrs-esm-core/pull/1203
* (feat) O3-4170: Add `Syringe` icon to CarbonMRS icon pack by @Munyua123 in https://github.com/openmrs/openmrs-esm-core/pull/1196
* (feat) O3-4160: Patient header redesign by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1195
* (feat) O3-4161: Add `Report` icon to CarbonMRS icon pack by @Munyua123 in https://github.com/openmrs/openmrs-esm-core/pull/1194
* (feat) O3-4143: `useLocations` should support searching by tag or query string by @mogoodrich in https://github.com/openmrs/openmrs-esm-core/pull/1191
* (feat) Allow passing action menu state to the workspace container by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/1189
* (feat) Add translation override for district address field by @makombe in https://github.com/openmrs/openmrs-esm-core/pull/1188
* (feat) O3-4074: Add `CheckmarkOutlineIcon` to the styleguide by @usamaidrsk in https://github.com/openmrs/openmrs-esm-core/pull/1176
* (feat) Add variable name extractor to expression runner by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/1173
* (feat) O3-3774: Add Nav Group implementation to the styleguide by @hadijahkyampeire in https://github.com/openmrs/openmrs-esm-core/pull/1116
* (feat) O3-4018: Add `Information` and `CheckmarkFilled` icons to the styleguide by @usamaidrsk in https://github.com/openmrs/openmrs-esm-core/pull/1163
* (feat) Disable most automatic revalidations by default by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1157
* (feat) O3-3759: Refactor `usePatient` hook to leverage `useSWR` by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1156
* (feat) O3-3889: Update `Change Password` modal to the `sm` variant by @suubi-joshua in https://github.com/openmrs/openmrs-esm-core/pull/1155
* (feat) Make it possible to change modal container size by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1151
* (feat) Add patient registration pictogram by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1150
* (feat) O3-3859: Ability to customize or add logos to login page footer by @suubi-joshua in https://github.com/openmrs/openmrs-esm-core/pull/1127
 
### Refactors

* (refactor) Refactor reusable patient banner components by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1209
* (refactor) Switch visit requests to use promises instead of observables by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1184
* (refactor) Refactor REST API calls to reuse `restBaseUrl` by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1168

### Bug fixes

* (fix) O3-4327: Fix `openmrsFetchAll` calling url twice when more than 1 page is fetched by @kb019 in https://github.com/openmrs/openmrs-esm-core/pull/1217
* (fix) Fix typo in OpenMRS component decorator for strict mode by @kb019 in https://github.com/openmrs/openmrs-esm-core/pull/1213
* (fix) Fix change password modal by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1210
* (fix) Fixed wrong print icon name by @CynthiaKamau in https://github.com/openmrs/openmrs-esm-core/pull/1201
* (fix) O3-4135: Disable help icon while user is logged out by @suubi-joshua in https://github.com/openmrs/openmrs-esm-core/pull/1186
* (fix) O3-4134: Translation overrides not being overridden correctly by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/1187
* (fix) O3-3627: Preserve original filename when saving an attachment by @suubi-joshua in https://github.com/openmrs/openmrs-esm-core/pull/1183
* (fix) O3-3888: Tweak help menu hover state  by @elishabantana in https://github.com/openmrs/openmrs-esm-core/pull/1179
* (fix) Fix docstring for `extractVariableNames` by @brandones in https://github.com/openmrs/openmrs-esm-core/pull/1178
* (fix) Expression evaluator should use typeof not instanceof to detect functions by @samuelmale in https://github.com/openmrs/openmrs-esm-core/pull/1174
* (fix) O3-4018: Fix `checkmark--filled.svg` for CheckmarkFilledIcon by @usamaidrsk in https://github.com/openmrs/openmrs-esm-core/pull/1172
* (fix) O3-4018: Cleanup `checkmark--filled.svg` for CheckmarkFilledIcon by @usamaidrsk in https://github.com/openmrs/openmrs-esm-core/pull/1171
* (fix) O3-4018: Fix `CheckmarkFilled` icon registration by @usamaidrsk in https://github.com/openmrs/openmrs-esm-core/pull/1170
* (fix) Pass patient object to the banner action buttons by @vasharma05 in https://github.com/openmrs/openmrs-esm-core/pull/1158
* (fix) O3-3891: Adjust the `Change Language` modal to size `sm` by @Samstar10 in https://github.com/openmrs/openmrs-esm-core/pull/1162
* (fix) O3-3709: Fix `useOpenmrsFetchAll` not fetching more than 2 pages by @chibongho in https://github.com/openmrs/openmrs-esm-core/pull/1160
* (fix) Wrap Workspace in suspense container by @ibacher in https://github.com/openmrs/openmrs-esm-core/pull/1148
* (fix) O3-3189: Fix `useOpemrsInfinite` hook to correctly take in URL by @chibongho in https://github.com/openmrs/openmrs-esm-core/pull/1146

### Housekeeping

_Transifex automated updates omitted for brevity_

* (chore) Add missing translations for header menu tooltips by @usamaidrsk in https://github.com/openmrs/openmrs-esm-core/pull/1219
* (chore) Flag duplicate imports by @denniskigen in https://github.com/openmrs/openmrs-esm-core/pull/1206
* (chore) Bump Playwright by @kdaud in https://github.com/openmrs/openmrs-esm-core/pull/1199
* (chore) O3-4011: Make patient banner patient identifiers a reusable component by @chibongho in https://github.com/openmrs/openmrs-esm-core/pull/1159
* (chore) O3-4018: Add checkmarkFilled and information icons mocks by @usamaidrsk in https://github.com/openmrs/openmrs-esm-core/pull/1166
* (chore) O3-3973: Cache playwright browsers install step in E2E workflow by @virajwathsalag in https://github.com/openmrs/openmrs-esm-core/pull/1147

### Miscellaneous

* (test) O3-4011 - Add stub for `PatientBannerPatientIdentifier` to styleguide mock by @chibongho in https://github.com/openmrs/openmrs-esm-core/pull/1181

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
