### PR TITLE
(fix) Add extra guard-rails around `displayedValidationMessages`

### DIFF
--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -74,6 +74,9 @@ temporaryConfigStore.subscribe((tempConfigState) => {
   computeExtensionConfigs(configInternalStore.getState(), configExtensionStore.getState(), tempConfigState);
 });
 
+/** Keep track of which validation errors we have displayed. Each one should only be displayed once. */
+let displayedValidationMessages = new Set<string>();
+
 function computeModuleConfig(state: ConfigInternalStore, tempState: TemporaryConfigStore) {
   for (let moduleName of Object.keys(state.schemas)) {
     // At this point the schema could be either just the implicit schema or the actually
@@ -818,11 +821,13 @@ function isOrdinaryObject(value) {
   return typeof value === 'object' && !Array.isArray(value) && value !== null;
 }
 
-/** Keep track of which validation errors we have displayed. Each one should only be displayed once. */
-const displayedValidationMessages = new Set<string>();
-
 function logError(keyPath: string, message: string) {
   const key = `${keyPath}:::${message}`;
+  // technically, this should not be possible, but because of how things wind-up transpiled, this isn't impossible
+  if (!displayedValidationMessages) {
+    displayedValidationMessages = new Set<string>();
+  }
+
   if (!displayedValidationMessages.has(key)) {
     console.error(message);
     displayedValidationMessages.add(key);

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -3476,7 +3476,7 @@ for more information about defining a config schema.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:165](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L165)
+[packages/framework/esm-config/src/module-config/module-config.ts:168](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L168)
 
 ___
 
@@ -3508,7 +3508,7 @@ for more information about defining a config schema.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:241](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L241)
+[packages/framework/esm-config/src/module-config/module-config.ts:244](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L244)
 
 ___
 
@@ -3540,7 +3540,7 @@ of the execution of a function.
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:274](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L274)
+[packages/framework/esm-config/src/module-config/module-config.ts:277](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L277)
 
 ___
 
@@ -3561,7 +3561,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-config/src/module-config/module-config.ts:258](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L258)
+[packages/framework/esm-config/src/module-config/module-config.ts:261](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L261)
 
 ___
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This fixes an obscure and what should be semantically impossible corner case.

The previous implementation of this code was this:

```ts
const displayedValidationMessages = new Set<string>();

function logError(keyPath: string, message: string) {
  const key = `${keyPath}:::${message}`;
  if (!displayedValidationMessages.has(key)) {
    console.error(message);
    displayedValidationMessages.add(key);
  }
}
```

Which transpiles into this (beautified):

```js
var Ie = new Set;
function Re(e, t) {
    var n = "".concat(e, ":::").concat(t);
    Ie.has(n) || (console.error(t),
    Ie.add(n))
}
```

These two snippets are _almost_ semantically identical except that `var` declarations are treated slightly differently than `const` declarations (see [this MDN section](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Grammar_and_types#variable_hoisting)). Specifically, `var`s are able to be referenced within their scope before the line defining them has been defined.

What seems to be happening here is that the function `logError()` gets called [in](https://github.com/openmrs/openmrs-esm-core/blob/c0100b7d658d363c5be475f683952bf299971254/packages/framework/esm-config/src/module-config/module-config.ts#L458) [a](https://github.com/openmrs/openmrs-esm-core/blob/c0100b7d658d363c5be475f683952bf299971254/packages/framework/esm-config/src/module-config/module-config.ts#L615) [few](https://github.com/openmrs/openmrs-esm-core/blob/c0100b7d658d363c5be475f683952bf299971254/packages/framework/esm-config/src/module-config/module-config.ts#L735) places _before_ the line assigning a value to the `Ie` variable, resulting in a `Cannot find property "has" of type undefined` style error message, which isn't caught or handled resulting in an app crash.

This PR does two things to attempt to make this impossible:

1. The definition of `displayedValidationMessages` is moved to the top of the file, so it should be executed before any functions in this scope are defined, meaning that it should always have a value when the `logError()` function is called, which is how the code-as-written would behave.
2. Adds a couple of guards to try to provide a value for `displayedValidationMessages` if `logError()` somehow gets called before `displayedValidationMessages` is defined.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
