### PR TITLE
(chore) Correct `useAbortController` mock to return object directly

### DIFF
--- a/packages/framework/esm-react-utils/mock.tsx
+++ b/packages/framework/esm-react-utils/mock.tsx
@@ -93,19 +93,16 @@ export const useVisit = jest.fn().mockReturnValue({
 
 export const useVisitTypes = jest.fn(() => []);
 
-export const useAbortController = jest.fn().mockReturnValue(() => {
+export const useAbortController = jest.fn(() => {
   let aborted = false;
-  return jest.fn(
-    () =>
-      ({
-        abort: () => {
-          aborted = true;
-        },
-        signal: {
-          aborted,
-        },
-      }) as AbortController,
-  );
+  return {
+    abort: () => {
+      aborted = true;
+    },
+    signal: {
+      aborted,
+    },
+  } as AbortController;
 });
 
 export const useOpenmrsSWR = jest.fn((key: string | Array<any>) => {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Provides a more accurate mock implementation of the `useAbortController` hook. The updated mock directly returns an AbortController object, aligning with the original hook's behavior and improving test consistency.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
