### PR TITLE
(fix) O3-4425 only render left nav if it has a slot with elements

### DIFF
--- a/packages/framework/esm-styleguide/src/left-nav/index.tsx
+++ b/packages/framework/esm-styleguide/src/left-nav/index.tsx
@@ -1,6 +1,6 @@
 /** @module @category UI */
 import { SideNav } from '@carbon/react';
-import { ExtensionSlot, useStore } from '@openmrs/esm-react-utils';
+import { ExtensionSlot, useAssignedExtensions, useExtensionSlot, useStore } from '@openmrs/esm-react-utils';
 import { createGlobalStore } from '@openmrs/esm-state';
 import React from 'react';
 import styles from './left-nav.module.scss';
@@ -53,8 +53,9 @@ type LeftNavMenuProps = SideNavProps;
 export const LeftNavMenu = React.forwardRef<HTMLElement, LeftNavMenuProps>((props, ref) => {
   const { slotName, basePath } = useLeftNavStore();
   const currentPath = window.location ?? { pathname: '' };
+  const navMenuItems = useAssignedExtensions(slotName ?? '');
 
-  if (props.isChildOfHeader) {
+  if (props.isChildOfHeader && slotName && navMenuItems.length > 0) {
     return (
       <SideNav ref={ref} expanded aria-label="Left navigation" className={styles.leftNav} {...props}>
         <ExtensionSlot name="global-nav-menu-slot" />


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This fixes an issue with the left nav rendering in apps that don't have a left nav slot defined, like Dispensing and System administration.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![image](https://github.com/user-attachments/assets/2aea5847-f2fb-4a4e-930d-8c3a61168eef)

After:
![image](https://github.com/user-attachments/assets/934efec0-260d-457b-8a5f-57a934444af1)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
