### PR TITLE
(fix): infer currentVisitIsRetrospective from the absence of cu

### DIFF
--- a/packages/framework/esm-react-utils/src/useVisit.ts
+++ b/packages/framework/esm-react-utils/src/useVisit.ts
@@ -109,7 +109,7 @@ export function useVisit(patientUuid: string, representation = defaultVisitCusto
     isValidating: activeIsValidating || retroIsValidating,
     activeVisit,
     currentVisit,
-    currentVisitIsRetrospective: Boolean(retrospectiveVisitUuid),
+    currentVisitIsRetrospective: Boolean(currentVisit?.stopDatetime),
     isLoading: Boolean((!activeData || (retrospectiveVisitUuid && !retroData)) && (!activeError || !retroError)),
   };
 }


### PR DESCRIPTION
…rrentvisit.stopDateTime

# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
This PR is an attempt to fix a bug with the `currentVisitIsRetrospective` variable. Previously, the variable would have a value of true regardless of whether the current visit was an active visit. In this PR, I check for the presence of a `stopDateTime` value on the `currentVisit` object and infer whether the visit is retrospective.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
