### PR TITLE
(fix) O3-4778 only render side nav when in desktop mode and leftNavMo…

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar-header-panels/side-menu-panel.component.tsx
@@ -27,8 +27,8 @@ const SideMenuPanel: React.FC<SideMenuPanelProps> = ({ expanded, hidePanel }) =>
     <>
       {(!isDesktop(layout) || mode === 'collapsed') && expanded && <LeftNavMenu ref={menuRef} isChildOfHeader />}
       {isDesktop(layout) &&
-        mode !== 'collapsed' &&
-				leftNavContainer &&
+        mode === 'normal' &&
+        leftNavContainer &&
         createPortal(<LeftNavMenu ref={menuRef} isChildOfHeader />, leftNavContainer)}
     </>
   );

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -6663,7 +6663,7 @@ Sets the current left nav context. Must be paired with [unsetLeftNav](API.md#uns
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/left-nav.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L35)
+[packages/framework/esm-extensions/src/left-nav.ts:37](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L37)
 
 ___
 
@@ -6687,7 +6687,7 @@ Unsets the left nav context if the current context is for the supplied name.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/left-nav.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L44)
+[packages/framework/esm-extensions/src/left-nav.ts:46](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L46)
 
 ___
 

--- a/packages/framework/esm-framework/docs/interfaces/LeftNavStore.md
+++ b/packages/framework/esm-framework/docs/interfaces/LeftNavStore.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/left-nav.ts:7](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L7)
+[packages/framework/esm-extensions/src/left-nav.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L8)
 
 ___
 
@@ -29,17 +29,17 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/left-nav.ts:9](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L9)
+[packages/framework/esm-extensions/src/left-nav.ts:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L10)
 
 ___
 
 ### mode
 
-• **mode**: ``"normal"`` \| ``"collapsed"``
+• **mode**: `LeftNavMode`
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/left-nav.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L8)
+[packages/framework/esm-extensions/src/left-nav.ts:9](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L9)
 
 ___
 
@@ -49,4 +49,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/left-nav.ts:6](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L6)
+[packages/framework/esm-extensions/src/left-nav.ts:7](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L7)

--- a/packages/framework/esm-framework/docs/interfaces/SetLeftNavParams.md
+++ b/packages/framework/esm-framework/docs/interfaces/SetLeftNavParams.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/left-nav.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L21)
+[packages/framework/esm-extensions/src/left-nav.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L22)
 
 ___
 
@@ -29,20 +29,21 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/left-nav.ts:27](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L27)
+[packages/framework/esm-extensions/src/left-nav.ts:29](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L29)
 
 ___
 
 ### mode
 
-• `Optional` **mode**: ``"normal"`` \| ``"collapsed"``
+• `Optional` **mode**: `LeftNavMode`
 
 In normal mode, the left nav is shown in desktop mode, and collapse into hamburger menu button in tablet mode
-In collapsed mode, the left nav is always collapsed, regardless of desktop / tablet mode
+In collapsed mode, the left nav is always collapsed, regardless of desktop / tablet mode.
+In hidden mode, the left nav is not shown at all.
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/left-nav.ts:26](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L26)
+[packages/framework/esm-extensions/src/left-nav.ts:28](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L28)
 
 ___
 
@@ -52,4 +53,4 @@ ___
 
 #### Defined in
 
-[packages/framework/esm-extensions/src/left-nav.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L20)
+[packages/framework/esm-extensions/src/left-nav.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/left-nav.ts#L21)


### PR DESCRIPTION
…de is normal

# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR fixes an issue where the left nav (side nav) gets rendered in desktop mode even when leftNavMode is 'hidden'.  This bug was hidden in the home app because the home app's dashboard effectively renders over the side nav. However, this bug surfaces in the dispensing app.

## Screenshots
<!-- Required if you are making UI changes. -->
Before:
![image](https://github.com/user-attachments/assets/8a48d8b3-6f46-4455-8cb9-1162dfcd886d)

After:
![image](https://github.com/user-attachments/assets/75f54536-c3f8-4288-bd29-71481b7e1a50)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
