### PR TITLE
(test) Add explicit login step to navbar e2e test

### DIFF
--- a/e2e/specs/navbar.spec.ts
+++ b/e2e/specs/navbar.spec.ts
@@ -1,17 +1,28 @@
 import { test } from '../core';
 import { expect } from '@playwright/test';
-import { HomePage } from '../pages';
+import { HomePage, LoginPage } from '../pages';
 
-test('action buttons in top nav', async ({ page }) => {
+test('View action buttons in the navbar', async ({ page }) => {
+  const loginPage = new LoginPage(page);
   const homePage = new HomePage(page);
   const topNav = page.getByRole('banner', { name: 'OpenMRS' });
+
+  await test.step('When I log in as admin', async () => {
+    await loginPage.goto();
+    await page.getByLabel(/username/i).fill(`${process.env.E2E_USER_ADMIN_USERNAME}`);
+    await page.getByText(/continue/i).click();
+    await page.getByLabel(/^password$/i).fill(`${process.env.E2E_USER_ADMIN_PASSWORD}`);
+    await page.getByRole('button', { name: /log in/i }).click();
+    await page.getByText(/outpatient clinic/i).click();
+    await page.getByRole('button', { name: /confirm/i }).click();
+  });
 
   await test.step('When I visit the home page', async () => {
     await homePage.goto();
   });
 
   await test.step('Then the action buttons should be in the top nav', async () => {
-    await expect(topNav.getByRole('button', { name: /Search patient/i })).toBeVisible();
+    await expect(topNav.getByRole('button', { name: /search patient/i })).toBeVisible();
     await expect(topNav.getByRole('button', { name: /add patient/i })).toBeVisible();
     await expect(topNav.getByRole('button', { name: /implementer tools/i })).toBeVisible();
     await expect(topNav.getByRole('button', { name: /my account/i })).toBeVisible();


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Ensure navbar e2e tests have proper authentication before accessing the home page. This change adds the necessary login flow that was previously missing, which should resolve authentication-related test failures.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
