### PR TITLE
(fix) Gender icons not showing in non-English locales

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -7054,7 +7054,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.component.tsx:43](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.component.tsx#L43)
+[packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.component.tsx:54](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.component.tsx#L54)
 
 ___
 

--- a/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.component.tsx
+++ b/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.component.tsx
@@ -35,14 +35,25 @@ const GenderIcon = ({ gender }: GenderIconProps) => {
   return <IconComponent fill="#525252" />;
 };
 
-const getGender = (gender: string): string => {
-  const key = gender.toLowerCase() as Gender;
-  return getCoreTranslation(key, gender);
+const GENDER_MAP = {
+  male: 'Male',
+  female: 'Female',
+  other: 'Other',
+  unknown: 'Unknown',
+} as const;
+
+const getGender = (gender: string) => {
+  const normalizedGender = gender.toLowerCase() as Gender;
+  const iconKey = GENDER_MAP[normalizedGender] ?? 'Unknown';
+  return {
+    displayText: getCoreTranslation(normalizedGender, gender),
+    iconKey,
+  };
 };
 
 export function PatientBannerPatientInfo({ patient }: PatientBannerPatientInfoProps) {
   const name = `${patient?.name?.[0]?.given?.join(' ')} ${patient?.name?.[0]?.family}`;
-  const gender = patient?.gender && getGender(patient.gender);
+  const genderInfo = patient?.gender && getGender(patient.gender);
 
   const extensionState = useMemo(() => ({ patientUuid: patient.id, patient }), [patient.id, patient]);
 
@@ -52,10 +63,10 @@ export function PatientBannerPatientInfo({ patient }: PatientBannerPatientInfoPr
         <div className={styles.flexRow}>
           <span className={styles.patientName}>{name}</span>
 
-          {gender && (
+          {genderInfo && (
             <div className={styles.gender}>
-              <GenderIcon gender={gender as keyof typeof GENDER_ICONS} />
-              <span>{gender}</span>
+              <GenderIcon gender={genderInfo.iconKey} />
+              <span>{genderInfo.displayText}</span>
             </div>
           )}
 

--- a/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.test.tsx
+++ b/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.test.tsx
@@ -74,4 +74,16 @@ describe('PatientBannerPatientInfo', () => {
     expect(screen.getByText(/national id/i)).toBeInTheDocument();
     expect(screen.getByText(/123456789/i)).toBeInTheDocument();
   });
+
+  it('renders the correct gender icon based on patient gender', () => {
+    render(<PatientBannerPatientInfo patient={mockPatient} />);
+
+    expect(screen.getByText('', { selector: 'use[href="#omrs-icon-gender-male"]' })).toBeInTheDocument();
+
+    const patientWithUnknownGender = { ...mockPatient, gender: 'unknown' };
+
+    render(<PatientBannerPatientInfo patient={patientWithUnknownGender} />);
+
+    expect(screen.getByText('', { selector: 'use[href="#omrs-icon-gender-unknown"]' })).toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Fixes an issue where gender icons would not show in non-English locales. With this fix, gender icons will now show in all locales.

## Screenshots

### Before

![CleanShot 2024-12-16 at 9  30 47@2x](https://github.com/user-attachments/assets/7bae1dfe-218b-49ad-8d5d-d8fe11bb5fa4)

#### After

![CleanShot 2024-12-16 at 9  29 57@2x](https://github.com/user-attachments/assets/10a929e7-ddc0-4ced-a15c-089aecde7a37)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
