### PR TITLE
(feat) Allow left nav to preserve correct component context

### DIFF
--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -24,12 +24,15 @@ import { type FeatureFlagsStore, featureFlagsStore } from '@openmrs/esm-feature-
 import { subscribeConnectivityChanged } from '@openmrs/esm-globals';
 import { isOnline as isOnlineFn } from '@openmrs/esm-utils';
 import { isEqual } from 'lodash-es';
-import { type AssignedExtension, checkStatusFor, type ExtensionSlotState, getExtensionInternalStore } from '.';
+import { checkStatusFor } from './helpers';
 import {
+  type AssignedExtension,
   type ExtensionRegistration,
   type ExtensionSlotInfo,
   type ExtensionInternalStore,
+  type ExtensionSlotState,
   getExtensionStore,
+  getExtensionInternalStore,
   updateInternalExtensionStore,
 } from './store';
 

--- a/packages/framework/esm-extensions/src/index.ts
+++ b/packages/framework/esm-extensions/src/index.ts
@@ -1,14 +1,8 @@
-export * from './store';
 export * from './extensions';
+export * from './helpers';
+export * from './left-nav';
 export * from './modals';
 export * from './workspaces';
-export * from './helpers';
 export * from './render';
-
-// Temporary compatibility hack
-// What is now `extensionInternalStore` used to be exposed
-// and used as `extensionStore`.
-import { getExtensionInternalStore } from './store';
-/** @deprecated Use `getExtensionStore`. The structure of this store has also changed. */
-const internalStore = getExtensionInternalStore();
-export { internalStore as extensionStore };
+export * from './store';
+export * from './types';

--- a/packages/framework/esm-extensions/src/left-nav.ts
+++ b/packages/framework/esm-extensions/src/left-nav.ts
@@ -1,0 +1,48 @@
+import type {} from '@openmrs/esm-globals';
+import { createGlobalStore } from '@openmrs/esm-state';
+import { type ComponentConfig } from './types';
+
+export interface LeftNavStore {
+  slotName: string | null;
+  basePath: string;
+  mode: 'normal' | 'collapsed';
+  componentContext?: ComponentConfig;
+}
+
+/** @internal */
+export const leftNavStore = createGlobalStore<LeftNavStore>('left-nav', {
+  slotName: null,
+  basePath: window.spaBase,
+  mode: 'normal',
+});
+
+export interface SetLeftNavParams {
+  name: string;
+  basePath: string;
+  /**
+   * In normal mode, the left nav is shown in desktop mode, and collapse into hamburger menu button in tablet mode
+   * In collapsed mode, the left nav is always collapsed, regardless of desktop / tablet mode
+   */
+  mode?: 'normal' | 'collapsed';
+  componentContext?: ComponentConfig;
+}
+
+/**
+ * Sets the current left nav context. Must be paired with {@link unsetLeftNav}.
+ *
+ * @deprecated Please use {@link useLeftNav} instead. This function will be made internal in a future release.
+ */
+export function setLeftNav({ name, basePath, mode, componentContext }: SetLeftNavParams) {
+  leftNavStore.setState({ slotName: name, basePath, mode: mode ?? 'normal', componentContext });
+}
+
+/**
+ * Unsets the left nav context if the current context is for the supplied name.
+ *
+ * @deprecated Please use {@link useLeftNav} instead. This function will be made internal in a future release.
+ */
+export function unsetLeftNav(name: string) {
+  if (leftNavStore.getState().slotName === name) {
+    leftNavStore.setState(leftNavStore.getInitialState(), true);
+  }
+}

--- a/packages/framework/esm-extensions/src/public.ts
+++ b/packages/framework/esm-extensions/src/public.ts
@@ -7,6 +7,7 @@ export {
   getAssignedExtensions,
   registerExtensionSlot,
 } from './extensions';
+export { type LeftNavStore, setLeftNav, unsetLeftNav, type SetLeftNavParams } from './left-nav';
 export { type CancelLoading, renderExtension } from './render';
 export {
   type ExtensionMeta,
@@ -18,3 +19,4 @@ export {
   getExtensionStore,
 } from './store';
 export { type WorkspaceRegistration } from './workspaces';
+export { type ExtensionData, type ComponentConfig } from './types';

--- a/packages/framework/esm-extensions/src/types.ts
+++ b/packages/framework/esm-extensions/src/types.ts
@@ -1,0 +1,11 @@
+export interface ExtensionData {
+  extensionSlotName: string;
+  extensionSlotModuleName: string;
+  extensionId: string;
+}
+
+export interface ComponentConfig {
+  moduleName: string;
+  featureName: string;
+  extension?: ExtensionData;
+}

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -191,8 +191,12 @@
 - [isOnline](API.md#isonline)
 - [isVersionSatisfied](API.md#isversionsatisfied)
 - [reportError](API.md#reporterror)
+- [setLeftNav](API.md#setleftnav)
+- [unsetLeftNav](API.md#unsetleftnav)
 - [useFhirFetchAll](API.md#usefhirfetchall)
 - [useFhirInfinite](API.md#usefhirinfinite)
+- [useLeftNav](API.md#useleftnav)
+- [useLeftNavStore](API.md#useleftnavstore)
 - [useVisitContextStore](API.md#usevisitcontextstore)
 
 ### Store Functions
@@ -220,7 +224,6 @@
 - [PatientPhoto](API.md#patientphoto)
 - [getFhirServerPaginationHandlers](API.md#getfhirserverpaginationhandlers)
 - [isDesktop](API.md#isdesktop)
-- [setLeftNav](API.md#setleftnav)
 - [showActionableNotification](API.md#showactionablenotification)
 - [showModal](API.md#showmodal)
 - [showNotification](API.md#shownotification)
@@ -230,11 +233,9 @@
 - [subscribeNotificationShown](API.md#subscribenotificationshown)
 - [subscribeSnackbarShown](API.md#subscribesnackbarshown)
 - [subscribeToastShown](API.md#subscribetoastshown)
-- [unsetLeftNav](API.md#unsetleftnav)
 - [useBodyScrollLock](API.md#usebodyscrolllock)
 - [useFhirPagination](API.md#usefhirpagination)
 - [useLayoutType](API.md#uselayouttype)
-- [useLeftNavStore](API.md#useleftnavstore)
 - [useOnClickOutside](API.md#useonclickoutside)
 - [useOnVisible](API.md#useonvisible)
 - [useOpenmrsFetchAll](API.md#useopenmrsfetchall)
@@ -2398,7 +2399,7 @@ is deprecated; it simply renders nothing.
 
 #### Defined in
 
-[packages/framework/esm-styleguide/src/left-nav/index.tsx:52](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L52)
+[packages/framework/esm-styleguide/src/left-nav/index.tsx:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L20)
 
 ___
 
@@ -3609,7 +3610,7 @@ Use this React Hook to obtain your module's configuration.
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useConfig.ts:139](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useConfig.ts#L139)
+[packages/framework/esm-react-utils/src/useConfig.ts:145](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useConfig.ts#L145)
 
 ___
 
@@ -4478,7 +4479,7 @@ writing a module for a specific implementation.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:212](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L212)
+[packages/framework/esm-extensions/src/extensions.ts:215](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L215)
 
 ___
 
@@ -4501,7 +4502,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:245](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L245)
+[packages/framework/esm-extensions/src/extensions.ts:248](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L248)
 
 ___
 
@@ -4523,7 +4524,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:269](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L269)
+[packages/framework/esm-extensions/src/extensions.ts:272](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L272)
 
 ___
 
@@ -4547,7 +4548,7 @@ An array of extensions assigned to the named slot
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:396](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L396)
+[packages/framework/esm-extensions/src/extensions.ts:399](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L399)
 
 ___
 
@@ -4579,7 +4580,7 @@ getExtensionNameFromId("baz")
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/extensions.ts:160](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L160)
+[packages/framework/esm-extensions/src/extensions.ts:163](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L163)
 
 ___
 
@@ -6642,6 +6643,54 @@ packages/framework/esm-error-handling/dist/index.d.ts:1
 
 ___
 
+### setLeftNav
+
+▸ **setLeftNav**(`__namedParameters`): `void`
+
+Sets the current left nav context. Must be paired with [unsetLeftNav](API.md#unsetleftnav).
+
+**`deprecated`** Please use [useLeftNav](API.md#useleftnav) instead. This function will be made internal in a future release.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `__namedParameters` | [`SetLeftNavParams`](interfaces/SetLeftNavParams.md) |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/left-nav.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L35)
+
+___
+
+### unsetLeftNav
+
+▸ **unsetLeftNav**(`name`): `void`
+
+Unsets the left nav context if the current context is for the supplied name.
+
+**`deprecated`** Please use [useLeftNav](API.md#useleftnav) instead. This function will be made internal in a future release.
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `name` | `string` |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/left-nav.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L44)
+
+___
+
 ### useFhirFetchAll
 
 ▸ **useFhirFetchAll**<`T`\>(`url`, `options?`): `UseServerInfiniteReturnObject`<`T`, `fhir.Bundle`\>
@@ -6719,6 +6768,40 @@ a UseServerInfiniteReturnObject object
 #### Defined in
 
 [packages/framework/esm-react-utils/src/useFhirInfinite.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useFhirInfinite.ts#L24)
+
+___
+
+### useLeftNav
+
+▸ **useLeftNav**(`params`): `void`
+
+#### Parameters
+
+| Name | Type |
+| :------ | :------ |
+| `params` | `Omit`<`SetLeftNavParams`, ``"module"``\> |
+
+#### Returns
+
+`void`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/useLeftNav.ts:5](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useLeftNav.ts#L5)
+
+___
+
+### useLeftNavStore
+
+▸ **useLeftNavStore**(): `LeftNavStore`
+
+#### Returns
+
+`LeftNavStore`
+
+#### Defined in
+
+[packages/framework/esm-react-utils/src/useLeftNavStore.ts:4](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useLeftNavStore.ts#L4)
 
 ___
 
@@ -7334,26 +7417,6 @@ ___
 
 ___
 
-### setLeftNav
-
-▸ **setLeftNav**(`__namedParameters`): `void`
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `__namedParameters` | `SetLeftNavParams` |
-
-#### Returns
-
-`void`
-
-#### Defined in
-
-[packages/framework/esm-styleguide/src/left-nav/index.tsx:31](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L31)
-
-___
-
 ### showActionableNotification
 
 ▸ **showActionableNotification**(`notification`): `void`
@@ -7591,26 +7654,6 @@ packages/framework/esm-globals/dist/events.d.ts:62
 
 ___
 
-### unsetLeftNav
-
-▸ **unsetLeftNav**(`name`): `void`
-
-#### Parameters
-
-| Name | Type |
-| :------ | :------ |
-| `name` | `string` |
-
-#### Returns
-
-`void`
-
-#### Defined in
-
-[packages/framework/esm-styleguide/src/left-nav/index.tsx:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L35)
-
-___
-
 ### useBodyScrollLock
 
 ▸ **useBodyScrollLock**(`active`): `void`
@@ -7702,20 +7745,6 @@ ___
 #### Defined in
 
 [packages/framework/esm-react-utils/src/useLayoutType.ts:26](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useLayoutType.ts#L26)
-
-___
-
-### useLeftNavStore
-
-▸ **useLeftNavStore**(): `LeftNavStore`
-
-#### Returns
-
-`LeftNavStore`
-
-#### Defined in
-
-[packages/framework/esm-styleguide/src/left-nav/index.tsx:41](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/left-nav/index.tsx#L41)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/ComponentConfig.md
+++ b/packages/framework/esm-framework/docs/interfaces/ComponentConfig.md
@@ -1,0 +1,41 @@
+[@openmrs/esm-framework](../API.md) / ComponentConfig
+
+# Interface: ComponentConfig
+
+## Table of contents
+
+### Properties
+
+- [extension](ComponentConfig.md#extension)
+- [featureName](ComponentConfig.md#featurename)
+- [moduleName](ComponentConfig.md#modulename)
+
+## Properties
+
+### extension
+
+• `Optional` **extension**: [`ExtensionData`](ExtensionData.md)
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/types.ts:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/types.ts#L10)
+
+___
+
+### featureName
+
+• **featureName**: `string`
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/types.ts:9](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/types.ts#L9)
+
+___
+
+### moduleName
+
+• **moduleName**: `string`
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/types.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/types.ts#L8)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionData.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionData.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ComponentContext.ts:6](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ComponentContext.ts#L6)
+[packages/framework/esm-extensions/src/types.ts:4](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/types.ts#L4)
 
 ___
 
@@ -28,7 +28,7 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ComponentContext.ts:5](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ComponentContext.ts#L5)
+[packages/framework/esm-extensions/src/types.ts:3](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/types.ts#L3)
 
 ___
 
@@ -38,4 +38,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/ComponentContext.ts:4](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/ComponentContext.ts#L4)
+[packages/framework/esm-extensions/src/types.ts:2](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/types.ts#L2)

--- a/packages/framework/esm-framework/docs/interfaces/LeftNavStore.md
+++ b/packages/framework/esm-framework/docs/interfaces/LeftNavStore.md
@@ -1,0 +1,52 @@
+[@openmrs/esm-framework](../API.md) / LeftNavStore
+
+# Interface: LeftNavStore
+
+## Table of contents
+
+### Properties
+
+- [basePath](LeftNavStore.md#basepath)
+- [componentContext](LeftNavStore.md#componentcontext)
+- [mode](LeftNavStore.md#mode)
+- [slotName](LeftNavStore.md#slotname)
+
+## Properties
+
+### basePath
+
+• **basePath**: `string`
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/left-nav.ts:7](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L7)
+
+___
+
+### componentContext
+
+• `Optional` **componentContext**: [`ComponentConfig`](ComponentConfig.md)
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/left-nav.ts:9](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L9)
+
+___
+
+### mode
+
+• **mode**: ``"normal"`` \| ``"collapsed"``
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/left-nav.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L8)
+
+___
+
+### slotName
+
+• **slotName**: ``null`` \| `string`
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/left-nav.ts:6](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L6)

--- a/packages/framework/esm-framework/docs/interfaces/SetLeftNavParams.md
+++ b/packages/framework/esm-framework/docs/interfaces/SetLeftNavParams.md
@@ -1,0 +1,55 @@
+[@openmrs/esm-framework](../API.md) / SetLeftNavParams
+
+# Interface: SetLeftNavParams
+
+## Table of contents
+
+### Properties
+
+- [basePath](SetLeftNavParams.md#basepath)
+- [componentContext](SetLeftNavParams.md#componentcontext)
+- [mode](SetLeftNavParams.md#mode)
+- [name](SetLeftNavParams.md#name)
+
+## Properties
+
+### basePath
+
+• **basePath**: `string`
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/left-nav.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L21)
+
+___
+
+### componentContext
+
+• `Optional` **componentContext**: [`ComponentConfig`](ComponentConfig.md)
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/left-nav.ts:27](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L27)
+
+___
+
+### mode
+
+• `Optional` **mode**: ``"normal"`` \| ``"collapsed"``
+
+In normal mode, the left nav is shown in desktop mode, and collapse into hamburger menu button in tablet mode
+In collapsed mode, the left nav is always collapsed, regardless of desktop / tablet mode
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/left-nav.ts:26](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L26)
+
+___
+
+### name
+
+• **name**: `string`
+
+#### Defined in
+
+[packages/framework/esm-extensions/src/left-nav.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L20)

--- a/packages/framework/esm-framework/docs/interfaces/UseConfigOptions.md
+++ b/packages/framework/esm-framework/docs/interfaces/UseConfigOptions.md
@@ -19,4 +19,4 @@ absolutely necessary as it can end up making frontend modules coupled to one ano
 
 #### Defined in
 
-[packages/framework/esm-react-utils/src/useConfig.ts:131](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useConfig.ts#L131)
+[packages/framework/esm-react-utils/src/useConfig.ts:137](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useConfig.ts#L137)

--- a/packages/framework/esm-react-utils/mock-jest.tsx
+++ b/packages/framework/esm-react-utils/mock-jest.tsx
@@ -140,6 +140,10 @@ export const useExtensionSlot = jest.fn();
 
 export const useForceUpdate = jest.fn();
 
+export const useLeftNav = jest.fn();
+
+export const useLeftNavStore = jest.fn();
+
 // TODO: Remove this in favour of usePrimaryIdentifierCode below
 export const usePrimaryIdentifierResource = jest.fn();
 

--- a/packages/framework/esm-react-utils/mock.tsx
+++ b/packages/framework/esm-react-utils/mock.tsx
@@ -148,6 +148,10 @@ export const useExtensionSlot = vi.fn();
 
 export const useForceUpdate = vi.fn();
 
+export const useLeftNav = vi.fn();
+
+export const useLeftNavStore = vi.fn();
+
 // TODO: Remove this in favour of usePrimaryIdentifierCode below
 export const usePrimaryIdentifierResource = vi.fn();
 

--- a/packages/framework/esm-react-utils/src/ComponentContext.ts
+++ b/packages/framework/esm-react-utils/src/ComponentContext.ts
@@ -1,21 +1,10 @@
-import React from 'react';
-
-export interface ExtensionData {
-  extensionSlotName: string;
-  extensionSlotModuleName: string;
-  extensionId: string;
-}
-
-export interface ComponentConfig {
-  moduleName: string;
-  featureName: string;
-  extension?: ExtensionData;
-}
+import { createContext } from 'react';
+import { type ComponentConfig } from '@openmrs/esm-extensions';
 
 /**
  * Available to all components. Provided by `openmrsComponentDecorator`.
  */
-export const ComponentContext = React.createContext<ComponentConfig>({
+export const ComponentContext = createContext<ComponentConfig>({
   moduleName: '',
   featureName: '',
 });

--- a/packages/framework/esm-react-utils/src/index.ts
+++ b/packages/framework/esm-react-utils/src/index.ts
@@ -30,6 +30,8 @@ export * from './useFhirFetchAll';
 export * from './useFhirInfinite';
 export * from './useFhirPagination';
 export * from './useLayoutType';
+export * from './useLeftNav';
+export * from './useLeftNavStore';
 export * from './useLocations';
 export * from './useOnClickOutside';
 export * from './useOnVisible';

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
@@ -3,7 +3,8 @@ import { I18nextProvider } from 'react-i18next';
 import { SWRConfig, type SWRConfiguration } from 'swr';
 import type {} from '@openmrs/esm-globals';
 import { openmrsFetch } from '@openmrs/esm-api';
-import { ComponentContext, type ComponentConfig, type ExtensionData } from './ComponentContext';
+import { type ComponentConfig, type ExtensionData } from '@openmrs/esm-extensions';
+import { ComponentContext } from './ComponentContext';
 
 const defaultOpts = {
   strictMode: true,

--- a/packages/framework/esm-react-utils/src/public.ts
+++ b/packages/framework/esm-react-utils/src/public.ts
@@ -1,4 +1,3 @@
-export { type ExtensionData } from './ComponentContext';
 export * from './ConfigurableLink';
 export * from './Extension';
 export * from './ExtensionSlot';
@@ -23,6 +22,8 @@ export * from './useExtensionStore';
 export * from './useExtensionSlotStore';
 export * from './useFeatureFlag';
 export * from './useLayoutType';
+export * from './useLeftNav';
+export * from './useLeftNavStore';
 export * from './useLocations';
 export * from './useOnClickOutside';
 export * from './useOnVisible';

--- a/packages/framework/esm-react-utils/src/useConfig.ts
+++ b/packages/framework/esm-react-utils/src/useConfig.ts
@@ -1,10 +1,16 @@
 /** @module @category Config */
 import { useContext, useEffect, useMemo, useState } from 'react';
-import type { ConfigStore, ConfigObject, ExtensionsConfigStore } from '@openmrs/esm-config';
-import { getConfigStore, getExtensionsConfigStore, getExtensionConfigFromStore } from '@openmrs/esm-config';
-import type { StoreApi } from 'zustand';
 import { isEqual } from 'lodash-es';
-import type { ExtensionData } from './ComponentContext';
+import type { StoreApi } from 'zustand';
+import {
+  type ConfigStore,
+  type ConfigObject,
+  type ExtensionsConfigStore,
+  getConfigStore,
+  getExtensionsConfigStore,
+  getExtensionConfigFromStore,
+} from '@openmrs/esm-config';
+import { type ExtensionData } from '@openmrs/esm-extensions';
 import { ComponentContext } from './ComponentContext';
 
 const promises: Record<string, Promise<ConfigObject>> = {};

--- a/packages/framework/esm-react-utils/src/useLeftNav.ts
+++ b/packages/framework/esm-react-utils/src/useLeftNav.ts
@@ -1,0 +1,19 @@
+import { useContext, useEffect } from 'react';
+import { type SetLeftNavParams, setLeftNav, unsetLeftNav } from '@openmrs/esm-extensions';
+import { ComponentContext } from './ComponentContext';
+
+export function useLeftNav(params: Omit<SetLeftNavParams, 'module'>) {
+  const componentContext = useContext(ComponentContext);
+
+  useEffect(() => {
+    if (componentContext && componentContext.moduleName) {
+      (params as SetLeftNavParams).componentContext = componentContext;
+    }
+
+    setLeftNav(params);
+
+    return () => {
+      unsetLeftNav(params.name);
+    };
+  }, [componentContext, params]);
+}

--- a/packages/framework/esm-react-utils/src/useLeftNavStore.ts
+++ b/packages/framework/esm-react-utils/src/useLeftNavStore.ts
@@ -1,0 +1,6 @@
+import { leftNavStore } from '@openmrs/esm-extensions';
+import { useStore } from './useStore';
+
+export function useLeftNavStore() {
+  return useStore(leftNavStore);
+}


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

There's a regression, accidentally introduced by [this commit](https://github.com/openmrs/openmrs-esm-core/commit/47e2a1def83eb3ece030156e27c009166c67f019), which tries to switch to using a single left nav. The issue here is that the LeftNav is now always rendered by the primary navigation app, which removes the ability to actually configure the left nav slot.

This PR fixes this by storing the underlying component context for the app containing the LeftNav in the `leftNavStore`, so that that context can be used when rendering the LeftNav.

Because actually fetching the component context is not generally something we require app-authors to do, this PR also introduces a React Hook to make things easy, called `useLeftNav()`. The component that defines a page rendered by the framework can call `useLeftNav()` in place of `setLeftNav()`. This hook takes care of two things:

1. Calling `setLeftNav()` when mounted and calling `unsetLeftNav()` on unmount
2. It will grab the module name from the ComponentContext.

This is a non-breaking change as we do not remove any APIs, but it is highly recommended that all apps switch to using this new hook or it's equivalent.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

In line with the principle that components in the styleguide should be stateless, the internal implementation of the LeftNav and store, etc. are moved in esm-extensions. I'm not sure that this is the ideal place for them, but it seemed better than creating another component library for ~50 lines of code.
