### PR TITLE
(fix) Fix edge case with formatting dates in January

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language-link.extension.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/change-language/change-language-link.extension.tsx
@@ -17,13 +17,15 @@ function ChangeLanguageLink() {
     });
   }, []);
 
-  const languageNames = new Intl.DisplayNames([session?.locale], { type: 'language' });
+  const languageName = session?.locale
+    ? new Intl.DisplayNames([session.locale], { type: 'language' })
+    : new Intl.DisplayNames(['en'], { type: 'language' });
 
   return (
     <SwitcherItem className={styles.panelItemContainer} aria-label={t('changeLanguage', 'Change language')}>
       <div>
         <TranslateIcon size={20} />
-        <p>{capitalize(languageNames.of(session?.locale))}</p>
+        <p>{capitalize(languageName.of(session?.locale ?? 'en'))}</p>
       </div>
       <Button kind="ghost" onClick={launchChangeLanguageModal}>
         {t('change', 'Change')}

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -380,7 +380,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:25](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L25)
+[packages/framework/esm-utils/src/dates/date-util.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L24)
 
 ___
 
@@ -390,7 +390,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:168](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L168)
+[packages/framework/esm-utils/src/dates/date-util.ts:167](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L167)
 
 ___
 
@@ -414,7 +414,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:170](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L170)
+[packages/framework/esm-utils/src/dates/date-util.ts:169](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L169)
 
 ___
 
@@ -4038,7 +4038,7 @@ CalendarDate
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:407](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L407)
+[packages/framework/esm-utils/src/dates/date-util.ts:406](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L406)
 
 ___
 
@@ -4077,7 +4077,7 @@ locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:296](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L296)
+[packages/framework/esm-utils/src/dates/date-util.ts:295](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L295)
 
 ___
 
@@ -4106,7 +4106,7 @@ output of `Date.prototype.toLocaleString` for *most* locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:399](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L399)
+[packages/framework/esm-utils/src/dates/date-util.ts:398](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L398)
 
 ___
 
@@ -4145,7 +4145,7 @@ locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:235](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L235)
+[packages/framework/esm-utils/src/dates/date-util.ts:234](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L234)
 
 ___
 
@@ -4168,7 +4168,7 @@ Formats the input as a time, according to the current locale.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:383](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L383)
+[packages/framework/esm-utils/src/dates/date-util.ts:382](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L382)
 
 ___
 
@@ -4190,7 +4190,7 @@ Retrieves the default calendar for the specified locale if any.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:162](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L162)
+[packages/framework/esm-utils/src/dates/date-util.ts:161](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L161)
 
 ___
 
@@ -4213,7 +4213,7 @@ The format should be YYYY-MM-DDTHH:mm:ss.SSSZZ
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:33](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L33)
+[packages/framework/esm-utils/src/dates/date-util.ts:32](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L32)
 
 ___
 
@@ -4233,7 +4233,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:62](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L62)
+[packages/framework/esm-utils/src/dates/date-util.ts:61](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L61)
 
 ___
 
@@ -4256,7 +4256,7 @@ Uses `dayjs(dateString)`.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:95](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L95)
+[packages/framework/esm-utils/src/dates/date-util.ts:94](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L94)
 
 ___
 
@@ -4284,7 +4284,7 @@ registerDefaultCalendar('en', 'buddhist') // sets the default calendar for the '
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:153](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L153)
+[packages/framework/esm-utils/src/dates/date-util.ts:152](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L152)
 
 ___
 
@@ -4307,7 +4307,7 @@ Otherwise returns null.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L70)
+[packages/framework/esm-utils/src/dates/date-util.ts:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L69)
 
 ___
 
@@ -4330,7 +4330,7 @@ Formats the input to OpenMRS ISO format: "YYYY-MM-DDTHH:mm:ss.SSSZZ".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L81)
+[packages/framework/esm-utils/src/dates/date-util.ts:80](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L80)
 
 ___
 

--- a/packages/framework/esm-utils/src/dates/date-util.test.ts
+++ b/packages/framework/esm-utils/src/dates/date-util.test.ts
@@ -6,6 +6,7 @@ import {
   formatDatetime,
   formatTime,
   registerDefaultCalendar,
+  formatPartialDate,
 } from './date-util';
 import dayjs from 'dayjs';
 import timezoneMock from 'timezone-mock';
@@ -77,6 +78,16 @@ describe('Openmrs Dates', () => {
     expect(formatDate(testDate)).toEqual('09 Des 2021');
     window.i18next.language = 'ru';
     expect(formatDate(testDate, { mode: 'wide' })).toMatch(/09\s—\sдек\.\s—\s2021\sг\./);
+  });
+
+  it('formats partial dates', () => {
+    timezoneMock.register('UTC');
+    window.i18next.language = 'en';
+    expect(formatPartialDate('2021')).toEqual('2021');
+    expect(formatPartialDate('2021-04')).toEqual('Apr 2021');
+    expect(formatPartialDate('2021-04-09')).toEqual('09-Apr-2021');
+    expect(formatPartialDate('2021-01-01')).toEqual('01-Jan-2021');
+    expect(formatPartialDate('2021-12')).toEqual('Dec 2021');
   });
 
   it('formats dates with respect to the active calendar', () => {

--- a/packages/framework/esm-utils/src/dates/date-util.ts
+++ b/packages/framework/esm-utils/src/dates/date-util.ts
@@ -15,8 +15,7 @@ import dayjs from 'dayjs';
 import isToday from 'dayjs/plugin/isToday';
 import objectSupport from 'dayjs/plugin/objectSupport';
 import utc from 'dayjs/plugin/utc';
-import type { i18n } from 'i18next';
-import { omit } from 'lodash-es';
+import { isNil, omit } from 'lodash-es';
 
 dayjs.extend(isToday);
 dayjs.extend(utc);
@@ -242,7 +241,7 @@ export function formatPartialDate(dateString: string, options: Partial<FormatDat
   }
 
   // hack here but any date interprets 2000-01, etc. as yyyy-dd rather than yyyy-mm
-  if (parsed.day && !parsed.month) {
+  if (!isNil(parsed.day) && isNil(parsed.month)) {
     parsed = Object.assign({}, omit(parsed, 'day'), { month: parsed.day });
   }
 
@@ -258,15 +257,15 @@ export function formatPartialDate(dateString: string, options: Partial<FormatDat
 
   const date = dayjs().set(parsed).toDate();
 
-  if (!parsed.year) {
+  if (isNil(parsed.year)) {
     options.year = false;
   }
 
-  if (!parsed.month) {
+  if (isNil(parsed.month)) {
     options.month = false;
   }
 
-  if (!parsed.date) {
+  if (isNil(parsed.date)) {
     options.day = false;
   }
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

In #1280, we added support for estimated birthdates. Unfortunately, the code there had some checks using !parsed.month to detect null or undefined values. In addition to treating null and undefined as falsy, JS treats 0 as truthy and hence !0 as falsy. But, for JS Date objects, a month of 0 is January and so on. This meant that we accidentally treated dates in January as dates without a month.

This PR fixes that but switching from !parsed.month to isNil(parsed.month) and adds tests to cover the basic functions of the formatPartialDate() function.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documentation to accurately reflect the current line numbers for date formatting details.
- **Refactor**
  - Enhanced the internal logic for partial date formatting for improved robustness.
  - Improved language name generation logic to ensure a default language option is always available.
- **Tests**
  - Added comprehensive tests covering various date input scenarios to ensure consistent formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->