### PR TITLE
(feat) O3-4897 Redirect 401 request to URL location specified by resp…

### DIFF
--- a/packages/framework/esm-api/src/config-schema.ts
+++ b/packages/framework/esm-api/src/config-schema.ts
@@ -1,0 +1,50 @@
+import { type ConfigSchema, Type, validators } from '@openmrs/esm-config';
+
+export const defaultRedirectAuthFailureUrl = '${openmrsSpaBase}/login';
+
+export const configSchema: ConfigSchema = {
+  redirectAuthFailure: {
+    enabled: {
+      _type: Type.Boolean,
+      _default: true,
+      _description: 'Whether to redirect logged-out users to `redirectAuthFailure.url`',
+    },
+    url: {
+      _type: Type.String,
+      _default: defaultRedirectAuthFailureUrl,
+      _validators: [validators.isUrl],
+      _description:
+        'The url to which users will be redirected when they are logged out. If set to blank, the `location` header from the response will be used.',
+    },
+    errors: {
+      _type: Type.Array,
+      _default: [401],
+      _elements: {
+        _type: Type.Number,
+        _validators: [validators.inRange(100, 600)],
+      },
+      _description: 'The HTTP error codes for which users will be redirected',
+    },
+    resolvePromise: {
+      _type: Type.Boolean,
+      _default: false,
+      _description:
+        "Changes how requests that fail authentication are handled. Try messing with this if redirects to the login page aren't working correctly.",
+    },
+  },
+  followRedirects: {
+    _type: Type.Boolean,
+    _default: true,
+    _description: 'Whether openmrsFetch should support redirects returned from the backend',
+  },
+};
+
+export interface EsmApiConfigObject {
+  redirectAuthFailure: {
+    enabled: boolean;
+    url: string;
+    errors: number[];
+    resolvePromise: boolean;
+  };
+  followRedirects: boolean;
+}

--- a/packages/framework/esm-api/src/openmrs-fetch.ts
+++ b/packages/framework/esm-api/src/openmrs-fetch.ts
@@ -4,6 +4,7 @@ import { isPlainObject } from 'lodash-es';
 import { getConfig } from '@openmrs/esm-config';
 import { clearHistory, navigate } from '@openmrs/esm-navigation';
 import type { FetchResponse } from './types';
+import { defaultRedirectAuthFailureUrl, type EsmApiConfigObject } from './config-schema';
 
 export const restBaseUrl = '/ws/rest/v1';
 export const fhirBaseUrl = '/ws/fhir2/R4';
@@ -148,9 +149,9 @@ export function openmrsFetch<T = any>(path: string, fetchInit: FetchConfig = {})
 
   return window.fetch(url, fetchInit as RequestInit).then(async (r) => {
     const response = r as FetchResponse<T>;
+    const { redirectAuthFailure, followRedirects } = await getConfig<EsmApiConfigObject>('@openmrs/esm-api');
     if (response.ok) {
       if (response.status === 204) {
-        const { followRedirects } = await getConfig('@openmrs/esm-api');
         if (followRedirects && response.headers.has('location')) {
           const location = response.headers.get('location');
           if (location) {
@@ -190,14 +191,16 @@ export function openmrsFetch<T = any>(path: string, fetchInit: FetchConfig = {})
       /*
        * Redirect to given url when redirect on auth failure is enabled
        */
-      const { redirectAuthFailure } = await getConfig('@openmrs/esm-api');
-
       if (
         (url === makeUrl(sessionEndpoint) && response.status === 403) ||
         (redirectAuthFailure.enabled && redirectAuthFailure.errors.includes(response.status))
       ) {
         clearHistory();
-        navigate({ to: redirectAuthFailure.url });
+        // by default, redirect to the url specified in the config.
+        // If blank, use the location header from the response.
+        // If that is also blank, use the default redirect url.
+        const location = redirectAuthFailure.url || response.headers.get('location') || defaultRedirectAuthFailureUrl;
+        navigate({ to: location });
 
         /* We sometimes don't really want this promise to resolve since there's no response data,
          * nor do we want it to reject because that would trigger error handling. We instead

--- a/packages/framework/esm-api/src/setup.ts
+++ b/packages/framework/esm-api/src/setup.ts
@@ -1,44 +1,12 @@
-import { defineConfigSchema, Type, validators } from '@openmrs/esm-config';
+import { defineConfigSchema } from '@openmrs/esm-config';
 import { refetchCurrentUser } from './current-user';
+import { configSchema } from './config-schema';
 
 /**
  * @internal
  */
 export function setupApiModule() {
-  defineConfigSchema('@openmrs/esm-api', {
-    redirectAuthFailure: {
-      enabled: {
-        _type: Type.Boolean,
-        _default: true,
-        _description: 'Whether to redirect logged-out users to `redirectAuthFailure.url`',
-      },
-      url: {
-        _type: Type.String,
-        _default: '${openmrsSpaBase}/login',
-        _validators: [validators.isUrl],
-      },
-      errors: {
-        _type: Type.Array,
-        _default: [401],
-        _elements: {
-          _type: Type.Number,
-          _validators: [validators.inRange(100, 600)],
-        },
-        _description: 'The HTTP error codes for which users will be redirected',
-      },
-      resolvePromise: {
-        _type: Type.Boolean,
-        _default: false,
-        _description:
-          "Changes how requests that fail authentication are handled. Try messing with this if redirects to the login page aren't working correctly.",
-      },
-    },
-    followRedirects: {
-      _type: Type.Boolean,
-      _default: true,
-      _description: 'Whether openmrsFetch should support redirects returned from the backend',
-    },
-  });
+  defineConfigSchema('@openmrs/esm-api', configSchema);
 
   refetchCurrentUser();
 }

--- a/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
+++ b/packages/framework/esm-framework/docs/classes/OpenmrsFetchError.md
@@ -2,7 +2,7 @@
 
 # Class: OpenmrsFetchError
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:301](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L301)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:304](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L304)
 
 ## Extends
 
@@ -18,7 +18,7 @@ Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:301](https://github
 
 > **new OpenmrsFetchError**(`url`, `response`, `responseBody`, `requestStacktrace`): `OpenmrsFetchError`
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:302](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L302)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:305](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L305)
 
 #### Parameters
 
@@ -120,7 +120,7 @@ https://v8.dev/docs/stack-trace-api#customizing-stack-traces
 
 > **response**: `Response`
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:310](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L310)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:313](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L313)
 
 #### Implementation of
 
@@ -132,7 +132,7 @@ Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:310](https://github
 
 > **responseBody**: `null` \| `string` \| [`FetchResponseJson`](../interfaces/FetchResponseJson.md)
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:311](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L311)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:314](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L314)
 
 #### Implementation of
 

--- a/packages/framework/esm-framework/docs/functions/convertToLocaleCalendar.md
+++ b/packages/framework/esm-framework/docs/functions/convertToLocaleCalendar.md
@@ -4,7 +4,7 @@
 
 > **convertToLocaleCalendar**(`date`, `locale`): `CalendarDate` \| `CalendarDateTime` \| `ZonedDateTime`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:146
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:145
 
 Converts a calendar date to the equivalent locale calendar date.
 

--- a/packages/framework/esm-framework/docs/functions/formatDate.md
+++ b/packages/framework/esm-framework/docs/functions/formatDate.md
@@ -4,7 +4,7 @@
 
 > **formatDate**(`date`, `options?`): `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:126
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:125
 
 Formats the input date according to the current locale and the
 given options.

--- a/packages/framework/esm-framework/docs/functions/formatDatetime.md
+++ b/packages/framework/esm-framework/docs/functions/formatDatetime.md
@@ -4,7 +4,7 @@
 
 > **formatDatetime**(`date`, `options?`): `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:141
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:140
 
 Formats the input into a string showing the date and time, according
 to the current locale. The `mode` parameter is as described for

--- a/packages/framework/esm-framework/docs/functions/formatDuration.md
+++ b/packages/framework/esm-framework/docs/functions/formatDuration.md
@@ -2,9 +2,9 @@
 
 # Function: formatDuration()
 
-> **formatDuration**(`duration`, `options?`): `any`
+> **formatDuration**(`duration`, `options?`): `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:154
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:153
 
 Formats the input duration according to the current locale.
 
@@ -24,6 +24,6 @@ Optional options for formatting.
 
 ## Returns
 
-`any`
+`string`
 
 The formatted duration string.

--- a/packages/framework/esm-framework/docs/functions/formatPartialDate.md
+++ b/packages/framework/esm-framework/docs/functions/formatPartialDate.md
@@ -4,7 +4,7 @@
 
 > **formatPartialDate**(`dateString`, `options?`): `null` \| `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:106
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:105
 
 Formats the string representing a date, including partial representations of dates, according to the current
 locale and the given options.

--- a/packages/framework/esm-framework/docs/functions/formatTime.md
+++ b/packages/framework/esm-framework/docs/functions/formatTime.md
@@ -4,7 +4,7 @@
 
 > **formatTime**(`date`): `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:131
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:130
 
 Formats the input as a time, according to the current locale.
 12-hour or 24-hour clock depends on locale.

--- a/packages/framework/esm-framework/docs/functions/getDefaultCalendar.md
+++ b/packages/framework/esm-framework/docs/functions/getDefaultCalendar.md
@@ -4,7 +4,7 @@
 
 > **getDefaultCalendar**(`locale`): `undefined` \| `CalendarIdentifier`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:50
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:49
 
 Retrieves the default calendar for the specified locale if any.
 

--- a/packages/framework/esm-framework/docs/functions/isOmrsDateStrict.md
+++ b/packages/framework/esm-framework/docs/functions/isOmrsDateStrict.md
@@ -4,7 +4,7 @@
 
 > **isOmrsDateStrict**(`omrsPayloadString`): `boolean`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:13
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:12
 
 This function checks whether a date string is the OpenMRS ISO format.
 The format should be YYYY-MM-DDTHH:mm:ss.SSSZZ

--- a/packages/framework/esm-framework/docs/functions/isOmrsDateToday.md
+++ b/packages/framework/esm-framework/docs/functions/isOmrsDateToday.md
@@ -4,7 +4,7 @@
 
 > **isOmrsDateToday**(`date`): `boolean`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:18
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:17
 
 ## Parameters
 

--- a/packages/framework/esm-framework/docs/functions/makeUrl.md
+++ b/packages/framework/esm-framework/docs/functions/makeUrl.md
@@ -4,7 +4,7 @@
 
 > **makeUrl**(`path`): `string`
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L22)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:23](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L23)
 
 Append `path` to the OpenMRS SPA base.
 

--- a/packages/framework/esm-framework/docs/functions/openmrsFetch.md
+++ b/packages/framework/esm-framework/docs/functions/openmrsFetch.md
@@ -4,7 +4,7 @@
 
 > **openmrsFetch**\<`T`\>(`path`, `fetchInit`): `Promise`\<[`FetchResponse`](../interfaces/FetchResponse.md)\<`T`\>\>
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:82](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L82)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:83](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L83)
 
 The openmrsFetch function is a wrapper around the
 [browser's built-in fetch function](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API/Using_Fetch),

--- a/packages/framework/esm-framework/docs/functions/openmrsObservableFetch.md
+++ b/packages/framework/esm-framework/docs/functions/openmrsObservableFetch.md
@@ -4,7 +4,7 @@
 
 > **openmrsObservableFetch**\<`T`\>(`url`, `fetchInit`): `Observable`\<[`FetchResponse`](../interfaces/FetchResponse.md)\<`T`\>\>
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:269](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L269)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:272](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L272)
 
 The openmrsObservableFetch function is a wrapper around openmrsFetch
 that returns an [Observable](https://rxjs-dev.firebaseapp.com/guide/observable)

--- a/packages/framework/esm-framework/docs/functions/parseDate.md
+++ b/packages/framework/esm-framework/docs/functions/parseDate.md
@@ -4,7 +4,7 @@
 
 > **parseDate**(`dateString`): `Date`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:32
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:31
 
 Utility function to parse an arbitrary string into a date.
 Uses `dayjs(dateString)`.

--- a/packages/framework/esm-framework/docs/functions/registerDefaultCalendar.md
+++ b/packages/framework/esm-framework/docs/functions/registerDefaultCalendar.md
@@ -4,7 +4,7 @@
 
 > **registerDefaultCalendar**(`locale`, `calendar`): `void`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:44
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:43
 
 Provides the name of the calendar to associate, as a default, with the given base locale.
 

--- a/packages/framework/esm-framework/docs/functions/toDateObjectStrict.md
+++ b/packages/framework/esm-framework/docs/functions/toDateObjectStrict.md
@@ -4,7 +4,7 @@
 
 > **toDateObjectStrict**(`omrsDateString`): `null` \| `Date`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:23
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:22
 
 Converts the object to a date object if it is an OpenMRS ISO date time string.
 Otherwise returns null.

--- a/packages/framework/esm-framework/docs/functions/toOmrsIsoString.md
+++ b/packages/framework/esm-framework/docs/functions/toOmrsIsoString.md
@@ -4,7 +4,7 @@
 
 > **toOmrsIsoString**(`date`, `toUTC?`): `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:27
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:26
 
 Formats the input to OpenMRS ISO format: "YYYY-MM-DDTHH:mm:ss.SSSZZ".
 

--- a/packages/framework/esm-framework/docs/interfaces/FetchConfig.md
+++ b/packages/framework/esm-framework/docs/interfaces/FetchConfig.md
@@ -2,7 +2,7 @@
 
 # Interface: FetchConfig
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:314](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L314)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:317](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L317)
 
 ## Extends
 
@@ -14,7 +14,7 @@ Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:314](https://github
 
 > `optional` **body**: `string` \| `FetchBody`
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:316](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L316)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:319](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L319)
 
 ***
 
@@ -50,7 +50,7 @@ A string indicating whether credentials will be sent with the request always, ne
 
 > `optional` **headers**: [`FetchHeaders`](FetchHeaders.md)
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:315](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L315)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:318](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L318)
 
 ***
 

--- a/packages/framework/esm-framework/docs/interfaces/FetchError.md
+++ b/packages/framework/esm-framework/docs/interfaces/FetchError.md
@@ -2,7 +2,7 @@
 
 # Interface: FetchError
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:333](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L333)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:336](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L336)
 
 ## Properties
 
@@ -10,7 +10,7 @@ Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:333](https://github
 
 > **response**: `Response`
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:334](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L334)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:337](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L337)
 
 ***
 
@@ -18,4 +18,4 @@ Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:334](https://github
 
 > **responseBody**: `null` \| `ResponseBody`
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:335](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L335)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:338](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L338)

--- a/packages/framework/esm-framework/docs/interfaces/FetchHeaders.md
+++ b/packages/framework/esm-framework/docs/interfaces/FetchHeaders.md
@@ -2,7 +2,7 @@
 
 # Interface: FetchHeaders
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:321](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L321)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:324](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L324)
 
 ## Indexable
 

--- a/packages/framework/esm-framework/docs/interfaces/FetchResponseJson.md
+++ b/packages/framework/esm-framework/docs/interfaces/FetchResponseJson.md
@@ -2,7 +2,7 @@
 
 # Interface: FetchResponseJson
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:329](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L329)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:332](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L332)
 
 ## Indexable
 

--- a/packages/framework/esm-framework/docs/type-aliases/DateInput.md
+++ b/packages/framework/esm-framework/docs/type-aliases/DateInput.md
@@ -4,4 +4,4 @@
 
 > **DateInput** = `string` \| `number` \| `Date`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:8
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:7

--- a/packages/framework/esm-framework/docs/type-aliases/FormatDateMode.md
+++ b/packages/framework/esm-framework/docs/type-aliases/FormatDateMode.md
@@ -4,4 +4,4 @@
 
 > **FormatDateMode** = `"standard"` \| `"wide"`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:51
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:50

--- a/packages/framework/esm-framework/docs/type-aliases/FormatDateOptions.md
+++ b/packages/framework/esm-framework/docs/type-aliases/FormatDateOptions.md
@@ -4,7 +4,7 @@
 
 > **FormatDateOptions** = `object`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:52
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:51
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:52
 
 > `optional` **calendar**: `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:56
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:55
 
 The calendar to use when formatting this date.
 
@@ -22,7 +22,7 @@ The calendar to use when formatting this date.
 
 > **day**: `boolean`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:72
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:71
 
 Whether to include the day number
 
@@ -32,7 +32,7 @@ Whether to include the day number
 
 > `optional` **locale**: `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:60
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:59
 
 The locale to use when formatting this date
 
@@ -42,7 +42,7 @@ The locale to use when formatting this date
 
 > **mode**: [`FormatDateMode`](FormatDateMode.md)
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:65
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:64
 
 - `standard`: "03 Feb 2022"
 - `wide`:     "03 — Feb — 2022"
@@ -53,7 +53,7 @@ Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:65
 
 > **month**: `boolean`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:74
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:73
 
 Whether to include the month number
 
@@ -63,7 +63,7 @@ Whether to include the month number
 
 > **noToday**: `boolean`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:85
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:84
 
 Disables the special handling of dates that are today. If false
 (the default), then dates that are today will be formatted as "Today"
@@ -76,7 +76,7 @@ formatted the same as all other dates.
 
 > `optional` **numberingSystem**: `string`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:78
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:77
 
 The unicode numbering system to use
 
@@ -86,7 +86,7 @@ The unicode numbering system to use
 
 > **time**: `true` \| `false` \| `"for today"`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:70
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:69
 
 Whether the time should be included in the output always (`true`),
 never (`false`), or only when the input date is today (`for today`).
@@ -97,6 +97,6 @@ never (`false`), or only when the input date is today (`for today`).
 
 > **year**: `boolean`
 
-Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:76
+Defined in: packages/framework/esm-utils/dist/dates/date-util.d.ts:75
 
 Whether to include the year

--- a/packages/framework/esm-framework/docs/variables/fhirBaseUrl.md
+++ b/packages/framework/esm-framework/docs/variables/fhirBaseUrl.md
@@ -4,4 +4,4 @@
 
 > `const` **fhirBaseUrl**: `"/ws/fhir2/R4"` = `'/ws/fhir2/R4'`
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:9](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L9)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L10)

--- a/packages/framework/esm-framework/docs/variables/restBaseUrl.md
+++ b/packages/framework/esm-framework/docs/variables/restBaseUrl.md
@@ -4,4 +4,4 @@
 
 > `const` **restBaseUrl**: `"/ws/rest/v1"` = `'/ws/rest/v1'`
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L8)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:9](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L9)

--- a/packages/framework/esm-framework/docs/variables/sessionEndpoint.md
+++ b/packages/framework/esm-framework/docs/variables/sessionEndpoint.md
@@ -4,4 +4,4 @@
 
 > `const` **sessionEndpoint**: `"/ws/rest/v1/session"`
 
-Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L10)
+Defined in: [packages/framework/esm-api/src/openmrs-fetch.ts:11](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-api/src/openmrs-fetch.ts#L11)


### PR DESCRIPTION
…onse header if frontend config URL is blank

# Requirements

- x ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [x] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

Currently, `openmrsFetch()` can be configured so that it redirects user to a configured URL (default: `/${openmrsSpaBase}/login`) when it encounters a certain set of HTTP response code (default: `[401]`). This PR changes it so that if the frontend configured URL is blank, we use the URL in the `Location` header of the HTTP response instead.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
https://openmrs.atlassian.net/browse/O3-4897

## Other
<!-- Anything not covered above -->
