### PR TITLE
(test) Add mock for OpenmrsDatePicker

### DIFF
--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
@@ -161,7 +161,7 @@ Omit.children
 
 #### Defined in
 
-node_modules/react-aria-components/dist/types.d.ts:60
+node_modules/react-aria-components/dist/types.d.ts:53
 
 ___
 
@@ -607,7 +607,7 @@ Omit.slot
 
 #### Defined in
 
-node_modules/react-aria-components/dist/types.d.ts:77
+node_modules/react-aria-components/dist/types.d.ts:70
 
 ___
 
@@ -623,7 +623,7 @@ Omit.style
 
 #### Defined in
 
-node_modules/react-aria-components/dist/types.d.ts:54
+node_modules/react-aria-components/dist/types.d.ts:47
 
 ___
 
@@ -643,7 +643,7 @@ Omit.validationBehavior
 
 #### Defined in
 
-node_modules/react-aria-components/dist/types.d.ts:88
+node_modules/react-aria-components/dist/types.d.ts:81
 
 ___
 

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { NEVER } from 'rxjs';
 import type {} from '@openmrs/esm-globals';
 import * as utils from '@openmrs/esm-utils';
-export { OpenmrsDatePicker } from './src';
+import dayjs from 'dayjs';
 
 window.i18next = { ...window.i18next, language: 'en' };
 
@@ -95,6 +95,18 @@ export const launchWorkspace = jest.fn();
 export const launchWorkspaceGroup = jest.fn();
 export const navigateAndLaunchWorkspace = jest.fn();
 export const useWorkspaces = jest.fn();
+
+export const OpenmrsDatePicker = jest.fn(({ id, labelText, value, onChange }) => (
+  <>
+    <label htmlFor={id}>{labelText}</label>
+    <input
+      id={id}
+      type="date"
+      value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
+      onChange={(evt) => onChange?.(dayjs(evt.target.value).toDate())}
+    />
+  </>
+));
 
 /* esm-utils */
 export {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Adds a mock implementation of the `OpenmrsDatePicker` component for testing purposes. This mock implementation:

- Takes `id`, `labelText`, `value`, and `onChange` props
- Renders a simple date input with a labelText
- Formats dates using dayjs
- Handles changes by converting the input value back to a date object and passing it to the `onChange` prop

There's probably more that could be done here, but this seems like a good baseline per previous attempts at stubbing the component.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
