### PR TITLE
(fix) Ensure that i18next namespace matches state rather than props

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/dashboard/dashboard.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/dashboard/dashboard.component.tsx
@@ -49,7 +49,7 @@ interface DashboardProps {
 
 export default function Dashboard({ basePath, moduleName }: DashboardProps) {
   const componentContext = useContext(ComponentContext);
-  const module = moduleName ?? componentContext.moduleName;
+  const module = moduleName ?? componentContext.extension?.extensionSlotModuleName ?? componentContext.moduleName;
 
   const Component = useMemo(
     () =>

--- a/packages/framework/esm-framework/docs/functions/defineConfigSchema.md
+++ b/packages/framework/esm-framework/docs/functions/defineConfigSchema.md
@@ -4,7 +4,7 @@
 
 > **defineConfigSchema**(`moduleName`, `schema`): `void`
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:168](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L168)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:165](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L165)
 
 This defines a configuration schema for a module. The schema tells the
 configuration system how the module can be configured. It specifies

--- a/packages/framework/esm-framework/docs/functions/defineExtensionConfigSchema.md
+++ b/packages/framework/esm-framework/docs/functions/defineExtensionConfigSchema.md
@@ -4,7 +4,7 @@
 
 > **defineExtensionConfigSchema**(`extensionName`, `schema`): `void`
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:244](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L244)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:241](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L241)
 
 This defines a configuration schema for an extension. When a schema is defined
 for an extension, that extension will receive the configuration corresponding

--- a/packages/framework/esm-framework/docs/functions/getConfig.md
+++ b/packages/framework/esm-framework/docs/functions/getConfig.md
@@ -4,7 +4,7 @@
 
 > **getConfig**\<`T`\>(`moduleName`): `Promise`\<`T`\>
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:277](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L277)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:274](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L274)
 
 A promise-based way to access the config as soon as it is fully loaded.
 If it is already loaded, resolves the config in its present state.

--- a/packages/framework/esm-framework/docs/functions/provide.md
+++ b/packages/framework/esm-framework/docs/functions/provide.md
@@ -4,7 +4,7 @@
 
 > **provide**(`config`, `sourceName`): `void`
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:261](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L261)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:258](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L258)
 
 ## Parameters
 

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
@@ -114,9 +114,9 @@ export function openmrsComponentDecorator<T>(userOpts: ComponentDecoratorOptions
                     <I18nextProvider
                       i18n={window.i18next}
                       defaultNS={
-                        this.props._extensionContext
-                          ? `${opts.moduleName}___${this.props._extensionContext.extensionSlotName}___${this.props._extensionContext.extensionId}`
-                          : opts.moduleName
+                        this.state.config.extension
+                          ? `${this.state.config.moduleName}___${this.state.config.extension.extensionSlotName}___${this.state.config.extension.extensionId}`
+                          : this.state.config.moduleName
                       }
                     >
                       <Comp {...this.props} />


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

For some reason, in the `nav-group` extension, the `I18nextProvider` wasn't "seeing" the correct extension context, but the wrapping `ComponentContext` was. This switches the `I18nextProvider` to extract the extension context from the component state like the `ComponentContext` does.

I also made a small update to the `dashboard` component so that if falls back more gracefully to the correct module name.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

I think this is the last bit in the nav-groups / dashboard thing.
