### PR TITLE
(feat) - Ability to configure number of results per page in useOpenmrsInfinite

### DIFF
--- a/packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts
+++ b/packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts
@@ -125,7 +125,7 @@ export function useServerInfinite<T, R>(
         return serverPaginationHandlers.getNextUrl(previousPageData.data)+`&limit=${resultsPerPage}`;
       }
     },
-    [url],
+    [url,resultsPerPage],
   );
 
   const { data, size, setSize, ...rest } = useSWRInfinite<FetchResponse<R>>(getKey, fetcher, {

--- a/packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts
+++ b/packages/framework/esm-react-utils/src/useOpenmrsInfinite.ts
@@ -26,6 +26,8 @@ export interface UseServerInfiniteOptions<R> {
   immutable?: boolean;
 
   swrInfiniteConfig?: SWRInfiniteConfiguration;
+
+  resultsPerPage?:number;
 }
 
 export interface UseServerInfiniteReturnObject<T, R> {
@@ -112,15 +114,15 @@ export function useServerInfinite<T, R>(
   serverPaginationHandlers: ServerPaginationHandlers<T, R>,
   options: UseServerInfiniteOptions<R> = {},
 ): UseServerInfiniteReturnObject<T, R> {
-  const { swrInfiniteConfig, immutable } = options;
+  const { swrInfiniteConfig, immutable,resultsPerPage=50 } = options;
   const { getNextUrl, getTotalCount, getData } = serverPaginationHandlers;
   const fetcher: (key: string) => Promise<FetchResponse<R>> = options.fetcher ?? openmrsFetch;
   const getKey = useCallback(
     (pageIndex: number, previousPageData: FetchResponse<R>): string | null => {
       if (pageIndex == 0) {
-        return url?.toString() ?? null;
+        return url?.toString().concat(`&limit=${resultsPerPage}`) ?? null;
       } else {
-        return serverPaginationHandlers.getNextUrl(previousPageData.data);
+        return serverPaginationHandlers.getNextUrl(previousPageData.data)+`&limit=${resultsPerPage}`;
       }
     },
     [url],


### PR DESCRIPTION
# Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
Currently, while using the infinite hook, the number of results fetched per page is 50, which is the default value. I was just thinking, what if we wanted to fetch only 20 results per page or any number other than 50? I think it would be nice to have an option to configure that in the useOpenMrsInfinite hook. I have made the necessary changes accordingly.Thanks

