### PR TITLE
(fix) O3-4707 Update visit context when active visit is created or ended

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -6597,7 +6597,7 @@ ___
 
 ### useVisitContextStore
 
-▸ **useVisitContextStore**(`mutateVisitCallback?`): [`VisitStoreState`](interfaces/VisitStoreState.md) & `BindFunctionsIn`<{ `mutateVisit`: (`currState`: [`VisitStoreState`](interfaces/VisitStoreState.md)) => {} ; `setVisitContext`: (`_`: [`VisitStoreState`](interfaces/VisitStoreState.md), `newSelectedVisit`: [`Visit`](interfaces/Visit.md)) => { `manuallySetVisitUuid`: `string` = newSelectedVisit.uuid; `patientUuid`: `undefined` \| `string` = newSelectedVisit.patient.uuid }  }\>
+▸ **useVisitContextStore**(`mutateVisitCallback?`): [`VisitStoreState`](interfaces/VisitStoreState.md) & `BindFunctionsIn`<{ `mutateVisit`: (`currState`: [`VisitStoreState`](interfaces/VisitStoreState.md)) => {} ; `setVisitContext`: (`_`: [`VisitStoreState`](interfaces/VisitStoreState.md), `newSelectedVisit`: ``null`` \| [`Visit`](interfaces/Visit.md)) => { `manuallySetVisitUuid`: ``null`` \| `string` ; `patientUuid`: `undefined` \| ``null`` \| `string`  }  }\>
 
 A hook to return the visit context store and corresponding actions.
 
@@ -6609,7 +6609,7 @@ A hook to return the visit context store and corresponding actions.
 
 #### Returns
 
-[`VisitStoreState`](interfaces/VisitStoreState.md) & `BindFunctionsIn`<{ `mutateVisit`: (`currState`: [`VisitStoreState`](interfaces/VisitStoreState.md)) => {} ; `setVisitContext`: (`_`: [`VisitStoreState`](interfaces/VisitStoreState.md), `newSelectedVisit`: [`Visit`](interfaces/Visit.md)) => { `manuallySetVisitUuid`: `string` = newSelectedVisit.uuid; `patientUuid`: `undefined` \| `string` = newSelectedVisit.patient.uuid }  }\>
+[`VisitStoreState`](interfaces/VisitStoreState.md) & `BindFunctionsIn`<{ `mutateVisit`: (`currState`: [`VisitStoreState`](interfaces/VisitStoreState.md)) => {} ; `setVisitContext`: (`_`: [`VisitStoreState`](interfaces/VisitStoreState.md), `newSelectedVisit`: ``null`` \| [`Visit`](interfaces/Visit.md)) => { `manuallySetVisitUuid`: ``null`` \| `string` ; `patientUuid`: `undefined` \| ``null`` \| `string`  }  }\>
 
 #### Defined in
 

--- a/packages/framework/esm-react-utils/src/useVisitContextStore.ts
+++ b/packages/framework/esm-react-utils/src/useVisitContextStore.ts
@@ -4,10 +4,10 @@ import { useEffect, useId } from 'react';
 
 // TODO: add better typing with `satisfies` keyword when we upgrade typescript
 const visitContextStoreActions = {
-  setVisitContext(_: VisitStoreState, newSelectedVisit: Visit) {
+  setVisitContext(_: VisitStoreState, newSelectedVisit: Visit | null) {
     return {
-      manuallySetVisitUuid: newSelectedVisit.uuid,
-      patientUuid: newSelectedVisit.patient?.uuid,
+      manuallySetVisitUuid: newSelectedVisit?.uuid ?? null,
+      patientUuid: newSelectedVisit?.patient?.uuid ?? null,
     };
   },
   mutateVisit(currState: VisitStoreState) {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently, the visit context does not get updated when we create an active visit. This is bad because:
- When a user creates a new active visit and tries to place an order, the order should be associated with the newly created visit, but is associated with whichever visit is in context instead.
- When the visit context is set to the active visit, and the user ends the visit. The user should not be able to place an order, but is able to do so with the visit in context.

The above behavior is especially confusing with RDE feature flag off, because the order basket’s visit context is hidden from the user.

To fix this:
- When an active visit is created, if there is no visit in visit context, we set the visit context to the active visit
- When the visit in context was an active visit, but it’s just been made inactive, we clear the visit context (make it null)

## Screenshots
<!-- Required if you are making UI changes. -->
Video. Note that:
- the "start visit" modal is prompted when there is no active visit
- The placed order is correctly associated with the active visit


https://github.com/user-attachments/assets/eec04b84-4279-4657-8d8e-5769104fa5eb




## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4707

## Other
<!-- Anything not covered above -->
