### PR TITLE
(chore) Optimize lodash imports

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/configuration/configuration.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/configuration.component.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { Button, Column, FlexGrid, Row, TextInput, Toggle } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
-import cloneDeep from 'lodash-es/cloneDeep';
-import isEmpty from 'lodash-es/isEmpty';
+import { cloneDeep, isEmpty } from 'lodash-es';
 import type { Config } from '@openmrs/esm-framework/src/internal';
 import {
   ChevronDownIcon,
@@ -18,8 +17,7 @@ import {
 } from '@openmrs/esm-framework/src/internal';
 import { ConfigTree } from './interactive-editor/config-tree.component';
 import { Description } from './interactive-editor/description.component';
-import type { ImplementerToolsStore } from '../store';
-import { implementerToolsStore } from '../store';
+import { implementerToolsStore, type ImplementerToolsStore } from '../store';
 import styles from './configuration.styles.scss';
 
 const JsonEditor = React.lazy(() => import('./json-editor/json-editor.component'));

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/config-subtree.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/config-subtree.component.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
-import EditableValue from './editable-value.component';
+import { isEqual } from 'lodash-es';
 import { implementerToolsStore } from '../../store';
-import isEqual from 'lodash-es/isEqual';
 import { Subtree } from './layout/subtree.component';
+import EditableValue from './editable-value.component';
 
 export interface ConfigSubtreeProps {
   config: Record<string, any>;

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/config-tree-for-module.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/config-tree-for-module.component.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
+import { pickBy } from 'lodash-es';
 import { ExtensionSlotsConfigTree } from './extension-slots-config-tree';
 import { ConfigSubtree } from './config-subtree.component';
-import pickBy from 'lodash-es/pickBy';
 import { TreeContainer } from './layout/tree-container.component';
 
 export interface ConfigTreeForModuleProps {

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/editable-value.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/editable-value.component.tsx
@@ -1,18 +1,20 @@
 import React, { useState, useEffect, useRef } from 'react';
-import isEqual from 'lodash-es/isEqual';
-import unset from 'lodash-es/unset';
-import cloneDeep from 'lodash-es/cloneDeep';
-import styles from './editable-value.styles.scss';
-import { Button } from '@carbon/react';
-import type { ConfigValue, Validator, Type, Config } from '@openmrs/esm-framework/src/internal';
-import { EditIcon, ResetIcon } from '@openmrs/esm-framework';
-import { clearConfigErrors, temporaryConfigStore } from '@openmrs/esm-framework/src/internal';
-import type { CustomValueType } from './value-editor';
-import { ValueEditor } from './value-editor';
-import type { ImplementerToolsStore } from '../../store';
-import { implementerToolsStore } from '../../store';
-import { DisplayValue } from './display-value';
 import { useTranslation } from 'react-i18next';
+import { isEqual, cloneDeep, unset } from 'lodash-es';
+import { Button } from '@carbon/react';
+import { EditIcon, ResetIcon } from '@openmrs/esm-framework';
+import {
+  clearConfigErrors,
+  temporaryConfigStore,
+  type ConfigValue,
+  type Config,
+  type Validator,
+  type Type,
+} from '@openmrs/esm-framework/src/internal';
+import { implementerToolsStore, type ImplementerToolsStore } from '../../store';
+import { DisplayValue } from './display-value';
+import { ValueEditor, type CustomValueType } from './value-editor';
+import styles from './editable-value.styles.scss';
 
 export interface EditableValueProps {
   path: Array<string>;

--- a/packages/apps/esm-offline-tools-app/src/offline-patients/offline-patient-table.component.tsx
+++ b/packages/apps/esm-offline-tools-app/src/offline-patients/offline-patient-table.component.tsx
@@ -1,4 +1,6 @@
 import React, { useMemo, useState } from 'react';
+import { capitalize } from 'lodash-es';
+import { useTranslation } from 'react-i18next';
 import {
   Button,
   DataTable,
@@ -18,24 +20,22 @@ import {
   TableSelectRow,
 } from '@carbon/react';
 import { Renew } from '@carbon/react/icons';
-import type { DynamicOfflineDataSyncState } from '@openmrs/esm-framework';
 import {
   age,
-  isDesktop,
-  showModal,
   deleteSynchronizationItem,
-  getFullSynchronizationItems,
-  removeDynamicOfflineData,
-  syncDynamicOfflineData,
   getDynamicOfflineDataEntries,
+  getFullSynchronizationItems,
+  isDesktop,
+  removeDynamicOfflineData,
+  showModal,
+  syncDynamicOfflineData,
   useLayoutType,
+  type DynamicOfflineDataSyncState,
 } from '@openmrs/esm-framework';
-import { useTranslation } from 'react-i18next';
-import capitalize from 'lodash-es/capitalize';
+import { useOfflinePatientsWithEntries, useOfflineRegisteredPatients } from '../hooks/offline-patient-data-hooks';
 import EmptyState from './empty-state.component';
 import LastUpdatedTableCell from './last-updated-table-cell.component';
 import PatientNameTableCell from './patient-name-table-cell.component';
-import { useOfflinePatientsWithEntries, useOfflineRegisteredPatients } from '../hooks/offline-patient-data-hooks';
 import styles from './offline-patient-table.scss';
 
 export interface OfflinePatientTableProps {

--- a/packages/apps/esm-offline-tools-app/src/offline-tools-page/offline-tools-page.component.tsx
+++ b/packages/apps/esm-offline-tools-app/src/offline-tools-page/offline-tools-page.component.tsx
@@ -1,8 +1,8 @@
-import { ExtensionSlot, useExtensionSlotMeta } from '@openmrs/esm-framework';
 import React from 'react';
+import { trimEnd } from 'lodash-es';
+import { useLocation, useParams } from 'react-router-dom';
+import { ExtensionSlot, useExtensionSlotMeta } from '@openmrs/esm-framework';
 import type { OfflineToolsPageConfig } from '../types';
-import trimEnd from 'lodash-es/trimEnd';
-import { useLocation, useMatch, useParams } from 'react-router-dom';
 
 export interface OfflineToolsPageParams {
   page: string;

--- a/packages/apps/esm-primary-navigation-app/jest.config.js
+++ b/packages/apps/esm-primary-navigation-app/jest.config.js
@@ -5,7 +5,6 @@ module.exports = {
   },
   transformIgnorePatterns: [],
   moduleNameMapper: {
-    'lodash-es/(.*)': 'lodash/$1',
     'lodash-es': 'lodash',
     '@openmrs/esm-framework': '@openmrs/esm-framework/mock.tsx',
     '\\.(s?css)$': 'identity-obj-proxy',

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language-link.extension.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language-link.extension.tsx
@@ -1,7 +1,7 @@
 import React, { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Button, SwitcherItem } from '@carbon/react';
-import capitalize from 'lodash-es/capitalize';
+import { capitalize } from 'lodash-es';
 import { TranslateIcon, showModal, useSession } from '@openmrs/esm-framework';
 import styles from './change-language-link.scss';
 

--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language.modal.tsx
@@ -9,7 +9,7 @@ import {
   RadioButton,
   RadioButtonGroup,
 } from '@carbon/react';
-import capitalize from 'lodash-es/capitalize';
+import { capitalize } from 'lodash-es';
 import { useConnectivity, useSession } from '@openmrs/esm-framework';
 import { postUserPropertiesOffline, postUserPropertiesOnline } from './change-language.resource';
 import styles from './change-language.scss';


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR optimizes lodash imports in Core by standardizing lodash imports to using named imports from `lodash-es`. Other unrelated changes include:

- Improving component import ordering patterns
- Rewriting type imports to use the `type` keyword

The lodash imports change may marginally reduce bundle size through better tree-shaking, but the primary benefit is improved code readability and maintainability.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
