### PR TITLE
(fix) O3-4760: Icon-only content switcher style overrides

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -123,6 +123,7 @@
 
     &::after {
       background-color: colors.$blue-10;
+      box-shadow: none !important;
     }
 
     &::before {
@@ -133,6 +134,23 @@
       border: 0 !important;
     }
   }
+}
+
+.cds--content-switcher--icon-only .cds--content-switcher-popover__wrapper:first-child .cds--content-switcher-btn {
+  box-shadow: none !important;
+}
+
+.cds--content-switcher--icon-only .cds--content-switcher-popover__wrapper:last-child .cds--content-switcher-btn {
+  box-shadow: none !important;
+}
+
+.cds--content-switcher-popover--selected:has(+ .cds--content-switcher-popover__wrapper .cds--content-switcher-btn:hover)
+  .cds--content-switcher-btn::before,
+.cds--content-switcher-popover__wrapper:hover
+  + .cds--content-switcher-popover__wrapper
+  .cds--content-switcher--selected::before {
+  border-bottom: none !important;
+  border-top: none !important;
 }
 
 .cds--content-switcher--icon-only


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Fixes some quirks with the appearance of the icon-only content switcher variant following the recent Carbon migration by:

- Removing box shadows from content switcher buttons in both the default and selected states
- Removing top/bottom borders from content switcher buttons in hover states

## Screenshots

### Before

https://github.com/user-attachments/assets/0e1798b8-d379-482b-b282-ec941ac32a85

### After

https://github.com/user-attachments/assets/26019766-29b7-4b73-a183-ea0d28c1903a

## Related Issue
https://openmrs.atlassian.net/browse/O3-4760

## Other

This is by no means a comprehensive styling fix. This just covers the bases for now. I still need to align the behaviour and appearance of the component with its equivalent upstream.
