### PR TITLE
(feat) Implement an OpenMRS DateRangePicker

### DIFF
--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDateRangePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDateRangePickerProps.md
@@ -1,0 +1,783 @@
+[O3 Framework](../API.md) / OpenmrsDateRangePickerProps
+
+# Interface: OpenmrsDateRangePickerProps
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:36](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L36)
+
+## Extends
+
+- `Omit`\<`DateRangePickerProps`\<`CalendarDate`\>, `"className"` \| `"onChange"` \| `"defaultValue"` \| `"value"`\>
+
+## Properties
+
+### allowsNonContiguousRanges?
+
+> `optional` **allowsNonContiguousRanges**: `boolean`
+
+Defined in: node\_modules/@react-types/datepicker/src/index.d.ts:91
+
+When combined with `isDateUnavailable`, determines whether non-contiguous ranges,
+i.e. ranges containing unavailable dates, may be selected.
+
+#### Inherited from
+
+`Omit.allowsNonContiguousRanges`
+
+***
+
+### aria-describedby?
+
+> `optional` **aria-describedby**: `string`
+
+Defined in: node\_modules/@react-types/shared/src/dom.d.ts:40
+
+Identifies the element (or elements) that describes the object.
+
+#### Inherited from
+
+`Omit.aria-describedby`
+
+***
+
+### aria-details?
+
+> `optional` **aria-details**: `string`
+
+Defined in: node\_modules/@react-types/shared/src/dom.d.ts:45
+
+Identifies the element (or elements) that provide a detailed, extended description for the object.
+
+#### Inherited from
+
+`Omit.aria-details`
+
+***
+
+### aria-label?
+
+> `optional` **aria-label**: `string`
+
+Defined in: node\_modules/@react-types/shared/src/dom.d.ts:30
+
+Defines a string value that labels the current element.
+
+#### Inherited from
+
+`Omit.aria-label`
+
+***
+
+### aria-labelledby?
+
+> `optional` **aria-labelledby**: `string`
+
+Defined in: node\_modules/@react-types/shared/src/dom.d.ts:35
+
+Identifies the element (or elements) that labels the current element.
+
+#### Inherited from
+
+`Omit.aria-labelledby`
+
+***
+
+### autoFocus?
+
+> `optional` **autoFocus**: `boolean`
+
+Defined in: node\_modules/@react-types/shared/src/events.d.ts:128
+
+Whether the element should receive focus on render.
+
+#### Inherited from
+
+`Omit.autoFocus`
+
+***
+
+### children?
+
+> `optional` **children**: `ReactNode` \| (`values`) => `ReactNode`
+
+Defined in: node\_modules/react-aria-components/dist/types.d.ts:53
+
+The children of the component. A function may be provided to alter the children based on component state.
+
+#### Inherited from
+
+`Omit.children`
+
+***
+
+### className?
+
+> `optional` **className**: `Argument`
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L39)
+
+Any CSS classes to add to the outer div of the date picker
+
+***
+
+### defaultOpen?
+
+> `optional` **defaultOpen**: `boolean`
+
+Defined in: node\_modules/@react-types/overlays/src/index.d.ts:112
+
+Whether the overlay is open by default (uncontrolled).
+
+#### Inherited from
+
+`Omit.defaultOpen`
+
+***
+
+### defaultValue?
+
+> `optional` **defaultValue**: \[`DateInputValue`, `DateInputValue`\]
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:41](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L41)
+
+The default value (uncontrolled)
+
+***
+
+### endName?
+
+> `optional` **endName**: `string`
+
+Defined in: node\_modules/@react-types/datepicker/src/index.d.ts:99
+
+The name of the end date input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
+
+#### Inherited from
+
+`Omit.endName`
+
+***
+
+### firstDayOfWeek?
+
+> `optional` **firstDayOfWeek**: `"sun"` \| `"mon"` \| `"tue"` \| `"wed"` \| `"thu"` \| `"fri"` \| `"sat"`
+
+Defined in: node\_modules/@react-types/datepicker/src/index.d.ts:78
+
+The day that starts the week.
+
+#### Inherited from
+
+`Omit.firstDayOfWeek`
+
+***
+
+### granularity?
+
+> `optional` **granularity**: `Granularity`
+
+Defined in: node\_modules/@react-types/datepicker/src/index.d.ts:52
+
+Determines the smallest unit that is displayed in the date picker. By default, this is `"day"` for dates, and `"minute"` for times.
+
+#### Inherited from
+
+`Omit.granularity`
+
+***
+
+### hideTimeZone?
+
+> `optional` **hideTimeZone**: `boolean`
+
+Defined in: node\_modules/@react-types/datepicker/src/index.d.ts:57
+
+Whether to hide the time zone abbreviation.
+
+#### Default
+
+```ts
+false
+```
+
+#### Inherited from
+
+`Omit.hideTimeZone`
+
+***
+
+### hourCycle?
+
+> `optional` **hourCycle**: `12` \| `24`
+
+Defined in: node\_modules/@react-types/datepicker/src/index.d.ts:50
+
+Whether to display the time in 12 or 24 hour format. By default, this is determined by the user's locale.
+
+#### Inherited from
+
+`Omit.hourCycle`
+
+***
+
+### id?
+
+> `optional` **id**: `string`
+
+Defined in: node\_modules/@react-types/shared/src/dom.d.ts:62
+
+The element's unique identifier. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id).
+
+#### Inherited from
+
+`Omit.id`
+
+***
+
+### invalid?
+
+> `optional` **invalid**: `boolean`
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:43](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L43)
+
+Whether the input value is invalid.
+
+***
+
+### invalidText?
+
+> `optional` **invalidText**: `string`
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L45)
+
+Text to show if the input is invalid e.g. an error message
+
+***
+
+### isDateUnavailable()?
+
+> `optional` **isDateUnavailable**: (`date`) => `boolean`
+
+Defined in: node\_modules/@react-types/datepicker/src/index.d.ts:46
+
+Callback that is called for each date of the calendar. If it returns true, then the date is unavailable.
+
+#### Parameters
+
+##### date
+
+`DateValue`
+
+#### Returns
+
+`boolean`
+
+#### Inherited from
+
+`Omit.isDateUnavailable`
+
+***
+
+### isDisabled?
+
+> `optional` **isDisabled**: `boolean`
+
+Defined in: node\_modules/@react-types/shared/src/inputs.d.ts:60
+
+Whether the input is disabled.
+
+#### Inherited from
+
+`Omit.isDisabled`
+
+***
+
+### isInvalid?
+
+> `optional` **isInvalid**: `boolean`
+
+Defined in: node\_modules/@react-types/shared/src/inputs.d.ts:25
+
+Whether the input value is invalid.
+
+#### Inherited from
+
+`Omit.isInvalid`
+
+***
+
+### isOpen?
+
+> `optional` **isOpen**: `boolean`
+
+Defined in: node\_modules/@react-types/overlays/src/index.d.ts:110
+
+Whether the overlay is open by default (controlled).
+
+#### Inherited from
+
+`Omit.isOpen`
+
+***
+
+### isReadOnly?
+
+> `optional` **isReadOnly**: `boolean`
+
+Defined in: node\_modules/@react-types/shared/src/inputs.d.ts:62
+
+Whether the input can be selected but not changed by the user.
+
+#### Inherited from
+
+`Omit.isReadOnly`
+
+***
+
+### isRequired?
+
+> `optional` **isRequired**: `boolean`
+
+Defined in: node\_modules/@react-types/shared/src/inputs.d.ts:23
+
+Whether user input is required on the input before form submission.
+
+#### Inherited from
+
+`Omit.isRequired`
+
+***
+
+### ~~label?~~
+
+> `optional` **label**: `string` \| `ReactElement`\<`any`, `string` \| `JSXElementConstructor`\<`any`\>\>
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L50)
+
+The label for this DatePicker element
+
+#### Deprecated
+
+Use labelText instead
+
+***
+
+### labelText?
+
+> `optional` **labelText**: `string` \| `ReactElement`\<`any`, `string` \| `JSXElementConstructor`\<`any`\>\>
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:52](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L52)
+
+The label for this DatePicker element.
+
+***
+
+### light?
+
+> `optional` **light**: `boolean`
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:54](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L54)
+
+'true' to use the light version.
+
+***
+
+### maxDate?
+
+> `optional` **maxDate**: `DateInputValue`
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:56](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L56)
+
+The latest date it is possible to select
+
+***
+
+### maxValue?
+
+> `optional` **maxValue**: `null` \| `DateValue`
+
+Defined in: node\_modules/@react-types/datepicker/src/index.d.ts:44
+
+The maximum allowed date that a user may select.
+
+#### Inherited from
+
+`Omit.maxValue`
+
+***
+
+### minDate?
+
+> `optional` **minDate**: `DateInputValue`
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:58](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L58)
+
+The earliest date it is possible to select
+
+***
+
+### minValue?
+
+> `optional` **minValue**: `null` \| `DateValue`
+
+Defined in: node\_modules/@react-types/datepicker/src/index.d.ts:42
+
+The minimum allowed date that a user may select.
+
+#### Inherited from
+
+`Omit.minValue`
+
+***
+
+### onBlur()?
+
+> `optional` **onBlur**: (`e`) => `void`
+
+Defined in: node\_modules/@react-types/shared/src/events.d.ts:87
+
+Handler that is called when the element loses focus.
+
+#### Parameters
+
+##### e
+
+`FocusEvent`\<`Element`\>
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+`Omit.onBlur`
+
+***
+
+### onChange()?
+
+> `optional` **onChange**: (`value`) => `void`
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:60](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L60)
+
+Handler that is called when the value changes.
+
+#### Parameters
+
+##### value
+
+\[`undefined` \| `null` \| `Date`, `undefined` \| `null` \| `Date`\]
+
+#### Returns
+
+`void`
+
+***
+
+### onChangeRaw()?
+
+> `optional` **onChangeRaw**: (`value`) => `void`
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:62](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L62)
+
+Handler that is called when the value changes. Note that this provides types from @internationalized/date.
+
+#### Parameters
+
+##### value
+
+`null` | `DateRange`
+
+#### Returns
+
+`void`
+
+***
+
+### onFocus()?
+
+> `optional` **onFocus**: (`e`) => `void`
+
+Defined in: node\_modules/@react-types/shared/src/events.d.ts:85
+
+Handler that is called when the element receives focus.
+
+#### Parameters
+
+##### e
+
+`FocusEvent`\<`Element`\>
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+`Omit.onFocus`
+
+***
+
+### onFocusChange()?
+
+> `optional` **onFocusChange**: (`isFocused`) => `void`
+
+Defined in: node\_modules/@react-types/shared/src/events.d.ts:89
+
+Handler that is called when the element's focus status changes.
+
+#### Parameters
+
+##### isFocused
+
+`boolean`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+`Omit.onFocusChange`
+
+***
+
+### onKeyDown()?
+
+> `optional` **onKeyDown**: (`e`) => `void`
+
+Defined in: node\_modules/@react-types/shared/src/events.d.ts:78
+
+Handler that is called when a key is pressed.
+
+#### Parameters
+
+##### e
+
+`KeyboardEvent`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+`Omit.onKeyDown`
+
+***
+
+### onKeyUp()?
+
+> `optional` **onKeyUp**: (`e`) => `void`
+
+Defined in: node\_modules/@react-types/shared/src/events.d.ts:80
+
+Handler that is called when a key is released.
+
+#### Parameters
+
+##### e
+
+`KeyboardEvent`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+`Omit.onKeyUp`
+
+***
+
+### onOpenChange()?
+
+> `optional` **onOpenChange**: (`isOpen`) => `void`
+
+Defined in: node\_modules/@react-types/overlays/src/index.d.ts:114
+
+Handler that is called when the overlay's open state changes.
+
+#### Parameters
+
+##### isOpen
+
+`boolean`
+
+#### Returns
+
+`void`
+
+#### Inherited from
+
+`Omit.onOpenChange`
+
+***
+
+### pageBehavior?
+
+> `optional` **pageBehavior**: `PageBehavior`
+
+Defined in: node\_modules/@react-types/datepicker/src/index.d.ts:74
+
+Controls the behavior of paging. Pagination either works by advancing the visible page by visibleDuration (default) or one unit of visibleDuration.
+
+#### Default
+
+```ts
+visible
+```
+
+#### Inherited from
+
+`Omit.pageBehavior`
+
+***
+
+### placeholderValue?
+
+> `optional` **placeholderValue**: `null` \| `CalendarDate`
+
+Defined in: node\_modules/@react-types/datepicker/src/index.d.ts:48
+
+A placeholder date that influences the format of the placeholder shown when no value is selected. Defaults to today's date at midnight.
+
+#### Inherited from
+
+`Omit.placeholderValue`
+
+***
+
+### shouldCloseOnSelect?
+
+> `optional` **shouldCloseOnSelect**: `boolean` \| () => `boolean`
+
+Defined in: node\_modules/@react-stately/datepicker/dist/types.d.ts:171
+
+Determines whether the date picker popover should close automatically when a date is selected.
+
+#### Default
+
+```ts
+true
+```
+
+#### Inherited from
+
+`Omit.shouldCloseOnSelect`
+
+***
+
+### shouldForceLeadingZeros?
+
+> `optional` **shouldForceLeadingZeros**: `boolean`
+
+Defined in: node\_modules/@react-types/datepicker/src/index.d.ts:62
+
+Whether to always show leading zeros in the month, day, and hour fields.
+By default, this is determined by the user's locale.
+
+#### Inherited from
+
+`Omit.shouldForceLeadingZeros`
+
+***
+
+### slot?
+
+> `optional` **slot**: `null` \| `string`
+
+Defined in: node\_modules/react-aria-components/dist/types.d.ts:70
+
+A slot name for the component. Slots allow the component to receive props from a parent component.
+An explicit `null` value indicates that the local props completely override all props received from a parent.
+
+#### Inherited from
+
+`Omit.slot`
+
+***
+
+### startName?
+
+> `optional` **startName**: `string`
+
+Defined in: node\_modules/@react-types/datepicker/src/index.d.ts:95
+
+The name of the start date input element, used when submitting an HTML form. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname).
+
+#### Inherited from
+
+`Omit.startName`
+
+***
+
+### style?
+
+> `optional` **style**: `CSSProperties` \| (`values`) => `undefined` \| `CSSProperties`
+
+Defined in: node\_modules/react-aria-components/dist/types.d.ts:47
+
+The inline [style](https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/style) for the element. A function may be provided to compute the style based on component state.
+
+#### Inherited from
+
+`Omit.style`
+
+***
+
+### validate()?
+
+> `optional` **validate**: (`value`) => `undefined` \| `null` \| `true` \| `ValidationError`
+
+Defined in: node\_modules/@react-types/shared/src/inputs.d.ts:41
+
+A function that returns an error message if a given value is invalid.
+Validation errors are displayed to the user when the form is submitted
+if `validationBehavior="native"`. For realtime validation, use the `isInvalid`
+prop instead.
+
+#### Parameters
+
+##### value
+
+`RangeValue`
+
+#### Returns
+
+`undefined` \| `null` \| `true` \| `ValidationError`
+
+#### Inherited from
+
+`Omit.validate`
+
+***
+
+### validationBehavior?
+
+> `optional` **validationBehavior**: `"aria"` \| `"native"`
+
+Defined in: node\_modules/react-aria-components/dist/types.d.ts:81
+
+Whether to use native HTML form validation to prevent form submission
+when the value is missing or invalid, or mark the field as required
+or invalid via ARIA.
+
+#### Default
+
+```ts
+'native'
+```
+
+#### Inherited from
+
+`Omit.validationBehavior`
+
+***
+
+### value?
+
+> `optional` **value**: \[`DateInputValue`, `DateInputValue`\]
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:64](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L64)
+
+The value (controlled)

--- a/packages/framework/esm-framework/docs/variables/OpenmrsDateRangePicker.md
+++ b/packages/framework/esm-framework/docs/variables/OpenmrsDateRangePicker.md
@@ -1,0 +1,9 @@
+[O3 Framework](../API.md) / OpenmrsDateRangePicker
+
+# Variable: OpenmrsDateRangePicker
+
+> `const` **OpenmrsDateRangePicker**: `ForwardRefExoticComponent`\<[`OpenmrsDateRangePickerProps`](../interfaces/OpenmrsDateRangePickerProps.md) & `RefAttributes`\<`HTMLDivElement`\>\>
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx:70](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx#L70)
+
+A date range picker to enter or select a date and time range. Based on React Aria, but styled to look like Carbon.

--- a/packages/framework/esm-framework/mock-jest.tsx
+++ b/packages/framework/esm-framework/mock-jest.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { NEVER } from 'rxjs';
 import type {} from '@openmrs/esm-globals';
 import * as utils from '@openmrs/esm-utils';
@@ -109,6 +109,36 @@ export const OpenmrsDatePicker = jest.fn(({ id, labelText, value, onChange, isIn
     {isInvalid && <span>{invalidText}</span>}
   </>
 ));
+
+export const OpenmrsDateRangePicker = jest.fn(({ id, labelText, value = [], onChange, isInvalid, invalidText }) => {
+  const [inputValue, setInputValue] = useState(() => {
+    const [start, end] = value;
+    const formattedStart = start ? dayjs(start).format('DD/MM/YYYY') : 'dd/mm/yyyy';
+    const formattedEnd = end ? dayjs(end).format('DD/MM/YYYY') : 'dd/mm/yyyy';
+    return `${formattedStart}–${formattedEnd}`;
+  });
+
+  const handleChange = (e) => {
+    const raw = e.target.value;
+    setInputValue(raw);
+
+    const [startStr, endStr] = raw.split('–');
+    const start = dayjs(startStr, 'DD/MM/YYYY', true);
+    const end = dayjs(endStr, 'DD/MM/YYYY', true);
+
+    if (start.isValid() && end.isValid()) {
+      onChange?.([start.toDate(), end.toDate()]);
+    }
+  };
+
+  return (
+    <div>
+      <label htmlFor={id}>{labelText}</label>
+      <input id={id} type="text" value={inputValue} onChange={handleChange} />
+      {isInvalid && <span>{invalidText}</span>}
+    </div>
+  );
+});
 
 /* esm-utils */
 export {

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { vi } from 'vitest';
 import { NEVER } from 'rxjs';
 import type {} from '@openmrs/esm-globals';
@@ -110,6 +110,36 @@ export const OpenmrsDatePicker = vi.fn(({ id, labelText, value, onChange, isInva
     {isInvalid && <span>{invalidText}</span>}
   </>
 ));
+
+export const OpenmrsDateRangePicker = vi.fn(({ id, labelText, value = [], onChange, isInvalid, invalidText }) => {
+  const [inputValue, setInputValue] = useState(() => {
+    const [start, end] = value;
+    const formattedStart = start ? dayjs(start).format('DD/MM/YYYY') : 'dd/mm/yyyy';
+    const formattedEnd = end ? dayjs(end).format('DD/MM/YYYY') : 'dd/mm/yyyy';
+    return `${formattedStart}–${formattedEnd}`;
+  });
+
+  const handleChange = (e) => {
+    const raw = e.target.value;
+    setInputValue(raw);
+
+    const [startStr, endStr] = raw.split('–');
+    const start = dayjs(startStr, 'DD/MM/YYYY', true);
+    const end = dayjs(endStr, 'DD/MM/YYYY', true);
+
+    if (start.isValid() && end.isValid()) {
+      onChange?.([start.toDate(), end.toDate()]);
+    }
+  };
+
+  return (
+    <div>
+      <label htmlFor={id}>{labelText}</label>
+      <input id={id} type="text" value={inputValue} onChange={handleChange} />
+      {isInvalid && <span>{invalidText}</span>}
+    </div>
+  );
+});
 
 /* esm-utils */
 export {

--- a/packages/framework/esm-styleguide/mock-jest.tsx
+++ b/packages/framework/esm-styleguide/mock-jest.tsx
@@ -104,6 +104,7 @@ export const MaybePictogram = ({ pictogram }) => <span>{pictogram}</span>;
 export { PageHeader, PageHeaderContent } from './src/page-header/page-header.component';
 
 export const OpenmrsDatePicker = () => <span>OpenmrsDatePicker</span>;
+export const OpenmrsDateRangePicker = () => <span>OpenmrsDateRangePicker</span>;
 
 export const LocationPicker = jest.fn(({ onChange, selectedLocationUuid }) => {
   const locations = [

--- a/packages/framework/esm-styleguide/mock.tsx
+++ b/packages/framework/esm-styleguide/mock.tsx
@@ -106,6 +106,7 @@ export const MaybePictogram = ({ pictogram }) => <span>{pictogram}</span>;
 export { PageHeader, PageHeaderContent } from './src/page-header/page-header.component';
 
 export const OpenmrsDatePicker = () => <span>OpenmrsDatePicker</span>;
+export const OpenmrsDateRangePicker = () => <span>OpenmrsDateRangePicker</span>;
 
 export const LocationPicker = vi.fn(({ onChange, selectedLocationUuid }) => {
   const locations = [

--- a/packages/framework/esm-styleguide/src/datepicker/OpenmrsDatePicker.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/OpenmrsDatePicker.tsx
@@ -84,7 +84,7 @@ const defaultProps: OpenmrsDatePickerProps = {
   size: 'md',
 };
 
-function I18nWrapper(props: I18nProviderProps): JSX.Element {
+export function I18nWrapper(props: I18nProviderProps): JSX.Element {
   return React.createElement(I18nProvider as (props: I18nProviderProps) => JSX.Element, props);
 }
 

--- a/packages/framework/esm-styleguide/src/datepicker/OpenmrsDatePicker.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/OpenmrsDatePicker.tsx
@@ -126,7 +126,7 @@ export const OpenmrsDatePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, Openmr
       }
 
       return locale;
-    }, []);
+    }, [window.i18next.language]);
 
     const calendar = useMemo(() => {
       const cal = getDefaultCalendar(locale);

--- a/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-icon.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-icon.component.tsx
@@ -1,0 +1,13 @@
+import React, { useContext, forwardRef } from 'react';
+import { DateRangePickerStateContext } from 'react-aria-components';
+import { CalendarIcon, WarningIcon } from '../../icons';
+
+export const DateRangePickerIcon = /*#__PURE__*/ forwardRef<SVGSVGElement>(function DateRangePickerIcon(props, ref) {
+  const state = useContext(DateRangePickerStateContext)!;
+
+  return state.isInvalid ? (
+    <WarningIcon ref={ref} size={16} {...props} />
+  ) : (
+    <CalendarIcon ref={ref} size={16} {...props} />
+  );
+});

--- a/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-input-group.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-input-group.component.tsx
@@ -1,0 +1,18 @@
+import React, { useContext } from 'react';
+import { DateRangePickerStateContext, Group } from 'react-aria-components';
+import { useOnClickOutside } from '@openmrs/esm-react-utils';
+import styles from './date-range-picker.module.scss';
+
+interface DateRangeInputGroupProps {
+  children: React.ReactNode;
+}
+
+export function DateRangeInputGroup({ children }: DateRangeInputGroupProps) {
+  let state = useContext(DateRangePickerStateContext);
+  const boundaryRef = useOnClickOutside<HTMLDivElement>(() => state?.close());
+  return (
+    <Group className={styles.inputGroup} ref={boundaryRef}>
+      {children}
+    </Group>
+  );
+}

--- a/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-input-group.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-input-group.component.tsx
@@ -8,7 +8,7 @@ interface DateRangeInputGroupProps {
 }
 
 export function DateRangeInputGroup({ children }: DateRangeInputGroupProps) {
-  let state = useContext(DateRangePickerStateContext);
+  const state = useContext(DateRangePickerStateContext);
   const boundaryRef = useOnClickOutside<HTMLDivElement>(() => state?.close());
   return (
     <Group className={styles.inputGroup} ref={boundaryRef}>

--- a/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx
@@ -170,28 +170,34 @@ export const OpenmrsDateRangePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, O
                 )}
 
                 <DateRangeInputGroup>
-                  <DateInput
-                    className={classNames(
-                      'cds--date-picker-input__wrapper',
-                      styles.startInput,
-                      styles.dateInputWrapper,
-                    )}
-                    slot="start"
-                  >
-                    {(segment) => <DateSegment className={styles.inputSegment} segment={segment} />}
-                  </DateInput>
-                  <div className={styles.separator}>
-                    <span aria-hidden="true" data-readonly>
-                      –
-                    </span>
+                  <div className={styles.inputsWrapper}>
+                    <DateInput
+                      className={classNames(
+                        'cds--date-picker-input__wrapper',
+                        styles.startInput,
+                        styles.dateInputWrapper,
+                      )}
+                      slot="start"
+                    >
+                      {(segment) => <DateSegment className={styles.inputSegment} segment={segment} />}
+                    </DateInput>
+                    <div className={styles.separator}>
+                      <span aria-hidden="true" data-readonly>
+                        –
+                      </span>
+                    </div>
+                    <DateInput
+                      className={classNames(
+                        'cds--date-picker-input__wrapper',
+                        styles.endInput,
+                        styles.dateInputWrapper,
+                      )}
+                      slot="end"
+                    >
+                      {(segment) => <DateSegment className={styles.inputSegment} segment={segment} />}
+                    </DateInput>
                   </div>
-                  <DateInput
-                    className={classNames('cds--date-picker-input__wrapper', styles.endInput, styles.dateInputWrapper)}
-                    slot="end"
-                  >
-                    {(segment) => <DateSegment className={styles.inputSegment} segment={segment} />}
-                  </DateInput>
-                  <Button className={classNames(styles.pickerButton, styles.flatButton, styles.flatButtonMd)}>
+                  <Button className={classNames(styles.flatButton, styles.flatButtonMd)}>
                     <DateRangePickerIcon />
                   </Button>
                 </DateRangeInputGroup>

--- a/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx
@@ -1,0 +1,236 @@
+import React, { forwardRef, type ReactElement, useId, useMemo } from 'react';
+import classNames, { type Argument } from 'classnames';
+import { createCalendar, getLocalTimeZone, toCalendar, today, type CalendarDate } from '@internationalized/date';
+import {
+  Button,
+  CalendarCell,
+  CalendarGrid,
+  DateInput,
+  DateRangePicker,
+  type DateRangePickerProps,
+  Dialog,
+  FieldError,
+  Label,
+  Popover,
+  Provider,
+  RangeCalendar,
+  type DateRange,
+} from 'react-aria-components';
+import { DateSegment } from '../DateSegment';
+import styles from './date-range-picker.module.scss';
+import { MonthYear } from '../MonthYear';
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  getDefaultCalendar,
+  getLocale,
+  useConfig,
+  type StyleguideConfigObject,
+} from '@openmrs/esm-framework';
+import { OpenmrsIntlLocaleContext } from '../locale-context';
+import { type DateInputValue, I18nWrapper } from '../OpenmrsDatePicker';
+import { DateRangePickerIcon } from './date-range-icon.component';
+import { dateToInternationalizedDate, internationalizedDateToDate } from '../utils';
+import { DateRangeInputGroup } from './date-range-input-group.component';
+
+export interface OpenmrsDateRangePickerProps
+  extends Omit<DateRangePickerProps<CalendarDate>, 'className' | 'onChange' | 'defaultValue' | 'value'> {
+  /** Any CSS classes to add to the outer div of the date picker */
+  className?: Argument;
+  /** The default value (uncontrolled) */
+  defaultValue?: [DateInputValue, DateInputValue];
+  /** Whether the input value is invalid. */
+  invalid?: boolean;
+  /** Text to show if the input is invalid e.g. an error message */
+  invalidText?: string;
+  /**
+   * The label for this DatePicker element
+   * @deprecated Use labelText instead
+   */
+  label?: string | ReactElement;
+  /** The label for this DatePicker element. */
+  labelText?: string | ReactElement;
+  /** 'true' to use the light version. */
+  light?: boolean;
+  /** The latest date it is possible to select */
+  maxDate?: DateInputValue;
+  /** The earliest date it is possible to select */
+  minDate?: DateInputValue;
+  /** Handler that is called when the value changes. */
+  onChange?: (value: [Date | null | undefined, Date | null | undefined]) => void;
+  /** Handler that is called when the value changes. Note that this provides types from @internationalized/date. */
+  onChangeRaw?: (value: DateRange | null) => void;
+  /** The value (controlled) */
+  value?: [DateInputValue, DateInputValue];
+}
+
+/**
+ * A date range picker to enter or select a date and time range. Based on React Aria, but styled to look like Carbon.
+ */
+export const OpenmrsDateRangePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, OpenmrsDateRangePickerProps>(
+  function OpenmrsDateRangePicker(
+    {
+      className,
+      defaultValue: rawDefaultValue,
+      invalid,
+      invalidText,
+      isDisabled,
+      isInvalid: isInvalidRaw,
+      label,
+      labelText,
+      light,
+      maxDate: rawMaxDate,
+      minDate: rawMinDate,
+      onChange,
+      onChangeRaw,
+      value: rawValue,
+      ...dateRangePickerProps
+    },
+    ref,
+  ) {
+    const config = useConfig<StyleguideConfigObject>({ externalModuleName: '@openmrs/esm-styleguide' });
+    const preferredDateLocaleMap = config.preferredDateLocale;
+
+    const id = useId();
+
+    const locale = useMemo(() => {
+      let locale = getLocale();
+      if (preferredDateLocaleMap[locale]) {
+        locale = preferredDateLocaleMap[locale];
+      }
+
+      return locale;
+      // Notes: Adding a dependency on "window.i18next.language" is not ideal,
+      // but it's the only way I managed to get the locale to update consistently when the language changes.
+    }, [window.i18next.language]);
+
+    const calendar = useMemo(() => {
+      const cal = getDefaultCalendar(locale);
+      return typeof cal !== 'undefined' ? createCalendar(cal) : undefined;
+    }, [locale]);
+
+    const intlLocale = useMemo(() => new Intl.Locale(locale, { calendar: calendar?.identifier }), [locale, calendar]);
+    const value = useMemo(() => {
+      if (rawValue) {
+        return {
+          start: dateToInternationalizedDate(rawValue[0], calendar, true),
+          end: dateToInternationalizedDate(rawValue[1], calendar, true),
+        } as DateRange;
+      }
+      return undefined;
+    }, [rawValue]);
+    const defaultValue = useMemo(() => {
+      if (rawDefaultValue) {
+        return {
+          start: dateToInternationalizedDate(rawDefaultValue[0], calendar, true),
+          end: dateToInternationalizedDate(rawDefaultValue[1], calendar, true),
+        } as DateRange;
+      }
+      return undefined;
+    }, [rawDefaultValue]);
+    const minDate = useMemo(() => dateToInternationalizedDate(rawMinDate, calendar, true), [rawMinDate]);
+    const maxDate = useMemo(() => dateToInternationalizedDate(rawMaxDate, calendar, true), [rawMaxDate]);
+    const isInvalid = useMemo(() => invalid ?? isInvalidRaw, [invalid, isInvalidRaw]);
+    const today_ = calendar ? toCalendar(today(getLocalTimeZone()), calendar) : today(getLocalTimeZone());
+
+    const innerOnChange = useMemo(() => {
+      if (onChangeRaw && onChange) {
+        console.error(
+          'An OpenmrsDateRangePicker component was created with both onChange and onChangeRaw handlers defined. Only onChangeRaw will be used.',
+        );
+      }
+      return onChangeRaw
+        ? onChangeRaw
+        : (range: DateRange) =>
+            onChange?.([internationalizedDateToDate(range.start), internationalizedDateToDate(range.end)]);
+    }, [onChangeRaw, onChange]);
+
+    return (
+      <I18nWrapper locale={intlLocale.toString()}>
+        <div className={classNames('cds--form-item', className)}>
+          <Provider values={[[OpenmrsIntlLocaleContext, intlLocale]]}>
+            <DateRangePicker
+              id={id}
+              className={classNames('cds--date-picker', {
+                'cds--date-picker--light': light,
+                'cds--date-picker--disabled': isDisabled,
+              })}
+              isInvalid={isInvalid}
+              shouldForceLeadingZeros={intlLocale.language === 'en' ? true : undefined}
+              maxValue={maxDate}
+              minValue={minDate}
+              value={value}
+              defaultValue={defaultValue}
+              ref={ref}
+              isDisabled={isDisabled}
+              {...dateRangePickerProps}
+              onChange={innerOnChange}
+            >
+              <div className="cds--date-picker-container">
+                {(labelText ?? label) && (
+                  <Label className={classNames('cds--label', { 'cds--label--disabled': isDisabled })}>
+                    {labelText ?? label}
+                  </Label>
+                )}
+
+                <DateRangeInputGroup>
+                  <DateInput
+                    className={classNames(
+                      'cds--date-picker-input__wrapper',
+                      styles.startInput,
+                      styles.dateInputWrapper,
+                    )}
+                    slot="start"
+                  >
+                    {(segment) => <DateSegment className={styles.inputSegment} segment={segment} />}
+                  </DateInput>
+                  <div className={styles.separator}>
+                    <span aria-hidden="true" data-readonly>
+                      –
+                    </span>
+                  </div>
+                  <DateInput
+                    className={classNames('cds--date-picker-input__wrapper', styles.endInput, styles.dateInputWrapper)}
+                    slot="end"
+                  >
+                    {(segment) => <DateSegment className={styles.inputSegment} segment={segment} />}
+                  </DateInput>
+                  <Button className={classNames(styles.pickerButton, styles.flatButton, styles.flatButtonMd)}>
+                    <DateRangePickerIcon />
+                  </Button>
+                </DateRangeInputGroup>
+                {invalid && invalidText && <FieldError className={styles.invalidText}>{invalidText}</FieldError>}
+                <Popover className={styles.popover} placement="bottom start" offset={1} isNonModal={true}>
+                  <Dialog className={styles.dialog}>
+                    <RangeCalendar minValue={minDate} maxValue={maxDate} className="cds--date-picker__calendar">
+                      <header className={styles.header}>
+                        <Button className={classNames(styles.flatButton, styles.flatButtonMd)} slot="previous">
+                          <ChevronLeftIcon size={16} />
+                        </Button>
+                        <MonthYear className={styles.monthYear} />
+                        <Button className={classNames(styles.flatButton, styles.flatButtonMd)} slot="next">
+                          <ChevronRightIcon size={16} />
+                        </Button>
+                      </header>
+                      <CalendarGrid className={styles.calendarGrid}>
+                        {(date) => (
+                          <CalendarCell
+                            key={date.toString()}
+                            className={classNames('cds--date-picker__day', {
+                              [styles.today]: today_.compare(date) === 0,
+                            })}
+                            date={date}
+                          />
+                        )}
+                      </CalendarGrid>
+                    </RangeCalendar>
+                  </Dialog>
+                </Popover>
+              </div>
+            </DateRangePicker>
+          </Provider>
+        </div>
+      </I18nWrapper>
+    );
+  },
+);

--- a/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.component.tsx
@@ -19,19 +19,15 @@ import {
 import { DateSegment } from '../DateSegment';
 import styles from './date-range-picker.module.scss';
 import { MonthYear } from '../MonthYear';
-import {
-  ChevronLeftIcon,
-  ChevronRightIcon,
-  getDefaultCalendar,
-  getLocale,
-  useConfig,
-  type StyleguideConfigObject,
-} from '@openmrs/esm-framework';
 import { OpenmrsIntlLocaleContext } from '../locale-context';
 import { type DateInputValue, I18nWrapper } from '../OpenmrsDatePicker';
 import { DateRangePickerIcon } from './date-range-icon.component';
 import { dateToInternationalizedDate, internationalizedDateToDate } from '../utils';
 import { DateRangeInputGroup } from './date-range-input-group.component';
+import { ChevronLeftIcon, ChevronRightIcon } from '../../icons';
+import { useConfig } from '@openmrs/esm-react-utils';
+import { getDefaultCalendar, getLocale } from '@openmrs/esm-utils';
+import { type StyleguideConfigObject } from '../../config-schema';
 
 export interface OpenmrsDateRangePickerProps
   extends Omit<DateRangePickerProps<CalendarDate>, 'className' | 'onChange' | 'defaultValue' | 'value'> {
@@ -199,7 +195,7 @@ export const OpenmrsDateRangePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, O
                     <DateRangePickerIcon />
                   </Button>
                 </DateRangeInputGroup>
-                {invalid && invalidText && <FieldError className={styles.invalidText}>{invalidText}</FieldError>}
+                {isInvalid && invalidText && <FieldError className={styles.invalidText}>{invalidText}</FieldError>}
                 <Popover className={styles.popover} placement="bottom start" offset={1} isNonModal={true}>
                   <Dialog className={styles.dialog}>
                     <RangeCalendar minValue={minDate} maxValue={maxDate} className="cds--date-picker__calendar">

--- a/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.module.scss
@@ -1,0 +1,41 @@
+@use '@carbon/styles/scss/theme';
+@use '../datepicker.module.scss' as *;
+
+.dateInputWrapper {
+  @extend .inputWrapper;
+  min-width: unset;
+  margin: 0px;
+}
+
+.pickerButton {
+  margin-inline-start: 2rem;
+}
+
+.startInput {
+  margin-left: 1rem;
+  inline-size: 5rem;
+}
+
+.endInput {
+  inline-size: 6.5rem;
+}
+
+.separator {
+  margin-inline: 0.5rem;
+}
+
+.inputGroup:has([data-placeholder]) > .separator > span {
+  color: theme.$text-disabled;
+}
+
+:global([dir='rtl']) {
+  .startInput {
+    margin-left: 0;
+    inline-size: 5rem;
+  }
+
+  .endInput {
+    padding-right: 0;
+    inline-size: 6.5rem;
+  }
+}

--- a/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.module.scss
@@ -1,41 +1,38 @@
 @use '@carbon/styles/scss/theme';
 @use '../datepicker.module.scss' as *;
 
+.inputsWrapper {
+  display: flex;
+  min-width: 10rem;
+  max-width: 15rem;
+  margin-left: 1rem;
+  inline-size: 15rem;
+}
+
 .dateInputWrapper {
   @extend .inputWrapper;
   min-width: unset;
   margin: 0px;
 }
 
-.pickerButton {
-  margin-inline-start: 2rem;
-}
-
 .startInput {
-  margin-left: 1rem;
-  inline-size: 5rem;
+  flex-basis: fit-content;
 }
 
 .endInput {
-  inline-size: 6.5rem;
+  padding-right: unset;
 }
 
 .separator {
   margin-inline: 0.5rem;
 }
 
-.inputGroup:has([data-placeholder]) > .separator > span {
+.inputGroup:has([data-placeholder]) > .inputsWrapper > .separator > span {
   color: theme.$text-disabled;
 }
 
 :global([dir='rtl']) {
-  .startInput {
-    margin-left: 0;
-    inline-size: 5rem;
-  }
-
   .endInput {
     padding-right: 0;
-    inline-size: 6.5rem;
   }
 }

--- a/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.test.tsx
@@ -1,0 +1,60 @@
+import React from 'react';
+import type { i18n } from 'i18next';
+import { beforeEach, describe, expect, it } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { render, screen } from '@testing-library/react';
+import { useConfig } from '@openmrs/esm-react-utils/mock';
+import { OpenmrsDateRangePicker } from '../index';
+
+describe('OpenmrsDateRangePicker', () => {
+  beforeEach(() => {
+    window.i18next = { language: 'en' } as i18n;
+
+    useConfig.mockReturnValue({
+      preferredDateLocale: {
+        en: 'en-GB',
+      },
+    });
+  });
+
+  it('uses dd/mm/yyyy for english by default', () => {
+    render(<OpenmrsDateRangePicker aria-label="datepicker" />);
+
+    const input = screen.getByLabelText('datepicker');
+    expect(input).toHaveTextContent('dd/mm/yyyy–dd/mm/yyyy');
+  });
+
+  it('should respect the preferred date locale', () => {
+    useConfig.mockReturnValue({
+      preferredDateLocale: {
+        en: 'en-US',
+      },
+    });
+    render(<OpenmrsDateRangePicker aria-label="datepicker" />);
+    const input = screen.getByLabelText('datepicker');
+    expect(input).toHaveTextContent('mm/dd/yyyy–mm/dd/yyyy');
+  });
+
+  it('should render RTL layout for Arabic locale', () => {
+    window.i18next = { language: 'ar' } as i18n;
+
+    render(<OpenmrsDateRangePicker aria-label="datepicker" />);
+    const input = screen.getByLabelText('datepicker');
+    const text = input.textContent?.replace(/\u200F/g, '');
+
+    expect(text).toBe('يوم/شهر/سنة–يوم/شهر/سنة');
+  });
+
+  it('should display prefilled date range from form value', () => {
+    render(
+      <OpenmrsDateRangePicker
+        aria-label="datepicker"
+        startName="start"
+        endName="end"
+        value={[new Date(2025, 2, 15), new Date(2025, 5, 18)]}
+      />,
+    );
+    const input = screen.getByLabelText('datepicker');
+    expect(input).toHaveTextContent('15/03/2025–18/06/2025');
+  });
+});

--- a/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range/date-range-picker.test.tsx
@@ -45,6 +45,16 @@ describe('OpenmrsDateRangePicker', () => {
     expect(text).toBe('يوم/شهر/سنة–يوم/شهر/سنة');
   });
 
+  it('should render RTL layout for Amharic locale', () => {
+    window.i18next = { language: 'am' } as i18n;
+
+    render(<OpenmrsDateRangePicker aria-label="datepicker" />);
+    const input = screen.getByLabelText('datepicker');
+    const text = input.textContent?.replace(/\u200F/g, '');
+
+    expect(text).toBe('ቀቀ/ሚሜ/ዓዓዓዓ–ቀቀ/ሚሜ/ዓዓዓዓ');
+  });
+
   it('should display prefilled date range from form value', () => {
     render(
       <OpenmrsDateRangePicker

--- a/packages/framework/esm-styleguide/src/datepicker/index.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/index.tsx
@@ -1,1 +1,2 @@
 export { OpenmrsDatePicker, type OpenmrsDatePickerProps } from './OpenmrsDatePicker';
+export { OpenmrsDateRangePicker, type OpenmrsDateRangePickerProps } from './date-range/date-range-picker.component';


### PR DESCRIPTION
# Requirements

- [X] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->
Introduces a variant of the `OpenmrsDatePicker` that lets us capture date ranges. Under the hood, this component is based on React Aria's [DateRangePicker](https://react-spectrum.adobe.com/react-aria/DateRangePicker.html) but styled to mimic Carbon's design language. 

## Screenshots
<!-- Required if you are making UI changes. -->

<img width="704" height="857" alt="Screenshot 2025-07-22 at 22 30 44" src="https://github.com/user-attachments/assets/35261565-c3b3-411e-84f8-1f0a7b5b50c6" />

_The screenshot above demonstrates the date range picker in different states. The first picker is our OpenmrsDatePicker added for perspective._

https://github.com/user-attachments/assets/b11835c9-e233-44cf-81ba-1051aabf2a50

_The video above demonstrates the OpenmrsDateRangePicker used to implement a date range filter for the Order details widget. It's configured with a maxDate of now (new Date())_

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://openmrs.atlassian.net/browse/O3-4517

## Other
<!-- Anything not covered above -->
The `size` and `short` properties are not yet implemented, but they are typical Carbon properties. While these appear to be supported by the `OpenmrsDatePicker`, they are not functional. We will need to add support for these props in both components.
