### PR TITLE
(fix) O3-4455 :  Update translated workspace title once rendered

### DIFF
--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-container.component.tsx
@@ -1,4 +1,4 @@
-import React, { Suspense, useCallback, useContext, useMemo } from 'react';
+import React, { Suspense, useCallback, useContext, useEffect, useMemo } from 'react';
 import classNames from 'classnames';
 import { Header, HeaderGlobalAction, HeaderGlobalBar, HeaderMenuButton, HeaderName } from '@carbon/react';
 import { DownToBottom, Maximize, Minimize } from '@carbon/react/icons';
@@ -147,6 +147,17 @@ function Workspace({ workspaceInstance, additionalWorkspaceProps }: WorkspacePro
   const { workspaceWindowState, workspaceGroup } = useWorkspaces();
   const currentGroupName = workspaceGroup?.name;
   const isMaximized = workspaceWindowState === 'maximized';
+
+  // Translate the workspace title
+  // The workspace title is a translation key whose translation resides in the workspace module.
+  // Since the workspace module is not loaded at the time of workspace registration, we need to translate it here
+  // when the workspace is actually rendered and the workspace module along with its translations are loaded.
+  useEffect(() => {
+    const translatedTitle = t(workspaceInstance.title);
+    if (translatedTitle !== workspaceInstance.title) {
+      workspaceInstance.setTitle(translatedTitle);
+    }
+  }, [workspaceInstance.title, t, workspaceInstance.setTitle]);
 
   // We use the feature name of the app containing the workspace in order to set the extension
   // slot name. We can't use contextKey for this because we don't want the slot name to be

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.test.ts
@@ -88,7 +88,7 @@ describe('workspace system', () => {
       expect(prompt).toBeTruthy();
       expect(prompt.title).toMatch(/unsaved changes/i);
       expect(prompt.body).toMatch(
-        'There may be unsaved changes in Allergies. Please save them before opening another workspace.',
+        'There may be unsaved changes in "Allergies". Please save them before opening another workspace.',
       );
       expect(prompt.confirmText).toMatch(/Open anyway/i);
 
@@ -179,7 +179,7 @@ describe('workspace system', () => {
       expect(prompt).toBeTruthy();
       expect(prompt.title).toMatch(/unsaved changes/i);
       expect(prompt.body).toMatch(
-        'There may be unsaved changes in Allergies. Please save them before opening another workspace.',
+        'There may be unsaved changes in "Allergies". Please save them before opening another workspace.',
       );
       expect(prompt.confirmText).toMatch(/Open anyway/i);
 
@@ -287,7 +287,7 @@ describe('workspace system', () => {
       const prompt = store.getState().prompt as Prompt;
       expect(prompt).toBeTruthy();
       expect(prompt.body).toMatch(
-        'There may be unsaved changes in Conditions. Please save them before opening another workspace.',
+        'There may be unsaved changes in "Conditions". Please save them before opening another workspace.',
       );
       // Closing the conditions workspace because it cannot be hidden
 
@@ -301,7 +301,7 @@ describe('workspace system', () => {
 
       expect(prompt2).toBeTruthy();
       expect(prompt2.body).toMatch(
-        'There may be unsaved changes in Allergies. Please save them before opening another workspace.',
+        'There may be unsaved changes in "Allergies". Please save them before opening another workspace.',
       );
 
       prompt2.onConfirm();

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -617,7 +617,7 @@ export function showWorkspacePrompts(
         title: getCoreTranslation('unsavedChangesTitleText', 'Unsaved changes'),
         body: getCoreTranslation(
           'unsavedChangesInWorkspace',
-          'There may be unsaved changes in {{workspaceName}}. Please save them before opening another workspace.',
+          'There may be unsaved changes in "{{workspaceName}}". Please save them before opening another workspace.',
           { workspaceName: workspaceTitle },
         ),
         onConfirm: () => {

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -9,7 +9,7 @@ import {
 import { type WorkspaceWindowState } from '@openmrs/esm-globals';
 import { navigate } from '@openmrs/esm-navigation';
 import { getGlobalStore, createGlobalStore } from '@openmrs/esm-state';
-import { getCoreTranslation, translateFrom } from '@openmrs/esm-translations';
+import { getCoreTranslation } from '@openmrs/esm-translations';
 import { useStore } from '@openmrs/esm-react-utils';
 import type { StoreApi } from 'zustand/vanilla';
 
@@ -246,7 +246,6 @@ function promptBeforeLaunchingWorkspace(
 ) {
   const { name, additionalProps } = newWorkspaceDetails;
   const newWorkspaceRegistration = getWorkspaceRegistration(name);
-  const workspaceModuleName = workspace.moduleName;
 
   const proceed = () => {
     closeWorkspace(workspace.name, {
@@ -260,12 +259,7 @@ function promptBeforeLaunchingWorkspace(
   };
 
   if (!canCloseWorkspaceWithoutPrompting(workspace.name)) {
-    showWorkspacePrompts(
-      'closing-workspace-launching-new-workspace',
-      proceed,
-      workspace.title ?? workspace.name,
-      workspaceModuleName,
-    );
+    showWorkspacePrompts('closing-workspace-launching-new-workspace', proceed, workspace.title ?? workspace.name);
   } else {
     proceed();
   }
@@ -574,7 +568,6 @@ export function showWorkspacePrompts(
   promptType: PromptType,
   onConfirmation: () => void = () => {},
   workspaceTitle: string = '',
-  workspaceModuleName: string = ' ',
 ) {
   const store = getWorkspaceStore();
 
@@ -625,7 +618,7 @@ export function showWorkspacePrompts(
         body: getCoreTranslation(
           'unsavedChangesInWorkspace',
           'There may be unsaved changes in {{workspaceName}}. Please save them before opening another workspace.',
-          { workspaceName: translateFrom(workspaceModuleName, workspaceTitle) },
+          { workspaceName: workspaceTitle },
         ),
         onConfirm: () => {
           store.setState((state) => ({

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -9,7 +9,7 @@ import {
 import { type WorkspaceWindowState } from '@openmrs/esm-globals';
 import { navigate } from '@openmrs/esm-navigation';
 import { getGlobalStore, createGlobalStore } from '@openmrs/esm-state';
-import { getCoreTranslation } from '@openmrs/esm-translations';
+import { getCoreTranslation, translateFrom } from '@openmrs/esm-translations';
 import { useStore } from '@openmrs/esm-react-utils';
 import type { StoreApi } from 'zustand/vanilla';
 
@@ -246,6 +246,7 @@ function promptBeforeLaunchingWorkspace(
 ) {
   const { name, additionalProps } = newWorkspaceDetails;
   const newWorkspaceRegistration = getWorkspaceRegistration(name);
+  const workspaceModuleName = workspace.moduleName;
 
   const proceed = () => {
     closeWorkspace(workspace.name, {
@@ -259,7 +260,12 @@ function promptBeforeLaunchingWorkspace(
   };
 
   if (!canCloseWorkspaceWithoutPrompting(workspace.name)) {
-    showWorkspacePrompts('closing-workspace-launching-new-workspace', proceed, workspace.title ?? workspace.name);
+    showWorkspacePrompts(
+      'closing-workspace-launching-new-workspace',
+      proceed,
+      workspace.title ?? workspace.name,
+      workspaceModuleName,
+    );
   } else {
     proceed();
   }
@@ -568,6 +574,7 @@ export function showWorkspacePrompts(
   promptType: PromptType,
   onConfirmation: () => void = () => {},
   workspaceTitle: string = '',
+  workspaceModuleName: string = ' ',
 ) {
   const store = getWorkspaceStore();
 
@@ -618,7 +625,7 @@ export function showWorkspacePrompts(
         body: getCoreTranslation(
           'unsavedChangesInWorkspace',
           'There may be unsaved changes in {{workspaceName}}. Please save them before opening another workspace.',
-          { workspaceName: workspaceTitle },
+          { workspaceName: translateFrom(workspaceModuleName, workspaceTitle) },
         ),
         onConfirm: () => {
           store.setState((state) => ({

--- a/packages/framework/esm-translations/src/translations.ts
+++ b/packages/framework/esm-translations/src/translations.ts
@@ -29,7 +29,7 @@ const workspaceTranslations = {
   openAnyway: 'Open anyway',
   unsavedChangesInOpenedWorkspace: `You may have unsaved changes in the opened workspace. Do you want to discard these changes?`,
   unsavedChangesInWorkspace:
-    'There may be unsaved changes in {{workspaceName}}. Please save them before opening another workspace.',
+    'There may be unsaved changes in "{{workspaceName}}". Please save them before opening another workspace.',
   unsavedChangesTitleText: 'Unsaved changes',
   workspaceHeader: 'Workspace header',
 };

--- a/packages/framework/esm-translations/translations/en.json
+++ b/packages/framework/esm-translations/translations/en.json
@@ -55,7 +55,7 @@
   "stateProvince": "State",
   "toggleDevTools": "Toggle dev tools",
   "unknown": "Unknown",
-  "unsavedChangesInWorkspace": "There are unsaved changes in {{workspaceName}}. Please save them before opening another workspace.",
+  "unsavedChangesInWorkspace": "There may be unsaved changes in \"{{workspaceName}}\". Please save them before opening another workspace.",
   "unsavedChangesTitleText": "Unsaved changes",
   "workspaceHeader": "Workspace header"
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [design documentation](https://om.rs/o3ui).
- [x] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
In the pop-up shown below (prompting while adding a drug order), the title of the workspace is not translated. This title must be translated correctly

so used translateFrom to translate workspaceTitle

## Screenshots
<!-- Required if you are making UI changes. -->
<img width="1470" alt="Screenshot 2025-02-17 at 6 18 29 PM" src="https://github.com/user-attachments/assets/f95b4ef9-5b81-43b9-a099-48b20983e6f1" />


<img width="1470" alt="Screenshot 2025-02-17 at 5 55 32 PM" src="https://github.com/user-attachments/assets/9a534eae-a168-48bf-9025-2dc1118f38dd" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
[Jira ticket](https://openmrs.atlassian.net/browse/O3-4455)
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
