### PR TITLE
(feat) O3-4864 Support including CSS and JS assets in generated HTML …

### DIFF
--- a/packages/shell/esm-app-shell/webpack.config.js
+++ b/packages/shell/esm-app-shell/webpack.config.js
@@ -4,6 +4,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const WebpackPwaManifest = require('webpack-pwa-manifest');
+const HtmlWebpackTagsPlugin = require('html-webpack-tags-plugin');
 const { InjectManifest } = require('workbox-webpack-plugin');
 const { DefinePlugin, container } = require('webpack');
 const { basename, dirname, resolve } = require('path');
@@ -39,6 +40,10 @@ const openmrsConfigUrls = (process.env.OMRS_CONFIG_URLS || '')
   .filter((url) => url.length > 0)
   .map((url) => JSON.stringify(url))
   .join(', ');
+const openmrsHtmlCssAssets = (process.env.OMRS_HTML_CSS_ASSETS || '')
+  .split(';')
+  .filter((filePath) => filePath.length > 0);
+
 const openmrsCleanBeforeBuild =
   (() => {
     try {
@@ -135,6 +140,10 @@ module.exports = (env, argv = []) => {
       }
     });
   }
+
+  openmrsHtmlCssAssets.forEach(asset => {
+    appPatterns.push({from: asset, to: dirname(asset) });
+  })
 
   return {
     entry: resolve(__dirname, 'src/index.ts'),
@@ -331,6 +340,7 @@ module.exports = (env, argv = []) => {
           openmrsCoreRoutes: Object.keys(coreRoutes).length > 0 && JSON.stringify(coreRoutes),
         },
       }),
+      new HtmlWebpackTagsPlugin({ tags: openmrsHtmlCssAssets }),
       new WebpackPwaManifest({
         name: 'OpenMRS',
         short_name: 'OpenMRS',

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -47,6 +47,7 @@
     "ejs": "^3.1.8",
     "glob": "^7.1.3",
     "html-webpack-plugin": "^5.5.0",
+    "html-webpack-tags-plugin": "^3.0.2",
     "inquirer": "^7.3.3",
     "lodash": "^4.17.21",
     "lodash-es": "^4.17.21",

--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -300,12 +300,19 @@ yargs.command(
         default: 'production',
         describe: 'The environment to build for. e.g., development, production.',
         type: 'string',
+      })
+      .option('asset', {
+        default: [],
+        describe:
+          'The path to CSS or HTML assets to copy into the build directory and include in <link> and <script> tags in generated HTML. Can be used multiple times.',
+        type: 'array',
       }),
   async (args) =>
     runCommand('runBuild', {
       ...args,
       configUrls: args['config-url'],
       configPaths: args['config-path'],
+      assets: args['asset'],
     }),
 );
 

--- a/packages/tooling/openmrs/src/commands/build.ts
+++ b/packages/tooling/openmrs/src/commands/build.ts
@@ -22,6 +22,7 @@ export interface BuildArgs {
   configPaths: Array<string>;
   buildConfig?: string;
   env: string;
+  assets: Array<string>;
 }
 
 export type BuildConfig = Partial<{
@@ -35,6 +36,7 @@ export type BuildConfig = Partial<{
   routes: string;
   spaPath: string;
   env: string;
+  assets: Array<string>;
 }>;
 
 function loadBuildConfig(buildConfigPath?: string): BuildConfig {
@@ -119,6 +121,7 @@ export async function runBuild(args: BuildArgs) {
     supportOffline: buildConfig.supportOffline ?? args.supportOffline,
     spaPath: buildConfig.spaPath || args.spaPath,
     fresh: args.fresh ?? false,
+    assets: args.assets || buildConfig.assets || [],
   });
 
   logInfo(`Running build process ...`);

--- a/packages/tooling/openmrs/src/utils/config.ts
+++ b/packages/tooling/openmrs/src/utils/config.ts
@@ -16,6 +16,7 @@ export interface WebpackOptions {
   coreAppsDir?: string;
   addCookie?: string;
   fresh?: boolean;
+  assets?: Array<string>;
 }
 
 export function loadWebpackConfig(options: WebpackOptions = {}) {
@@ -86,6 +87,10 @@ export function loadWebpackConfig(options: WebpackOptions = {}) {
 
   if (typeof options.fresh === 'boolean') {
     variables.OMRS_CLEAN_BEFORE_BUILD = options.fresh;
+  }
+
+  if (Array.isArray(options.assets)) {
+    variables.OMRS_HTML_CSS_ASSETS = options.assets.join(';');
   }
 
   setEnvVariables(variables);

--- a/yarn.lock
+++ b/yarn.lock
@@ -13074,7 +13074,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^7.0.3, glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6":
+"glob@npm:^7.0.3, glob@npm:^7.1.1, glob@npm:^7.1.3, glob@npm:^7.1.4, glob@npm:^7.1.6, glob@npm:^7.2.0":
   version: 7.2.3
   resolution: "glob@npm:7.2.3"
   dependencies:
@@ -13449,6 +13449,20 @@ __metadata:
   peerDependencies:
     webpack: ^5.20.0
   checksum: 10/01d302a434e3db9f0e2db370f06300fb613de0fb8bdcafd4693e44c2528b8608621e5e7ca5d8302446db3f20c5f8875f1f675926d469b13ebab139954d241055
+  languageName: node
+  linkType: hard
+
+"html-webpack-tags-plugin@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "html-webpack-tags-plugin@npm:3.0.2"
+  dependencies:
+    glob: "npm:^7.2.0"
+    minimatch: "npm:^3.0.4"
+    slash: "npm:^3.0.0"
+  peerDependencies:
+    html-webpack-plugin: ^5.0.0
+    webpack: ^5.0.0
+  checksum: 10/3754945dc9e19420600b1864d48bb74dc44e4d4658350232ea701aeb827d95d6cccc8fcd8f2144378b03107611240db24067f52e5d82e509439cfa15fdf33e2d
   languageName: node
   linkType: hard
 
@@ -16846,6 +16860,7 @@ __metadata:
     ejs: "npm:^3.1.8"
     glob: "npm:^7.1.3"
     html-webpack-plugin: "npm:^5.5.0"
+    html-webpack-tags-plugin: "npm:^3.0.2"
     inquirer: "npm:^7.3.3"
     lodash: "npm:^4.17.21"
     lodash-es: "npm:^4.17.21"


### PR DESCRIPTION
…file

# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR provides a way for the `openmrs build` command to copy static CSS or JS assets in the build output and include those files as `<link>` and `<script>` tags in the generated `index.html` file.

Testing done:

- go to openmrs-esm-core/packages/tooling/openmrs, create 2 files: `assets/a.css` and `assets/b.js`, fill them with dummy content.
- run command: `npx openmrs build --asset assets/a.css --asset assets/b.js`
- verify that the output `dist/` directory contains the `assets/a.css` and `assets/b.js` files,
- verify that the `dist/index.html` file includes those assets as `<link>` and `<script>` tags.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4864

## Other
<!-- Anything not covered above -->
