### PR TITLE
(fix) O3-4323 - age() function should handle time duration of 0 minutes

### DIFF
--- a/packages/framework/esm-utils/src/age-helpers.test.ts
+++ b/packages/framework/esm-utils/src/age-helpers.test.ts
@@ -9,6 +9,7 @@ describe('Age Helper', () => {
   // https://webarchive.nationalarchives.gov.uk/ukgwa/20160921162509mp_/http://systems.digital.nhs.uk/data/cui/uig/patben.pdf
   // (Table 8)
   const now = dayjs('2024-07-30');
+  const test0 = now;
   const test1 = now.subtract(1, 'hour').subtract(30, 'minutes');
   const test2 = now.subtract(1, 'day').subtract(2, 'hours').subtract(5, 'minutes');
   const test3 = now.subtract(3, 'days').subtract(17, 'hours').subtract(30, 'minutes');
@@ -22,6 +23,7 @@ describe('Age Helper', () => {
   const test11 = now.subtract(18, 'year').subtract(39, 'day');
 
   it('should render durations correctly', () => {
+    expect(age(test0, now)).toBe('0 min');
     expect(age(test1, now)).toBe('90 min');
     expect(age(test2, now)).toBe('26 hr');
     expect(age(test3, now)).toBe('3 days');

--- a/packages/framework/esm-utils/src/age-helpers.ts
+++ b/packages/framework/esm-utils/src/age-helpers.ts
@@ -2,7 +2,7 @@
 import dayjs from 'dayjs';
 import { getLocale } from './omrs-dates';
 import { DurationFormat } from '@formatjs/intl-durationformat';
-import { type DurationInput } from '@formatjs/intl-durationformat/src/types';
+import { type DurationFormatOptions, type DurationInput } from '@formatjs/intl-durationformat/src/types';
 
 /**
  * Gets a human readable and locale supported representation of a person's age, given their birthDate,
@@ -32,9 +32,14 @@ export function age(birthDate: dayjs.ConfigType, currentDate: dayjs.ConfigType =
 
   const locale = getLocale();
 
+  const options: DurationFormatOptions = { style: 'short', localeMatcher: 'lookup' };
+
   if (hourDiff < 2) {
     const minuteDiff = to.diff(from, 'minutes');
     duration['minutes'] = minuteDiff;
+    if (minuteDiff == 0) {
+      options.minutesDisplay = 'always';
+    }
   } else if (dayDiff < 2) {
     duration['hours'] = hourDiff;
   } else if (weekDiff < 4) {
@@ -55,5 +60,5 @@ export function age(birthDate: dayjs.ConfigType, currentDate: dayjs.ConfigType =
     duration['years'] = yearDiff;
   }
 
-  return new DurationFormat(locale, { style: 'short', localeMatcher: 'lookup' }).format(duration);
+  return new DurationFormat(locale, options).format(duration);
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
https://openmrs.atlassian.net/browse/O3-4323

The age() function age-helper.ts should return a localized string representation the duration between 2 points in time. Currently, it returns an empty string if the duration is 0. This PR fixes it to "0 min" in English.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
