### PR TITLE
(test) Add jest mock for useVisitContextStore hook

### DIFF
--- a/packages/framework/esm-react-utils/mock-jest.tsx
+++ b/packages/framework/esm-react-utils/mock-jest.tsx
@@ -12,6 +12,7 @@ import {
   useFhirPagination as realUseFhirPagination,
   useFhirInfinite as realUseFhirInfinite,
   useFhirFetchAll as realUseFhirFetchAll,
+  useVisitContextStore as realUseVisitContextStore,
 } from './src/index';
 export { ConfigurableLink } from './src/ConfigurableLink';
 export { useStore, useStoreWithActions, createUseStore } from './src/useStore';
@@ -91,6 +92,8 @@ export const useVisit = jest.fn().mockReturnValue({
   activeVisit: null,
   currentVisitIsRetrospective: false,
 });
+
+export const useVisitContextStore = jest.fn(realUseVisitContextStore);
 
 export const useVisitTypes = jest.fn(() => []);
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Adds a test stub for the useVisitContextStore hook, enabling it to be spied on or mocked in tests. This fixes a type error in the Patient Chart repo: `TypeError: (0 , _esmframework.useVisitContextStore) is not a function`.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
https://openmrs.atlassian.net/browse/O3-4745

## Other
<!-- Anything not covered above -->
