### PR TITLE
(feat) OA-41: openmrsFetch() should handle redirects

### DIFF
--- a/packages/framework/esm-api/src/openmrs-fetch.ts
+++ b/packages/framework/esm-api/src/openmrs-fetch.ts
@@ -152,6 +152,14 @@ export function openmrsFetch<T = any>(path: string, fetchInit: FetchConfig = {})
     const response = r as FetchResponse<T>;
     if (response.ok) {
       if (response.status === 204) {
+        const { followRedirects } = await getConfig('@openmrs/esm-api');
+        if (followRedirects && response.headers.has('location')) {
+          const location = response.headers.get('location');
+          if (location) {
+            navigate({ to: location });
+          }
+        }
+
         /* HTTP 204 - No Content
          * We should not try to download the empty response as json. Instead,
          * we return null since there is no response body.

--- a/packages/framework/esm-api/src/setup.ts
+++ b/packages/framework/esm-api/src/setup.ts
@@ -33,6 +33,11 @@ export function setupApiModule() {
           "Changes how requests that fail authentication are handled. Try messing with this if redirects to the login page aren't working correctly.",
       },
     },
+    followRedirects: {
+      _type: Type.Boolean,
+      _default: true,
+      _description: 'Whether openmrsFetch should support redirects returned from the backend',
+    },
   });
 
   refetchCurrentUser();

--- a/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
+++ b/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
@@ -53,7 +53,7 @@ Error.constructor
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:296](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L296)
+[packages/framework/esm-api/src/openmrs-fetch.ts:304](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L304)
 
 ## API Properties
 
@@ -63,7 +63,7 @@ Error.constructor
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:304](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L304)
+[packages/framework/esm-api/src/openmrs-fetch.ts:312](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L312)
 
 ___
 
@@ -73,7 +73,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:305](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L305)
+[packages/framework/esm-api/src/openmrs-fetch.ts:313](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L313)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/FetchConfig.md
+++ b/packages/framework/esm-framework/docs/interfaces/FetchConfig.md
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:310](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L310)
+[packages/framework/esm-api/src/openmrs-fetch.ts:318](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L318)
 
 ___
 
@@ -47,7 +47,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:309](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L309)
+[packages/framework/esm-api/src/openmrs-fetch.ts:317](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L317)
 
 ___
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This implements a simple protocol for the backend to be able to send redirect responses to the frontend.

Normally, redirect responses are handled by a HTTP response in the 300-399 range, with a `Location` header indicating where the page should redirect to. The problem is how this is handled with `fetch()` requests. Specifically, while using the `fetch()` API, 3xx responses cause the fetch request itself to redirect to the new URL, meaning that the user's UI doesn't change at all. For SPAs, this is usually the desired behaviour, since SPAs will usually do the work on the frontend.

Instead, this hijacks the meaning of a 204 ("No Content") response from the backend. If the response is a 204 and there's a `Location` header _and_ this feature hasn't been turned off via config, then `openmrsFetch()` will redirect to the URL specified in the header. This gives us a small escape hatch so the backend can redirect the browser to a specific page.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
