### PR TITLE
(fix) O3-4606 Enable display of Spanish format names

### DIFF
--- a/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.component.tsx
+++ b/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.component.tsx
@@ -3,7 +3,7 @@ import React, { useMemo } from 'react';
 import classNames from 'classnames';
 import { ExtensionSlot } from '@openmrs/esm-react-utils';
 import { getCoreTranslation } from '@openmrs/esm-translations';
-import { age, formatPartialDate } from '@openmrs/esm-utils';
+import { age, formatPartialDate, getPatientName } from '@openmrs/esm-utils';
 import { GenderFemaleIcon, GenderMaleIcon, GenderOtherIcon, GenderUnknownIcon } from '../../icons';
 import PatientBannerPatientIdentifiers from './patient-banner-patient-identifiers.component';
 import styles from './patient-banner-patient-info.module.scss';
@@ -59,7 +59,7 @@ const getGender = (gender: string) => {
 };
 
 export function PatientBannerPatientInfo({ patient, renderedFrom }: PatientBannerPatientInfoProps) {
-  const name = `${patient?.name?.[0]?.given?.join(' ')} ${patient?.name?.[0]?.family}`;
+  const name = getPatientName(patient);
   const genderInfo = patient?.gender && getGender(patient.gender);
 
   const extensionState = useMemo(

--- a/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.test.tsx
+++ b/packages/framework/esm-styleguide/src/patient-banner/patient-info/patient-banner-patient-info.test.tsx
@@ -65,9 +65,9 @@ describe('PatientBannerPatientInfo', () => {
   it("renders the patient's name, demographics, and identifier details in the banner", () => {
     render(<PatientBannerPatientInfo patient={mockPatient} />);
 
-    expect(screen.getByText(/john wilson/i)).toBeInTheDocument();
+    expect(screen.getByText(/wilson, john/i)).toBeInTheDocument();
     expect(screen.getByText(/male/i)).toBeInTheDocument();
-    expect(screen.getByText(/52 yrs/i)).toBeInTheDocument();
+    expect(screen.getByText(/53 yrs/i)).toBeInTheDocument();
     expect(screen.getByText(/04-Apr-1972/i)).toBeInTheDocument();
     expect(screen.getByText(/openmrs id/i)).toBeInTheDocument();
     expect(screen.getByText(/100gej/i)).toBeInTheDocument();

--- a/packages/framework/esm-styleguide/src/patient-photo/patient-photo.component.tsx
+++ b/packages/framework/esm-styleguide/src/patient-photo/patient-photo.component.tsx
@@ -47,7 +47,7 @@ export function PatientPhoto({ patientUuid, patientName, size }: PatientPhotoPro
     <Avatar
       alt={altText}
       color="rgba(0,0,0,0)"
-      maxInitials={3}
+      maxInitials={4}
       name={patientName}
       size="56"
       src={validImageSrc ?? undefined}

--- a/packages/framework/esm-styleguide/src/patient-photo/patient-photo.component.tsx
+++ b/packages/framework/esm-styleguide/src/patient-photo/patient-photo.component.tsx
@@ -47,7 +47,7 @@ export function PatientPhoto({ patientUuid, patientName, size }: PatientPhotoPro
     <Avatar
       alt={altText}
       color="rgba(0,0,0,0)"
-      maxInitials={4}
+      maxInitials={3}
       name={patientName}
       size="56"
       src={validImageSrc ?? undefined}


### PR DESCRIPTION
# Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [X] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.  (**not applicable**)

## Summary
<!-- Please describe what problems your PR addresses. -->

1. When displaying the patient name in the patient banner, patient search bar etc.,  use the formatted display name rather than simply a concatenation of givenName(s) and familyName. In particular, this affects locales with a different name layout, e.g. `layout.name.format=latinamerica`.

2. Allow up to 4 initials in the patient avatar tile. Again, in Spanish-speaking countries it is customary to have 4 names.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4606

## Other
<!-- Anything not covered above -->
