### PR TITLE
(BREAKING) Use a single global cache instance for SWR

### DIFF
--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
@@ -58,6 +58,7 @@ export function openmrsComponentDecorator<T>(userOpts: ComponentDecoratorOptions
   }
 
   const opts = Object.assign({}, defaultOpts, userOpts);
+  const swrConfig = { ...defaultSwrConfig, ...opts.swrConfig };
 
   return function decorateComponent(Comp: ComponentType<T>): ComponentType<T> {
     return class OpenmrsReactComponent extends React.Component<
@@ -103,7 +104,6 @@ export function openmrsComponentDecorator<T>(userOpts: ComponentDecoratorOptions
           // TO-DO have a UX designed for when a catastrophic error occurs
           return <div>An error has occurred. Please try reloading the page.</div>;
         } else {
-          const swrConfig = { ...defaultSwrConfig, ...opts.swrConfig };
           const content = (
             <Suspense fallback={null}>
               <SWRConfig value={swrConfig}>


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This PR leverages SWR's capability to use a custom Cache Provider to provide a global SWR cache for OpenMRS that should be the same regardless of runtime order.

**BREAKING:** this does mean that SWR's global mutate() function will no longer function correctly.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
