### PR TITLE
(fix) O3-4605: Update remove icon fill color to use lighter background in Implementer Tools

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/array-editor.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/array-editor.tsx
@@ -49,7 +49,7 @@ export function ArrayEditor({ element, valueArray, setValue }: ArrayEditorProps)
                 <Button
                   renderIcon={(props) => <TrashCanIcon {...props} size={16} />}
                   size="sm"
-                  kind="secondary"
+                  kind="ghost"
                   iconDescription="Remove"
                   hasIconOnly
                   onClick={() => {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR addresses a UI issue where the Remove icon had a dark fill color that blended into the background, making it difficult to see. The icon’s styling has been updated to ensure better contrast and improved visibility.

## Screenshots
### Before
<img width="935" alt="Screenshot 2025-04-14 at 5 38 16 PM" src="https://github.com/user-attachments/assets/abd4c222-069d-43f4-a890-e537165a385f" />

### After
<img width="935" alt="Screenshot 2025-04-14 at 5 36 36 PM" src="https://github.com/user-attachments/assets/2f86488e-36f5-44c7-9acc-82b1ebf747fb" />

## Related Issue
[O3-4605](https://openmrs.atlassian.net/issues/O3-4605?filter=-1)

[O3-4605]: https://openmrs.atlassian.net/browse/O3-4605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ