### PR TITLE
(fix) O3-4339: Frontend should properly support locales with region specifiers

### DIFF
--- a/packages/framework/esm-api/src/shared-api-objects/current-user.ts
+++ b/packages/framework/esm-api/src/shared-api-objects/current-user.ts
@@ -114,14 +114,22 @@ function isValidLocale(locale: unknown): locale is string {
 }
 
 export function setUserLanguage(data: Session) {
-  const locale = data?.user?.userProperties?.defaultLocale ?? data.locale;
-  const htmlLang = document.documentElement.getAttribute('lang');
+  let locale = data.user?.userProperties?.defaultLocale ?? data.locale;
 
-  if (isValidLocale(locale) && locale !== htmlLang) {
+  if (locale && locale.includes('_')) {
+    locale = locale.replaceAll('_', '-');
+  }
+
+  if (isValidLocale(locale) && locale !== document.documentElement.getAttribute('lang')) {
     document.documentElement.setAttribute('lang', locale);
   }
 }
-sessionStore.subscribe((state) => state.session && setUserLanguage(state.session));
+
+sessionStore.subscribe((state: SessionStore) => {
+  if (state.loaded && state.session) {
+    setUserLanguage(state.session);
+  }
+});
 
 function userHasPrivilege(requiredPrivilege: string | string[] | undefined, user: { privileges: Array<Privilege> }) {
   if (typeof requiredPrivilege === 'string') {

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -2407,7 +2407,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:169](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L169)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:177](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L177)
 
 ___
 
@@ -2628,7 +2628,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:193](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L193)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:201](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L201)
 
 ___
 
@@ -2642,7 +2642,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:211](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L211)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:219](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L219)
 
 ___
 
@@ -2888,7 +2888,7 @@ refetchCurrentUser()
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:155](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L155)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:163](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L163)
 
 ___
 
@@ -2951,7 +2951,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:220](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L220)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:228](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L228)
 
 ___
 
@@ -2993,7 +2993,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:233](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L233)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:241](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L241)
 
 ___
 
@@ -3253,7 +3253,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-api/src/shared-api-objects/current-user.ts:176](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L176)
+[packages/framework/esm-api/src/shared-api-objects/current-user.ts:184](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/shared-api-objects/current-user.ts#L184)
 
 ___
 

--- a/packages/shell/esm-app-shell/src/locale.ts
+++ b/packages/shell/esm-app-shell/src/locale.ts
@@ -11,11 +11,10 @@ import {
 registerTranslationNamespace('core');
 
 export function setupI18n() {
-  window.i18next = i18next.default || i18next;
+  const i18n = (window.i18next = i18next.default || i18next);
 
   const languageChangeObserver = new MutationObserver(() => {
-    const reDetect: any = undefined;
-    window.i18next.changeLanguage(reDetect).catch((e) => console.error('i18next failed to re-detect language', e));
+    i18n.changeLanguage().catch((e) => console.error('i18next failed to re-detect language', e));
   });
 
   languageChangeObserver.observe(document.documentElement, {
@@ -23,11 +22,11 @@ export function setupI18n() {
     attributes: true,
   });
 
-  window.i18next.on('languageChanged', () => {
-    document.documentElement.setAttribute('dir', window.i18next.dir());
+  i18n.on('languageChanged', () => {
+    document.documentElement.setAttribute('dir', i18n.dir());
   });
 
-  return window.i18next
+  return i18n
     .use(LanguageDetector)
     .use<i18next.BackendModule>({
       type: 'backend',
@@ -110,6 +109,12 @@ function getImportPromise(
 ) {
   if (typeof module.importTranslation !== 'function') {
     throw Error(`Module ${namespace} does not export an importTranslation function`);
+  }
+
+  if (!language) {
+    return Promise.resolve({});
+  } else if (language.includes('-')) {
+    language = language.replace('-', '_');
   }
 
   const importPromise = module.importTranslation(`./${language}.json`);


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This attempts to fix a couple of different issues bound up with how specifiers for locales with regions work. Per BCP 47, locales are expressed in the form `<ISO 639 Language Tag>[-<ISO 639 Region Tag>]` (the full spec is slightly more complicated; this is the part we care about), so, e.g., `en` represents "English" and `en-GB` represents "British English".

However, some tooling supports something like BCP 47 with underscores instead of hyphens as separators, representing "English" as `en` and "British English" as `en_GB`. Because both formats agree on the representation of "English" (and the like) we hadn't really noticed until we actually got some translations that were sensitive to regional changes. 

It turns out that the stuff we have that deals with locales wasn't adapted for this change. Specifically:

* Transifex uses the underscore variant, so files created from Transifex are named like `en.json` and `en_GB.json`, but when loading the translations, we use the "correct" BCP 47 tags, and so try to load `en-GB.json`. Since this doesn't resolve correctly, the frontend could never find region-specific translations.
* The backend _correctly_ translates the `locale` property into the correct BCP 47 tag, but this doesn't work with the "defaultLocale" user property, which appears to get set to the the incorrect BCP 47 tag. Since the code to `setUserLanguage()` didn't correctly handle locales with underscores instead of hyphens, the user's locale would not be updated when configured to use a "defaultLocale" with a region specifier

This PR addresses both of those issues.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
