### PR TITLE
(fix) Remove autoFocus prop from Search component

### DIFF
--- a/packages/framework/esm-styleguide/src/location-picker/location-picker.component.tsx
+++ b/packages/framework/esm-styleguide/src/location-picker/location-picker.component.tsx
@@ -60,7 +60,6 @@ export const LocationPicker: React.FC<LocationPickerProps> = ({
   return (
     <div>
       <Search
-        autoFocus
         labelText={t('searchForLocation', 'Search for a location')}
         id="search-1"
         placeholder={t('searchForLocation', 'Search for a location')}


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Removes the `autoFocus` prop from the Search component in the location picker to fix TypeScript type errors. The Search component from `@carbon/react` doesn't support an autoFocus prop in its type definitions, causing type errors in consuming packages such as the [dispensing app](https://github.com/openmrs/openmrs-esm-dispensing-app/pull/214/checks).

![CleanShot 2025-06-02 at 13 00 22@2x](https://github.com/user-attachments/assets/61d4a176-5691-4217-852f-189b8066cf5e)

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
