### PR TITLE
(fix) O3-3370: Also fix handling when not specifying a backend

### DIFF
--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -40,9 +40,10 @@ yargs.command(
         type: 'string',
       })
       .option('backend', {
-        default: 'https://dev3.openmrs.org/',
+        default: 'https://dev3.openmrs.org',
         describe: 'The backend to proxy API requests to.',
         type: 'string',
+        coerce: (arg) => (arg.endsWith('/') ? arg.slice(0, -1) : arg),
       })
       .option('add-cookie', {
         default: '',
@@ -132,9 +133,10 @@ yargs.command(
         type: 'string',
       })
       .option('backend', {
-        default: 'https://dev3.openmrs.org/',
+        default: 'https://dev3.openmrs.org',
         describe: 'The backend to proxy API requests to.',
         type: 'string',
+        coerce: (arg) => (arg.endsWith('/') ? arg.slice(0, -1) : arg),
       })
       .option('add-cookie', {
         default: '',


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This fixes the issue reported [in this comment](https://github.com/openmrs/openmrs-esm-core/pull/1258#issuecomment-2578483337). Basically, by chomping off the `/` at the end of the backend, paths from the import map on dev3 (not available for testing when I wrote that last PR) now look like `https://dev3.openmrs.org/openmrs/spa/module-123/module.js` instead of `https://dev3.openmrs.org//openmrs/spa/module-123/module.js`, so things function normally when _not_ specifying a backend. I also added a coerce function so if you pass, e.g., `--backend `http://localhost/` it will work as expected.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-3370

## Other
<!-- Anything not covered above -->
