### PR TITLE
(fix) Allow user to login by selecting a location if default one is invalid

### DIFF
--- a/packages/apps/esm-login-app/src/login.resource.ts
+++ b/packages/apps/esm-login-app/src/login.resource.ts
@@ -135,7 +135,7 @@ export function useValidateLocationUuid(userPreferredLocationUuid: string) {
 
   const results = useMemo(
     () => ({
-      isLocationValid: data?.ok,
+      isLocationValid: data?.ok && data?.data.total > 0,
       defaultLocation: data?.data?.entry ?? [],
       error,
       isLoading,


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes an issue where the location selection screen would get stuck in a loading state after login if the user had an invalid location configured in their properties. The fix ensures that the default location exists before posting it to server.

## Screenshots
<!-- Required if you are making UI changes. -->
Before fix:
![image](https://github.com/user-attachments/assets/83455e5c-f295-4f18-b9d7-5ff34048095d)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
