### PR TITLE
(fix) Correctly extract function names in expression evaluation exceptions

### DIFF
--- a/packages/framework/esm-expression-evaluator/src/evaluator.test.ts
+++ b/packages/framework/esm-expression-evaluator/src/evaluator.test.ts
@@ -6,7 +6,7 @@ describe('OpenMRS Expression Evaluator', () => {
     expect(evaluate('1 + 1')).toBe(2);
   });
 
-  it('Should support mulitplication', () => {
+  it('Should support multiplication', () => {
     expect(evaluate('1 * 2')).toBe(2);
   });
 
@@ -93,7 +93,7 @@ describe('OpenMRS Expression Evaluator', () => {
     expect(evaluate('a ? 1 : 2', { a: false })).toBe(2);
   });
 
-  it('Should support hexdecimal', () => {
+  it('Should support hexadecimal', () => {
     expect(evaluate('0xff')).toBe(255);
   });
 
@@ -154,7 +154,7 @@ describe('OpenMRS Expression Evaluator', () => {
     expect(evaluate(exp)).toBe(2);
   });
 
-  it('Should not support variable assignement', () => {
+  it('Should not support variable assignment', () => {
     expect(() => evaluate('var a = 1; a')).toThrow();
   });
 
@@ -197,5 +197,32 @@ describe('OpenMRS Expression Evaluator', () => {
         },
       ),
     ).toBe(true);
+  });
+
+  it('Should throw an error with correct message for non-existent function', () => {
+    expect(() => {
+      evaluate('api.nonExistingFunction()', { api: {} });
+    }).toThrow('No function named nonExistingFunction is defined in this context');
+
+    // nested ref
+    expect(() => {
+      evaluate('objectWrapper.path.deepNested()', {
+        objectWrapper: {
+          path: {
+            deepNested: undefined,
+          },
+        },
+      });
+    }).toThrow('No function named deepNested is defined in this context');
+  });
+
+  it('Should throw an error with correct message for non-callable targets', () => {
+    expect(() => {
+      evaluate('objectWrapper.path()', {
+        objectWrapper: {
+          path: {},
+        },
+      });
+    }).toThrow('path is not a function');
   });
 });

--- a/packages/framework/esm-expression-evaluator/src/evaluator.ts
+++ b/packages/framework/esm-expression-evaluator/src/evaluator.ts
@@ -1,5 +1,5 @@
 /** @category Utility */
-import jsep from 'jsep';
+import jsep, { type Expression, type MemberExpression } from 'jsep';
 import jsepArrow, { type ArrowExpression } from '@jsep-plugin/arrow';
 import jsepNew, { type NewExpression } from '@jsep-plugin/new';
 import jsepNumbers from '@jsep-plugin/numbers';
@@ -467,9 +467,9 @@ function visitCallExpression(expression: jsep.CallExpression, context: Evaluatio
   let callee = visitExpression(expression.callee, context);
 
   if (!callee) {
-    throw `No function named ${expression.callee} is defined in this context`;
+    throw `No function named ${getCallTargetName(expression.callee)} is defined in this context`;
   } else if (!(typeof callee === 'function')) {
-    throw `${expression.callee} is not a function`;
+    throw `${getCallTargetName(expression.callee)} is not a function`;
   }
 
   return callee(...args);
@@ -721,4 +721,15 @@ function isValidVariableType(val: unknown): val is VariablesMap['a'] {
   }
 
   return false;
+}
+
+function getCallTargetName(expression: Expression) {
+  if (!expression) {
+    return null;
+  }
+  if (expression.type === 'MemberExpression') {
+    return (expression.property as MemberExpression)?.name;
+  }
+  // identifier expression
+  return expression.name;
 }


### PR DESCRIPTION
# Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [X] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
There is a limitation in the expression runner's error handling that fails to properly identify the root cause when resolving function references, specifically for membership expressions like path.myFunction(). The current implementation does not accurately extract and display the function name in error messages, making debugging challenging for complex expression calls.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
