### PR TITLE
(fix) O3-3890: Help menu (and menu items) should use a standard Carbon menu

### DIFF
--- a/packages/apps/esm-help-menu-app/src/help-menu/components/styles.scss
+++ b/packages/apps/esm-help-menu-app/src/help-menu/components/styles.scss
@@ -7,7 +7,9 @@
   align-items: center;
   justify-content: space-between;
   color: black !important;
-  &:focus {
-    outline: none;
+  padding: layout.$spacing-03;
+
+  &:hover {
+    background-color: $ui-03;
   }
 }

--- a/packages/apps/esm-help-menu-app/src/help-menu/help-popup.styles.scss
+++ b/packages/apps/esm-help-menu-app/src/help-menu/help-popup.styles.scss
@@ -9,7 +9,7 @@
   right: layout.$spacing-09;
   width: 11rem;
   z-index: 8000;
-  background-color: $ui-02;
+  background-color: $ui-01;
   gap: layout.$spacing-05;
   padding: layout.$spacing-02;
   margin: layout.$spacing-02;
@@ -21,11 +21,11 @@
 }
 
 .helpextension {
-  margin: layout.$spacing-04;
+  margin: layout.$spacing-02;
   padding: layout.$spacing-01;
   cursor: pointer;
   text-align: left;
   display: flex;
   flex-direction: column;
-  gap: layout.$spacing-05;
+  gap: layout.$spacing-02;
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

## Screenshots
<!-- Required if you are making UI changes. -->
![Screenshot 2025-04-28 at 23 56 42](https://github.com/user-attachments/assets/cfe22d64-460d-45d6-a0de-141ee93594b3)

https://github.com/user-attachments/assets/901e9bff-072f-448b-8455-ebe092a3c872

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-3890
