### PR TITLE
(chore) Update @internationalized/date version

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -380,7 +380,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L24)
+[packages/framework/esm-utils/src/dates/date-util.ts:25](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L25)
 
 ___
 
@@ -390,7 +390,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:167](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L167)
+[packages/framework/esm-utils/src/dates/date-util.ts:168](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L168)
 
 ___
 
@@ -414,7 +414,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:169](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L169)
+[packages/framework/esm-utils/src/dates/date-util.ts:170](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L170)
 
 ___
 
@@ -4038,7 +4038,7 @@ CalendarDate
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:406](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L406)
+[packages/framework/esm-utils/src/dates/date-util.ts:407](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L407)
 
 ___
 
@@ -4077,7 +4077,7 @@ locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:295](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L295)
+[packages/framework/esm-utils/src/dates/date-util.ts:296](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L296)
 
 ___
 
@@ -4106,7 +4106,7 @@ output of `Date.prototype.toLocaleString` for *most* locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:398](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L398)
+[packages/framework/esm-utils/src/dates/date-util.ts:399](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L399)
 
 ___
 
@@ -4145,7 +4145,7 @@ locales.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:234](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L234)
+[packages/framework/esm-utils/src/dates/date-util.ts:235](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L235)
 
 ___
 
@@ -4168,13 +4168,13 @@ Formats the input as a time, according to the current locale.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:382](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L382)
+[packages/framework/esm-utils/src/dates/date-util.ts:383](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L383)
 
 ___
 
 ### getDefaultCalendar
 
-▸ **getDefaultCalendar**(`locale`): `undefined` \| `string`
+▸ **getDefaultCalendar**(`locale`): `undefined` \| `CalendarIdentifier`
 
 Retrieves the default calendar for the specified locale if any.
 
@@ -4186,11 +4186,11 @@ Retrieves the default calendar for the specified locale if any.
 
 #### Returns
 
-`undefined` \| `string`
+`undefined` \| `CalendarIdentifier`
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:161](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L161)
+[packages/framework/esm-utils/src/dates/date-util.ts:162](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L162)
 
 ___
 
@@ -4213,7 +4213,7 @@ The format should be YYYY-MM-DDTHH:mm:ss.SSSZZ
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:32](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L32)
+[packages/framework/esm-utils/src/dates/date-util.ts:33](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L33)
 
 ___
 
@@ -4233,7 +4233,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:61](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L61)
+[packages/framework/esm-utils/src/dates/date-util.ts:62](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L62)
 
 ___
 
@@ -4256,7 +4256,7 @@ Uses `dayjs(dateString)`.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:94](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L94)
+[packages/framework/esm-utils/src/dates/date-util.ts:95](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L95)
 
 ___
 
@@ -4276,7 +4276,7 @@ registerDefaultCalendar('en', 'buddhist') // sets the default calendar for the '
 | Name | Type | Description |
 | :------ | :------ | :------ |
 | `locale` | `string` | the locale to register this calendar for |
-| `calendar` | `string` | the calendar to use for this registration |
+| `calendar` | `CalendarIdentifier` | the calendar to use for this registration |
 
 #### Returns
 
@@ -4284,7 +4284,7 @@ registerDefaultCalendar('en', 'buddhist') // sets the default calendar for the '
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:152](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L152)
+[packages/framework/esm-utils/src/dates/date-util.ts:153](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L153)
 
 ___
 
@@ -4307,7 +4307,7 @@ Otherwise returns null.
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L69)
+[packages/framework/esm-utils/src/dates/date-util.ts:70](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L70)
 
 ___
 
@@ -4330,7 +4330,7 @@ Formats the input to OpenMRS ISO format: "YYYY-MM-DDTHH:mm:ss.SSSZZ".
 
 #### Defined in
 
-[packages/framework/esm-utils/src/dates/date-util.ts:80](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L80)
+[packages/framework/esm-utils/src/dates/date-util.ts:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/dates/date-util.ts#L81)
 
 ___
 

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "@carbon/charts": "^1.23.0",
     "@carbon/react": "^1.76.0",
-    "@internationalized/date": "^3.5.5",
+    "@internationalized/date": "^3.8.0",
     "core-js-pure": "^3.36.0",
     "d3": "^7.8.0",
     "geopattern": "^1.2.3",

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@formatjs/intl-durationformat": "^0.7.3",
-    "@internationalized/date": "^3.5.5",
+    "@internationalized/date": "^3.8.0",
     "any-date-parser": "^2.0.3",
     "lodash-es": "^4.17.21",
     "semver": "7.3.2"

--- a/packages/framework/esm-utils/src/dates/date-util.ts
+++ b/packages/framework/esm-utils/src/dates/date-util.ts
@@ -3,11 +3,12 @@
  * @category Date and Time
  */
 import {
+  type CalendarDate,
   type CalendarDateTime,
+  type CalendarIdentifier,
   type ZonedDateTime,
   createCalendar,
   toCalendar,
-  type CalendarDate,
 } from '@internationalized/date';
 import { getLocale } from '@openmrs/esm-utils';
 import { attempt } from 'any-date-parser';
@@ -99,21 +100,21 @@ export function parseDate(dateString: string) {
  * Internal cache for per-locale calendars
  */
 class LocaleCalendars {
-  #registry = new Map<string, string>();
+  #registry = new Map<string, CalendarIdentifier>();
 
   constructor() {}
 
-  register(locale: string, calendar: string) {
+  register(locale: string, calendar: CalendarIdentifier) {
     this.#registry.set(locale, calendar);
   }
 
-  getCalendar(locale: Intl.Locale) {
+  getCalendar(locale: Intl.Locale): CalendarIdentifier | undefined {
     if (!Boolean(locale)) {
       return undefined;
     }
 
     if (locale.calendar) {
-      return locale.calendar;
+      return locale.calendar as CalendarIdentifier;
     }
 
     if (locale.region) {
@@ -127,7 +128,7 @@ class LocaleCalendars {
       return this.#registry.get(locale.language);
     }
 
-    const defaultCalendar = new Intl.DateTimeFormat(locale.toString()).resolvedOptions().calendar;
+    const defaultCalendar = new Intl.DateTimeFormat(locale.toString()).resolvedOptions().calendar as CalendarIdentifier;
 
     // cache this result
     this.#registry.set(`${locale.language}${locale.region ? `-${locale.region}` : ''}`, defaultCalendar);
@@ -149,7 +150,7 @@ const registeredLocaleCalendars = new LocaleCalendars();
  * @param locale the locale to register this calendar for
  * @param calendar the calendar to use for this registration
  */
-export function registerDefaultCalendar(locale: string, calendar: string) {
+export function registerDefaultCalendar(locale: string, calendar: CalendarIdentifier) {
   registeredLocaleCalendars.register(locale, calendar);
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1993,12 +1993,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@internationalized/date@npm:^3.5.5, @internationalized/date@npm:^3.7.0":
-  version: 3.7.0
-  resolution: "@internationalized/date@npm:3.7.0"
+"@internationalized/date@npm:^3.7.0, @internationalized/date@npm:^3.8.0":
+  version: 3.8.0
+  resolution: "@internationalized/date@npm:3.8.0"
   dependencies:
     "@swc/helpers": "npm:^0.5.0"
-  checksum: 10/59adffb57f1391e17bfe9b2e9b1a71c0957a1835b0176a86ad5a99fd2f2919f094d3f553fb39be157d84c315a88917e0eda779c9101026e3bfac217ace18a559
+  checksum: 10/01e783001f788e8a8c97ea86f577cd3f2c92cbdf86445f8824c60ca2f7c4b02798b2ed55bd193c9ef72af15af5cdb196eb51ab0509ee1e7240d015cb5cb10550
   languageName: node
   linkType: hard
 
@@ -3510,7 +3510,7 @@ __metadata:
   dependencies:
     "@carbon/charts": "npm:^1.23.0"
     "@carbon/react": "npm:^1.76.0"
-    "@internationalized/date": "npm:^3.5.5"
+    "@internationalized/date": "npm:^3.8.0"
     "@openmrs/esm-error-handling": "workspace:*"
     "@openmrs/esm-extensions": "workspace:*"
     "@openmrs/esm-navigation": "workspace:*"
@@ -3567,7 +3567,7 @@ __metadata:
   resolution: "@openmrs/esm-utils@workspace:packages/framework/esm-utils"
   dependencies:
     "@formatjs/intl-durationformat": "npm:^0.7.3"
-    "@internationalized/date": "npm:^3.5.5"
+    "@internationalized/date": "npm:^3.8.0"
     "@openmrs/esm-globals": "workspace:*"
     "@types/lodash-es": "npm:^4.17.12"
     "@types/semver": "npm:^7.3.4"


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This updates core to use @internationalized/date 3.8.0 or higher which adds stricter type-checking for the calendar identifier passed at various points.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

Necessary because of https://github.com/adobe/react-spectrum/pull/7803 which does a lot of things, but restricts the type for Calendar identifiers to only the set of values defined by Mozilla at https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf#supported_calendar_types. While this makes the TS more correct, it also requires some casting and restrictions in our calendar-handling machinery.
