### PR TITLE
(fix) O3-3189 fix useOpenmrsPagination to properly take in string URL

### DIFF
--- a/packages/framework/esm-react-utils/src/useOpenmrsPagination.ts
+++ b/packages/framework/esm-react-utils/src/useOpenmrsPagination.ts
@@ -1,5 +1,5 @@
 /** @module @category UI */
-import { type FetchResponse, openmrsFetch } from '@openmrs/esm-api';
+import { type FetchResponse, makeUrl, openmrsFetch } from '@openmrs/esm-api';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import useSWR, { type SWRConfiguration } from 'swr';
 import useSWRImmutable from 'swr/immutable';
@@ -68,7 +68,7 @@ type OpenmrsServerPaginationHandlers<T> = ServerPaginationHandlers<T, OpenMRSPag
 export const openmrsServerPaginationHandlers: OpenmrsServerPaginationHandlers<any> = {
   getPaginatedUrl: (url: string | URL, limit: number, startIndex: number) => {
     if (url) {
-      const urlUrl = new URL(url.toString());
+      const urlUrl = new URL(makeUrl(url.toString()), window.location.toString());
       urlUrl.searchParams.set('limit', '' + limit);
       urlUrl.searchParams.set('startIndex', '' + startIndex);
       urlUrl.searchParams.set('totalCount', 'true');


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
`useOpenmrsPagination` should accept a url that is either of type `string` or `URL`. If it's a `string`, it converts it to `URL`. The conversion is incorrect; this PR fixes it.

Note that [similar fix](https://github.com/openmrs/openmrs-esm-core/blob/c2da7a0f45f7e8b402cce111e0e28c0f26d5c9ed/packages/framework/esm-react-utils/src/useFhirPagination.ts#L40) is already in `useFhirPagination`.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
