### PR TITLE
(fix) Restore name prop for user menu button

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/user-menu-button.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/user-menu-button.component.tsx
@@ -25,6 +25,8 @@ const UserMenuButton: React.FC<MenuButtonProps> = ({ isActivePanel, togglePanel,
             [styles.headerGlobalBarButton]: isActivePanel('userMenu'),
             [styles.activePanel]: !isActivePanel('userMenu'),
           })}
+          // @ts-ignore - `name` is not a valid prop for the HeaderGlobalAction component, but we need the name prop for user onboarding app to work correctly
+          name="User"
           isActive={isActivePanel('userMenu')}
           onClick={() => {
             togglePanel('userMenu');


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR fixes an issue affecting the user onboarding app where the user menu button was not getting triggered correctly. This issue manifested itself in a [failing e2e test](https://github.com/openmrs/openmrs-esm-user-onboarding/actions/runs/15449920137/job/43489748773?pr=32) after updating the versions of the core tooling and framework used in the project. More specifically, this fix restores the name prop for the user menu button, which was removed in a previous commit. It also adds a `@ts-ignore` comment to the user menu button component to avoid type errors.

## Screenshots

Full e2e trace:

![CleanShot 2025-06-05 at 21 22 20@2x](https://github.com/user-attachments/assets/28136751-509d-4d17-836f-66c6bf8be086)

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
