### PR TITLE
(fix)O3-4516: Design standards: use the appropriate workspace size for workspaces

### DIFF
--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace.module.scss
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace.module.scss
@@ -126,7 +126,7 @@ $extraWideWorkspaceWidth: 48.25rem;
     width: $widerWorkspaceWidth;
 
     .workspaceFixedContainer {
-      width: $widerWorkspaceWidth;
+      width: $narrowWorkspaceWidth;
     }
 
     &.hiddenRelative {


### PR DESCRIPTION
I have made sure that the “Create new appointment“ workspace, the “Add patient to queue“ workspace and the “Admission requests“ workspaces now use the  “normal“ workspace size.
 These widgets now match the correct size as the ticket describes


## Screenshots
before:
![Appointment-before](https://github.com/user-attachments/assets/7c665668-4119-4ccd-9c3b-0b3e054de25f)
![Admission-request-before](https://github.com/user-attachments/assets/efca7619-67a7-400b-9f6b-6a7c54a63ea8)
![Add patient-before](https://github.com/user-attachments/assets/0d4a5c7c-636f-485f-a1ee-55b15b714f0f)
After:
![Appointment-after](https://github.com/user-attachments/assets/a148b7ed-d029-4ea6-bff7-000fd68f4681)
![Admission-request-after](https://github.com/user-attachments/assets/b6a7c013-8475-408f-bf4c-474f63724197)
![Add-patient-after](https://github.com/user-attachments/assets/e6488513-6828-48d9-a161-5768cf05f891)

Ticket-Link:
[ticket](https://openmrs.atlassian.net/browse/O3-4516l)


@ibacher  please review this


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Adjusted the workspace layout in wide mode for a more balanced display, resulting in a noticeably refined appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->