### PR TITLE
(fix) Setup redirect for static assets served from wrong location

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -93,11 +93,11 @@ function escapeRegExp(string) {
 }
 
 /**
- * @param {*} env
- * @param {*} argv
+ * @param {Record<string, string>} env
+ * @param {Array<string>} argv
  * @returns {import("webpack").Configuration}
  */
-module.exports = (env, argv = {}) => {
+module.exports = (env, argv = []) => {
   const mode = argv.mode || process.env.NODE_ENV || production;
   const outDir = mode === production ? 'dist' : 'lib';
   const isProd = mode === 'production';
@@ -201,6 +201,21 @@ module.exports = (env, argv = {}) => {
            */
           onProxyRes(proxyRes) {
             proxyRes.headers && delete proxyRes.headers['content-security-policy'];
+          },
+          /**
+           * @param {string} path
+           * @param {Request} req
+           * @returns {string}
+           */
+          pathRewrite(path) {
+            if (path.startsWith(openmrsPublicPath)) {
+              const matcher = /^.*\/([^\/]*\.(?!html|js)[^.]+)$/i.exec(path);
+              if (matcher) {
+                return `${openmrsPublicPath}/${matcher[1]}`;
+              }
+            }
+
+            return path;
           },
         },
       ],

--- a/packages/tooling/openmrs/src/utils/helpers.ts
+++ b/packages/tooling/openmrs/src/utils/helpers.ts
@@ -1,13 +1,13 @@
 import { util } from 'webpack';
 
-export function trimEnd(text: string, chr: string) {
+export function trimEnd(text: string, chr: string): string {
   while (text.endsWith(chr)) {
     text = text.slice(0, text.length - chr.length);
   }
   return text;
 }
 
-export function removeTrailingSlash(path: string) {
+export function removeTrailingSlash(path: string): string {
   const i = path.length - 1;
   return path[i] === '/' ? removeTrailingSlash(path.slice(0, i)) : path;
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

Basically, on some pages (e.g., the chart) its possible to do a hard refresh that results in trying to load the Carbon's Plex fonts relative to the current route rather than the base SPA URL. This adds a rewrite so that these cases serve the right asset.

I couldn't reproduce the issue either on dev3 or using the `develop` command, so I haven't made any additional changes.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

@denniskigen  Could you let me know if you think I've missed a case. This just fixes things with `run:shell` which was the only case I could reproduce.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced dynamic URL rewriting logic in the build configuration to streamline asset request routing.

- **Refactor**
  - Enhanced internal utility methods with explicit return types for improved consistency and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->