### PR TITLE
(feat) O3-4277: Enable app-specific SWRConfig

### DIFF
--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
@@ -1,6 +1,6 @@
 import React, { type ComponentType, type ErrorInfo, Suspense } from 'react';
 import { I18nextProvider } from 'react-i18next';
-import { SWRConfig } from 'swr';
+import { SWRConfig, type SWRConfiguration } from 'swr';
 import type {} from '@openmrs/esm-globals';
 import { openmrsFetch } from '@openmrs/esm-api';
 import { ComponentContext, type ComponentConfig, type ExtensionData } from './ComponentContext';
@@ -31,6 +31,7 @@ export interface ComponentDecoratorOptions {
   featureName: string;
   disableTranslations?: boolean;
   strictMode?: boolean;
+  swrConfig?: Partial<Omit<SWRConfiguration, 'fetcher'>>;
 }
 
 export interface OpenmrsReactComponentProps {
@@ -98,9 +99,10 @@ export function openmrsComponentDecorator<T>(userOpts: ComponentDecoratorOptions
           // TO-DO have a UX designed for when a catastrophic error occurs
           return <div>An error has occurred. Please try reloading the page.</div>;
         } else {
+          const swrConfig = { ...defaultSwrConfig, ...opts.swrConfig };
           const content = (
             <Suspense fallback={null}>
-              <SWRConfig value={defaultSwrConfig}>
+              <SWRConfig value={swrConfig}>
                 <ComponentContext.Provider value={this.state.config}>
                   {opts.disableTranslations ? (
                     <Comp {...this.props} />
@@ -120,7 +122,7 @@ export function openmrsComponentDecorator<T>(userOpts: ComponentDecoratorOptions
               </SWRConfig>
             </Suspense>
           );
-          
+
           if (!opts.strictMode || !React.StrictMode) {
             return content;
           } else {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

### **Description**

Work in this PR allows app-specific SWR configurations for example the **service queues** and **ward apps**, ensuring their data refresh rates align with their real-time requirements.

### **Background**

Both the service queues and ward apps are used to display near real-time dashboards for **OPD/IPD workflows**. A recent global configuration change in the SWR library increased the default data cache time to 30 minutes. While this change optimizes performance for many apps, it is not suitable for apps requiring more frequent updates.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
[https://openmrs.atlassian.net/browse/O3-4277](https://openmrs.atlassian.net/browse/O3-4277)
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
