### PR TITLE
(feat) Patient banner styling refinements

### DIFF
--- a/packages/framework/esm-styleguide/src/custom-overflow-menu/custom-overflow-menu.module.scss
+++ b/packages/framework/esm-styleguide/src/custom-overflow-menu/custom-overflow-menu.module.scss
@@ -1,4 +1,5 @@
 @use '@carbon/colors';
+@use '@carbon/layout';
 @import '@openmrs/esm-styleguide/src/vars';
 
 .container {
@@ -6,7 +7,7 @@
   height: auto;
 
   :global(.cds--overflow-menu__trigger) {
-    min-height: 3rem;
+    min-height: layout.$spacing-09;
   }
 }
 

--- a/packages/framework/esm-styleguide/src/custom-overflow-menu/custom-overflow-menu.module.scss
+++ b/packages/framework/esm-styleguide/src/custom-overflow-menu/custom-overflow-menu.module.scss
@@ -4,6 +4,10 @@
 .container {
   width: auto;
   height: auto;
+
+  :global(.cds--overflow-menu__trigger) {
+    min-height: 3rem;
+  }
 }
 
 .menu {

--- a/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.module.scss
+++ b/packages/framework/esm-styleguide/src/patient-banner/contact-details/patient-banner-contact-details.module.scss
@@ -7,6 +7,7 @@
 .deceased {
   color: $text-02;
   width: 100%;
+  border-top: 1px solid $ui-03;
 }
 
 .heading {

--- a/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.module.scss
+++ b/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.module.scss
@@ -41,7 +41,7 @@
 .patientInfo {
   display: flex;
   flex-direction: column;
-  padding: layout.$spacing-05 0 layout.$spacing-05 0;
+  padding: layout.$spacing-05 layout.$spacing-03 layout.$spacing-05 0;
   width: 100%;
 }
 
@@ -50,7 +50,7 @@
   color: $text-02;
   display: flex;
   align-items: center;
-  column-gap: layout.$spacing-02;
+  gap: layout.$spacing-02;
   margin-top: layout.$spacing-02;
   flex-wrap: wrap;
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Refines the Patient Banner layout and visual consistency with the following changes:

- Sets an explicit height for the Actions menu button to ensure consistent vertical alignment (explicitly sets it to `3rem` instead of `2.5rem` from Carbon).
- Adds a top border to the contact details panel, eliminating the need for consuming components to add their own.
- Adds row gap to demographic elements (patient name and identifiers) to maintain consistent spacing when their content overflows.
- Adds right-edge padding to the patient info section to prevent the overflow menu from touching the container edge.

## Screenshots

### Contact details panel missing its own top border

![CleanShot 2025-02-14 at 10  35 27@2x](https://github.com/user-attachments/assets/6d1bd1c2-3016-40d9-b14a-77f7c760b01d)

### Actions overflow menu trigger button has the wrong size (tablet)

![CleanShot 2025-02-14 at 10  38 40@2x](https://github.com/user-attachments/assets/78eb0c51-8a03-4e16-8e06-7cf7f0a20974)

### Likewise on desktop

![CleanShot 2025-02-14 at 10  42 36@2x](https://github.com/user-attachments/assets/af7bffd2-6730-4133-8103-727d5cce9536)

### Cramped overflowing content in the demographics section

![CleanShot 2025-02-14 at 10  44 50@2x](https://github.com/user-attachments/assets/7a43e3fa-59d1-4e05-a0e2-b7054fc43600)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other

These changes support https://openmrs.atlassian.net/browse/O3-4114, which will refactor Patient Management repo's patient banner implementations to use shared banner components from the styleguide.