### PR TITLE
(fix) Simpler types for AppContext

### DIFF
--- a/packages/framework/esm-config/src/module-config/state.ts
+++ b/packages/framework/esm-config/src/module-config/state.ts
@@ -1,4 +1,3 @@
-/** @module @category Config */
 import { createGlobalStore, getGlobalStore } from '@openmrs/esm-state';
 import { shallowEqual } from '@openmrs/esm-utils';
 import { type StoreApi } from 'zustand';

--- a/packages/framework/esm-context/src/context.ts
+++ b/packages/framework/esm-context/src/context.ts
@@ -5,7 +5,7 @@ import { createStore } from 'zustand/vanilla';
 import { registerGlobalStore } from '@openmrs/esm-state';
 
 interface OpenmrsAppContext {
-  [namespace: string]: unknown;
+  [namespace: string]: NonNullable<object>;
 }
 
 /**
@@ -26,9 +26,10 @@ const nothing = Object();
  * @param namespace the namespace to register
  * @param initialValue the initial value of the namespace
  */
-export function registerContext<
-  T extends Record<string | symbol | number, unknown> = Record<string | symbol | number, any>,
->(namespace: string, initialValue: T = nothing) {
+export function registerContext<T extends NonNullable<object> = NonNullable<object>>(
+  namespace: string,
+  initialValue: T = nothing,
+) {
   contextStore.setState((state) => {
     if (namespace in state) {
       throw new Error(
@@ -59,9 +60,7 @@ export function unregisterContext(namespace: string) {
  * @typeParam T The type of the value stored in the namespace
  * @param namespace The namespace to load properties from
  */
-export function getContext<T extends Record<string | symbol | number, unknown> = Record<string | symbol | number, any>>(
-  namespace: string,
-): Readonly<T> | null;
+export function getContext<T extends NonNullable<object> = NonNullable<object>>(namespace: string): Readonly<T> | null;
 /**
  * Returns an _immutable_ version of the state of the namespace as it is currently
  *
@@ -70,10 +69,10 @@ export function getContext<T extends Record<string | symbol | number, unknown> =
  * @param namespace The namespace to load properties from
  * @param selector An optional function which extracts the relevant part of the state
  */
-export function getContext<
-  T extends Record<string | symbol | number, unknown> = Record<string | symbol | number, any>,
-  U extends Record<string | symbol | number, unknown> = T,
->(namespace: string, selector: (state: Readonly<T>) => U = (state) => state as unknown as U): Readonly<U> | null {
+export function getContext<T extends NonNullable<object> = NonNullable<object>, U extends NonNullable<object> = T>(
+  namespace: string,
+  selector: (state: Readonly<T>) => U = (state) => state as unknown as U,
+): Readonly<U> | null {
   const state = contextStore.getState();
   if (namespace in state) {
     return Object.freeze(Object.assign({}, (selector ? selector(state[namespace] as T) : state[namespace]) as U));
@@ -85,9 +84,10 @@ export function getContext<
 /**
  * Updates a namespace in the global context. If the namespace does not exist, it is registered.
  */
-export function updateContext<
-  T extends Record<string | symbol | number, unknown> = Record<string | symbol | number, any>,
->(namespace: string, update: (state: T) => T) {
+export function updateContext<T extends NonNullable<object> = NonNullable<object>>(
+  namespace: string,
+  update: (state: T) => T,
+) {
   contextStore.setState((state) => {
     if (!(namespace in state)) {
       state[namespace] = {};
@@ -98,9 +98,9 @@ export function updateContext<
   });
 }
 
-export type ContextCallback<
-  T extends Record<string | symbol | number, unknown> = Record<string | symbol | number, any>,
-> = (state: Readonly<T> | null | undefined) => void;
+export type ContextCallback<T extends NonNullable<object> = NonNullable<object>> = (
+  state: Readonly<T> | null | undefined,
+) => void;
 
 /**
  * Subscribes to updates of a given namespace. Note that the returned object is immutable.
@@ -109,9 +109,10 @@ export type ContextCallback<
  * @param callback a function invoked with the current context whenever
  * @returns A function to unsubscribe from the context
  */
-export function subscribeToContext<
-  T extends Record<string | symbol | number, unknown> = Record<string | symbol | number, any>,
->(namespace: string, callback: ContextCallback<T>) {
+export function subscribeToContext<T extends NonNullable<object> = NonNullable<object>>(
+  namespace: string,
+  callback: ContextCallback<T>,
+) {
   let previous = getContext<T>(namespace);
 
   // set initial value

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -228,41 +228,12 @@
 
 ## Config
 
-### ConfigStore
-
-Defined in: /Users/ibacher/Documents/openmrs/openmrs-esm-core/packages/framework/esm-config/src/module-config/state.ts:99
-
-**`Internal`**
-
-Output configs
-
-Each module has its own stores for its config and its extension slots' configs.
-
-#### config
-
-> **config**: `null` \| [`ConfigObject`](interfaces/ConfigObject.md)
-
-Defined in: /Users/ibacher/Documents/openmrs/openmrs-esm-core/packages/framework/esm-config/src/module-config/state.ts:100
-
-#### loaded
-
-> **loaded**: `boolean`
-
-Defined in: /Users/ibacher/Documents/openmrs/openmrs-esm-core/packages/framework/esm-config/src/module-config/state.ts:101
-
-#### translationOverridesLoaded
-
-> **translationOverridesLoaded**: `boolean`
-
-Defined in: /Users/ibacher/Documents/openmrs/openmrs-esm-core/packages/framework/esm-config/src/module-config/state.ts:102
-
-***
-
-### getConfigStore
-
-> **getConfigStore**: 
-
-Defined in: /Users/ibacher/Documents/openmrs/openmrs-esm-core/packages/framework/esm-config/src/module-config/state.ts:114
+- [useConfig](functions/useConfig.md)
+- [UseConfigOptions](interfaces/UseConfigOptions.md)
+- [defineConfigSchema](functions/defineConfigSchema.md)
+- [defineExtensionConfigSchema](functions/defineExtensionConfigSchema.md)
+- [provide](functions/provide.md)
+- [getConfig](functions/getConfig.md)
 
 ## Feature Flags
 

--- a/packages/framework/esm-framework/docs/functions/OpenmrsAppContext.md
+++ b/packages/framework/esm-framework/docs/functions/OpenmrsAppContext.md
@@ -4,7 +4,7 @@
 
 > **OpenmrsAppContext**\<`T`\>(`__namedParameters`): `null`
 
-Defined in: [packages/framework/esm-react-utils/src/OpenmrsContext.ts:26](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/OpenmrsContext.ts#L26)
+Defined in: [packages/framework/esm-react-utils/src/OpenmrsContext.ts:24](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/OpenmrsContext.ts#L24)
 
 OpenmrsAppContext is a simple React component meant to function similarly to React's Context,
 but built on top of the OpenmrsAppContext.
@@ -13,7 +13,7 @@ but built on top of the OpenmrsAppContext.
 
 ### T
 
-`T` *extends* `Record`\<`string` \| `number` \| `symbol`, `unknown`\> = `Record`\<`string` \| `number` \| `symbol`, `any`\>
+`T` *extends* `object` = `object`
 
 ## Parameters
 

--- a/packages/framework/esm-framework/docs/functions/getContext.md
+++ b/packages/framework/esm-framework/docs/functions/getContext.md
@@ -4,7 +4,7 @@
 
 > **getContext**\<`T`\>(`namespace`): `null` \| `Readonly`\<`T`\>
 
-Defined in: [packages/framework/esm-context/src/context.ts:62](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-context/src/context.ts#L62)
+Defined in: [packages/framework/esm-context/src/context.ts:63](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-context/src/context.ts#L63)
 
 Returns an _immutable_ version of the state of the namespace as it is currently
 
@@ -12,7 +12,7 @@ Returns an _immutable_ version of the state of the namespace as it is currently
 
 ### T
 
-`T` *extends* `Record`\<`string` \| `number` \| `symbol`, `unknown`\> = `Record`\<`string` \| `number` \| `symbol`, `any`\>
+`T` *extends* `object` = `object`
 
 The type of the value stored in the namespace
 

--- a/packages/framework/esm-framework/docs/functions/registerContext.md
+++ b/packages/framework/esm-framework/docs/functions/registerContext.md
@@ -13,7 +13,7 @@ an already-registered namespace will display a warning and make no modifications
 
 ### T
 
-`T` *extends* `Record`\<`string` \| `number` \| `symbol`, `unknown`\> = `Record`\<`string` \| `number` \| `symbol`, `any`\>
+`T` *extends* `object` = `object`
 
 ## Parameters
 

--- a/packages/framework/esm-framework/docs/functions/subscribeToContext.md
+++ b/packages/framework/esm-framework/docs/functions/subscribeToContext.md
@@ -12,7 +12,7 @@ Subscribes to updates of a given namespace. Note that the returned object is imm
 
 ### T
 
-`T` *extends* `Record`\<`string` \| `number` \| `symbol`, `unknown`\> = `Record`\<`string` \| `number` \| `symbol`, `any`\>
+`T` *extends* `object` = `object`
 
 ## Parameters
 

--- a/packages/framework/esm-framework/docs/functions/unregisterContext.md
+++ b/packages/framework/esm-framework/docs/functions/unregisterContext.md
@@ -4,7 +4,7 @@
 
 > **unregisterContext**(`namespace`): `void`
 
-Defined in: [packages/framework/esm-context/src/context.ts:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-context/src/context.ts#L47)
+Defined in: [packages/framework/esm-context/src/context.ts:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-context/src/context.ts#L48)
 
 Used by caller to unregister a namespace in the application context. Unregistering a namespace
 will remove the namespace and all associated data.

--- a/packages/framework/esm-framework/docs/functions/updateContext.md
+++ b/packages/framework/esm-framework/docs/functions/updateContext.md
@@ -4,7 +4,7 @@
 
 > **updateContext**\<`T`\>(`namespace`, `update`): `void`
 
-Defined in: [packages/framework/esm-context/src/context.ts:88](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-context/src/context.ts#L88)
+Defined in: [packages/framework/esm-context/src/context.ts:87](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-context/src/context.ts#L87)
 
 Updates a namespace in the global context. If the namespace does not exist, it is registered.
 
@@ -12,7 +12,7 @@ Updates a namespace in the global context. If the namespace does not exist, it i
 
 ### T
 
-`T` *extends* `Record`\<`string` \| `number` \| `symbol`, `unknown`\> = `Record`\<`string` \| `number` \| `symbol`, `any`\>
+`T` *extends* `object` = `object`
 
 ## Parameters
 

--- a/packages/framework/esm-framework/docs/functions/useAppContext.md
+++ b/packages/framework/esm-framework/docs/functions/useAppContext.md
@@ -14,7 +14,7 @@ returned from the namespace.
 
 ### T
 
-`T` *extends* `Record`\<`string` \| `number` \| `symbol`, `unknown`\> = `Record`\<`string` \| `number` \| `symbol`, `any`\>
+`T` *extends* `object` = `object`
 
 The type of the value stored in the namespace
 

--- a/packages/framework/esm-framework/docs/functions/useDefineAppContext.md
+++ b/packages/framework/esm-framework/docs/functions/useDefineAppContext.md
@@ -14,7 +14,7 @@ will be automatically removed when the component using this hook is unmounted.
 
 ### T
 
-`T` *extends* `Record`\<`string` \| `number` \| `symbol`, `unknown`\> = `Record`\<`string` \| `number` \| `symbol`, `any`\>
+`T` *extends* `object` = `object`
 
 The type of the value of the namespace
 

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsAppContextProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsAppContextProps.md
@@ -8,7 +8,7 @@ Defined in: [packages/framework/esm-react-utils/src/OpenmrsContext.ts:4](https:/
 
 ### T
 
-`T` *extends* `Record`\<`string` \| `symbol` \| `number`, `unknown`\> = `Record`\<`string` \| `symbol` \| `number`, `any`\>
+`T` *extends* `NonNullable`\<`object`\> = `NonNullable`\<`object`\>
 
 ## Properties
 
@@ -16,7 +16,7 @@ Defined in: [packages/framework/esm-react-utils/src/OpenmrsContext.ts:4](https:/
 
 > **namespace**: `string`
 
-Defined in: [packages/framework/esm-react-utils/src/OpenmrsContext.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/OpenmrsContext.ts#L8)
+Defined in: [packages/framework/esm-react-utils/src/OpenmrsContext.ts:6](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/OpenmrsContext.ts#L6)
 
 the namespace that this component defines
 
@@ -26,6 +26,6 @@ the namespace that this component defines
 
 > `optional` **value**: `T`
 
-Defined in: [packages/framework/esm-react-utils/src/OpenmrsContext.ts:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/OpenmrsContext.ts#L10)
+Defined in: [packages/framework/esm-react-utils/src/OpenmrsContext.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/OpenmrsContext.ts#L8)
 
 used to control the value associated with the namespace

--- a/packages/framework/esm-framework/docs/type-aliases/ContextCallback.md
+++ b/packages/framework/esm-framework/docs/type-aliases/ContextCallback.md
@@ -10,7 +10,7 @@ Defined in: [packages/framework/esm-context/src/context.ts:101](https://github.c
 
 ### T
 
-`T` *extends* `Record`\<`string` \| `symbol` \| `number`, `unknown`\> = `Record`\<`string` \| `symbol` \| `number`, `any`\>
+`T` *extends* `NonNullable`\<`object`\> = `NonNullable`\<`object`\>
 
 ## Parameters
 

--- a/packages/framework/esm-framework/typedoc.json
+++ b/packages/framework/esm-framework/typedoc.json
@@ -13,6 +13,7 @@
     "typedoc-plugin-markdown",
     "typedoc-plugin-no-inherit"
   ],
+  "basePath": "../../../",
   "readme": "none",
   "excludeInternal": true,
   "entryFileName": "API.md",

--- a/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
+++ b/packages/framework/esm-react-utils/src/ExtensionSlot.tsx
@@ -24,7 +24,7 @@ export interface ExtensionSlotBaseProps {
    *   has children, you must pass the state through the `state` param of the
    *   `Extension` component.
    */
-  state?: Record<string | number | symbol, unknown>;
+  state?: Record<string | symbol | number, unknown>;
 }
 
 export interface ExtensionSlotProps

--- a/packages/framework/esm-react-utils/src/OpenmrsContext.ts
+++ b/packages/framework/esm-react-utils/src/OpenmrsContext.ts
@@ -1,9 +1,7 @@
 /** @module @category Context */
 import { useDefineAppContext } from './useDefineAppContext';
 
-export interface OpenmrsAppContextProps<
-  T extends Record<string | symbol | number, unknown> = Record<string | symbol | number, any>,
-> {
+export interface OpenmrsAppContextProps<T extends NonNullable<object> = NonNullable<object>> {
   /** the namespace that this component defines */
   namespace: string;
   /** used to control the value associated with the namespace */
@@ -23,9 +21,10 @@ export interface OpenmrsAppContextProps<
  * context component, the `OpenmrsAppContext` is inherently global in scope. That means that _all applications_
  * will see the values that you set for the namespace if they load the value of the namespace.
  */
-export function OpenmrsAppContext<
-  T extends Record<string | symbol | number, unknown> = Record<string | symbol | number, any>,
->({ namespace, value }: OpenmrsAppContextProps<T>) {
+export function OpenmrsAppContext<T extends NonNullable<object> = NonNullable<object>>({
+  namespace,
+  value,
+}: OpenmrsAppContextProps<T>) {
   useDefineAppContext<T>(namespace, value);
 
   return null;

--- a/packages/framework/esm-react-utils/src/useAppContext.ts
+++ b/packages/framework/esm-react-utils/src/useAppContext.ts
@@ -23,9 +23,9 @@ import { shallowEqual } from '@openmrs/esm-utils';
  * @typeParam T The type of the value stored in the namespace
  * @param namespace The namespace to load properties from
  */
-export function useAppContext<
-  T extends Record<string | symbol | number, unknown> = Record<string | symbol | number, any>,
->(namespace: string): Readonly<T> | undefined;
+export function useAppContext<T extends NonNullable<object> = NonNullable<object>>(
+  namespace: string,
+): Readonly<T> | undefined;
 
 /**
  * This hook is used to access a namespace within the overall AppContext, so that a component can
@@ -49,10 +49,7 @@ export function useAppContext<
  * @param namespace The namespace to load properties from
  * @param selector An optional function which extracts the relevant part of the state
  */
-export function useAppContext<
-  T extends Record<string | symbol | number, unknown> = Record<string | symbol | number, any>,
-  U = T,
->(
+export function useAppContext<T extends NonNullable<object> = NonNullable<object>, U = T>(
   namespace: string,
   selector: (state: Readonly<T> | null) => Readonly<U> = (state) => (state ?? {}) as Readonly<U>,
 ): Readonly<U> | undefined {

--- a/packages/framework/esm-react-utils/src/useDefineAppContext.ts
+++ b/packages/framework/esm-react-utils/src/useDefineAppContext.ts
@@ -34,9 +34,7 @@ import { shallowEqual } from '@openmrs/esm-utils';
  *   the namespace value.
  * @returns A function which can be used to update the state associated with the namespace
  */
-export function useDefineAppContext<
-  T extends Record<string | symbol | number, unknown> = Record<string | symbol | number, any>,
->(namespace: string, value?: T) {
+export function useDefineAppContext<T extends NonNullable<object> = NonNullable<object>>(namespace: string, value?: T) {
   const previousValue = useRef<T>(value ?? ({} as T));
   const updateFunction = useRef((update: (state: T) => T) => updateContext<T>(namespace, update));
 

--- a/packages/framework/esm-state/src/state.ts
+++ b/packages/framework/esm-state/src/state.ts
@@ -14,7 +14,7 @@ const availableStores: Record<string, StoreEntity> = {};
 // spaEnv isn't available immediately. Wait a bit before making stores available
 // on window in development mode.
 setTimeout(() => {
-  if (window.spaEnv === 'development') {
+  if (window && window.spaEnv === 'development') {
     window['stores'] = availableStores;
   }
 }, 1000);


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

This hopefully addresses the overly strict types accidentally added for the AppContext feature.

It also removes the files paths from the TypeDoc output and addresses an issue in esm-state that was triggered occasionally during tests, when `window` was not defined.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
