### PR TITLE
(fix) O3-4501: Fix header panel positioning in RTL mode

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -380,11 +380,13 @@ html[dir='rtl'] {
   }
 
   .cds--header-panel--expanded {
-    right: calc(100vw - var(--omrs-sidenav-width));
+    left: 0;
+    right: auto;
   }
 
   .cds--btn--tertiary {
     padding: calc(0.875rem - 3px) 15px calc(0.875rem - 3px) 63px;
+
     svg {
       left: spacing.$spacing-05;
       right: unset;
@@ -416,6 +418,7 @@ html[dir='rtl'] {
 
   .cds--btn--primary {
     padding: calc(0.875rem - 3px) 15px calc(0.875rem - 3px) 63px;
+
     svg {
       left: spacing.$spacing-05;
       right: unset;
@@ -431,6 +434,7 @@ html[dir='rtl'] {
     & > svg {
       margin: 2px 0 0 1rem;
     }
+
     p {
       text-align: right;
     }
@@ -560,6 +564,7 @@ html[dir='rtl'] {
 
   .cds--list-box__field {
     padding: 0 spacing.$spacing-05 0 spacing.$spacing-09;
+
     .cds--list-box__menu-icon {
       left: spacing.$spacing-05;
       right: unset;
@@ -571,6 +576,7 @@ html[dir='rtl'] {
     select {
       padding: 0 spacing.$spacing-05 0 spacing.$spacing-09;
     }
+
     svg {
       right: unset;
       left: spacing.$spacing-05;
@@ -616,6 +622,7 @@ html[dir='rtl'] {
       & > section {
         margin-left: unset;
         margin-right: var(--omrs-sidenav-width);
+
         nav {
           left: calc(100vw - var(--omrs-sidenav-width));
           border-left: 1px solid #e0e0e0;
@@ -637,10 +644,12 @@ html[dir='rtl'] {
         & > button {
           text-align: right;
         }
+
         .active {
           border-left: unset !important;
           border-right: 0.5rem solid #009d9a;
         }
+
         .enabled {
           border-left: unset !important;
           border-right: 0.5rem solid #9ef0f0;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR improves the header panel's alignment when using RTL languages. Previously, the header panel was positioned based on a calculated right value, causing it to appear misaligned and partially hidden. With these updates, the header panel is now properly aligned to the edge as specified for RTL layouts, ensuring better visibility and a more consistent user experience.

## Screenshots

### Before
![before](https://github.com/user-attachments/assets/8c942b94-f23d-4cc4-82b1-9d10e792dd18)

### After
![after](https://github.com/user-attachments/assets/6e029d88-f6ef-45a9-862e-14e7f79cfbaa)

## Related Issue

https://openmrs.atlassian.net/browse/O3-4501

<!-- Anything not covered above -->
