### PR TITLE
(fix) O3-4803 hide help icon when help menu has no items

### DIFF
--- a/packages/apps/esm-help-menu-app/src/help-menu/help.component.tsx
+++ b/packages/apps/esm-help-menu-app/src/help-menu/help.component.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Button } from '@carbon/react';
 import { Help } from '@carbon/react/icons';
-import { useSession } from '@openmrs/esm-framework';
+import { useAssignedExtensions, useSession } from '@openmrs/esm-framework';
 import HelpMenuPopup from './help-popup.component';
 import styles from './help.styles.scss';
 
@@ -10,6 +10,7 @@ export default function HelpMenu() {
   const [helpMenuOpen, setHelpMenuOpen] = useState(false);
   const helpMenuButtonRef = useRef(null);
   const popupRef = useRef(null);
+  const helpMenuItems = useAssignedExtensions('help-menu-slot');
 
   const toggleHelpMenu = () => {
     setHelpMenuOpen((prevState) => !prevState);
@@ -34,6 +35,10 @@ export default function HelpMenu() {
       window.removeEventListener(`touchstart`, handleClickOutside);
     };
   }, []);
+
+  if (helpMenuItems.length === 0) {
+    return null;
+  }
 
   return (
     <>


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR hides the "?" help icon when the help menu extension slot is configured to have 0 items.

## Screenshots
<!-- Required if you are making UI changes. -->
Before (note the empty help menu):
![image](https://github.com/user-attachments/assets/285e0a00-9ad2-40e5-954d-4bc9c32a098a)


After:
![image](https://github.com/user-attachments/assets/694bbbf3-a812-41ca-8182-e8e7e790128c)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
