### PR TITLE
(feat) Allow registering workspace groups via routes.json

### DIFF
--- a/packages/framework/esm-extensions/src/workspaces.ts
+++ b/packages/framework/esm-extensions/src/workspaces.ts
@@ -20,7 +20,9 @@ export interface WorkspaceRegistration {
   groups: Array<string>;
 }
 
-export type WorkspaceGroupRegistration = WorkspaceGroupDefinition;
+export type WorkspaceGroupRegistration = WorkspaceGroupDefinition & {
+  members: Array<string>;
+};
 
 interface WorkspaceRegistrationStore {
   workspaces: Record<string, WorkspaceRegistration>;
@@ -74,20 +76,18 @@ export function registerWorkspace(workspace: RegisterWorkspaceOptions) {
   }));
 }
 
-export type RegisterWorkspaceGroupOptions = WorkspaceGroupRegistration;
-
 /**
  * Tells the workspace system about a workspace group. This is used by the app shell
  * to register workspace groups defined in the `routes.json` file.
  * @internal
  */
-export function registerWorkspaceGroup(workspaceGroup: RegisterWorkspaceGroupOptions) {
+export function registerWorkspaceGroup(workspaceGroup: WorkspaceGroupRegistration) {
   workspaceGroupStore.setState((state) => ({
     workspaceGroups: {
       ...state.workspaceGroups,
       [workspaceGroup.name]: {
         name: workspaceGroup.name,
-        members: workspaceGroup.members ?? [],
+        members: workspaceGroup.members,
       },
     },
   }));
@@ -123,7 +123,7 @@ export function getWorkspaceRegistration(name: string): WorkspaceRegistration {
         canHide: workspaceExtension.meta?.canHide ?? false,
         canMaximize: workspaceExtension.meta?.canMaximize ?? false,
         width: workspaceExtension.meta?.width ?? 'narrow',
-        groups: workspaceExtension.meta?.groups,
+        groups: workspaceExtension.meta?.groups ?? [],
       };
     } else {
       throw new Error(`No workspace named '${name}' has been registered.`);

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -610,7 +610,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:409](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L409)
+[packages/framework/esm-globals/src/types.ts:422](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L422)
 
 ___
 
@@ -623,7 +623,7 @@ Basically, this is the same as the app routes, with each routes definition keyed
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:400](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L400)
+[packages/framework/esm-globals/src/types.ts:413](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L413)
 
 ___
 
@@ -8231,7 +8231,7 @@ Function to close an opened workspace
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:425](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L425)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:433](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L433)
 
 ___
 
@@ -8282,7 +8282,7 @@ prop named `workspaceTitle` will override the title of the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:289](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L289)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:297](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L297)
 
 ___
 
@@ -8313,7 +8313,7 @@ launchWorkspaceGroup("myGroup", {
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:205](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L205)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:211](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L211)
 
 ___
 
@@ -8339,7 +8339,7 @@ Use this function to navigate to a new page and launch a workspace on that page.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:382](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L382)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:390](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L390)
 
 ___
 
@@ -8353,4 +8353,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:536](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L536)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:544](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L544)

--- a/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
+++ b/packages/framework/esm-framework/docs/interfaces/CloseWorkspaceOptions.md
@@ -27,7 +27,7 @@ Defaults to true except when opening a new workspace of the same group.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:33](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L33)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L38)
 
 ___
 
@@ -42,7 +42,7 @@ even if the `testFcn` passed to `promptBeforeClosing` returns `true`.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L18)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:23](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L23)
 
 ## Workspace Methods
 
@@ -62,4 +62,4 @@ void
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:25](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L25)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:30](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L30)

--- a/packages/framework/esm-framework/docs/interfaces/DefaultWorkspaceProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/DefaultWorkspaceProps.md
@@ -43,7 +43,7 @@ closed, given the user forcefully closes the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L45)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L50)
 
 ___
 
@@ -66,7 +66,7 @@ will directly close the workspace without any prompt
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:55](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L55)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:60](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L60)
 
 ___
 
@@ -89,7 +89,7 @@ this workspace is closed; e.g. if there is unsaved data.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L50)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:55](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L55)
 
 ___
 
@@ -117,4 +117,4 @@ title needs to be set dynamically.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L70)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:75](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L75)

--- a/packages/framework/esm-framework/docs/interfaces/FeatureFlagDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/FeatureFlagDefinition.md
@@ -22,7 +22,7 @@ An explanation of what the flag does, which will be displayed in the Implementer
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:363](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L363)
+[packages/framework/esm-globals/src/types.ts:374](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L374)
 
 ___
 
@@ -34,7 +34,7 @@ A code-friendly name for the flag, which will be used to reference it in code
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:359](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L359)
+[packages/framework/esm-globals/src/types.ts:370](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L370)
 
 ___
 
@@ -46,4 +46,4 @@ A human-friendly name which will be displayed in the Implementer Tools
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:361](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L361)
+[packages/framework/esm-globals/src/types.ts:372](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L372)

--- a/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
@@ -16,7 +16,6 @@
 
 - [canHide](OpenWorkspace.md#canhide)
 - [canMaximize](OpenWorkspace.md#canmaximize)
-- [groups](OpenWorkspace.md#groups)
 - [moduleName](OpenWorkspace.md#modulename)
 - [name](OpenWorkspace.md#name)
 - [preferredWindowSize](OpenWorkspace.md#preferredwindowsize)
@@ -65,20 +64,6 @@ ___
 #### Defined in
 
 [packages/framework/esm-extensions/src/workspaces.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L15)
-
-___
-
-### groups
-
-• `Optional` **groups**: `string`[]
-
-#### Inherited from
-
-[WorkspaceRegistration](WorkspaceRegistration.md).[groups](WorkspaceRegistration.md#groups)
-
-#### Defined in
-
-[packages/framework/esm-extensions/src/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L20)
 
 ___
 
@@ -188,7 +173,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:109](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L109)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:115](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L115)
 
 ___
 
@@ -198,7 +183,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:110](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L110)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:116](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L116)
 
 ## Methods
 
@@ -228,7 +213,7 @@ closed, given the user forcefully closes the workspace.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L45)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L50)
 
 ___
 
@@ -255,7 +240,7 @@ will directly close the workspace without any prompt
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:55](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L55)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:60](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L60)
 
 ___
 
@@ -300,7 +285,7 @@ this workspace is closed; e.g. if there is unsaved data.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L50)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:55](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L55)
 
 ___
 
@@ -332,4 +317,4 @@ title needs to be set dynamically.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L70)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:75](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L75)

--- a/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenWorkspace.md
@@ -16,6 +16,7 @@
 
 - [canHide](OpenWorkspace.md#canhide)
 - [canMaximize](OpenWorkspace.md#canmaximize)
+- [groups](OpenWorkspace.md#groups)
 - [moduleName](OpenWorkspace.md#modulename)
 - [name](OpenWorkspace.md#name)
 - [preferredWindowSize](OpenWorkspace.md#preferredwindowsize)
@@ -64,6 +65,20 @@ ___
 #### Defined in
 
 [packages/framework/esm-extensions/src/workspaces.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L15)
+
+___
+
+### groups
+
+• **groups**: `string`[]
+
+#### Inherited from
+
+[WorkspaceRegistration](WorkspaceRegistration.md).[groups](WorkspaceRegistration.md#groups)
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L20)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
@@ -15,6 +15,7 @@ This interface describes the format of the routes provided by an app
 - [optionalBackendDependencies](OpenmrsAppRoutes.md#optionalbackenddependencies)
 - [pages](OpenmrsAppRoutes.md#pages)
 - [version](OpenmrsAppRoutes.md#version)
+- [workspaceGroups](OpenmrsAppRoutes.md#workspacegroups)
 - [workspaces](OpenmrsAppRoutes.md#workspaces)
 
 ## Properties
@@ -27,7 +28,7 @@ A list of backend modules necessary for this frontend module and the correspondi
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:371](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L371)
+[packages/framework/esm-globals/src/types.ts:382](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L382)
 
 ___
 
@@ -39,7 +40,7 @@ An array of all extensions supported by this frontend module. Extensions can be 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:387](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L387)
+[packages/framework/esm-globals/src/types.ts:398](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L398)
 
 ___
 
@@ -51,7 +52,7 @@ An array of all feature flags for any beta-stage features this module provides.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:389](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L389)
+[packages/framework/esm-globals/src/types.ts:400](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L400)
 
 ___
 
@@ -63,7 +64,7 @@ An array of all modals supported by this frontend module. Modals can be launched
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:391](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L391)
+[packages/framework/esm-globals/src/types.ts:402](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L402)
 
 ___
 
@@ -81,7 +82,7 @@ The name of the backend dependency and either the required version or an object 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:373](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L373)
+[packages/framework/esm-globals/src/types.ts:384](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L384)
 
 ___
 
@@ -93,7 +94,7 @@ An array of all pages supported by this frontend module. Pages are automatically
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:385](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L385)
+[packages/framework/esm-globals/src/types.ts:396](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L396)
 
 ___
 
@@ -105,7 +106,19 @@ The version of this frontend module.
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:369](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L369)
+[packages/framework/esm-globals/src/types.ts:380](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L380)
+
+___
+
+### workspaceGroups
+
+• `Optional` **workspaceGroups**: [`WorkspaceGroupDefinition`](WorkspaceGroupDefinition.md)[]
+
+An array of all workspace groups supported by this frontend module.
+
+#### Defined in
+
+[packages/framework/esm-globals/src/types.ts:406](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L406)
 
 ___
 
@@ -117,4 +130,4 @@ An array of all workspaces supported by this frontend module. Workspaces can be 
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:393](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L393)
+[packages/framework/esm-globals/src/types.ts:404](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L404)

--- a/packages/framework/esm-framework/docs/interfaces/Prompt.md
+++ b/packages/framework/esm-framework/docs/interfaces/Prompt.md
@@ -23,7 +23,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:89](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L89)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:94](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L94)
 
 ___
 
@@ -35,7 +35,7 @@ Defaults to "Cancel"
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:94](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L94)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:99](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L99)
 
 ___
 
@@ -47,7 +47,7 @@ Defaults to "Confirm"
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:91](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L91)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:96](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L96)
 
 ___
 
@@ -57,7 +57,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:88](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L88)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L93)
 
 ## Methods
 
@@ -71,4 +71,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:92](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L92)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:97](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L97)

--- a/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
+++ b/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
@@ -20,4 +20,4 @@
 
 #### Defined in
 
-[packages/framework/esm-globals/src/types.ts:403](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L403)
+[packages/framework/esm-globals/src/types.ts:416](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L416)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceGroupDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceGroupDefinition.md
@@ -13,7 +13,7 @@
 
 ### members
 
-• **members**: `string`[]
+• `Optional` **members**: `string`[]
 
 List of workspace names which are part of the workspace group.
 

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceGroupDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceGroupDefinition.md
@@ -1,0 +1,34 @@
+[@openmrs/esm-framework](../API.md) / WorkspaceGroupDefinition
+
+# Interface: WorkspaceGroupDefinition
+
+## Table of contents
+
+### Properties
+
+- [members](WorkspaceGroupDefinition.md#members)
+- [name](WorkspaceGroupDefinition.md#name)
+
+## Properties
+
+### members
+
+• **members**: `string`[]
+
+List of workspace names which are part of the workspace group.
+
+#### Defined in
+
+[packages/framework/esm-globals/src/types.ts:362](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L362)
+
+___
+
+### name
+
+• **name**: `string`
+
+Name of the workspace group. This is used to launch the workspace group
+
+#### Defined in
+
+[packages/framework/esm-globals/src/types.ts:358](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L358)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
@@ -16,7 +16,6 @@ See [WorkspaceDefinition](../API.md#workspacedefinition) for more information ab
 
 - [canHide](WorkspaceRegistration.md#canhide)
 - [canMaximize](WorkspaceRegistration.md#canmaximize)
-- [groups](WorkspaceRegistration.md#groups)
 - [moduleName](WorkspaceRegistration.md#modulename)
 - [name](WorkspaceRegistration.md#name)
 - [preferredWindowSize](WorkspaceRegistration.md#preferredwindowsize)
@@ -48,16 +47,6 @@ ___
 #### Defined in
 
 [packages/framework/esm-extensions/src/workspaces.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L15)
-
-___
-
-### groups
-
-• `Optional` **groups**: `string`[]
-
-#### Defined in
-
-[packages/framework/esm-extensions/src/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L20)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceRegistration.md
@@ -16,6 +16,7 @@ See [WorkspaceDefinition](../API.md#workspacedefinition) for more information ab
 
 - [canHide](WorkspaceRegistration.md#canhide)
 - [canMaximize](WorkspaceRegistration.md#canmaximize)
+- [groups](WorkspaceRegistration.md#groups)
 - [moduleName](WorkspaceRegistration.md#modulename)
 - [name](WorkspaceRegistration.md#name)
 - [preferredWindowSize](WorkspaceRegistration.md#preferredwindowsize)
@@ -47,6 +48,16 @@ ___
 #### Defined in
 
 [packages/framework/esm-extensions/src/workspaces.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L15)
+
+___
+
+### groups
+
+• **groups**: `string`[]
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/workspaces.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/workspaces.ts#L20)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspacesInfo.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:529](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L529)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:537](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L537)
 
 ___
 
@@ -30,7 +30,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:530](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L530)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:538](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L538)
 
 ___
 
@@ -43,11 +43,12 @@ ___
 | Name | Type |
 | :------ | :------ |
 | `cleanup?` | `Function` |
+| `members` | `string`[] |
 | `name` | `string` |
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:533](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L533)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:541](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L541)
 
 ___
 
@@ -57,7 +58,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:531](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L531)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:539](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L539)
 
 ___
 
@@ -67,4 +68,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:532](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L532)
+[packages/framework/esm-styleguide/src/workspaces/workspaces.ts:540](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces/workspaces.ts#L540)

--- a/packages/framework/esm-globals/src/types.ts
+++ b/packages/framework/esm-globals/src/types.ts
@@ -359,7 +359,7 @@ export interface WorkspaceGroupDefinition {
   /**
    * List of workspace names which are part of the workspace group.
    */
-  members: Array<string>;
+  members?: Array<string>;
 }
 
 /**

--- a/packages/framework/esm-globals/src/types.ts
+++ b/packages/framework/esm-globals/src/types.ts
@@ -351,6 +351,17 @@ export type WorkspaceDefinition = {
     }
 );
 
+export interface WorkspaceGroupDefinition {
+  /**
+   * Name of the workspace group. This is used to launch the workspace group
+   */
+  name: string;
+  /**
+   * List of workspace names which are part of the workspace group.
+   */
+  members: Array<string>;
+}
+
 /**
  * A definition of a feature flag extracted from the routes.json
  */
@@ -391,6 +402,8 @@ export interface OpenmrsAppRoutes {
   modals?: Array<ModalDefinition>;
   /** An array of all workspaces supported by this frontend module. Workspaces can be launched by name. */
   workspaces?: Array<WorkspaceDefinition>;
+  /** An array of all workspace groups supported by this frontend module. */
+  workspaceGroups?: Array<WorkspaceGroupDefinition>;
 }
 
 /**

--- a/packages/framework/esm-routes/src/loaders/components.ts
+++ b/packages/framework/esm-routes/src/loaders/components.ts
@@ -4,12 +4,14 @@ import {
   registerExtension,
   registerModal,
   registerWorkspace,
+  registerWorkspaceGroup,
 } from '@openmrs/esm-extensions';
 import {
   type FeatureFlagDefinition,
   type ExtensionDefinition,
   type ModalDefinition,
   type WorkspaceDefinition,
+  type WorkspaceGroupDefinition,
 } from '@openmrs/esm-globals';
 import { getLoader } from './app';
 import { registerFeatureFlag } from '@openmrs/esm-feature-flags';
@@ -194,9 +196,49 @@ supported, so the workspace will not be loaded.`,
       canMaximize: workspace.canMaximize,
       width: workspace.width,
       preferredWindowSize: workspace.preferredWindowSize,
-      groups: workspace.groups ?? [],
     });
   }
+}
+
+/**
+ * This function registers a workspace group definition with the framework so that it can be launched.
+ *
+ * @param appName The name of the app defining this workspace
+ * @param workspace An object that describes the workspace, derived from `routes.json`
+ */
+export function tryRegisterWorkspaceGroup(appName: string, workspaceGroup: WorkspaceGroupDefinition) {
+  const name = workspaceGroup.name;
+  if (!name) {
+    console.error(
+      `A workspace group definition in ${appName} is missing a name and thus cannot be registered.
+To fix this, ensure that you define the "name" field inside the workspace definition.`,
+      workspaceGroup,
+    );
+    return;
+  }
+
+  if (!workspaceGroup.members) {
+    console.error(
+      `The workspace ${name} from ${appName} is missing a 'members' entry and thus cannot be registered.
+To fix this, ensure that you define a 'members' field inside the workspace definition.`,
+      workspaceGroup,
+    );
+    return;
+  }
+
+  if (!workspaceGroup.members.length) {
+    console.error(
+      `The workspace ${name} from ${appName} has empty 'members' property and thus cannot be registered.
+To fix this, ensure that you define atleast one 'workspace name' part of the workspace group field inside the workspace group's 'member' definition.`,
+      workspaceGroup,
+    );
+    return;
+  }
+
+  registerWorkspaceGroup({
+    name,
+    members: workspaceGroup.members ?? [],
+  });
 }
 
 /**

--- a/packages/framework/esm-routes/src/loaders/components.ts
+++ b/packages/framework/esm-routes/src/loaders/components.ts
@@ -1,5 +1,6 @@
 import {
   attach,
+  attachWorkspaceToGroup,
   type ExtensionRegistration,
   registerExtension,
   registerModal,
@@ -196,7 +197,12 @@ supported, so the workspace will not be loaded.`,
       canMaximize: workspace.canMaximize,
       width: workspace.width,
       preferredWindowSize: workspace.preferredWindowSize,
+      groups: workspace.groups,
     });
+  }
+
+  for (const group of workspace.groups || []) {
+    attachWorkspaceToGroup(name, group);
   }
 }
 

--- a/packages/framework/esm-routes/src/loaders/components.ts
+++ b/packages/framework/esm-routes/src/loaders/components.ts
@@ -223,24 +223,6 @@ To fix this, ensure that you define the "name" field inside the workspace defini
     return;
   }
 
-  if (!workspaceGroup.members) {
-    console.error(
-      `The workspace ${name} from ${appName} is missing a 'members' entry and thus cannot be registered.
-To fix this, ensure that you define a 'members' field inside the workspace definition.`,
-      workspaceGroup,
-    );
-    return;
-  }
-
-  if (!workspaceGroup.members.length) {
-    console.error(
-      `The workspace ${name} from ${appName} has empty 'members' property and thus cannot be registered.
-To fix this, ensure that you define atleast one 'workspace name' part of the workspace group field inside the workspace group's 'member' definition.`,
-      workspaceGroup,
-    );
-    return;
-  }
-
   registerWorkspaceGroup({
     name,
     members: workspaceGroup.members ?? [],

--- a/packages/framework/esm-routes/src/loaders/pages.ts
+++ b/packages/framework/esm-routes/src/loaders/pages.ts
@@ -1,6 +1,7 @@
 import { type ActivityFn, pathToActiveWhen, registerApplication } from 'single-spa';
 import { registerModuleWithConfigSystem } from '@openmrs/esm-config';
 import {
+  type WorkspaceGroupDefinition,
   type ExtensionDefinition,
   type FeatureFlagDefinition,
   type ModalDefinition,
@@ -12,7 +13,13 @@ import {
 import { getFeatureFlag } from '@openmrs/esm-feature-flags';
 import { routeRegex } from './helpers';
 import { getLoader } from './app';
-import { tryRegisterExtension, tryRegisterFeatureFlag, tryRegisterModal, tryRegisterWorkspace } from './components';
+import {
+  tryRegisterExtension,
+  tryRegisterFeatureFlag,
+  tryRegisterModal,
+  tryRegisterWorkspace,
+  tryRegisterWorkspaceGroup,
+} from './components';
 
 // this is the global holder of all pages registered in the app
 const pages: Array<RegisteredPageDefinition> = [];
@@ -93,6 +100,7 @@ export function registerApp(appName: string, routes: OpenmrsAppRoutes) {
     const availableExtensions: Array<ExtensionDefinition> = routes.extensions ?? [];
     const availableModals: Array<ModalDefinition> = routes.modals ?? [];
     const availableWorkspaces: Array<WorkspaceDefinition> = routes.workspaces ?? [];
+    const availableWorkspaceGroups: Array<WorkspaceGroupDefinition> = routes.workspaceGroups ?? [];
     const availableFeatureFlags: Array<FeatureFlagDefinition> = routes.featureFlags ?? [];
 
     routes.pages?.forEach((p) => {
@@ -149,6 +157,22 @@ export function registerApp(appName: string, routes: OpenmrsAppRoutes) {
         console.warn(
           `A workspace for ${appName} could not be registered as it does not appear to have the required properties`,
           workspace,
+        );
+      }
+    });
+
+    availableWorkspaceGroups.forEach((workspaceGroup) => {
+      if (
+        workspaceGroup &&
+        typeof workspaceGroup === 'object' &&
+        Object.hasOwn(workspaceGroup, 'name') &&
+        Object.hasOwn(workspaceGroup, 'members')
+      ) {
+        tryRegisterWorkspaceGroup(appName, workspaceGroup);
+      } else {
+        console.warn(
+          `A workspace group for ${appName} could not be registered as it does not appear to have the required properties`,
+          workspaceGroup,
         );
       }
     });

--- a/packages/framework/esm-routes/src/loaders/pages.ts
+++ b/packages/framework/esm-routes/src/loaders/pages.ts
@@ -162,12 +162,7 @@ export function registerApp(appName: string, routes: OpenmrsAppRoutes) {
     });
 
     availableWorkspaceGroups.forEach((workspaceGroup) => {
-      if (
-        workspaceGroup &&
-        typeof workspaceGroup === 'object' &&
-        Object.hasOwn(workspaceGroup, 'name') &&
-        Object.hasOwn(workspaceGroup, 'members')
-      ) {
+      if (workspaceGroup && typeof workspaceGroup === 'object' && Object.hasOwn(workspaceGroup, 'name')) {
         tryRegisterWorkspaceGroup(appName, workspaceGroup);
       } else {
         console.warn(

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -1,5 +1,5 @@
 import { clearMockExtensionRegistry } from '@openmrs/esm-framework/mock';
-import { registerExtension, registerWorkspace } from '@openmrs/esm-extensions';
+import { registerExtension, registerWorkspace, registerWorkspaceGroup } from '@openmrs/esm-extensions';
 import {
   type Prompt,
   cancelPrompt,
@@ -555,7 +555,7 @@ describe('workspace system', () => {
       });
 
       expect(workspaceGroupStore).toBeTruthy();
-      expect(workspaceGroupStore?.getState()?.['foo']).toBe(true);
+      expect(workspaceGroupStore?.getState()['foo']).toBe(true);
     });
 
     it('should update the store state with new additionalProps if workspaces with same workspaceGroup name calls the function', () => {
@@ -564,15 +564,15 @@ describe('workspace system', () => {
       });
 
       expect(workspaceGroupStore).toBeTruthy();
-      expect(workspaceGroupStore?.getState()?.['foo']).toBe(true);
+      expect(workspaceGroupStore?.getState()['foo']).toBe(true);
 
       workspaceGroupStore = getWorkspaceGroupStore('ward-patient-store', {
         bar: true,
       });
 
       expect(workspaceGroupStore).toBeTruthy();
-      expect(workspaceGroupStore?.getState()?.['foo']).toBe(true);
-      expect(workspaceGroupStore?.getState()?.['bar']).toBe(true);
+      expect(workspaceGroupStore?.getState()['foo']).toBe(true);
+      expect(workspaceGroupStore?.getState()['bar']).toBe(true);
     });
   });
 
@@ -590,7 +590,11 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        groups: ['ward-patient-store'],
+      });
+
+      registerWorkspaceGroup({
+        name: 'ward-patient-store',
+        members: ['ward-patient-workspace'],
       });
 
       launchWorkspaceGroup('ward-patient-store', {
@@ -620,7 +624,10 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        groups: ['ward-patient-store'],
+      });
+      registerWorkspaceGroup({
+        name: 'ward-patient-store',
+        members: ['ward-patient-workspace'],
       });
       launchWorkspaceGroup('ward-patient-store', {
         state: {
@@ -647,7 +654,6 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        groups: [workspaceGroup],
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -655,7 +661,10 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        groups: [workspaceGroup],
+      });
+      registerWorkspaceGroup({
+        name: workspaceGroup,
+        members: ['ward-patient-workspace', 'transfer-patient-workspace'],
       });
 
       launchWorkspaceGroup(workspaceGroup, {
@@ -689,7 +698,6 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        groups: ['ward-patient-store'],
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -697,7 +705,16 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        groups: ['another-sidebar-group'],
+      });
+
+      registerWorkspaceGroup({
+        name: 'ward-patient-store',
+        members: ['ward-patient-workspace'],
+      });
+
+      registerWorkspaceGroup({
+        name: 'another-sidebar-group',
+        members: ['transfer-patient-workspace'],
       });
 
       const workspaceStore = getWorkspaceStore();
@@ -737,7 +754,6 @@ describe('workspace system', () => {
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
         canHide: true,
-        groups: ['ward-patient-store'],
       });
       registerWorkspace({
         name: 'transfer-patient-workspace',
@@ -745,7 +761,11 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'transfer-patient',
         moduleName: '@openmrs/esm-ward-app',
-        groups: ['ward-patient-store'],
+      });
+
+      registerWorkspaceGroup({
+        name: 'ward-patient-store',
+        members: ['ward-patient-workspace', 'transfer-patient-workspace'],
       });
 
       const workspaceStore = getWorkspaceStore();
@@ -776,7 +796,10 @@ describe('workspace system', () => {
         load: jest.fn(),
         type: 'ward-patient',
         moduleName: '@openmrs/esm-ward-app',
-        groups: ['ward-patient-store'],
+      });
+      registerWorkspaceGroup({
+        name: 'ward-patient-store',
+        members: ['ward-patient-workspace'],
       });
       launchWorkspaceGroup('ward-patient-store', {
         state: { foo: true },

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -301,7 +301,7 @@ export function launchWorkspace<
   const workspace = getWorkspaceRegistration(name);
   const currentWorkspaceGroup = store.getState().workspaceGroup;
 
-  if (currentWorkspaceGroup && !currentWorkspaceGroup.members?.includes(currentWorkspaceGroup?.name)) {
+  if (currentWorkspaceGroup && !currentWorkspaceGroup.members?.includes(name)) {
     closeWorkspaceGroup(currentWorkspaceGroup.name, () => {
       launchWorkspace(name, additionalProps);
     });

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -1,6 +1,11 @@
 /** @module @category Workspace */
 import { useMemo, type ReactNode } from 'react';
-import { getWorkspaceRegistration, type WorkspaceRegistration } from '@openmrs/esm-extensions';
+import {
+  getWorkspaceGroupRegistration,
+  getWorkspaceRegistration,
+  WorkspaceGroupRegistration,
+  type WorkspaceRegistration,
+} from '@openmrs/esm-extensions';
 import { type WorkspaceWindowState } from '@openmrs/esm-globals';
 import { navigate } from '@openmrs/esm-navigation';
 import { getGlobalStore, createGlobalStore } from '@openmrs/esm-state';
@@ -101,6 +106,7 @@ export interface WorkspaceStoreState {
   workspaceWindowState: WorkspaceWindowState;
   workspaceGroup?: {
     name: string;
+    members: Array<string>;
     cleanup?: Function;
   };
 }
@@ -203,6 +209,7 @@ interface LaunchWorkspaceGroupArg {
  * });
  */
 export function launchWorkspaceGroup(groupName: string, args: LaunchWorkspaceGroupArg) {
+  const workspaceGroupRegistration = getWorkspaceGroupRegistration(groupName);
   const { state, onWorkspaceGroupLaunch, workspaceGroupCleanup, workspaceToLaunch } = args;
   const store = getWorkspaceStore();
   if (store.getState().openWorkspaces.length) {
@@ -221,6 +228,7 @@ export function launchWorkspaceGroup(groupName: string, args: LaunchWorkspaceGro
       ...prev,
       workspaceGroup: {
         name: groupName,
+        members: workspaceGroupRegistration.members,
         cleanup: workspaceGroupCleanup,
       },
     }));
@@ -293,7 +301,7 @@ export function launchWorkspace<
   const workspace = getWorkspaceRegistration(name);
   const currentWorkspaceGroup = store.getState().workspaceGroup;
 
-  if (currentWorkspaceGroup && !workspace.groups?.includes(currentWorkspaceGroup?.name)) {
+  if (currentWorkspaceGroup && !currentWorkspaceGroup.members?.includes(currentWorkspaceGroup?.name)) {
     closeWorkspaceGroup(currentWorkspaceGroup.name, () => {
       launchWorkspace(name, additionalProps);
     });


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR allows workspace groups to be registered via routes.json, which is similar to how workspaces are registered. In the previous implementation of `launchWorkspaceGroup` in #1185, there was a design flaw, wherein, for a workspace to be part of a workspace group, it should define the respective group under its definition in the `routes.json`. Now, the workspace group registration will define the individual workspaces that will be the `members` of the respective workspace group, hence the individual workspace will not need to know what all workspace groups it is a part of.

## Screenshots
Yet to test out changes, since dev3 is down.

## Related Issue
https://issues.openmrs.org/browse/O3-4077

## Other
<!-- Anything not covered above -->
