### PR TITLE
(fix) O3-4298: Capitalize language names in the `change language` modal

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { capitalize } from 'lodash-es';
 import {
   Button,
   InlineLoading,
@@ -12,7 +13,6 @@ import {
 import { useConnectivity, useSession } from '@openmrs/esm-framework';
 import { postUserPropertiesOffline, postUserPropertiesOnline } from './change-language.resource';
 import styles from './change-language.scss';
-import { capitalize } from 'lodash-es';
 
 interface ChangeLanguageModalProps {
   close(): void;

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
@@ -12,6 +12,7 @@ import {
 import { useConnectivity, useSession } from '@openmrs/esm-framework';
 import { postUserPropertiesOffline, postUserPropertiesOnline } from './change-language.resource';
 import styles from './change-language.scss';
+import { capitalize } from 'lodash-es';
 
 interface ChangeLanguageModalProps {
   close(): void;
@@ -51,9 +52,6 @@ export default function ChangeLanguageModal({ close }: ChangeLanguageModalProps)
       ),
     [allowedLocales],
   );
-  const Capitalize = (str: string) => {
-    return str.charAt(0).toUpperCase() + str.slice(1);
-  };
 
   return (
     <>
@@ -72,7 +70,7 @@ export default function ChangeLanguageModal({ close }: ChangeLanguageModalProps)
                 key={`locale-option-${locale}-${i}`}
                 id={`locale-option-${locale}-${i}`}
                 name={locale}
-                labelText={Capitalize(languageNames[locale])}
+                labelText={capitalize(languageNames[locale])}
                 value={locale}
               />
             ))}

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
@@ -12,7 +12,6 @@ import {
 import { useConnectivity, useSession } from '@openmrs/esm-framework';
 import { postUserPropertiesOffline, postUserPropertiesOnline } from './change-language.resource';
 import styles from './change-language.scss';
-import { capitalize } from 'lodash-es';
 
 interface ChangeLanguageModalProps {
   close(): void;
@@ -52,6 +51,9 @@ export default function ChangeLanguageModal({ close }: ChangeLanguageModalProps)
       ),
     [allowedLocales],
   );
+  const Capitalize = (str: string) => {
+    return str.charAt(0).toUpperCase() + str.slice(1);
+  };
 
   return (
     <>
@@ -70,7 +72,7 @@ export default function ChangeLanguageModal({ close }: ChangeLanguageModalProps)
                 key={`locale-option-${locale}-${i}`}
                 id={`locale-option-${locale}-${i}`}
                 name={locale}
-                labelText={capitalize(languageNames[locale])}
+                labelText={Capitalize(languageNames[locale])}
                 value={locale}
               />
             ))}

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
@@ -12,6 +12,7 @@ import {
 import { useConnectivity, useSession } from '@openmrs/esm-framework';
 import { postUserPropertiesOffline, postUserPropertiesOnline } from './change-language.resource';
 import styles from './change-language.scss';
+import { capitalize } from 'lodash-es';
 
 interface ChangeLanguageModalProps {
   close(): void;
@@ -69,7 +70,7 @@ export default function ChangeLanguageModal({ close }: ChangeLanguageModalProps)
                 key={`locale-option-${locale}-${i}`}
                 id={`locale-option-${locale}-${i}`}
                 name={locale}
-                labelText={languageNames[locale]}
+                labelText={capitalize(languageNames[locale])}
                 value={locale}
               />
             ))}

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.test.tsx
@@ -73,7 +73,7 @@ describe(`Change Language Modal`, () => {
 
     render(<ChangeLanguageModal close={jest.fn()} />);
 
-    await user.click(screen.getByRole('radio', { name: /English/i }));
+    await user.click(screen.getByRole('radio', { name: /english/i }));
     await user.click(screen.getByRole('button', { name: /change/i }));
 
     expect(screen.getByText(/changing language.../i)).toBeInTheDocument();
@@ -85,7 +85,7 @@ describe(`Change Language Modal`, () => {
 
     render(<ChangeLanguageModal close={jest.fn()} />);
 
-    await user.click(screen.getByRole('radio', { name: /English/i }));
+    await user.click(screen.getByRole('radio', { name: /english/i }));
     await user.click(screen.getByRole('button', { name: /change/i }));
 
     expect(mockPostUserPropertiesOffline).toHaveBeenCalledWith(

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.test.tsx
@@ -55,9 +55,9 @@ describe(`Change Language Modal`, () => {
 
     render(<ChangeLanguageModal close={jest.fn()} />);
 
-    expect(screen.getByRole('radio', { name: /français/ })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /Français/ })).toBeChecked();
 
-    await user.click(screen.getByRole('radio', { name: /english/i }));
+    await user.click(screen.getByRole('radio', { name: /English/i }));
     await user.click(screen.getByRole('button', { name: /change/i }));
 
     expect(mockPostUserPropertiesOnline).toHaveBeenCalledWith(

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.test.tsx
@@ -34,10 +34,10 @@ describe(`Change Language Modal`, () => {
   it('should correctly displays all allowed locales', () => {
     render(<ChangeLanguageModal close={jest.fn()} />);
 
-    expect(screen.getByRole('radio', { name: /english/i })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: /français/i })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: /italiano/i })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: /português/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /English/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /Français/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /Italiano/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /Português/i })).toBeInTheDocument();
   });
 
   it('should close the modal when the cancel button is clicked', async () => {
@@ -73,7 +73,7 @@ describe(`Change Language Modal`, () => {
 
     render(<ChangeLanguageModal close={jest.fn()} />);
 
-    await user.click(screen.getByRole('radio', { name: /english/i }));
+    await user.click(screen.getByRole('radio', { name: /English/i }));
     await user.click(screen.getByRole('button', { name: /change/i }));
 
     expect(screen.getByText(/changing language.../i)).toBeInTheDocument();
@@ -85,7 +85,7 @@ describe(`Change Language Modal`, () => {
 
     render(<ChangeLanguageModal close={jest.fn()} />);
 
-    await user.click(screen.getByRole('radio', { name: /english/i }));
+    await user.click(screen.getByRole('radio', { name: /English/i }));
     await user.click(screen.getByRole('button', { name: /change/i }));
 
     expect(mockPostUserPropertiesOffline).toHaveBeenCalledWith(

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.test.tsx
@@ -34,10 +34,10 @@ describe(`Change Language Modal`, () => {
   it('should correctly displays all allowed locales', () => {
     render(<ChangeLanguageModal close={jest.fn()} />);
 
-    expect(screen.getByRole('radio', { name: /English/i })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: /Français/i })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: /Italiano/i })).toBeInTheDocument();
-    expect(screen.getByRole('radio', { name: /Português/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /english/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /français/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /italiano/i })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: /português/i })).toBeInTheDocument();
   });
 
   it('should close the modal when the cancel button is clicked', async () => {
@@ -55,9 +55,9 @@ describe(`Change Language Modal`, () => {
 
     render(<ChangeLanguageModal close={jest.fn()} />);
 
-    expect(screen.getByRole('radio', { name: /Français/ })).toBeChecked();
+    expect(screen.getByRole('radio', { name: /français/i })).toBeChecked();
 
-    await user.click(screen.getByRole('radio', { name: /English/i }));
+    await user.click(screen.getByRole('radio', { name: /english/i }));
     await user.click(screen.getByRole('button', { name: /change/i }));
 
     expect(mockPostUserPropertiesOnline).toHaveBeenCalledWith(


### PR DESCRIPTION
# Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.
## For changes to apps
- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).
## If applicable
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.
## Summary
The "Change language" modal lists some language names in lowercase (e.g., "français," "español"), which is inconsistent with the proper capitalization of language names like "English" or "British English." 
## Screenshots
<!-- Required if you are making UI changes. -->
**Before**

https://github.com/user-attachments/assets/1b1e5e8c-9581-44d6-9181-91077301e82b


**After**

https://github.com/user-attachments/assets/4b7a96f9-79ba-4f6b-80f9-cc39f631ec39


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
## Other
<!-- Anything not covered above -->