### PR TITLE
(chore) Switch to maintained fork of markdown-link-check action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: tcort/github-action-markdown-link-check@v1
         with:
           max-depth: 4 # exclude the API docs
           use-quiet-mode: "yes"

--- a/markdown_link_check_config.json
+++ b/markdown_link_check_config.json
@@ -11,5 +11,8 @@
     {
       "pattern": "^https://dev3.openmrs.org"
     }
-  ]
+  ],
+  "retryOn429": true,
+  "retryCount": 3,
+  "retryDelay": 1000
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR ports us over to the [maintained fork](https://github.com/tcort/github-action-markdown-link-check) of the [markdown-link-check GitHub action](https://github.com/gaurav-nelson/github-action-markdown-link-check) as recommended by the original author. It also adds retry configuration to make it more resilient to rate limiting for GitHub links. This will hopefully ensure we see less false positives like [this one](https://github.com/openmrs/openmrs-esm-core/actions/runs/15922516300/job/44912337135?pr=1404).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
