### PR TITLE
feat: Add smooth height resizing to popup component

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/popup/popup.styles.scss
+++ b/packages/apps/esm-implementer-tools-app/src/popup/popup.styles.scss
@@ -12,6 +12,7 @@
   color: $color-gray-100;
   box-sizing: border-box;
 
+  transition: height 0.05s ease;
   tr {
     th,
     td {
@@ -22,7 +23,8 @@
 
 .content {
   width: 100%;
-  height: 50vh;
+  height: calc(100% - 50px);
+  overflow-y: auto;
 }
 
 .tabs {
@@ -66,5 +68,42 @@
 .closeButton {
   svg {
     fill: theme.$icon-primary;
+  }
+}
+
+.resizer {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 10px;
+  background-color: transparent;
+  cursor: n-resize;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  transform: translateY(-5px);
+  z-index: 100001;
+
+  &:hover .resizerHandle {
+    background-color: theme.$icon-primary;
+  }
+}
+
+.resizerHandle {
+  width: 60px;
+  height: 4px;
+  border-radius: 2px;
+  background-color: theme.$border-subtle;
+  transition: background-color 0.2s ease;
+}
+
+// Global class to prevent text selection during resizing
+:global(.no-select) {
+  user-select: none !important;
+  cursor: ns-resize !important;
+
+  * {
+    user-select: none !important;
   }
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR adds a smooth height resizing functionality to the DevTools popup component. Users can now resize the popup by dragging the top edge, with the minimum height constraint set to the default value (50vh).

### Changes
- Added smooth height resizing capability with transition animations
- Created an improved resizer handle with better visual feedback on hover
- Implemented text selection prevention during resize operations 
- Set minimum height constraint to maintain the original default height
- Utilized requestAnimationFrame for smoother resize performance
- Added appropriate cursor styling during resize operations
- Fixed SCSS variable usage to align with existing theme

### Testing
- Verified that the popup can be resized by dragging the top edge
- Confirmed that the minimum height constraint works as expected
- Checked that text cannot be selected during resize operations
- Tested that the resize handle provides visual feedback on hover
- Ensured that the popup maintains its width during resizing

## Screenshots
### Before:
![Screenshot 2025-03-09 234650](https://github.com/user-attachments/assets/66fddcc3-0928-4a26-a5c0-89076b49cdfc)

### After:
![Screenshot 2025-03-10 012918](https://github.com/user-attachments/assets/f1cc744d-7281-41b7-85b7-8273edce497d)
![Screenshot 2025-03-10 013021](https://github.com/user-attachments/assets/30f766f0-1638-479a-85f1-63cf8a4c8f98)

## Other
Next, I will work on resizing the internal components to ensure they adapt dynamically within the resized popup.



