### PR TITLE
(fix) O3-4366: Change languages in my account panel to sentence case

### DIFF
--- a/packages/apps/esm-primary-navigation-app/jest.config.js
+++ b/packages/apps/esm-primary-navigation-app/jest.config.js
@@ -5,6 +5,7 @@ module.exports = {
   },
   transformIgnorePatterns: [],
   moduleNameMapper: {
+    'lodash-es/(.*)': 'lodash/$1',
     'lodash-es': 'lodash',
     '@openmrs/esm-framework': '@openmrs/esm-framework/mock.tsx',
     '\\.(s?css)$': 'identity-obj-proxy',

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language-link.extension.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language-link.extension.tsx
@@ -1,9 +1,9 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, SwitcherItem } from '@carbon/react';
+import { capitalize } from 'lodash-es';
 import { TranslateIcon, showModal, useSession } from '@openmrs/esm-framework';
 import styles from './change-language-link.scss';
-import { capitalize } from 'lodash-es';
 
 /** The user menu item that shows the current language and has a button to change the language */
 function ChangeLanguageLink() {

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language-link.extension.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language-link.extension.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, SwitcherItem } from '@carbon/react';
-import { capitalize } from 'lodash-es';
+import capitalize from 'lodash-es/capitalize';
 import { TranslateIcon, showModal, useSession } from '@openmrs/esm-framework';
 import styles from './change-language-link.scss';
 

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language-link.extension.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language-link.extension.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, SwitcherItem } from '@carbon/react';
 import { TranslateIcon, showModal, useSession } from '@openmrs/esm-framework';
 import styles from './change-language-link.scss';
+import { capitalize } from 'lodash-es';
 
 /** The user menu item that shows the current language and has a button to change the language */
 function ChangeLanguageLink() {
@@ -22,7 +23,7 @@ function ChangeLanguageLink() {
     <SwitcherItem className={styles.panelItemContainer} aria-label={t('changeLanguage', 'Change language')}>
       <div>
         <TranslateIcon size={20} />
-        <p>{languageNames.of(session?.locale)}</p>
+        <p>{capitalize(languageNames.of(session?.locale))}</p>
       </div>
       <Button kind="ghost" onClick={launchChangeLanguageModal}>
         {t('change', 'Change')}

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
@@ -1,6 +1,5 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import capitalize from 'lodash-es/capitalize';
 import {
   Button,
   InlineLoading,
@@ -10,6 +9,7 @@ import {
   RadioButton,
   RadioButtonGroup,
 } from '@carbon/react';
+import capitalize from 'lodash-es/capitalize';
 import { useConnectivity, useSession } from '@openmrs/esm-framework';
 import { postUserPropertiesOffline, postUserPropertiesOnline } from './change-language.resource';
 import styles from './change-language.scss';

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { capitalize } from 'lodash-es';
+import capitalize from 'lodash-es/capitalize';
 import {
   Button,
   InlineLoading,


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

All language names in the “My Account” panel now follow the same sentence case format as seen in the “Change Language” modal, providing a consistent experience across the application:

<img width="141" alt="Screenshot 2025-01-23 at 6 31 36 PM" src="https://github.com/user-attachments/assets/7453abf7-9fc1-43d7-b638-789305a0401f" />

## Screenshots

### Before

<img width="256" alt="Screenshot 2025-01-23 at 6 25 13 PM" src="https://github.com/user-attachments/assets/e434c99c-dcbb-4a87-8033-8cb8c056020a" />

<img width="256" alt="Screenshot 2025-01-23 at 6 25 42 PM" src="https://github.com/user-attachments/assets/263d9092-e2ed-4624-aff2-56a821eba5d1" />

### After

<img width="256" alt="Screenshot 2025-01-23 at 6 30 11 PM" src="https://github.com/user-attachments/assets/d0e57b4b-5fa5-409a-9ecc-2aea0ebeb5cd" />

<img width="256" alt="Screenshot 2025-01-23 at 6 30 36 PM" src="https://github.com/user-attachments/assets/0456fc1b-a7e1-428d-9690-fa263aa56340" />

## Related Issue
[O3-4366](https://openmrs.atlassian.net/issues/O3-4366)

[O3-4366]: https://openmrs.atlassian.net/browse/O3-4366?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ