### PR TITLE
(fix) O3-4760: Content switcher style overrides

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -136,6 +136,14 @@
   }
 }
 
+.cds--content-switcher:not(.cds--content-switcher--icon-only) .cds--content-switcher-btn:first-child {
+  box-shadow: none !important;
+}
+
+.cds--content-switcher:not(.cds--content-switcher--icon-only) .cds--content-switcher-btn:last-child {
+  box-shadow: none !important;
+}
+
 .cds--content-switcher--icon-only .cds--content-switcher-popover__wrapper:first-child .cds--content-switcher-btn {
   box-shadow: none !important;
 }
@@ -149,6 +157,16 @@
 .cds--content-switcher-popover__wrapper:hover
   + .cds--content-switcher-popover__wrapper
   .cds--content-switcher--selected::before {
+  border-bottom: none !important;
+  border-top: none !important;
+}
+
+.cds--content-switcher-btn.cds--content-switcher--selected:has(+ .cds--content-switcher-btn:hover)::before {
+  border-bottom: none !important;
+  border-top: none !important;
+}
+
+.cds--content-switcher-btn:hover + .cds--content-switcher-btn.cds--content-switcher--selected::before {
   border-bottom: none !important;
   border-top: none !important;
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR is a follow-up to https://github.com/openmrs/openmrs-esm-core/pull/1375 that fixes style quirks in the default content switcher. More specifically, it makes the following changes:

- Removes box shadows from first/last content switcher buttons.
- Fixes border handling between adjacent buttons when one is selected and another is hovered.
- Ensures consistent visual appearance across all content switcher states.

## Screenshots

### Before

https://github.com/user-attachments/assets/52df8f75-3bb2-4f20-9a4f-07b7a075915d

### After

https://github.com/user-attachments/assets/8e74d09e-e821-434f-ac95-38cc6e2a5b9c

## Related Issue
https://openmrs.atlassian.net/browse/O3-4760

## Other
<!-- Anything not covered above -->
