### PR TITLE
(fix) O3-4753: Remove unnecessary padding from icon-only ghost buttons

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -241,7 +241,7 @@
   border-bottom: 1px solid $ui-03;
 }
 
-/* Misc */
+/* Buttons */
 .cds--btn--primary,
 .cds--btn--primary:active,
 .cds--btn--tertiary:hover,
@@ -270,6 +270,12 @@
   color: $ui-02;
 }
 
+// Override right padding applied to icon-only ghost buttons
+.cds--btn--ghost.cds--btn--icon-only {
+  padding-right: 0 !important;
+}
+
+/* Overflow menu */
 .cds--overflow-menu--flip {
   &.cds--overflow-menu-options {
     background-color: $openmrs-background-grey;
@@ -290,6 +296,7 @@
   }
 }
 
+/* Pagination */
 .cds--pagination-nav__page:not(.cds--pagination-nav__page--direction) {
   &::after {
     @include brand-03(background-color);
@@ -301,6 +308,7 @@
   outline: 2px solid var(--brand-03);
 }
 
+/* Data table overflow menu */
 .cds--data-table--xs .cds--overflow-menu {
   height: layout.$spacing-07;
 }
@@ -368,6 +376,7 @@
   margin-inline: layout.$spacing-03;
 }
 
+/* RTL overrides */
 html[dir='rtl'] {
   .cds--header {
     & > a:first-child {
@@ -414,6 +423,9 @@ html[dir='rtl'] {
   }
 
   .cds--btn--ghost.cds--btn--icon-only {
+    // Override left padding applied to icon-only ghost buttons
+    padding-left: 0 !important;
+
     svg {
       margin: unset;
     }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Following the migration to v1.83.0 of `@carbon/react`, we noticed that icon-only ghost buttons were receiving unnecessary padding based on the user's language direction. This PR fixes the issue by applying style overrides to the ghost variant of the icon-only button component. Specifically, it:

- Overrides Carbon's default right padding for `.cds--btn--ghost.cds--btn--icon-only` in LTR layouts by setting `padding-right: 0 !important;`.
- Adds a corresponding override for RTL layouts under `html[dir='rtl']`, setting `padding-left: 0 !important;` for `.cds--btn--ghost.cds--btn--icon-only`.
- Improves visual alignment of icon-only ghost buttons in both LTR and RTL interfaces.
- Adds and clarifies section comments for "Buttons", "Pagination", "Data table overflow menu", and "RTL overrides" in the overrides file for better code organization.

## Screenshots

### Before

#### LTR

https://github.com/user-attachments/assets/2213dd19-aa60-436d-bff2-7bef1791ab76

#### RTL

https://github.com/user-attachments/assets/f24d4556-cbdc-4590-a3c9-bc01685c3e2d

### After

#### LTR

https://github.com/user-attachments/assets/3ce6b264-83f5-41ee-a406-6f336d9d526c

#### RTL 

https://github.com/user-attachments/assets/6461b55d-2d6a-41fe-9256-eb02319ad669

## Related Issue

https://openmrs.atlassian.net/browse/O3-4753

## Other
<!-- Anything not covered above -->
