### PR TITLE
(fix) - O3-4349 - open workspace in declared workspace group

### DIFF
--- a/packages/framework/esm-extensions/src/workspaces.ts
+++ b/packages/framework/esm-extensions/src/workspaces.ts
@@ -82,15 +82,33 @@ export function registerWorkspace(workspace: RegisterWorkspaceOptions) {
  * @internal
  */
 export function registerWorkspaceGroup(workspaceGroup: WorkspaceGroupRegistration) {
-  workspaceGroupStore.setState((state) => ({
-    workspaceGroups: {
-      ...state.workspaceGroups,
-      [workspaceGroup.name]: {
-        name: workspaceGroup.name,
-        members: workspaceGroup.members,
-      },
-    },
-  }));
+  workspaceGroupStore.setState((state) => {
+    const group = state.workspaceGroups[workspaceGroup.name];
+    if (group) {
+      // This condition arises when a workspace with `groups` property registers
+      // before the workspace group is registered, hence the workspace group is
+      // registered by the `attachWorkspaceToGroup` function.
+      return {
+        workspaceGroups: {
+          ...state.workspaceGroups,
+          [workspaceGroup.name]: {
+            ...group,
+            members: Array.from(new Set([...group.members, ...workspaceGroup.members])),
+          },
+        },
+      };
+    } else {
+      return {
+        workspaceGroups: {
+          ...state.workspaceGroups,
+          [workspaceGroup.name]: {
+            name: workspaceGroup.name,
+            members: workspaceGroup.members,
+          },
+        },
+      };
+    }
+  });
 }
 
 const workspaceExtensionWarningsIssued = new Set();

--- a/packages/framework/esm-extensions/src/workspaces.ts
+++ b/packages/framework/esm-extensions/src/workspaces.ts
@@ -85,9 +85,9 @@ export function registerWorkspaceGroup(workspaceGroup: WorkspaceGroupRegistratio
   workspaceGroupStore.setState((state) => {
     const group = state.workspaceGroups[workspaceGroup.name];
     if (group) {
-      // This condition arises when a workspace with `groups` property registers
-      // before the workspace group is registered, hence the workspace group is
-      // registered by the `attachWorkspaceToGroup` function.
+      // This condition occurs when a workspace with a `groups` property is registered before
+      // the corresponding workspace group. In such cases, the workspace group is registered
+      // by the `attachWorkspaceToGroup` function.
       return {
         workspaceGroups: {
           ...state.workspaceGroups,
@@ -182,28 +182,8 @@ function createNewWorkspaceGroupInfo(groupName: string): WorkspaceGroupRegistrat
 }
 
 export function attachWorkspaceToGroup(workspaceName: string, groupName: string) {
-  workspaceGroupStore.setState((state) => {
-    const group = state.workspaceGroups[groupName];
-    if (group) {
-      return {
-        workspaceGroups: {
-          ...state.workspaceGroups,
-          [groupName]: {
-            ...group,
-            members: [...group.members, workspaceName],
-          },
-        },
-      };
-    } else {
-      return {
-        workspaceGroups: {
-          ...state.workspaceGroups,
-          [groupName]: {
-            ...createNewWorkspaceGroupInfo(groupName),
-            members: [workspaceName],
-          },
-        },
-      };
-    }
+  registerWorkspaceGroup({
+    name: groupName,
+    members: [workspaceName],
   });
 }

--- a/packages/framework/esm-extensions/src/workspaces.ts
+++ b/packages/framework/esm-extensions/src/workspaces.ts
@@ -173,17 +173,3 @@ function getTitleFromExtension(ext: ExtensionRegistration) {
   }
   return ext.name;
 }
-
-function createNewWorkspaceGroupInfo(groupName: string): WorkspaceGroupRegistration {
-  return {
-    name: groupName,
-    members: [],
-  };
-}
-
-export function attachWorkspaceToGroup(workspaceName: string, groupName: string) {
-  registerWorkspaceGroup({
-    name: groupName,
-    members: [workspaceName],
-  });
-}

--- a/packages/framework/esm-routes/src/loaders/components.ts
+++ b/packages/framework/esm-routes/src/loaders/components.ts
@@ -1,6 +1,5 @@
 import {
   attach,
-  attachWorkspaceToGroup,
   type ExtensionRegistration,
   registerExtension,
   registerModal,
@@ -202,7 +201,10 @@ supported, so the workspace will not be loaded.`,
   }
 
   for (const group of workspace.groups || []) {
-    attachWorkspaceToGroup(name, group);
+    registerWorkspaceGroup({
+      name: group,
+      members: [name],
+    });
   }
 }
 

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -301,7 +301,7 @@ export function launchWorkspace<
   const workspace = getWorkspaceRegistration(name);
   const currentWorkspaceGroup = store.getState().workspaceGroup;
 
-  if (currentWorkspaceGroup && !currentWorkspaceGroup.members?.includes(name)) {
+  if (currentWorkspaceGroup && !(currentWorkspaceGroup.members?.includes(name) || workspace?.groups.includes(currentWorkspaceGroup.name))) {
     closeWorkspaceGroup(currentWorkspaceGroup.name, () => {
       launchWorkspace(name, additionalProps);
     });

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -301,7 +301,7 @@ export function launchWorkspace<
   const workspace = getWorkspaceRegistration(name);
   const currentWorkspaceGroup = store.getState().workspaceGroup;
 
-  if (currentWorkspaceGroup && !(currentWorkspaceGroup.members?.includes(name) || workspace?.groups.includes(currentWorkspaceGroup.name))) {
+  if (currentWorkspaceGroup && !currentWorkspaceGroup.members?.includes(name)) {
     closeWorkspaceGroup(currentWorkspaceGroup.name, () => {
       launchWorkspace(name, additionalProps);
     });


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
We want to support both:
1. having a workspace group be able to declare member workspaces
2. having a workspace be able to declare which groups it belongs to

I think there was a regression with [this commit](https://github.com/openmrs/openmrs-esm-core/commit/a61deb8b#diff-1c03ea6c69f77e98ed8c9eb205bbb1b02b37aa6c3fe6dc0ddf45c1389b024aceL296) that dropped support for 2. This PR adds it back.

## Screenshots
<!-- Required if you are making UI changes. -->
"Visit Summary" is a workspace that we define in a PIH custom ESM. It declares that it belongs to the `ward-patient` workspace group.

```
  "workspaces": [
    {
      "name": "o2-visit-summary-workspace",
      "component": "o2VisitSummaryWorkspace",
      "title": "visitSummary",
      "type": "o2-visit-summary",
      "sidebarFamily": "ward-patient",
      "hasOwnSidebar": true,
      "width": "extra-wide",
      "groups": ["ward-patient"],
      "canMaximize": true
    },
  }
```

Before:
(notice the workspace action menu icons fail to load)
![image](https://github.com/user-attachments/assets/4e568aa1-d3d7-4f24-923f-2273e8ad045b)

After:
![image](https://github.com/user-attachments/assets/c5c845db-df92-4ab8-bfc5-90d5214ef1a2)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
I don't know why, but as seen in the screenshot, the content of the workspace is blank when I run `yarn run:shell` from `esm-core`. It seems not related to this change. It also doesn't seem to be a real issue in dev3, or when running `yarn start --sources esm-ward-app` in patient-management locally