### PR TITLE
(fix) Notify config system when app is fully loaded

### DIFF
--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -51,6 +51,8 @@ describe('defineConfigSchema', () => {
       bar: true,
     };
     Config.defineConfigSchema('foo-module', schema);
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/foo-module.*bar/));
   });
 
@@ -59,6 +61,8 @@ describe('defineConfigSchema', () => {
       bar: { baz: 'bad bad bad' },
     };
     Config.defineConfigSchema('foo-module', schema);
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/foo-module.*bar\.baz/));
   });
 
@@ -66,8 +70,9 @@ describe('defineConfigSchema', () => {
     const schema = {
       bar: { _default: 0, _type: 'numeral' },
     };
-    //@ts-ignore
     Config.defineConfigSchema('foo-module', schema);
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/foo-module.*bar[\s\S]*Number.*numeral/i));
   });
 
@@ -85,6 +90,8 @@ describe('defineConfigSchema', () => {
       },
     };
     Config.defineConfigSchema('foo-module', schema);
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     expect(console.error).not.toHaveBeenCalled();
   });
 
@@ -106,6 +113,8 @@ describe('defineConfigSchema', () => {
       ],
     };
     Config.defineConfigSchema('foo-module', schema);
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     Config.provide({ 'foo-module': { foo: 'different' } });
     expect(console.error).toHaveBeenCalledWith(
       expect.stringMatching(/The value of `foo` must start with the value of `fooStart`.*bar/),
@@ -116,8 +125,9 @@ describe('defineConfigSchema', () => {
     const schema = {
       bar: { _default: [], _validators: [false] },
     };
-    //@ts-ignore
     Config.defineConfigSchema('foo-module', schema);
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     expect(console.error).toHaveBeenCalledWith(
       expect.stringMatching(/foo-module.*has invalid validator.*bar[\s\S]*false.*/i),
     );
@@ -132,6 +142,8 @@ describe('defineConfigSchema', () => {
       },
     };
     Config.defineConfigSchema('mod-mod', schema);
+    // load to trigger validation
+    Config.registerModuleLoad('mod-mod');
     expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/mod-mod.*foo.*bar/));
   });
 
@@ -144,6 +156,8 @@ describe('defineConfigSchema', () => {
       },
     };
     Config.defineConfigSchema('mod-mod', schema);
+    // load to trigger validation
+    Config.registerModuleLoad('mod-mod');
     expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/mod-mod.*foo[\s\S]*elements.*Boolean/));
   });
 
@@ -152,6 +166,8 @@ describe('defineConfigSchema', () => {
       foo: { bar: { _description: 'lol idk' } },
     };
     Config.defineConfigSchema('mod-mod', schema);
+    // load to trigger validation
+    Config.registerModuleLoad('mod-mod');
     expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/mod-mod.*foo\.bar[\s\S]*default/));
   });
 
@@ -160,6 +176,8 @@ describe('defineConfigSchema', () => {
       foo: { bar: {} },
     };
     Config.defineConfigSchema('mod-mod', schema);
+    // load to trigger validation
+    Config.registerModuleLoad('mod-mod');
     expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/mod-mod.*foo\.bar[\s\S]*default/));
   });
 
@@ -174,6 +192,8 @@ describe('defineConfigSchema', () => {
       },
     };
     Config.defineConfigSchema('mod-mod', schema);
+    // load to trigger validation
+    Config.registerModuleLoad('mod-mod');
     expect(console.error).not.toHaveBeenCalled();
   });
 
@@ -186,6 +206,8 @@ describe('defineConfigSchema', () => {
     };
 
     Config.defineConfigSchema('mod-mod', schema);
+    // load to trigger validation
+    Config.registerModuleLoad('mod-mod');
     expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/mod-mod.*\bDisplay conditions\b/));
   });
 });
@@ -201,6 +223,8 @@ describe('getConfig', () => {
 
   it('uses config values from the provided config file', async () => {
     Config.defineConfigSchema('foo-module', { foo: { _default: 'qux' } });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     type FooConfig = { foo: string };
     const testConfig = { 'foo-module': { foo: 'bar' } };
     Config.provide(testConfig);
@@ -215,12 +239,16 @@ describe('getConfig', () => {
         _default: 'qux',
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('testmod');
     const config = await Config.getConfig('testmod');
     expect(config.foo).toBe('qux');
   });
 
   it('logs an error if config values not defined in the schema', async () => {
     Config.defineConfigSchema('foo-module', { foo: { _default: 'qux' } });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     Config.provide({ 'foo-module': { bar: 'baz' } });
     await Config.getConfig('foo-module');
     expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/Unknown.*key.*foo-module.*bar/));
@@ -230,6 +258,8 @@ describe('getConfig', () => {
     Config.defineConfigSchema('foo-module', {
       foo: { bar: { _default: 'qux' } },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     Config.provide({ 'foo-module': { foo: { doof: 'nope' } } });
     await Config.getConfig('foo-module');
     expect(console.error).toHaveBeenCalledWith(expect.stringMatching(/foo-module.*foo\.doof.*/));
@@ -245,6 +275,8 @@ describe('getConfig', () => {
       },
     };
     Config.defineConfigSchema('foo-module', fooSchema);
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const badConfig = {
       'foo-module': {
         bar: { a: { b: 5 } },
@@ -259,6 +291,8 @@ describe('getConfig', () => {
     await resetAll();
 
     Config.defineConfigSchema('foo-module', fooSchema);
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const goodConfig = { 'foo-module': { bar: { a: { b: 0 }, diff: 2 } } };
     Config.provide(goodConfig);
     const result = await Config.getConfig('foo-module');
@@ -294,6 +328,8 @@ describe('getConfig', () => {
         },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const testConfig = {
       'foo-module': {
         foo: {
@@ -314,8 +350,11 @@ describe('getConfig', () => {
 
   it('works for multiple modules and multiple provides', async () => {
     Config.defineConfigSchema('foo-module', { foo: { _default: 'qux' } });
+    Config.registerModuleLoad('foo-module');
     Config.defineConfigSchema('bar-module', { bar: { _default: 'quinn' } });
+    Config.registerModuleLoad('bar-module');
     Config.defineConfigSchema('baz-module', { baz: { _default: 'quip' } });
+    Config.registerModuleLoad('baz-module');
     const barTestConfig = { 'bar-module': { bar: 'barrr' } };
     const bazTestConfig = { 'baz-module': { baz: 'bazzz' } };
     Config.provide(barTestConfig);
@@ -336,6 +375,8 @@ describe('getConfig', () => {
         _validators: [validator((val) => val.startsWith('thi'), "must start with 'thi'")],
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const testConfig = {
       'foo-module': {
         foo: 'bar',
@@ -353,6 +394,8 @@ describe('getConfig', () => {
         _validators: [validator((val) => val.startsWith('thi'), "must start with 'thi'")],
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     await Config.getConfig('foo-module');
     expect(console.error).not.toHaveBeenCalled();
   });
@@ -364,6 +407,8 @@ describe('getConfig', () => {
         _validators: [validator((val) => val.startsWith('thi'), "must start with 'thi'")],
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const testConfig = {
       'foo-module': {
         foo: 'this',
@@ -383,6 +428,8 @@ describe('getConfig', () => {
       },
     };
     Config.defineConfigSchema('foo-module', fooSchema);
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const testConfig = {
       'foo-module': {
         baz: { what: 'ever', goes: 'here' },
@@ -396,6 +443,8 @@ describe('getConfig', () => {
     await resetAll();
 
     Config.defineConfigSchema('foo-module', fooSchema);
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const badConfig = {
       'foo-module': {
         baz: 0,
@@ -413,6 +462,8 @@ describe('getConfig', () => {
         _default: {},
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('object-null-module');
     const testConfig = {
       'object-null-module': {
         objnu: null,
@@ -433,6 +484,8 @@ describe('getConfig', () => {
         _default: {},
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const testConfig = {
       'foo-module': {
         foo: {
@@ -458,6 +511,8 @@ describe('getConfig', () => {
         _default: { kake: { gohan: 'ok' } },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('object-def');
     const config = await Config.getConfig('object-def');
     expect(config).toStrictEqual({
       furi: { kake: { gohan: 'ok' } },
@@ -477,6 +532,8 @@ describe('getConfig', () => {
         },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('object-def');
     Config.provide({
       'object-def': {
         tamago: {
@@ -500,6 +557,8 @@ describe('getConfig', () => {
         _default: [1, 2, 3],
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const testConfig = {
       'foo-module': {
         foo: [0, 2, 4],
@@ -521,6 +580,8 @@ describe('getConfig', () => {
         },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const testConfig = {
       'foo-module': {
         foo: ['bar', 'baz', 'qux'],
@@ -542,6 +603,8 @@ describe('getConfig', () => {
         },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const testConfig = {
       'foo-module': {
         foo: ['bar', 42],
@@ -562,6 +625,8 @@ describe('getConfig', () => {
         },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const testConfig = {
       'foo-module': {
         foo: [0, 1.5, 'bad'],
@@ -585,6 +650,8 @@ describe('getConfig', () => {
         },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const testConfig = {
       'foo-module': {
         bar: {
@@ -613,6 +680,8 @@ describe('getConfig', () => {
         },
       },
     };
+    // load to trigger validation
+    Config.registerModuleLoad('array-nest');
     Config.defineConfigSchema('array-nest', configSchema);
     const testConfig = {
       'array-nest': {
@@ -643,6 +712,8 @@ describe('getConfig', () => {
         },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const testConfig = {
       'foo-module': {
         foo: [{ a: { b: 0.2 } }],
@@ -664,6 +735,8 @@ describe('getConfig', () => {
       },
     };
     Config.defineConfigSchema('foo-module', fooSchema);
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const badConfig = {
       'foo-module': {
         bar: [
@@ -679,6 +752,8 @@ describe('getConfig', () => {
     await resetAll();
 
     Config.defineConfigSchema('foo-module', fooSchema);
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     const goodConfig = { 'foo-module': { bar: [{ a: { b: 2 }, c: 3 }] } };
     Config.provide(goodConfig);
     const result = await Config.getConfig('foo-module');
@@ -692,6 +767,8 @@ describe('getConfig', () => {
         _default: [1, 2, 3],
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('array-null-module');
     const testConfig = {
       'array-null-module': {
         arnu: null,
@@ -715,6 +792,8 @@ describe('getConfig', () => {
         },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('array-def');
     const testConfig = {
       'array-def': {
         foo: [{ a: { b: 'customB', filler: 'customFiller' } }, { a: { b: 'anotherB' } }],
@@ -741,6 +820,8 @@ describe('getConfig', () => {
         },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('array-array-simple');
 
     // Ensure sensible default behavior
     const configDefault = await Config.getConfig('array-array-simple');
@@ -775,6 +856,8 @@ describe('getConfig', () => {
         },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('array-array-def');
 
     // Ensure sensible default behavior
     const configDefault = await Config.getConfig('array-array-def');
@@ -817,6 +900,8 @@ describe('getConfig', () => {
         },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('array-array-valid');
     const testConfig = {
       'array-array-valid': {
         tamago: [{ yaki: { negi: 'one' } }],
@@ -847,6 +932,8 @@ describe('type validations', () => {
     Config.defineConfigSchema('foo-module', {
       foo: { _default: 'qux', _type: configType },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     Config.provide({ 'foo-module': { foo: badValue } });
     await Config.getConfig('foo-module');
     expect(console.error).toHaveBeenCalledWith(expect.stringMatching(new RegExp(`${badValue}.*foo-module.*foo`, 'i')));
@@ -913,7 +1000,9 @@ describe('implementer tools config', () => {
     Config.defineConfigSchema('foo-module', {
       foo: { _default: 'qux', _description: 'All the foo', _validators: [] },
     });
+    Config.registerModuleLoad('foo-module');
     Config.defineConfigSchema('bar-module', { bar: { _default: 'quinn' } });
+    Config.registerModuleLoad('bar-module');
     const testConfig = { 'bar-module': { bar: 'baz' } };
     Config.provide(testConfig, 'my config source');
     const devConfig = implementerToolsConfigStore.getState().config;
@@ -945,6 +1034,7 @@ describe('temporary config', () => {
 
   it('allows overriding the existing config', async () => {
     Config.defineConfigSchema('foo-module', { foo: { _default: 'qux' } });
+    Config.registerModuleLoad('foo-module');
     const testConfig = { 'foo-module': { foo: 'baz' } };
     Config.provide(testConfig);
     temporaryConfigStore.setState({ config: { 'foo-module': { foo: 3 } } });
@@ -962,6 +1052,7 @@ describe('temporary config', () => {
 
   it('can be gotten and cleared', async () => {
     Config.defineConfigSchema('foo-module', { foo: { _default: 'qux' } });
+    Config.registerModuleLoad('foo-module');
     temporaryConfigStore.setState({ config: { 'foo-module': { foo: 3 } } });
     expect(temporaryConfigStore.getState().config).toStrictEqual({
       'foo-module': { foo: 3 },
@@ -979,6 +1070,8 @@ describe('temporary config', () => {
         baz: { _default: 'also qux' },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     await Config.getConfig('foo-module');
     temporaryConfigStore.setState({
       config: { 'foo-module': { foo: { bar: 3 } } },
@@ -1033,6 +1126,8 @@ describe('extension slot config', () => {
     Config.defineConfigSchema('foo-module', {
       foo: { _default: 0 },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     Config.provide({
       'foo-module': {
         extensionSlots: { fooSlot: { remove: ['bar'] } },
@@ -1047,6 +1142,8 @@ describe('extension slot config', () => {
     Config.defineConfigSchema('foo-module', {
       foo: { _default: 0 },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     Config.provide({
       'foo-module': {
         extensionSlots: { fooSlot: { remove: ['bar'] } },
@@ -1061,6 +1158,8 @@ describe('extension slot config', () => {
     Config.defineConfigSchema('foo-module', {
       foo: { _default: 0 },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     Config.provide({
       'foo-module': {
         extensionSlots: { fooSlot: { remove: ['bar'] } },
@@ -1087,6 +1186,8 @@ describe('extension slot config', () => {
         extensionSlots: { fooSlot: { quitar: ['bar'] } },
       },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('foo-module');
     expect(console.error).toHaveBeenCalledWith(
       expect.stringMatching(/foo-module.extensionSlots.fooSlot.*invalid.*quitar/),
     );
@@ -1100,6 +1201,8 @@ describe('extension config', () => {
       bar: { _default: 'barry' },
       baz: { _default: 'bazzy' },
     });
+    // load to trigger validation
+    Config.registerModuleLoad('ext-mod');
   });
 
   afterEach(resetAll);
@@ -1162,6 +1265,7 @@ describe('extension config', () => {
     Config.defineExtensionConfigSchema('fooExt', {
       qux: { _default: 'quxxy' },
     });
+    Config.registerModuleLoad('fooExt');
     const extensionAtBaseConfig = { fooExt: { qux: 'quxolotl' } };
     Config.provide(extensionAtBaseConfig);
     const result = getExtensionConfig('barSlot', 'fooExt').getState().config;
@@ -1178,6 +1282,7 @@ describe('extension config', () => {
     Config.defineExtensionConfigSchema('fooExt', {
       qux: { _default: 'quxxy' },
     });
+    Config.registerModuleLoad('fooExt');
     const configureConfig = {
       fooExt: { qux: 'quxolotl' },
       'slot-mod': {
@@ -1202,6 +1307,7 @@ describe('extension config', () => {
     Config.defineExtensionConfigSchema('fooExt', {
       qux: { _default: 'quxxy' },
     });
+    Config.registerModuleLoad('fooExt');
     const configureConfig = {
       'slot-mod': {
         extensionSlots: {
@@ -1220,6 +1326,7 @@ describe('extension config', () => {
     Config.defineExtensionConfigSchema('fooExt', {
       qux: { _default: 'quxxy' },
     });
+    Config.registerModuleLoad('fooExt');
     const badConfigNoModuleConfigsForExtension = {
       fooExt: {
         bar: 'no good',
@@ -1234,6 +1341,7 @@ describe('extension config', () => {
     Config.defineExtensionConfigSchema('fooExt', {
       qux: { _default: 'quxxy' },
     });
+    Config.registerModuleLoad('fooExt');
     const badConfigNoExtensionConfigsForModule = {
       'ext-mod': {
         qux: 'also bad',

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -185,10 +185,25 @@ export function defineConfigSchema(moduleName: string, schema: ConfigSchema) {
  * @param moduleName
  */
 export function registerModuleWithConfigSystem(moduleName: string) {
-  const state = configInternalStore.getState();
-  configInternalStore.setState({
+  configInternalStore.setState((state) => ({
+    ...state,
     schemas: { ...state.schemas, [moduleName]: implicitConfigSchema },
-  });
+  }));
+}
+
+/**
+ * This alerts the configuration system that a module has been loaded.
+ *
+ * This should only be used in esm-app-shell.
+ *
+ * @internal
+ * @param moduleName
+ */
+export function registerModuleLoad(moduleName: string) {
+  configInternalStore.setState((state) => ({
+    ...state,
+    moduleLoaded: { ...state.moduleLoaded, [moduleName]: true },
+  }));
 }
 
 /**
@@ -201,10 +216,10 @@ export function registerModuleWithConfigSystem(moduleName: string) {
  * @param namespace
  */
 export function registerTranslationNamespace(namespace: string) {
-  const state = configInternalStore.getState();
-  configInternalStore.setState({
+  configInternalStore.setState((state) => ({
+    ...state,
     schemas: { ...state.schemas, [namespace]: translationOverridesSchema },
-  });
+  }));
 }
 
 /**
@@ -235,9 +250,10 @@ export function defineExtensionConfigSchema(extensionName: string, schema: Confi
     );
   }
 
-  configInternalStore.setState({
+  configInternalStore.setState((state) => ({
+    ...state,
     schemas: { ...state.schemas, [extensionName]: enhancedSchema },
-  });
+  }));
 }
 
 export function provide(config: Config, sourceName = 'provided') {

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -170,7 +170,6 @@ export function defineConfigSchema(moduleName: string, schema: ConfigSchema) {
   configInternalStore.setState((state) => ({
     ...state,
     schemas: { ...state.schemas, [moduleName]: enhancedSchema },
-    moduleLoaded: { ...state.moduleLoaded, [moduleName]: true },
   }));
 }
 

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -170,6 +170,7 @@ export function defineConfigSchema(moduleName: string, schema: ConfigSchema) {
   configInternalStore.setState((state) => ({
     ...state,
     schemas: { ...state.schemas, [moduleName]: enhancedSchema },
+    moduleLoaded: { ...state.moduleLoaded, [moduleName]: true },
   }));
 }
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -3391,7 +3391,7 @@ for more information about defining a config schema.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:241](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L241)
+[packages/framework/esm-config/src/module-config/module-config.ts:242](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L242)
 
 ___
 
@@ -3423,7 +3423,7 @@ of the execution of a function.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:274](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L274)
+[packages/framework/esm-config/src/module-config/module-config.ts:275](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L275)
 
 ___
 
@@ -3444,7 +3444,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:258](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L258)
+[packages/framework/esm-config/src/module-config/module-config.ts:259](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L259)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -3391,7 +3391,7 @@ for more information about defining a config schema.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:242](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L242)
+[packages/framework/esm-config/src/module-config/module-config.ts:241](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L241)
 
 ___
 
@@ -3423,7 +3423,7 @@ of the execution of a function.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:275](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L275)
+[packages/framework/esm-config/src/module-config/module-config.ts:274](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L274)
 
 ___
 
@@ -3444,7 +3444,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:259](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L259)
+[packages/framework/esm-config/src/module-config/module-config.ts:258](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L258)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -1736,7 +1736,7 @@ ___
 
 • `Const` **MaybeIcon**: `MemoExoticComponent`<`ForwardRefExoticComponent`<{ `fallback?`: `ReactNode` ; `icon`: `string`  } & [`IconProps`](API.md#iconprops) & `RefAttributes`<`SVGSVGElement`\>\>\>
 
-This is a utility component that takes an `icon` and render it if the sprite for the icon
+This is a utility component that takes an `icon` and renders it if the sprite for the icon
 is available. The goal is to make it easier to conditionally render configuration-specified icons.
 
 **`example`**
@@ -1754,12 +1754,12 @@ ___
 
 • `Const` **MaybePictogram**: `MemoExoticComponent`<`ForwardRefExoticComponent`<{ `fallback?`: `ReactNode` ; `pictogram`: `string`  } & [`PictogramProps`](API.md#pictogramprops) & `RefAttributes`<`SVGSVGElement`\>\>\>
 
-This is a utility component that takes an `icon` and render it if the sprite for the icon
-is available. The goal is to make it easier to conditionally render configuration-specified icons.
+This is a utility component that takes an `pictogram` and render it if the sprite for the pictogram
+is available. The goal is to make it easier to conditionally render configuration-specified pictograms.
 
 **`example`**
 ```tsx
-  <MaybeIcon icon='omrs-icon-baby' className={styles.myIconStyles} />
+  <MaybePictogram pictogram='omrs-icon-baby' className={styles.myPictogramStyles} />
 ```
 
 #### Defined in
@@ -3391,7 +3391,7 @@ for more information about defining a config schema.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:227](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L227)
+[packages/framework/esm-config/src/module-config/module-config.ts:242](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L242)
 
 ___
 
@@ -3423,7 +3423,7 @@ of the execution of a function.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:259](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L259)
+[packages/framework/esm-config/src/module-config/module-config.ts:275](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L275)
 
 ___
 
@@ -3444,7 +3444,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:243](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L243)
+[packages/framework/esm-config/src/module-config/module-config.ts:259](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L259)
 
 ___
 

--- a/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
@@ -14,6 +14,7 @@ import {
   defineConfigSchema,
   provide,
   Type,
+  registerModuleLoad,
   temporaryConfigStore,
   configInternalStore,
   getExtensionSlotsConfigStore,
@@ -46,6 +47,7 @@ describe('Interaction between configuration and extension systems', () => {
     attach('A slot', 'Fred');
     attach('A slot', 'Wilma');
     defineConfigSchema('esm-flintstone', {});
+    registerModuleLoad('esm-flintstone');
 
     provide({
       'esm-flintstone': {
@@ -87,6 +89,8 @@ describe('Interaction between configuration and extension systems', () => {
     defineConfigSchema('esm-flintstone', {
       town: { _type: Type.String, _default: 'Bedrock' },
     });
+    registerModuleLoad('esm-flintstone');
+
     attach('Flintstone slot', 'Pebbles');
     attach('Future slot', 'Pebbles');
     provide({
@@ -136,6 +140,8 @@ describe('Interaction between configuration and extension systems', () => {
     defineConfigSchema('esm-characters', {
       name: { _type: Type.String, _default: '(no-name)' },
     });
+    registerModuleLoad('esm-characters');
+
     attach('Flintstone slot', 'pet#Dino');
     attach('Flintstone slot', 'pet#BabyPuss');
     provide({
@@ -183,6 +189,7 @@ describe('Interaction between configuration and extension systems', () => {
     registerSimpleExtension('Pearl', 'esm-slaghoople');
     attach('A slot', 'Pearl');
     defineConfigSchema('esm-slaghoople', {});
+    registerModuleLoad('esm-flintstone');
 
     const App = openmrsComponentDecorator({
       moduleName: 'esm-slaghoople',
@@ -218,6 +225,7 @@ describe('Interaction between configuration and extension systems', () => {
     registerSimpleExtension('Mr. Slate', 'esm-flintstone', true);
     attach('A slot', 'Mr. Slate');
     defineConfigSchema('esm-flintstone', { tie: { _default: 'green' } });
+    registerModuleLoad('esm-flintstone');
 
     const App = openmrsComponentDecorator({
       moduleName: 'esm-quarry',
@@ -256,6 +264,8 @@ describe('Interaction between configuration and extension systems', () => {
     registerSimpleExtension('Bamm-Bamm', 'esm-flintstone', false);
     attach('A slot', 'Bamm-Bamm');
     defineConfigSchema('esm-flintstone', { clothes: { _default: 'leopard' } });
+    registerModuleLoad('esm-flintstone');
+
     function RootComponent() {
       const store = useExtensionStore();
       return (
@@ -329,6 +339,8 @@ describe('Interaction between configuration and extension systems', () => {
     attach('A slot', 'Wilma');
     defineConfigSchema('esm-bedrock', {});
     defineConfigSchema('esm-flintstones', {});
+    registerModuleLoad('esm-bedrock');
+    registerModuleLoad('esm-flintstones');
     provide({
       'esm-bedrock': {
         'Display conditions': {
@@ -389,6 +401,7 @@ describe('Interaction between configuration and extension systems', () => {
     registerSimpleExtension('Schmoo', 'esm-bedrock', true);
     attach('A slot', 'Schmoo');
     defineConfigSchema('esm-bedrock', {});
+    registerModuleLoad('esm-bedrock');
     provide({
       'esm-bedrock': {
         'Display conditions': {
@@ -448,6 +461,8 @@ describe('Interaction between configuration and extension systems', () => {
     attach('A slot', 'Wilma');
     defineConfigSchema('esm-bedrock', {});
     defineConfigSchema('esm-flintstones', {});
+    registerModuleLoad('esm-bedrock');
+    registerModuleLoad('esm-flintstones');
     provide({ 'esm-bedrock': {} });
     provide({ 'esm-flintstones': {} });
 

--- a/packages/framework/esm-routes/src/loaders/app.ts
+++ b/packages/framework/esm-routes/src/loaders/app.ts
@@ -1,4 +1,5 @@
 import { importDynamic } from '@openmrs/esm-dynamic-loading';
+import { registerModuleLoad } from '@openmrs/esm-config';
 import { type LifeCycles } from 'single-spa';
 import { emptyLifecycle } from './helpers';
 
@@ -68,10 +69,16 @@ export async function initializeApp(appName: string, module?: Module) {
       if (Object.hasOwn(_module, 'startupApp')) {
         const startup = _module['startupApp'];
         if (typeof startup === 'function') {
-          return Promise.resolve(startup()).then(resolve).catch(reject);
+          return Promise.resolve(startup())
+            .then(() => {
+              registerModuleLoad(appName);
+              resolve(null);
+            })
+            .catch(reject);
         }
       }
 
+      registerModuleLoad(appName);
       resolve(null);
     }));
   } else {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This is a companion commit for openmrs/openmrs-esm-patient-chart#2139. The underlying issue in that PR is that a module is only registered as loaded when `defineConfigSchema()` is called, causing the promises used to load the configuration to never resolve when `defineConfigSchema()` isn't called. (It is technically an error to call `useConfig()` without having called `defineConfigSchema()`, but its unclear when to log this error since we can't always know when the config is _read_).

This PR adds a call at the end of the app loading process to ensure that the module is marked as "loaded" in the configuration system.

Note that openmrs/openmrs-esm-patient-chart#2139 should still be committed even with this change.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
