### PR TITLE
(chore) Add FetchError interface for more granular error typing

### DIFF
--- a/packages/framework/esm-api/src/openmrs-fetch.ts
+++ b/packages/framework/esm-api/src/openmrs-fetch.ts
@@ -292,7 +292,7 @@ export function openmrsObservableFetch<T>(url: string, fetchInit: FetchConfig = 
   });
 }
 
-export class OpenmrsFetchError extends Error {
+export class OpenmrsFetchError extends Error implements FetchError {
   constructor(url: string, response: Response, responseBody: ResponseBody | null, requestStacktrace: Error) {
     super();
     this.message = `Server responded with ${response.status} (${response.statusText}) for url ${url}. Check err.responseBody or network tab in dev tools for more info`;
@@ -322,4 +322,9 @@ interface FetchBody {
 
 export interface FetchResponseJson {
   [key: string]: any;
+}
+
+export interface FetchError {
+  response: Response;
+  responseBody: ResponseBody | null;
 }

--- a/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
+++ b/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
@@ -8,6 +8,10 @@
 
   ↳ **`OpenmrsFetchError`**
 
+## Implements
+
+- [`FetchError`](../interfaces/FetchError.md)
+
 ## Table of contents
 
 ### API Constructors
@@ -61,6 +65,10 @@ Error.constructor
 
 • **response**: `Response`
 
+#### Implementation of
+
+[FetchError](../interfaces/FetchError.md).[response](../interfaces/FetchError.md#response)
+
 #### Defined in
 
 [packages/framework/esm-api/src/openmrs-fetch.ts:304](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L304)
@@ -70,6 +78,10 @@ ___
 ### responseBody
 
 • **responseBody**: ``null`` \| `string` \| [`FetchResponseJson`](../interfaces/FetchResponseJson.md)
+
+#### Implementation of
+
+[FetchError](../interfaces/FetchError.md).[responseBody](../interfaces/FetchError.md#responsebody)
 
 #### Defined in
 

--- a/packages/framework/esm-framework/docs/interfaces/FetchError.md
+++ b/packages/framework/esm-framework/docs/interfaces/FetchError.md
@@ -1,0 +1,34 @@
+[@openmrs/esm-framework](../API.md) / FetchError
+
+# Interface: FetchError
+
+## Implemented by
+
+- [`OpenmrsFetchError`](../classes/OpenmrsFetchError.md)
+
+## Table of contents
+
+### API Properties
+
+- [response](FetchError.md#response)
+- [responseBody](FetchError.md#responsebody)
+
+## API Properties
+
+### response
+
+• **response**: `Response`
+
+#### Defined in
+
+[packages/framework/esm-api/src/openmrs-fetch.ts:328](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L328)
+
+___
+
+### responseBody
+
+• **responseBody**: ``null`` \| `ResponseBody`
+
+#### Defined in
+
+[packages/framework/esm-api/src/openmrs-fetch.ts:329](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L329)


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR adds a `FetchError` interface to the framework that can be used to annotate errors that occur during fetch requests. It also amends the `OpenmrsFetchError` class to implement the `FetchError` interface. Presently, the `openmrsFetch` hook throws a custom error that includes the response status code and status text if a request fails. This is not always the most helpful message, and it's not always clear what the underlying error was.

The REST API returns a more useful message in the responseBody, and it would be preferable to show this message instead of the status code and status text. With this change, we can then use the FetchError interface further down the line in SWR hooks to annotate errors.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
