### PR TITLE
(feat) O3-4778 add way to define hidden left nav

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -37,7 +37,7 @@ const HeaderItems: React.FC = () => {
   );
 
   const showHamburger = useMemo(
-    () => (!isDesktop(layout) || mode === 'collapsed') && navMenuItems.length > 0,
+    () => (!isDesktop(layout) || mode === 'collapsed') && mode !== 'hidden' && navMenuItems.length > 0,
     [navMenuItems.length, layout, mode],
   );
 

--- a/packages/framework/esm-extensions/src/left-nav.ts
+++ b/packages/framework/esm-extensions/src/left-nav.ts
@@ -2,10 +2,11 @@ import type {} from '@openmrs/esm-globals';
 import { createGlobalStore } from '@openmrs/esm-state';
 import { type ComponentConfig } from './types';
 
+type LeftNavMode = 'normal' | 'collapsed' | 'hidden';
 export interface LeftNavStore {
   slotName: string | null;
   basePath: string;
-  mode: 'normal' | 'collapsed';
+  mode: LeftNavMode;
   componentContext?: ComponentConfig;
 }
 
@@ -21,9 +22,10 @@ export interface SetLeftNavParams {
   basePath: string;
   /**
    * In normal mode, the left nav is shown in desktop mode, and collapse into hamburger menu button in tablet mode
-   * In collapsed mode, the left nav is always collapsed, regardless of desktop / tablet mode
+   * In collapsed mode, the left nav is always collapsed, regardless of desktop / tablet mode.
+   * In hidden mode, the left nav is not shown at all.
    */
-  mode?: 'normal' | 'collapsed';
+  mode?: LeftNavMode;
   componentContext?: ComponentConfig;
 }
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Currently, the left nav can have two modes: 'normal' or 'collapsed'. This PR adds a third mode: 'hidden'. This allows `useLeftNav` hook to conditionally hide the left nav. 

See https://github.com/openmrs/openmrs-esm-home/pull/265 for tests.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4778

## Other
<!-- Anything not covered above -->
