### PR TITLE
(fix) O3-4081: Change help menu button to use IconButton

### DIFF
--- a/packages/apps/esm-help-menu-app/src/help-menu/help.component.tsx
+++ b/packages/apps/esm-help-menu-app/src/help-menu/help.component.tsx
@@ -1,11 +1,13 @@
 import React, { useState, useEffect, useRef } from 'react';
-import classNames from 'classnames';
+import { useTranslation } from 'react-i18next';
+import { IconButton } from '@carbon/react';
 import { Help } from '@carbon/react/icons';
-import { useSession } from '@openmrs/esm-framework'
+import { useSession } from '@openmrs/esm-framework';
 import HelpMenuPopup from './help-popup.component';
 import styles from './help.styles.scss';
 
 export default function HelpMenu() {
+  const { t } = useTranslation();
   const { user } = useSession();
   const [helpMenuOpen, setHelpMenuOpen] = useState(false);
   const helpMenuButtonRef = useRef(null);
@@ -38,15 +40,19 @@ export default function HelpMenu() {
   return (
     <>
       {user && (
-        <button
+        <IconButton
+          label={t('help', 'Help')}
+          align="left"
+          size="md"
           aria-expanded={helpMenuOpen}
           aria-controls="help-menu-popup"
           onClick={toggleHelpMenu}
           ref={helpMenuButtonRef}
-          className={classNames(styles.helpMenuButton)}
+          className={styles.helpMenuButton}
+          wrapperClasses={styles.popover}
         >
           <Help size={24} />
-        </button>
+        </IconButton>
       )}
       {helpMenuOpen && (
         <div id="help-menu-popup" ref={popupRef} className={styles.helpMenuPopup}>

--- a/packages/apps/esm-help-menu-app/src/help-menu/help.styles.scss
+++ b/packages/apps/esm-help-menu-app/src/help-menu/help.styles.scss
@@ -3,23 +3,31 @@
 
 .helpMenuButton {
   z-index: 7900;
-  background-color: white;
+  background-color: colors.$white;
   height: 2.5rem !important;
   width: 2.5rem !important;
   bottom: layout.$spacing-05;
-  position: fixed;
-  display: flex;
-  justify-content: center;
-  align-items: center;
   right: 0.25rem;
+  position: fixed;
+  padding: 0;
+  display: flex;
+  align-items: center;
   border: none;
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.1),
     0 1px 2px -1px rgba(0, 0, 0, 0.1);
   border-radius: layout.$spacing-03;
+  color: colors.$black;
 
   &:hover {
     background-color: colors.$gray-20;
-    cursor: pointer;
+    color: colors.$black;
   }
+}
+
+.popover {
+  z-index: 7900;
+  bottom: layout.$spacing-07;
+  position: fixed;
+  right: 3.25rem;
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR changes the help menu button to use the `IconButton` from carbon. This would give the carbon inbuilt tooltip when hovering over it.

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1710" alt="Screenshot 2025-01-07 at 11 59 02 PM" src="https://github.com/user-attachments/assets/f667b5c7-189b-4c8e-8368-dea7a6234b52" />
<img width="1710" alt="Screenshot 2025-01-07 at 11 59 17 PM" src="https://github.com/user-attachments/assets/28fd65de-1f53-496d-907f-f9087696416f" />
<img width="1710" alt="Screenshot 2025-01-07 at 11 59 31 PM" src="https://github.com/user-attachments/assets/bf691c53-d6f8-48fc-946e-eafed29a4e6b" />

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-4081

## Other
<!-- Anything not covered above -->
