### PR TITLE
(fix) O3-3370: Properly handle relative imports in development

### DIFF
--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -29,51 +29,78 @@ yargs.command(
   'Starts a new debugging session of the OpenMRS app shell. This uses Webpack as a debug server with proxy middleware.',
   (argv) =>
     argv
-      .number('port')
-      .default('port', 8080)
-      .describe('port', 'The port where the dev server should run.')
-      .number('host')
-      .default('host', 'localhost')
-      .describe('host', 'The host name or IP for the server to use.')
-      .string('backend')
-      .default('backend', 'https://dev3.openmrs.org/')
-      .describe('backend', 'The backend to proxy API requests to.')
-      .string('add-cookie')
-      .default('add-cookie', '')
-      .describe('add-cookie', 'Additional cookies to provide when proxying.')
-      .boolean('support-offline')
-      .describe('support-offline', 'Determines if a service worker should be installed for offline support.')
-      .default('support-offline', false)
-      .string('spa-path')
-      .default('spa-path', '/openmrs/spa/')
-      .describe('spa-path', 'The path of the application on the target server.')
-      .string('api-url')
-      .default('api-url', '/openmrs/')
-      .describe('api-url', 'The URL of the API. Can be a path if the API is on the same target server.')
-      .string('page-title')
-      .default('page-title', 'OpenMRS')
-      .describe('page-title', 'The title of the web app usually displayed in the browser tab.')
-      .array('config-url')
-      .default('config-url', [])
-      .describe('config-url', 'The URL to a valid frontend configuration. Can be used multiple times.')
-      .boolean('run-project')
-      .default('run-project', false)
-      .describe('run-project', 'Runs the project in the current directory fusing it with the specified import map.')
-      .array('sources')
-      .default('sources', ['.'])
-      .describe('sources', 'Runs the projects from the provided source directories. Can be used multiple times.')
-      .array('shared-dependencies')
-      .default('shared-dependencies', [])
-      .describe('shared-dependencies', 'The additional shared dependencies besides the ones from the app shell.')
-      .string('importmap')
-      .default('importmap', 'importmap.json')
-      .describe(
-        'importmap',
-        'The import map to use. Can be a path to a valid import map to be taken literally, an URL, or a fixed JSON object.',
-      )
-      .string('routes')
-      .default('routes', 'routes.registry.json')
-      .describe('routes', 'The routes.registry.json file to use.'),
+      .option('port', {
+        default: 8080,
+        describe: 'The port where the dev server should run.',
+        type: 'number',
+      })
+      .option('host', {
+        default: 'localhost',
+        describe: 'The host name or IP for the server to use.',
+        type: 'string',
+      })
+      .option('backend', {
+        default: 'https://dev3.openmrs.org/',
+        describe: 'The backend to proxy API requests to.',
+        type: 'string',
+      })
+      .option('add-cookie', {
+        default: '',
+        describe: 'Additional cookies to provide when proxying.',
+        type: 'string',
+      })
+      .option('spa-path', {
+        default: '/openmrs/spa/',
+        describe: 'The path of the application on the target server.',
+        type: 'string',
+      })
+      .option('api-url', {
+        default: '/openmrs/',
+        describe: 'The URL of the API. Can be a path if the API is on the same target server.',
+        type: 'string',
+      })
+      .option('open', {
+        default: true,
+        describe: 'Immediately opens the SPA page URL in the browser.',
+        type: 'boolean',
+      })
+      .option('config-url', {
+        default: [],
+        describe: 'The URL to a valid frontend configuration. Can be used multiple times.',
+        type: 'array',
+      })
+      .option('config-file', {
+        default: [],
+        describe: 'The path to a frontend configuration file. Can be used multiple times.',
+        type: 'array',
+      })
+      .option('sources', {
+        default: ['.'],
+        describe: 'Runs the projects from the provided source directories. Can be used multiple times.',
+        type: 'array',
+      })
+      .option('shared-dependencies', {
+        default: [],
+        describe: 'The additional shared dependencies besides the ones from the app shell.',
+        type: 'array',
+      })
+      .option('importmap', {
+        default: 'importmap.json',
+        describe:
+          'The import map to use. Can be a path to a valid import map to be taken literally, an URL, or a fixed JSON object.',
+        type: 'string',
+      })
+      .option('routes', {
+        default: 'routes.registry.json',
+        describe:
+          'The routes.registry.json file to use. Can be a path to a valid routes registry to be taken literally, an URL, or a fixed JSON object.',
+        type: 'string',
+      })
+      .option('support-offline', {
+        default: false,
+        describe: 'Determines if a service worker should be installed for offline support.',
+        type: 'boolean',
+      }),
   async (args) =>
     runCommand('runDebug', {
       configUrls: args['config-url'],
@@ -81,11 +108,10 @@ yargs.command(
       ...proxyImportmapAndRoutes(
         await mergeImportmapAndRoutes(
           await getImportmapAndRoutes(args.importmap, args.routes, args.port),
-          (args['run-project'] || (args.runProject as boolean)) && (await runProject(args.port, args.sources)),
+          await runProject(args.port, args.sources),
         ),
         args.backend,
-        args.host,
-        args.port,
+        args.spaPath,
       ),
     }),
 );
@@ -95,51 +121,78 @@ yargs.command(
   'Starts a new frontend module development session with the OpenMRS app shell.',
   (argv) =>
     argv
-      .number('port')
-      .default('port', 8080)
-      .describe('port', 'The port where the dev server should run.')
-      .number('host')
-      .default('host', 'localhost')
-      .describe('host', 'The host name or IP for the server to use.')
-      .string('backend')
-      .default('backend', 'https://dev3.openmrs.org/')
-      .describe('backend', 'The backend to proxy API requests to.')
-      .string('add-cookie')
-      .default('add-cookie', '')
-      .describe('add-cookie', 'Additional cookies to provide when proxying.')
-      .string('spa-path')
-      .default('spa-path', '/openmrs/spa/')
-      .describe('spa-path', 'The path of the application on the target server.')
-      .string('api-url')
-      .default('api-url', '/openmrs/')
-      .describe('api-url', 'The URL of the API. Can be a path if the API is on the same target server.')
-      .boolean('open')
-      .default('open', true)
-      .describe('open', 'Immediately opens the SPA page URL in the browser.')
-      .array('config-url')
-      .default('config-url', [])
-      .describe('config-url', 'The URL to a valid frontend configuration. Can be used multiple times.')
-      .array('config-file')
-      .default('config-file', [])
-      .describe('config-file', 'The path to a frontend configuration file. Can be used multiple times.')
-      .array('sources')
-      .default('sources', ['.'])
-      .describe('sources', 'Runs the projects from the provided source directories. Can be used multiple times.')
-      .array('shared-dependencies')
-      .default('shared-dependencies', [])
-      .describe('shared-dependencies', 'The additional shared dependencies besides the ones from the app shell.')
-      .string('importmap')
-      .default('importmap', 'importmap.json')
-      .describe(
-        'importmap',
-        'The import map to use. Can be a path to a valid import map to be taken literally, an URL, or a fixed JSON object.',
-      )
-      .string('routes')
-      .default('routes', 'routes.registry.json')
-      .describe('routes', 'The routes.registry.json file to use.')
-      .boolean('support-offline')
-      .default('support-offline', false)
-      .describe('support-offline', 'Determines if a service worker should be installed for offline support.'),
+      .option('port', {
+        default: 8080,
+        describe: 'The port where the dev server should run.',
+        type: 'number',
+      })
+      .option('host', {
+        default: 'localhost',
+        describe: 'The host name or IP for the server to use.',
+        type: 'string',
+      })
+      .option('backend', {
+        default: 'https://dev3.openmrs.org/',
+        describe: 'The backend to proxy API requests to.',
+        type: 'string',
+      })
+      .option('add-cookie', {
+        default: '',
+        describe: 'Additional cookies to provide when proxying.',
+        type: 'string',
+      })
+      .option('spa-path', {
+        default: '/openmrs/spa/',
+        describe: 'The path of the application on the target server.',
+        type: 'string',
+      })
+      .option('api-url', {
+        default: '/openmrs/',
+        describe: 'The URL of the API. Can be a path if the API is on the same target server.',
+        type: 'string',
+      })
+      .option('open', {
+        default: true,
+        describe: 'Immediately opens the SPA page URL in the browser.',
+        type: 'boolean',
+      })
+      .option('config-url', {
+        default: [],
+        describe: 'The URL to a valid frontend configuration. Can be used multiple times.',
+        type: 'array',
+      })
+      .option('config-file', {
+        default: [],
+        describe: 'The path to a frontend configuration file. Can be used multiple times.',
+        type: 'array',
+      })
+      .option('sources', {
+        default: ['.'],
+        describe: 'Runs the projects from the provided source directories. Can be used multiple times.',
+        type: 'array',
+      })
+      .option('shared-dependencies', {
+        default: [],
+        describe: 'The additional shared dependencies besides the ones from the app shell.',
+        type: 'array',
+      })
+      .option('importmap', {
+        default: 'importmap.json',
+        describe:
+          'The import map to use. Can be a path to a valid import map to be taken literally, an URL, or a fixed JSON object.',
+        type: 'string',
+      })
+      .option('routes', {
+        default: 'routes.registry.json',
+        describe:
+          'The routes.registry.json file to use. Can be a path to a valid routes registry to be taken literally, an URL, or a fixed JSON object.',
+        type: 'string',
+      })
+      .option('support-offline', {
+        default: false,
+        describe: 'Determines if a service worker should be installed for offline support.',
+        type: 'boolean',
+      }),
   async (args) =>
     runCommand('runDevelop', {
       configUrls: args['config-url'],
@@ -148,13 +201,12 @@ yargs.command(
       ...proxyImportmapAndRoutes(
         await mergeImportmapAndRoutes(
           await getImportmapAndRoutes(args.importmap, args.routes, args.port),
-          (args.sources[0] as string | boolean) !== false && (await runProject(args.port, args.sources)),
+          await runProject(args.port, args.sources),
           args.backend,
           args.spaPath,
         ),
         args.backend,
-        args.host,
-        args.port,
+        args.spaPath,
       ),
     }),
 );

--- a/packages/tooling/openmrs/src/commands/debug.ts
+++ b/packages/tooling/openmrs/src/commands/debug.ts
@@ -6,7 +6,6 @@ export interface DebugArgs {
   host: string;
   backend: string;
   importmap: ImportmapDeclaration;
-  pageTitle: string;
   supportOffline?: boolean;
   spaPath: string;
   apiUrl: string;

--- a/packages/tooling/openmrs/src/utils/importmap.ts
+++ b/packages/tooling/openmrs/src/utils/importmap.ts
@@ -226,8 +226,10 @@ export async function runProject(
 }
 
 /**
- * @param decl The initial import map declaration
- * @param additionalImports New imports to add
+ * @param importAndRoutes An ImportmapAndRoutes object that holds the current import map and routes registries
+ * @param additionalImportsAndRoutes An object containing any import map entries, routes, and watched route files to add to the setup
+ * @param backend The URL for the backend
+ * @param spaPath The spaPath for this instance
  * @returns The import map declaration with the new imports added in. If
  *   there are new imports to add, and if the original import map declaration
  *   had type "url", it is downloaded and resolved to one of type "inline".
@@ -366,12 +368,10 @@ export async function getRoutes(routesPath: string): Promise<RoutesDeclaration> 
 }
 
 /**
- * @param decl An import map declaration of type "inline"
- * @param backend The backend which is being proxied by the dev server
- * @param host The dev server host
- * @param port The dev server port
- * @returns The same import map declaration but with all imports from
- *   `backend` changed to import from `http://${host}:${port}`.
+ * @param importmapAndRoutes An ImportmapAndRoutes object that holds the import map and routes registry
+ * @param backend The URL for the backend
+ * @param spaPath The spaPath for this instance
+ * @returns The same import map declaration but with all imports changed to the appropriate path
  */
 export function proxyImportmapAndRoutes(
   importmapAndRoutes: ImportmapAndRoutesWithWatches,


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Follow-on for #1032. #1032 tried to add support for services like GitPod by converting URL references for JS files from fully-qualified names to relative names. However, it did this via string manipulation of the URL, which actually breaks things in the case when running against a local server (since the prefix replace of `http://localhost` with `""` leads to broken URLs like `:8081/openmrs-esm-login-app.js`, which fail to load).

This PR reworks things so that we're actually doing something similar to a browser's origin check (i.e., confirming that we're using the same host, port, and protocol). If the URL for a JS file is on the same origin as the backend, we convert it to a relative URL and if it is not, we leave it as an absolute URL.

Basically what this means is that when running `yarn start`, most of the import map will be converted into local links like:

```
"@openmrs/esm-patient-chart-app": "./openmrs-esm-patient-chart-app-9.0.1-pre.6450/openmrs-esm-patient-chart-app.js"
```

But the app that's under development will remain as an absolute URL like this:

```
"@openmrs/esm-login-app": "http://localhost:8081/openmrs-esm-login-app.js",
```

This should ensure that things work both in the case when connecting to a remote server via a reverse proxy and that it doesn't break things for local development.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->