### PR TITLE
(chore) Cache install dependencies step in e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -144,6 +144,7 @@ jobs:
       - name: 📦 Install dependencies
         if: steps.cache-dependencies.outputs.cache-hit != 'true'
         run: yarn install --immutable
+        working-directory: e2e_repo
 
       - name: 🚀 Setup local cache server for Turborepo
         uses: felixmosh/turborepo-gh-artifacts@v3
@@ -164,33 +165,41 @@ jobs:
           ref: main
           path: e2e_repo
 
-      - name: 📄 Copy test environment variables
+      - name: 📄 Copy test environment variables for ${{ matrix.repo }}
         run: cp example.env .env
         working-directory: e2e_repo
 
-      - name: 📦 Install dependencies
+      - name: 💾 Cache dependencies for ${{ matrix.repo }}
+        id: cache-other-repo-dependencies
+        uses: actions/cache@v4
+        with:
+          path: '**/node_modules'
+          key: ${{ runner.os }}-${{ hashFiles('e2e_repo/**/yarn.lock') }}
+
+      - name: 📦 Install dependencies for ${{ matrix.repo }}
+        if: steps.cache-other-repo-dependencies.outputs.cache-hit != 'true'
         run: yarn install --immutable
         working-directory: e2e_repo
 
-      - name: 💾 Cache Playwright Browsers
+      - name: 💾 Cache Playwright Browsers for ${{ matrix.repo }}
         id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
+          key: ${{ runner.os }}-playwright-${{ hashFiles('e2e_repo/**/yarn.lock') }}
 
-      - name: 🎭 Install Playwright Browsers
+      - name: 🎭 Install Playwright Browsers for ${{ matrix.repo }}
         run: yarn playwright install --with-deps
         working-directory: e2e_repo
 
       - name: ⏳ Wait for the OpenMRS instance to start
         run: while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' http://localhost:8080/openmrs/login.htm)" != "200" ]]; do sleep 10; done
 
-      - name: 🧪 Run E2E tests
+      - name: 🧪 Run E2E tests for ${{ matrix.repo }}
         run: yarn playwright test
         working-directory: e2e_repo
 
-      - name: 📤 Upload Report
+      - name: 📤 Upload Report for ${{ matrix.repo }}
         uses: actions/upload-artifact@v4
         if: always()
         with:

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -2855,7 +2855,7 @@ To cancel the network request, simply call `subscription.unsubscribe();`
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:263](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L263)
+[packages/framework/esm-api/src/openmrs-fetch.ts:271](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L271)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/FetchError.md
+++ b/packages/framework/esm-framework/docs/interfaces/FetchError.md
@@ -21,7 +21,7 @@
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:328](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L328)
+[packages/framework/esm-api/src/openmrs-fetch.ts:336](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L336)
 
 ___
 
@@ -31,4 +31,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/openmrs-fetch.ts:329](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L329)
+[packages/framework/esm-api/src/openmrs-fetch.ts:337](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L337)


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Makes it so that the `Install dependencies` step in the `run-e2e-on-other-repos` job is cached. Without caching, this step takes a full 2 minutes to run for Patient Chart. The commit also adds working-directory directives to keep the cache keys specific to the active repo. Additionally, these changes makes artifact names and steps more explicit by adding the repo name to both the artifact name and step name.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
