### PR TITLE
chore: use node protocol for node builtin module

### DIFF
--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -2,7 +2,7 @@
 
 import yargs from 'yargs';
 import { fork } from 'child_process';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 import { getImportmapAndRoutes, mergeImportmapAndRoutes, proxyImportmapAndRoutes, runProject, trimEnd } from './utils';
 
 import type * as commands from './commands';

--- a/packages/tooling/openmrs/src/commands/assemble.ts
+++ b/packages/tooling/openmrs/src/commands/assemble.ts
@@ -1,7 +1,7 @@
-import { mkdir, readFile, writeFile } from 'fs/promises';
-import { existsSync } from 'fs';
-import { resolve, dirname, basename } from 'path';
-import { Readable } from 'stream';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { resolve, dirname, basename } from 'node:path';
+import { Readable } from 'node:stream';
 import { prompt, type Question } from 'inquirer';
 import rimraf from 'rimraf';
 import axios from 'axios';

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -1,6 +1,6 @@
 import { copyFileSync, existsSync, readdirSync, readFileSync, statSync } from 'fs';
 import { checkImportmapJson, checkRoutesJson, getImportMap, getRoutes, loadWebpackConfig, logInfo } from '../utils';
-import { basename, join, parse, resolve } from 'path';
+import { basename, join, parse, resolve } from 'node:path';
 import type { webpack } from 'webpack';
 
 type WebpackExport = typeof webpack;

--- a/packages/tooling/openmrs/src/commands/start.ts
+++ b/packages/tooling/openmrs/src/commands/start.ts
@@ -1,6 +1,6 @@
 import express from 'express';
 import { createProxyMiddleware } from 'http-proxy-middleware';
-import { resolve } from 'path';
+import { resolve } from 'node:path';
 import { logInfo, logWarn } from '../utils';
 
 /* eslint-disable no-console */


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
The [node: protocol](https://nodejs.org/api/esm.html#esm_node_imports) has many benefits:

- Makes it perfectly clear that the import is a Node.js builtin module. (Beginners don't always realize this)
- Makes the import identifier a valid absolute URL.
- Avoids conflicts for future Node.js builtin modules.
## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
