### PR TITLE
(fix) Prompt for version of selected package in assemble survey mode

### DIFF
--- a/packages/tooling/openmrs/src/commands/assemble.ts
+++ b/packages/tooling/openmrs/src/commands/assemble.ts
@@ -130,17 +130,17 @@ async function readConfig(
       for (const pckg of packages) {
         questions.push(
           {
-            name: pckg.name,
+            name: `include:${pckg.name}`,
             message: `Include frontend module "${pckg.name}"?`,
             default: false,
             type: 'confirm',
           },
           {
-            name: pckg.name,
+            name: `version:${pckg.name}`,
             message: `Version for "${pckg.name}"?`,
             default: pckg.version,
             type: 'string',
-            when: (ans) => ans[pckg.name],
+            when: (ans) => ans[`include:${pckg.name}`],
             validate: (input) => {
               if (typeof input !== 'string') {
                 return `Expected a valid SemVer string, got ${typeof input}.`;


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Fixes an issue where users aren't prompted for versions of the selected packages when using the assemble CLI utility. This caused issues, as reported [here](https://openmrs.slack.com/archives/C02UNMKFH8V/p1749646583474519). The proposed solution ensures we use unique keys for the questions passed to [inquirer](https://www.npmjs.com/package/inquirer).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
