### PR TITLE
(fix) Config validation error caused by Type.Object elements with string _elements

### DIFF
--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -653,7 +653,7 @@ function validateFreeformObjectStructure(freeformObjectSchema: ConfigSchema, con
   if (freeformObjectSchema._elements) {
     for (const key of Object.keys(config)) {
       const value = config[key];
-      validateStructure(freeformObjectSchema._elements, value, `${keyPath}.${key}`);
+      validateBranchStructure(freeformObjectSchema._elements, value, `${keyPath}.${key}`);
     }
   }
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Validation errors were being produced for valid configurations provided to config elements of `Type.Object` with `_elements` of type `Type.String`. This fixes the problem with the config structure validator.

![Screenshot from 2025-03-13 22-40-32](https://github.com/user-attachments/assets/1f66d8ad-2025-4b24-a67f-8ef788b9162e)

## Screenshots

Imagine the console log but without those errors

## Related Issue

<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
