### PR TITLE
(fix) Fix implementer tools content switcher selected state

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/implementer-tools.styles.scss
+++ b/packages/apps/esm-implementer-tools-app/src/implementer-tools.styles.scss
@@ -36,4 +36,8 @@
 
 .darkTheme {
   @include theme.theme(themes.$g90);
+
+  :global(.cds--content-switcher-btn.cds--content-switcher--selected) {
+    background-color: $ui-01;
+  }
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Sets the background color of the selected content switcher button to light gray (#f4f4f4) in the default dark mode to ensure proper contrast and visibility of interactive elements.

## Screenshots

### Before

https://github.com/user-attachments/assets/8939de3f-91c1-4fdb-8927-e863e94f7ba9

### After

https://github.com/user-attachments/assets/09f34381-e021-4f05-8c91-26e47d14d3b5

## Related Issue
https://openmrs.atlassian.net/browse/O3-4758

## Other
<!-- Anything not covered above -->
