### PR TITLE
(feat) O3-4362: Move Location Picker to the top nav

### DIFF
--- a/e2e/specs/login.spec.ts
+++ b/e2e/specs/login.spec.ts
@@ -7,6 +7,7 @@ test.use({ storageState: { cookies: [], origins: [] } });
 test('Login as Admin user', async ({ page }) => {
   const loginPage = new LoginPage(page);
   const userPanel = page.locator('[data-extension-slot-name="user-panel-slot"]');
+  const topNav = page.getByRole('banner', { name: 'OpenMRS' });
 
   await test.step('When I navigate to the login page', async () => {
     await loginPage.goto();
@@ -35,16 +36,16 @@ test('Login as Admin user', async ({ page }) => {
     await expect(page).toHaveURL(`${process.env.E2E_BASE_URL}/spa/home`);
   });
 
+  await test.step('And I should see the location picker in top nav', async () => {
+    await expect(topNav.getByText(/outpatient clinic/i)).toBeVisible();
+  });
+
   await test.step('When I click on the my account button', async () => {
     await page.getByRole('button', { name: /My Account/i }).click();
   });
 
   await test.step('Then I should see the user details', async () => {
     await expect(userPanel.getByText(/super user/i)).toBeVisible();
-  });
-
-  await test.step('And I should see the location details', async () => {
-    await expect(userPanel.getByText(/outpatient clinic/i)).toBeVisible();
   });
 
   await test.step('And I should see the logout button', async () => {

--- a/packages/apps/esm-login-app/src/change-location-link/change-location-link.extension.tsx
+++ b/packages/apps/esm-login-app/src/change-location-link/change-location-link.extension.tsx
@@ -1,7 +1,7 @@
+import { HeaderGlobalAction } from '@carbon/react';
+import { LocationIcon, navigate, useSession } from '@openmrs/esm-framework';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { Button, SwitcherItem } from '@carbon/react';
-import { LocationIcon, navigate, useSession } from '@openmrs/esm-framework';
 import styles from './change-location-link.scss';
 
 const ChangeLocationLink: React.FC = () => {
@@ -18,15 +18,14 @@ const ChangeLocationLink: React.FC = () => {
   };
 
   return (
-    <SwitcherItem aria-label="Change Location" className={styles.panelItemContainer}>
-      <div>
-        <LocationIcon size={20} />
-        <p>{currentLocation}</p>
-      </div>
-      <Button kind="ghost" onClick={changeLocation}>
-        {t('change', 'Change')}
-      </Button>
-    </SwitcherItem>
+    <HeaderGlobalAction
+      aria-label={t('changeLocation', 'Change location')}
+      className={styles.changeLocationButton}
+      onClick={changeLocation}
+    >
+      <LocationIcon size={16} />
+      <span className={styles.currentLocationText}>{currentLocation}</span>
+    </HeaderGlobalAction>
   );
 };
 

--- a/packages/apps/esm-login-app/src/change-location-link/change-location-link.scss
+++ b/packages/apps/esm-login-app/src/change-location-link/change-location-link.scss
@@ -1,3 +1,4 @@
+@use '@carbon/layout';
 @import '~@openmrs/esm-styleguide/src/vars';
 @import '../root.scss';
 
@@ -10,4 +11,16 @@
 .panelItemContainer div {
   display: flex;
   align-items: center;
+}
+
+.changeLocationButton {
+  width: fit-content;
+  background-color: transparent;
+  color: white;
+  font-size: 14px;
+  padding: layout.$spacing-04 !important; // this gets unset in rtl language without !important
+}
+
+.currentLocationText {
+  padding-inline-start: layout.$spacing-03;
 }

--- a/packages/apps/esm-login-app/src/routes.json
+++ b/packages/apps/esm-login-app/src/routes.json
@@ -47,7 +47,7 @@
     },
     {
       "name": "location-changer",
-      "slot": "user-panel-slot",
+      "slot": "top-nav-info-slot",
       "component": "changeLocationLink",
       "online": true,
       "offline": true,

--- a/packages/apps/esm-login-app/translations/en.json
+++ b/packages/apps/esm-login-app/translations/en.json
@@ -2,6 +2,7 @@
   "builtWith": "Built with",
   "cancel": "Cancel",
   "change": "Change",
+  "changeLocation": "Change location",
   "changePassword": "Change password",
   "changingPassword": "Changing password",
   "confirmPassword": "Confirm new password",

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -67,7 +67,8 @@ const HeaderItems: React.FC = () => {
             <Logo />
           </div>
         </ConfigurableLink>
-        <ExtensionSlot className={styles.dividerOverride} name="top-nav-info-slot" />
+        <div className={styles.divider} />
+        <ExtensionSlot name="top-nav-info-slot" />
         <HeaderGlobalBar className={styles.headerGlobalBar}>
           <ExtensionSlot name="top-nav-actions-slot" className={styles.topNavActionsSlot} />
           <ExtensionSlot

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.scss
@@ -37,7 +37,7 @@
 
 .divider {
   width: 1px;
-  height: 24px;
+  height: layout.$spacing-06;
   background-color: rgba(244, 244, 244, 0.4);
   margin-inline-start: layout.$spacing-04;
 }

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.scss
@@ -28,9 +28,16 @@
   height: layout.$spacing-09;
   width: layout.$spacing-09;
   padding: layout.$spacing-04;
-  margin-right: layout.$spacing-02;
+  margin-inline-end: layout.$spacing-02;
 }
 
 .spacedLogo {
-  margin-left: layout.$spacing-05;
+  margin-inline-start: layout.$spacing-05;
+}
+
+.divider {
+  width: 1px;
+  height: 24px;
+  background-color: rgba(244, 244, 244, 0.4);
+  margin-inline-start: layout.$spacing-04;
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds the Location Picker directly onto the top nav, and removes it from the top-right user menu. Based on [mockup here](https://app.zeplin.io/project/60d59321e8100b0324762e05/screen/679760063c7ac6c05d760a97).

Minor deviations from mockup:
- In the mockup, the font size of the "OpenMRS" logo text and the Location are both ~12px. I made the location font size = 14px to better match the font size of the "OpenMRS" logo text
- margins / paddings are rounded to the nearest `$layout.spacingXX` size.

## Screenshots
<!-- Required if you are making UI changes. -->
ltr, desktop:
![image](https://github.com/user-attachments/assets/f043b816-1f94-4cab-bf70-1fb7022e5fd9)

ltr, mobile:
![image](https://github.com/user-attachments/assets/5ba86711-bb90-4260-a0f8-f733fea5285a)

rtl, desktop:
![image](https://github.com/user-attachments/assets/66d0f604-8743-4af1-9563-32e33e58395f)

rtl, mobile:
![image](https://github.com/user-attachments/assets/1350bfac-d953-43f0-9c2c-7886d0b03b50)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4362

## Other
<!-- Anything not covered above -->
