### PR TITLE
(fix) O3-4844: Update visit store only when useVisit is called for current patient

### DIFF
--- a/packages/framework/esm-framework/docs/functions/useVisitContextStore.md
+++ b/packages/framework/esm-framework/docs/functions/useVisitContextStore.md
@@ -2,9 +2,9 @@
 
 # Function: useVisitContextStore()
 
-> **useVisitContextStore**(`mutateVisitCallback?`): `VisitStoreState` & `BindFunctionsIn`\<\{ `mutateVisit`: \{ \}; `setVisitContext`: \{ `manuallySetVisitUuid`: `null` \| `string`; `patientUuid`: `null` \| `string`; \}; \}\>
+> **useVisitContextStore**(`mutateVisitCallback?`): `VisitStoreState` & `BindFunctionsIn`\<\{ `mutateVisit`: \{ \}; `setVisitContext`: \{ `manuallySetVisitUuid`: `null`; `patientUuid?`: `undefined`; \} \| \{ `manuallySetVisitUuid`: `string`; `patientUuid`: `undefined` \| `string`; \}; \}\>
 
-Defined in: [packages/framework/esm-react-utils/src/useVisitContextStore.ts:28](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisitContextStore.ts#L28)
+Defined in: [packages/framework/esm-react-utils/src/useVisitContextStore.ts:30](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisitContextStore.ts#L30)
 
 A hook to return the visit context store and corresponding actions.
 
@@ -20,4 +20,4 @@ callbacks also registered into the store)
 
 ## Returns
 
-`VisitStoreState` & `BindFunctionsIn`\<\{ `mutateVisit`: \{ \}; `setVisitContext`: \{ `manuallySetVisitUuid`: `null` \| `string`; `patientUuid`: `null` \| `string`; \}; \}\>
+`VisitStoreState` & `BindFunctionsIn`\<\{ `mutateVisit`: \{ \}; `setVisitContext`: \{ `manuallySetVisitUuid`: `null`; `patientUuid?`: `undefined`; \} \| \{ `manuallySetVisitUuid`: `string`; `patientUuid`: `undefined` \| `string`; \}; \}\>

--- a/packages/framework/esm-react-utils/src/useVisit.ts
+++ b/packages/framework/esm-react-utils/src/useVisit.ts
@@ -76,8 +76,8 @@ export function useVisit(patientUuid: string, representation = defaultVisitCusto
   const previousCurrentVisit = useRef<Visit | null>(null);
 
   useEffect(() => {
-    // if an active visit is created and either there is no visit in context or we've switched to a different patient, set the context to the active visit
-    if (!activeIsValidating && activeVisit && (visitStorePatientUuid != patientUuid || manuallySetVisitUuid == null)) {
+    // if an active visit is created for the visit store patient and they have no visit in context, set the context to the active visit
+    if (!activeIsValidating && activeVisit && visitStorePatientUuid === patientUuid && manuallySetVisitUuid === null) {
       setVisitContext(activeVisit);
     }
     if (!retroIsValidating) {

--- a/packages/framework/esm-react-utils/src/useVisitContextStore.ts
+++ b/packages/framework/esm-react-utils/src/useVisitContextStore.ts
@@ -1,13 +1,15 @@
 import { useEffect, useId } from 'react';
 import { getVisitStore, type Visit, type VisitStoreState } from '@openmrs/esm-emr-api';
-import { useStoreWithActions } from './useStore';
+import { type Actions, useStoreWithActions } from './useStore';
 
-// TODO: add better typing with `satisfies` keyword when we upgrade typescript
 const visitContextStoreActions = {
   setVisitContext(_: VisitStoreState, newSelectedVisit: Visit | null) {
+    if (newSelectedVisit == null) {
+      return { manuallySetVisitUuid: null };
+    }
     return {
-      manuallySetVisitUuid: newSelectedVisit?.uuid ?? null,
-      patientUuid: newSelectedVisit?.patient?.uuid ?? null,
+      manuallySetVisitUuid: newSelectedVisit.uuid,
+      patientUuid: newSelectedVisit.patient?.uuid,
     };
   },
   mutateVisit(currState: VisitStoreState) {
@@ -16,7 +18,7 @@ const visitContextStoreActions = {
     }
     return {};
   },
-};
+} satisfies Actions<VisitStoreState>;
 
 /**
  * A hook to return the visit context store and corresponding actions.


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
My previous fix was incorrect. The store should only be updated when `useVisit()` is called on the patient currently in the store.

Fix also requires corresponding PR in patient chart. See: https://github.com/openmrs/openmrs-esm-patient-chart/pull/2541.

## Screenshots
<!-- Required if you are making UI changes. -->
Videos of before / after change, with log statements printed every time we update the visit store

Before change:
- Note that the visit store is updated multiple times when we open the search results
- Note that at the :10 mark, the visit store does not even have the right patient

https://github.com/user-attachments/assets/3a7807b5-2de5-45f7-9758-cb2626643f05

After change:
- visit store updated (albeit multiple times) when:
  - we switch patient
  - we start a visit
  - we end a visit
- visit store NOT updated when we open search results

https://github.com/user-attachments/assets/b2759bbd-1571-4393-beda-9c8515c61752

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4844

## Other
<!-- Anything not covered above -->
