### PR TITLE
(chore): Add polyfill for Intl.DurationFormat

### DIFF
--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -269,6 +269,7 @@
 - [formatTime](functions/formatTime.md)
 - [formatDatetime](functions/formatDatetime.md)
 - [convertToLocaleCalendar](functions/convertToLocaleCalendar.md)
+- [formatDuration](functions/formatDuration.md)
 
 ## Dynamic Loading
 

--- a/packages/framework/esm-framework/docs/functions/convertToLocaleCalendar.md
+++ b/packages/framework/esm-framework/docs/functions/convertToLocaleCalendar.md
@@ -4,7 +4,7 @@
 
 > **convertToLocaleCalendar**(`date`, `locale`): `CalendarDate` \| `CalendarDateTime` \| `ZonedDateTime`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:144
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:146
 
 Converts a calendar date to the equivalent locale calendar date.
 

--- a/packages/framework/esm-framework/docs/functions/formatDate.md
+++ b/packages/framework/esm-framework/docs/functions/formatDate.md
@@ -4,7 +4,7 @@
 
 > **formatDate**(`date`, `options?`): `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:124
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:126
 
 Formats the input date according to the current locale and the
 given options.

--- a/packages/framework/esm-framework/docs/functions/formatDatetime.md
+++ b/packages/framework/esm-framework/docs/functions/formatDatetime.md
@@ -4,7 +4,7 @@
 
 > **formatDatetime**(`date`, `options?`): `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:139
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:141
 
 Formats the input into a string showing the date and time, according
 to the current locale. The `mode` parameter is as described for

--- a/packages/framework/esm-framework/docs/functions/formatDuration.md
+++ b/packages/framework/esm-framework/docs/functions/formatDuration.md
@@ -1,0 +1,29 @@
+[O3 Framework](../API.md) / formatDuration
+
+# Function: formatDuration()
+
+> **formatDuration**(`duration`, `options?`): `any`
+
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:154
+
+Formats the input duration according to the current locale.
+
+## Parameters
+
+### duration
+
+`DurationInput`
+
+The duration to format (DurationInput object).
+
+### options?
+
+`Partial`\<`ResolvedDurationFormatOptions`\>
+
+Optional options for formatting.
+
+## Returns
+
+`any`
+
+The formatted duration string.

--- a/packages/framework/esm-framework/docs/functions/formatPartialDate.md
+++ b/packages/framework/esm-framework/docs/functions/formatPartialDate.md
@@ -4,7 +4,7 @@
 
 > **formatPartialDate**(`dateString`, `options?`): `null` \| `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:104
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:106
 
 Formats the string representing a date, including partial representations of dates, according to the current
 locale and the given options.

--- a/packages/framework/esm-framework/docs/functions/formatTime.md
+++ b/packages/framework/esm-framework/docs/functions/formatTime.md
@@ -4,7 +4,7 @@
 
 > **formatTime**(`date`): `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:129
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:131
 
 Formats the input as a time, according to the current locale.
 12-hour or 24-hour clock depends on locale.

--- a/packages/framework/esm-framework/docs/functions/getDefaultCalendar.md
+++ b/packages/framework/esm-framework/docs/functions/getDefaultCalendar.md
@@ -4,7 +4,7 @@
 
 > **getDefaultCalendar**(`locale`): `undefined` \| `CalendarIdentifier`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:48
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:50
 
 Retrieves the default calendar for the specified locale if any.
 

--- a/packages/framework/esm-framework/docs/functions/isOmrsDateStrict.md
+++ b/packages/framework/esm-framework/docs/functions/isOmrsDateStrict.md
@@ -4,7 +4,7 @@
 
 > **isOmrsDateStrict**(`omrsPayloadString`): `boolean`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:11
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:13
 
 This function checks whether a date string is the OpenMRS ISO format.
 The format should be YYYY-MM-DDTHH:mm:ss.SSSZZ

--- a/packages/framework/esm-framework/docs/functions/isOmrsDateToday.md
+++ b/packages/framework/esm-framework/docs/functions/isOmrsDateToday.md
@@ -4,7 +4,7 @@
 
 > **isOmrsDateToday**(`date`): `boolean`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:16
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:18
 
 ## Parameters
 

--- a/packages/framework/esm-framework/docs/functions/parseDate.md
+++ b/packages/framework/esm-framework/docs/functions/parseDate.md
@@ -4,7 +4,7 @@
 
 > **parseDate**(`dateString`): `Date`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:30
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:32
 
 Utility function to parse an arbitrary string into a date.
 Uses `dayjs(dateString)`.

--- a/packages/framework/esm-framework/docs/functions/registerDefaultCalendar.md
+++ b/packages/framework/esm-framework/docs/functions/registerDefaultCalendar.md
@@ -4,7 +4,7 @@
 
 > **registerDefaultCalendar**(`locale`, `calendar`): `void`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:42
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:44
 
 Provides the name of the calendar to associate, as a default, with the given base locale.
 

--- a/packages/framework/esm-framework/docs/functions/toDateObjectStrict.md
+++ b/packages/framework/esm-framework/docs/functions/toDateObjectStrict.md
@@ -4,7 +4,7 @@
 
 > **toDateObjectStrict**(`omrsDateString`): `null` \| `Date`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:21
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:23
 
 Converts the object to a date object if it is an OpenMRS ISO date time string.
 Otherwise returns null.

--- a/packages/framework/esm-framework/docs/functions/toOmrsIsoString.md
+++ b/packages/framework/esm-framework/docs/functions/toOmrsIsoString.md
@@ -4,7 +4,7 @@
 
 > **toOmrsIsoString**(`date`, `toUTC?`): `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:25
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:27
 
 Formats the input to OpenMRS ISO format: "YYYY-MM-DDTHH:mm:ss.SSSZZ".
 

--- a/packages/framework/esm-framework/docs/type-aliases/DateInput.md
+++ b/packages/framework/esm-framework/docs/type-aliases/DateInput.md
@@ -4,4 +4,4 @@
 
 > **DateInput** = `string` \| `number` \| `Date`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:6
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:8

--- a/packages/framework/esm-framework/docs/type-aliases/FormatDateMode.md
+++ b/packages/framework/esm-framework/docs/type-aliases/FormatDateMode.md
@@ -4,4 +4,4 @@
 
 > **FormatDateMode** = `"standard"` \| `"wide"`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:49
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:51

--- a/packages/framework/esm-framework/docs/type-aliases/FormatDateOptions.md
+++ b/packages/framework/esm-framework/docs/type-aliases/FormatDateOptions.md
@@ -4,7 +4,7 @@
 
 > **FormatDateOptions** = `object`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:50
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:52
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:50
 
 > `optional` **calendar**: `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:54
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:56
 
 The calendar to use when formatting this date.
 
@@ -22,7 +22,7 @@ The calendar to use when formatting this date.
 
 > **day**: `boolean`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:70
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:72
 
 Whether to include the day number
 
@@ -32,7 +32,7 @@ Whether to include the day number
 
 > `optional` **locale**: `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:58
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:60
 
 The locale to use when formatting this date
 
@@ -42,7 +42,7 @@ The locale to use when formatting this date
 
 > **mode**: [`FormatDateMode`](FormatDateMode.md)
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:63
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:65
 
 - `standard`: "03 Feb 2022"
 - `wide`:     "03 — Feb — 2022"
@@ -53,7 +53,7 @@ Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:63
 
 > **month**: `boolean`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:72
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:74
 
 Whether to include the month number
 
@@ -63,7 +63,7 @@ Whether to include the month number
 
 > **noToday**: `boolean`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:83
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:85
 
 Disables the special handling of dates that are today. If false
 (the default), then dates that are today will be formatted as "Today"
@@ -76,7 +76,7 @@ formatted the same as all other dates.
 
 > `optional` **numberingSystem**: `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:76
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:78
 
 The unicode numbering system to use
 
@@ -86,7 +86,7 @@ The unicode numbering system to use
 
 > **time**: `true` \| `false` \| `"for today"`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:68
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:70
 
 Whether the time should be included in the output always (`true`),
 never (`false`), or only when the input date is today (`for today`).
@@ -97,6 +97,6 @@ never (`false`), or only when the input date is today (`for today`).
 
 > **year**: `boolean`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:74
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:76
 
 Whether to include the year

--- a/packages/framework/esm-utils/src/dates/date-util.test.ts
+++ b/packages/framework/esm-utils/src/dates/date-util.test.ts
@@ -11,6 +11,7 @@ import {
   formatTime,
   registerDefaultCalendar,
   formatPartialDate,
+  formatDuration,
 } from './date-util';
 
 window.i18next = { language: 'en' } as i18n;
@@ -195,5 +196,17 @@ describe('Openmrs Dates', () => {
         })
         .replace(/ /g, '-') + ', 03:22 PM';
     expect(formatDate(testDate, { noToday: true }).replaceAll(/[\u202F]/g, ' ')).toEqual(expected);
+  });
+
+  it('formats duration with respect to the locale', () => {
+    window.i18next.language = 'en';
+    const duration = { hours: 1, minutes: 1, seconds: 1, days: 1, months: 1, years: 1 };
+    expect(formatDuration(duration, { style: 'narrow' })).toMatch(/1y.*1m.*1d.*1h.*1m.*1s/);
+    expect(formatDuration(duration, { style: 'short' })).toMatch(
+      /1\s+yr,.*1\s+mth,.*1\s+day,.*1\s+hr,.*1\s+min,.*1\s+sec/,
+    );
+    expect(formatDuration(duration, { style: 'long' })).toMatch(
+      /1\s+year,.*1\s+month,.*1\s+day,.*1\s+hour,.*1\s+minute,.*1\s+second/,
+    );
   });
 });

--- a/packages/framework/esm-utils/src/dates/date-util.ts
+++ b/packages/framework/esm-utils/src/dates/date-util.ts
@@ -10,13 +10,13 @@ import {
   createCalendar,
   toCalendar,
 } from '@internationalized/date';
+import { DurationFormat } from '@formatjs/intl-durationformat';
 import { attempt } from 'any-date-parser';
 import dayjs from 'dayjs';
 import isToday from 'dayjs/plugin/isToday.js';
 import objectSupport from 'dayjs/plugin/objectSupport.js';
 import utc from 'dayjs/plugin/utc.js';
 import { isNil, omit } from 'lodash-es';
-import '@formatjs/intl-durationformat/polyfill';
 import { getLocale } from '../';
 import type { DurationFormatOptions, DurationInput } from '@formatjs/intl-durationformat/src/types';
 
@@ -424,6 +424,6 @@ export function convertToLocaleCalendar(
  * @returns The formatted duration string.
  */
 export function formatDuration(duration: DurationInput, options?: DurationFormatOptions) {
-  const formatter = new (Intl as any).DurationFormat(getLocale(), options);
+  const formatter = new DurationFormat(getLocale(), options);
   return formatter.format(duration);
 }

--- a/packages/framework/esm-utils/src/dates/date-util.ts
+++ b/packages/framework/esm-utils/src/dates/date-util.ts
@@ -16,7 +16,9 @@ import isToday from 'dayjs/plugin/isToday.js';
 import objectSupport from 'dayjs/plugin/objectSupport.js';
 import utc from 'dayjs/plugin/utc.js';
 import { isNil, omit } from 'lodash-es';
+import '@formatjs/intl-durationformat/polyfill';
 import { getLocale } from '../';
+import type { DurationFormatOptions, DurationInput } from '@formatjs/intl-durationformat/src/types';
 
 dayjs.extend(isToday);
 dayjs.extend(utc);
@@ -412,4 +414,16 @@ export function convertToLocaleCalendar(
   const localCalendarName = getDefaultCalendar(locale_);
 
   return localCalendarName ? toCalendar(date, createCalendar(localCalendarName)) : date;
+}
+
+/**
+ * Formats the input duration according to the current locale.
+ *
+ * @param duration The duration to format (DurationInput object).
+ * @param options Optional options for formatting.
+ * @returns The formatted duration string.
+ */
+export function formatDuration(duration: DurationInput, options?: DurationFormatOptions) {
+  const formatter = new (Intl as any).DurationFormat(getLocale(), options);
+  return formatter.format(duration);
 }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
This PR adds a wrapper for Intl.DurationFormat by using the [polyfill from formatjs](https://formatjs.github.io/docs/polyfills/intl-durationformat/).

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
