### PR TITLE
(feat) O3-4425 - add ability to define collapsed left nav

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
@@ -25,9 +25,10 @@ const SideMenuPanel: React.FC<SideMenuPanelProps> = ({ expanded, hidePanel }) =>
   const leftNavContainer = window.document.getElementById('omrs-left-nav-container-root');
   return (
     <>
-      {(!isDesktop(layout) || mode == 'collapsed') && expanded && <LeftNavMenu ref={menuRef} isChildOfHeader />}
+      {(!isDesktop(layout) || mode === 'collapsed') && expanded && <LeftNavMenu ref={menuRef} isChildOfHeader />}
       {isDesktop(layout) &&
-        mode != 'collapsed' &&
+        mode !== 'collapsed' &&
+				leftNavContainer &&
         createPortal(<LeftNavMenu ref={menuRef} isChildOfHeader />, leftNavContainer)}
     </>
   );

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
@@ -1,11 +1,17 @@
 import React, { useEffect } from 'react';
-import { LeftNavMenu, useOnClickOutside } from '@openmrs/esm-framework';
+import { isDesktop, LeftNavMenu, useLayoutType, useOnClickOutside } from '@openmrs/esm-framework';
+import { createPortal } from 'react-dom';
 
 interface SideMenuPanelProps {
   expanded: boolean;
   hidePanel: Parameters<typeof useOnClickOutside>[0];
 }
 
+/**
+ * This is the menu that pops up when clicking on the hamburger button
+ * on the top nav. It's also responsible for rendering the left nav
+ * in desktop mode (via a react portal).
+ */
 const SideMenuPanel: React.FC<SideMenuPanelProps> = ({ expanded, hidePanel }) => {
   const menuRef = useOnClickOutside(hidePanel, expanded);
 
@@ -13,8 +19,15 @@ const SideMenuPanel: React.FC<SideMenuPanelProps> = ({ expanded, hidePanel }) =>
     window.addEventListener('popstate', hidePanel);
     return () => window.removeEventListener('popstate', hidePanel);
   }, [hidePanel]);
+  const layout = useLayoutType();
 
-  return expanded && <LeftNavMenu ref={menuRef} isChildOfHeader />;
+  const leftNavContainer = window.document.getElementById('omrs-left-nav-container-root');
+  return (
+    <>
+      {!isDesktop(layout) && expanded && <LeftNavMenu ref={menuRef} isChildOfHeader />}
+      {isDesktop(layout) && createPortal(<LeftNavMenu ref={menuRef} isChildOfHeader />, leftNavContainer)}
+    </>
+  );
 };
 
 export default SideMenuPanel;

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect } from 'react';
-import { isDesktop, LeftNavMenu, useLayoutType, useOnClickOutside } from '@openmrs/esm-framework';
+import { isDesktop, LeftNavMenu, useLayoutType, useLeftNavStore, useOnClickOutside } from '@openmrs/esm-framework';
 import { createPortal } from 'react-dom';
 
 interface SideMenuPanelProps {
@@ -20,12 +20,15 @@ const SideMenuPanel: React.FC<SideMenuPanelProps> = ({ expanded, hidePanel }) =>
     return () => window.removeEventListener('popstate', hidePanel);
   }, [hidePanel]);
   const layout = useLayoutType();
+  const { mode } = useLeftNavStore();
 
   const leftNavContainer = window.document.getElementById('omrs-left-nav-container-root');
   return (
     <>
-      {!isDesktop(layout) && expanded && <LeftNavMenu ref={menuRef} isChildOfHeader />}
-      {isDesktop(layout) && createPortal(<LeftNavMenu ref={menuRef} isChildOfHeader />, leftNavContainer)}
+      {(!isDesktop(layout) || mode == 'collapsed') && expanded && <LeftNavMenu ref={menuRef} isChildOfHeader />}
+      {isDesktop(layout) &&
+        mode != 'collapsed' &&
+        createPortal(<LeftNavMenu ref={menuRef} isChildOfHeader />, leftNavContainer)}
     </>
   );
 };

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -47,7 +47,7 @@ const HeaderItems: React.FC = () => {
   );
 
   const showHamburger = useMemo(
-    () => (!isDesktop(layout) || mode == 'collapsed') && navMenuItems.length > 0,
+    () => (!isDesktop(layout) || mode === 'collapsed') && navMenuItems.length > 0,
     [navMenuItems.length, layout, mode],
   );
   const showAppMenu = useMemo(() => appMenuItems.length > 0, [appMenuItems.length]);

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -29,7 +29,7 @@ const HeaderItems: React.FC = () => {
   const config = useConfig();
   const [activeHeaderPanel, setActiveHeaderPanel] = useState<string>(null);
   const layout = useLayoutType();
-  const { slotName } = useLeftNavStore();
+  const { slotName, mode } = useLeftNavStore();
   const navMenuItems = useAssignedExtensions(slotName);
   const appMenuItems = useAssignedExtensions('app-menu-slot');
   const userMenuItems = useAssignedExtensions('user-panel-slot');
@@ -46,7 +46,10 @@ const HeaderItems: React.FC = () => {
     [],
   );
 
-  const showHamburger = useMemo(() => !isDesktop(layout) && navMenuItems.length > 0, [navMenuItems.length, layout]);
+  const showHamburger = useMemo(
+    () => (!isDesktop(layout) || mode == 'collapsed') && navMenuItems.length > 0,
+    [navMenuItems.length, layout, mode],
+  );
   const showAppMenu = useMemo(() => appMenuItems.length > 0, [appMenuItems.length]);
   const showUserMenu = useMemo(() => userMenuItems.length > 0, [userMenuItems.length]);
   return (

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -13,6 +13,7 @@ import {
   CloseIcon,
   UserAvatarIcon,
   SwitcherIcon,
+  useLeftNavStore,
 } from '@openmrs/esm-framework';
 import { isDesktop } from '../../utils';
 import AppMenuPanel from '../navbar-header-panels/app-menu-panel.component';
@@ -28,7 +29,8 @@ const HeaderItems: React.FC = () => {
   const config = useConfig();
   const [activeHeaderPanel, setActiveHeaderPanel] = useState<string>(null);
   const layout = useLayoutType();
-  const navMenuItems = useAssignedExtensions('patient-chart-dashboard-slot').map((e) => e.id);
+  const { slotName } = useLeftNavStore();
+  const navMenuItems = useAssignedExtensions(slotName);
   const appMenuItems = useAssignedExtensions('app-menu-slot');
   const userMenuItems = useAssignedExtensions('user-panel-slot');
   const isActivePanel = useCallback((panelName: string) => activeHeaderPanel === panelName, [activeHeaderPanel]);
@@ -115,7 +117,7 @@ const HeaderItems: React.FC = () => {
             </HeaderGlobalAction>
           )}
         </HeaderGlobalBar>
-        {!isDesktop(layout) && <SideMenuPanel hidePanel={hidePanel('sideMenu')} expanded={isActivePanel('sideMenu')} />}
+        <SideMenuPanel hidePanel={hidePanel('sideMenu')} expanded={isActivePanel('sideMenu')} />
         {showAppMenu && <AppMenuPanel expanded={isActivePanel('appMenu')} hidePanel={hidePanel('appMenu')} />}
         <NotificationsMenuPanel expanded={isActivePanel('notificationsMenu')} />
         {showUserMenu && <UserMenuPanel expanded={isActivePanel('userMenu')} hidePanel={hidePanel('userMenu')} />}

--- a/packages/apps/esm-primary-navigation-app/src/root.component.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/root.component.test.tsx
@@ -29,7 +29,7 @@ mockUseConfig.mockReturnValue({
 });
 mockUseAssignedExtensions.mockReturnValue(['mock-extension'] as unknown as AssignedExtension[]);
 mockUseSession.mockReturnValue(mockSession as unknown as Session);
-mockUseLeftNavStore.mockReturnValue({ slotName: '', basePath: '' });
+mockUseLeftNavStore.mockReturnValue({ slotName: '', basePath: '', mode: 'normal' });
 
 jest.mock('./root.resource', () => ({
   getSynchronizedCurrentUser: jest.fn(() => mockUserObservable),

--- a/packages/apps/esm-primary-navigation-app/src/root.component.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/root.component.test.tsx
@@ -8,6 +8,7 @@ import {
   useSession,
   type AssignedExtension,
   type Session,
+  useLeftNavStore,
 } from '@openmrs/esm-framework';
 import { isDesktop } from './utils';
 import { mockUser } from '../__mocks__/mock-user';
@@ -21,12 +22,14 @@ const mockIsDesktop = jest.mocked(isDesktop);
 const mockUseConfig = jest.mocked(useConfig);
 const mockUseAssignedExtensions = jest.mocked(useAssignedExtensions);
 const mockUseSession = jest.mocked(useSession);
+const mockUseLeftNavStore = jest.mocked(useLeftNavStore);
 
 mockUseConfig.mockReturnValue({
   logo: { src: null, alt: null, name: 'Mock EMR', link: 'Mock EMR' },
 });
 mockUseAssignedExtensions.mockReturnValue(['mock-extension'] as unknown as AssignedExtension[]);
 mockUseSession.mockReturnValue(mockSession as unknown as Session);
+mockUseLeftNavStore.mockReturnValue({ slotName: '', basePath: '' });
 
 jest.mock('./root.resource', () => ({
   getSynchronizedCurrentUser: jest.fn(() => mockUserObservable),

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -2372,7 +2372,7 @@ is deprecated; it simply renders nothing.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/left-nav/index.tsx:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L40)
+[packages/framework/esm-styleguide/src/left-nav/index.tsx:53](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L53)
 
 ___
 
@@ -7122,7 +7122,7 @@ ___
 
 | Name | Type |
 | :------ | :------ |
-| `__namedParameters` | `Object` |
+| `__namedParameters` | `SetLeftNavParams` |
 
 #### Returns
 
@@ -7130,7 +7130,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/left-nav/index.tsx:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L18)
+[packages/framework/esm-styleguide/src/left-nav/index.tsx:31](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L31)
 
 ___
 
@@ -7379,7 +7379,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/left-nav/index.tsx:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L22)
+[packages/framework/esm-styleguide/src/left-nav/index.tsx:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L35)
 
 ___
 
@@ -7487,7 +7487,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/left-nav/index.tsx:28](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L28)
+[packages/framework/esm-styleguide/src/left-nav/index.tsx:41](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L41)
 
 ___
 

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -230,6 +230,7 @@
 - [useBodyScrollLock](API.md#usebodyscrolllock)
 - [useFhirPagination](API.md#usefhirpagination)
 - [useLayoutType](API.md#uselayouttype)
+- [useLeftNavStore](API.md#useleftnavstore)
 - [useOnClickOutside](API.md#useonclickoutside)
 - [useOpenmrsFetchAll](API.md#useopenmrsfetchall)
 - [useOpenmrsInfinite](API.md#useopenmrsinfinite)
@@ -2363,9 +2364,15 @@ ___
 
 • `Const` **LeftNavMenu**: `ForwardRefExoticComponent`<`SideNavProps` & `RefAttributes`<`HTMLElement`\>\>
 
+This component renders the left nav in desktop mode. It's also used to render the same
+nav when the hamburger menu is clicked on in tablet mode. See side-menu-panel.component.tsx
+
+Use of this component by anything other than <SideMenuPanel> (where isChildOfHeader == false)
+is deprecated; it simply renders nothing.
+
 #### Defined in
 
-[packages/framework/esm-styleguide/src/left-nav/index.tsx:30](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L30)
+[packages/framework/esm-styleguide/src/left-nav/index.tsx:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L40)
 
 ___
 
@@ -7467,6 +7474,20 @@ ___
 #### Defined in
 
 [packages/framework/esm-react-utils/src/useLayoutType.ts:26](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useLayoutType.ts#L26)
+
+___
+
+### useLeftNavStore
+
+▸ **useLeftNavStore**(): `LeftNavStore`
+
+#### Returns
+
+`LeftNavStore`
+
+#### Defined in
+
+[packages/framework/esm-styleguide/src/left-nav/index.tsx:28](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L28)
 
 ___
 

--- a/packages/framework/esm-styleguide/mock.tsx
+++ b/packages/framework/esm-styleguide/mock.tsx
@@ -141,3 +141,4 @@ export const DiagnosisTags = jest.fn(({ diagnoses }) => (
     ))}
   </>
 ));
+export const useLeftNavStore = jest.fn();

--- a/packages/framework/esm-styleguide/src/index.ts
+++ b/packages/framework/esm-styleguide/src/index.ts
@@ -1,8 +1,8 @@
 import { defineConfigSchema } from '@openmrs/esm-config';
+import { setupLogo } from './logo';
+import { setupIcons } from './icons/icon-registration';
 import { setupBranding } from './brand';
 import { esmStyleGuideSchema } from './config-schema';
-import { setupIcons } from './icons/icon-registration';
-import { setupLogo } from './logo';
 import { setupPictograms } from './pictograms/pictogram-registration';
 
 export * from './breakpoints';

--- a/packages/framework/esm-styleguide/src/left-nav/index.tsx
+++ b/packages/framework/esm-styleguide/src/left-nav/index.tsx
@@ -8,15 +8,28 @@ import styles from './left-nav.module.scss';
 interface LeftNavStore {
   slotName: string | null;
   basePath: string;
+  mode: 'normal' | 'collapsed';
 }
 
 const leftNavStore = createGlobalStore<LeftNavStore>('left-nav', {
   slotName: null,
   basePath: window.spaBase,
+  mode: 'normal',
 });
 
-export function setLeftNav({ name, basePath }) {
-  leftNavStore.setState({ slotName: name, basePath });
+interface SetLeftNavParams {
+  name: string;
+  basePath: string;
+
+  /**
+   * In normal mode, the left nav is shown in desktop mode, and collapse into hamburger menu button in tablet mode
+   * In collapsed mode, the left nav is always collapsed, regardless of desktop / tablet mode
+   */
+  mode?: 'normal' | 'collapsed';
+}
+
+export function setLeftNav({ name, basePath, mode }: SetLeftNavParams) {
+  leftNavStore.setState({ slotName: name, basePath, mode: mode ?? 'normal' });
 }
 
 export function unsetLeftNav(name) {

--- a/packages/framework/esm-styleguide/src/left-nav/index.tsx
+++ b/packages/framework/esm-styleguide/src/left-nav/index.tsx
@@ -1,8 +1,8 @@
 /** @module @category UI */
-import React from 'react';
+import { SideNav } from '@carbon/react';
 import { ExtensionSlot, useStore } from '@openmrs/esm-react-utils';
 import { createGlobalStore } from '@openmrs/esm-state';
-import { SideNav } from '@carbon/react';
+import React from 'react';
 import styles from './left-nav.module.scss';
 
 interface LeftNavStore {
@@ -25,16 +25,30 @@ export function unsetLeftNav(name) {
   }
 }
 
+export function useLeftNavStore() {
+  return useStore(leftNavStore);
+}
 type LeftNavMenuProps = SideNavProps;
 
+/**
+ * This component renders the left nav in desktop mode. It's also used to render the same
+ * nav when the hamburger menu is clicked on in tablet mode. See side-menu-panel.component.tsx
+ *
+ * Use of this component by anything other than <SideMenuPanel> (where isChildOfHeader == false)
+ * is deprecated; it simply renders nothing.
+ */
 export const LeftNavMenu = React.forwardRef<HTMLElement, LeftNavMenuProps>((props, ref) => {
-  const { slotName, basePath } = useStore(leftNavStore);
+  const { slotName, basePath } = useLeftNavStore();
   const currentPath = window.location ?? { pathname: '' };
 
-  return (
-    <SideNav ref={ref} expanded aria-label="Left navigation" className={styles.leftNav} {...props}>
-      <ExtensionSlot name="global-nav-menu-slot" />
-      {slotName ? <ExtensionSlot name={slotName} state={{ basePath, currentPath }} /> : null}
-    </SideNav>
-  );
+  if (props.isChildOfHeader) {
+    return (
+      <SideNav ref={ref} expanded aria-label="Left navigation" className={styles.leftNav} {...props}>
+        <ExtensionSlot name="global-nav-menu-slot" />
+        {slotName ? <ExtensionSlot name={slotName} state={{ basePath, currentPath }} /> : null}
+      </SideNav>
+    );
+  } else {
+    return <></>;
+  }
 });

--- a/packages/shell/esm-app-shell/src/index.ejs
+++ b/packages/shell/esm-app-shell/src/index.ejs
@@ -48,6 +48,7 @@
     <div class="omrs-actionable-notifications-container"></div>
     <div class="omrs-snackbars-container"></div>
     <div class="omrs-modals-container"></div>
+    <div id="omrs-left-nav-container-root"></div>
     <template id="loading-spinner">
       <div class="omrs-loading-spinner">
         <div data-inline-loading="" class="cds--inline-loading" role="alert" aria-live="assertive">


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds the ability for apps to define a left nav that's always collapsed into the top nav hamburger menu.

This PR also includes refactoring to remove the need to render `<LeftNavMenu>` within the home or patient-chart app. Currently, the home / patient-chart app needs to render `<LeftNavMenu>` in its root component in order for the left nav to show in desktop mode. The top nav, however, also has a `<SideMenuPanel>`, which renders the menu when in tablet mode and the hamburger button is toggled on. (Incidentally, `<SideMenuPanel>` actually uses `<LeftNavMenu>` as child component)

Screenshot: `<LeftNavMenu>` rendered by home app:
![image](https://github.com/user-attachments/assets/600a46fa-f25d-47c0-96c7-1ac1aaa844df)

Screenshot: `<SideMenuPanel>` rendered by primary-navigation-app:
![image](https://github.com/user-attachments/assets/dcf6c4f6-ed12-45ef-836d-f311bbc1be69)

The `<LeftNavMenu>` is a carbon's `<SideNav>` component, which is a `position: fixed` element. This means we shouldn't really need the home or patient chart app to render it as part of its component tree. The refactoring makes it so the that the `<SideMenuPanel>` renders both:
-  the pop-up menu when the top nav hamburger is pressed, in tablet mode
- the actual left nav, in desktop mode

## Screenshots
<!-- Required if you are making UI changes. -->
Video of the home app with this change. No noticeable difference from before. (Not part of this PR, but in the video capture, `<LeftNavMenu>` is removed from the home app.)
https://github.com/user-attachments/assets/f89bae32-5b20-4270-aa44-8874fff62cf4

Video of the dispensing app with this change, The dispensing app added the following to define the left nav to be always collapsed:

    useEffect(() => {
      const basePath = window.spaBase + "/dispensing"; 
      setLeftNav({ name: 'homepage-dashboard-slot', basePath, mode: 'collapsed'});
      return () => unsetLeftNav('homepage-dashboard-slot');
    }, []);

https://github.com/user-attachments/assets/12f8b46f-2776-4676-a287-054db27ded27



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4425

## Other
<!-- Anything not covered above -->
I attempted to refactor `<LeftNavMenu>`  hoping this will give us a cleaner way to define a collapsed left nav. While this change removes the need to render `<LeftNavMenu>` in home / patient-chart, it fails to completely abstract the left nav logic away from those apps. In particular, the home dashboard actually needs to maintain a `margin-left` in order to be rendered to the right of the left nav in desktop mode. (That margin is set to 0 in tablet mode). ~~I'm not sure if there is a way around it as the left nav is `position: fixed`.~~ This is probably doable with a more invasive change by overriding the `position: fixed` in the carbon `<SideNav>` and adding a `top-nav-container` div in `index.ejs` (so we can render the top nav there via `createPortal())`.

![image](https://github.com/user-attachments/assets/aa130f52-a0d3-42fc-b4b0-8b8a98737cf4)

