### PR TITLE
(chore) Release v7.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-core",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "private": true,
   "workspaces": [
     "packages/apps/*",

--- a/packages/apps/esm-devtools-app/package.json
+++ b/packages/apps/esm-devtools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-devtools-app",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "Dev tools for frontend devs using OpenMRS",
   "browser": "dist/openmrs-esm-devtools-app.js",

--- a/packages/apps/esm-help-menu-app/package.json
+++ b/packages/apps/esm-help-menu-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-help-menu-app",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": " A microfrontend that provides a help menu for O3",
   "browser": "dist/openmrs-esm-help-menu-app.js",

--- a/packages/apps/esm-implementer-tools-app/package.json
+++ b/packages/apps/esm-implementer-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-implementer-tools-app",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "The admin interface for OpenMRS Frontend",
   "browser": "dist/openmrs-esm-implementer-tools-app.js",

--- a/packages/apps/esm-login-app/package.json
+++ b/packages/apps/esm-login-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-login-app",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "The login microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-login-app.js",

--- a/packages/apps/esm-offline-tools-app/package.json
+++ b/packages/apps/esm-offline-tools-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline-tools-app",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "The offline tools microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-offline-tools-app.js",

--- a/packages/apps/esm-primary-navigation-app/package.json
+++ b/packages/apps/esm-primary-navigation-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-primary-navigation-app",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "Main navbar microfrontend for the OpenMRS SPA",
   "browser": "dist/openmrs-esm-primary-navigation-app.js",

--- a/packages/framework/esm-api/package.json
+++ b/packages/framework/esm-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-api",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "The javascript module for interacting with the OpenMRS API",
   "type": "module",

--- a/packages/framework/esm-config/package.json
+++ b/packages/framework/esm-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-config",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "A configuration library for the OpenMRS Single-Spa framework.",
   "type": "module",

--- a/packages/framework/esm-context/package.json
+++ b/packages/framework/esm-context/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-context",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "Utilities for managing the current execution context",
   "type": "module",

--- a/packages/framework/esm-dynamic-loading/package.json
+++ b/packages/framework/esm-dynamic-loading/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-dynamic-loading",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "Utilities for dynamically loading code in OpenMRS",
   "type": "module",

--- a/packages/framework/esm-emr-api/package.json
+++ b/packages/framework/esm-emr-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-emr-api",
-  "version": "6.2.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "The javascript module for interacting with the OpenMRS API",
   "type": "module",

--- a/packages/framework/esm-error-handling/package.json
+++ b/packages/framework/esm-error-handling/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-error-handling",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "An ES module to help with error handling",
   "type": "module",

--- a/packages/framework/esm-expression-evaluator/package.json
+++ b/packages/framework/esm-expression-evaluator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-expression-evaluator",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "Utilities for evaluating user-defined expressions",
   "type": "module",

--- a/packages/framework/esm-extensions/package.json
+++ b/packages/framework/esm-extensions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-extensions",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "Coordinates extensions and extension points in the OpenMRS Frontend",
   "type": "module",

--- a/packages/framework/esm-feature-flags/package.json
+++ b/packages/framework/esm-feature-flags/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-feature-flags",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "A feature flag system for the OpenMRS Single-Spa framework.",
   "module": "dist/index.js",

--- a/packages/framework/esm-framework/package.json
+++ b/packages/framework/esm-framework/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-framework",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "type": "module",
   "module": "dist/openmrs-esm-framework.js",

--- a/packages/framework/esm-globals/package.json
+++ b/packages/framework/esm-globals/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-globals",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "type": "module",
   "module": "dist/index.js",

--- a/packages/framework/esm-navigation/package.json
+++ b/packages/framework/esm-navigation/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-navigation",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "OpenMRS library providing tools for breadcrumbs, navigation, and history.",
   "type": "module",

--- a/packages/framework/esm-offline/package.json
+++ b/packages/framework/esm-offline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-offline",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "type": "module",

--- a/packages/framework/esm-react-utils/package.json
+++ b/packages/framework/esm-react-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-react-utils",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "React utilities for OpenMRS.",
   "type": "module",

--- a/packages/framework/esm-routes/package.json
+++ b/packages/framework/esm-routes/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-routes",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "Utilities for working with the routes registry",
   "type": "module",

--- a/packages/framework/esm-state/package.json
+++ b/packages/framework/esm-state/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-state",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "Frontend stores & state management for OpenMRS",
   "type": "module",

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-styleguide",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "The styleguide for OpenMRS SPA",
   "main": "dist/openmrs-esm-styleguide.js",

--- a/packages/framework/esm-translations/package.json
+++ b/packages/framework/esm-translations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-translations",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "O3 Framework module for translation support",
   "type": "module",

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-utils",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "description": "Helper utilities for OpenMRS",
   "type": "module",

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/esm-app-shell",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "main": "dist/openmrs.js",
   "scripts": {

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openmrs",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "main": "dist/index.js",
   "bin": "./dist/cli.js",

--- a/packages/tooling/rspack-config/package.json
+++ b/packages/tooling/rspack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/rspack-config",
-  "version": "6.2.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/packages/tooling/typedoc-plugin-file-categories/package.json
+++ b/packages/tooling/typedoc-plugin-file-categories/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/typedoc-plugin-file-categories",
-  "version": "6.2.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/tooling/webpack-config/package.json
+++ b/packages/tooling/webpack-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openmrs/webpack-config",
-  "version": "6.3.0",
+  "version": "7.0.0",
   "license": "MPL-2.0",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
<!-- Please describe what problems your PR addresses. -->

### ⚠️ Breaking Changes
- Use a single global cache instance for SWR [#1397](https://github.com/openmrs/openmrs-esm-core/pull/1397) by @ibacher

### 🚀 Features
- **O3-4880**: Use Carbon React's Theme Component in Implementer Tools [#1423](https://github.com/openmrs/openmrs-esm-core/pull/1423) by @harshthakkr, @vasharma05  
- **O3-4897**: Redirect 401 request to URL location specified by response [#1430](https://github.com/openmrs/openmrs-esm-core/pull/1430) by @chibongho  
- Implement an OpenMRS DateRangePicker [#1428](https://github.com/openmrs/openmrs-esm-core/pull/1428) by @samuelmale  
- Update TypeDoc and TypeScript [#1406](https://github.com/openmrs/openmrs-esm-core/pull/1406) by @ibacher  
- Add dashboard into primary navigation app [#1358](https://github.com/openmrs/openmrs-esm-core/pull/1358) by @NethmiRodrigo  
- **O3-4778**: Add way to define hidden left nav [#1383](https://github.com/openmrs/openmrs-esm-core/pull/1383) by @chibongho  
- Allow left nav to preserve correct component context [#1380](https://github.com/openmrs/openmrs-esm-core/pull/1380) by @ibacher  
- Additional content switcher style overrides [commit](https://github.com/openmrs/openmrs-esm-core/commit/May29) by @denniskigen  
- Re-work Framework packages for lighter-weight builds [#1346](https://github.com/openmrs/openmrs-esm-core/pull/1346) by @ibacher  
- Add stock management pictogram [#1361](https://github.com/openmrs/openmrs-esm-core/pull/1361) by @denniskigen  

### 🐛 Fixes
- **O3-4829**: Integrate `_validators` from config schema files into Implementer Tools UI validation [#1404](https://github.com/openmrs/openmrs-esm-core/pull/1404) by @harshthakkr, @jwnasambu, @vasharma05  
- Prevent calendar from closing on internal clicks [#1432](https://github.com/openmrs/openmrs-esm-core/pull/1432) by @samuelmale  
- Fix dashboard component to update when basePath changes [#1431](https://github.com/openmrs/openmrs-esm-core/pull/1431) by @ibacher  
- **O3-4867**: Center initial loading spinner [#1418](https://github.com/openmrs/openmrs-esm-core/pull/1418) by @ELVISKATS, @denniskigen  
- Restore ability to merge multiple config files [commit](https://github.com/openmrs/openmrs-esm-core/commit/Jul11) by @ibacher  
- Ensure i18next namespace matches state [#1415](https://github.com/openmrs/openmrs-esm-core/pull/1415) by @ibacher  
- **O3-4844**: Update visit store only when `useVisit` is called for current patient [#1409](https://github.com/openmrs/openmrs-esm-core/pull/1409) and [#1412](https://github.com/openmrs/openmrs-esm-core/pull/1412) by @chibongho, @denniskigen  
- Fix dashboard stylesheet extension [#1413](https://github.com/openmrs/openmrs-esm-core/pull/1413) by @NethmiRodrigo  
- Simpler types for `AppContext` [#1408](https://github.com/openmrs/openmrs-esm-core/pull/1408) by @ibacher  
- Fix Dashboard and NavGroup components [#1407](https://github.com/openmrs/openmrs-esm-core/pull/1407) by @ibacher  
- **O3-4832**: Update external links to docs and changelog [#1403](https://github.com/openmrs/openmrs-esm-core/pull/1403) by @JayadityaGit  
- Fix visit context not changing to past visit [#1391](https://github.com/openmrs/openmrs-esm-core/pull/1391) by @chibongho  
- **O3-4803**: Hide help icon when help menu is empty [#1399](https://github.com/openmrs/openmrs-esm-core/pull/1399) by @chibongho  
- Downgrade SWR to 2.2.5 [#1398](https://github.com/openmrs/openmrs-esm-core/pull/1398) by @ibacher  
- Fix assemble prompt logic using unique keys [#1394](https://github.com/openmrs/openmrs-esm-core/pull/1394) by @samuelmale  
- Restore old way of federating SWR [#1395](https://github.com/openmrs/openmrs-esm-core/pull/1395) by @ibacher, @denniskigen  
- **O3-4778**: Only render side nav in desktop mode when `leftNavMode` is `normal` [#1389](https://github.com/openmrs/openmrs-esm-core/pull/1389) by @chibongho  
- Restore name prop for user menu button [#1388](https://github.com/openmrs/openmrs-esm-core/pull/1388) by @denniskigen  
- Assemble shouldn't break if numbers aren't specified [#1382](https://github.com/openmrs/openmrs-esm-core/pull/1382) by @ibacher, @denniskigen  
- Cast string to ReactNode instead of ReactElement [#1381](https://github.com/openmrs/openmrs-esm-core/pull/1381) by @ibacher  
- **O3-4760**: Content switcher style fixes [#1379](https://github.com/openmrs/openmrs-esm-core/pull/1379), [#1375](https://github.com/openmrs/openmrs-esm-core/pull/1375), [#1374](https://github.com/openmrs/openmrs-esm-core/pull/1374) by @denniskigen  
- Remove `autoFocus` from Search component [#1378](https://github.com/openmrs/openmrs-esm-core/pull/1378) by @denniskigen  
- Fix inline padding on devtools/help buttons [commit](https://github.com/openmrs/openmrs-esm-core/commit/May29) by @denniskigen  
- **O3-4753**: Remove unnecessary padding from icon-only ghost buttons [#1373](https://github.com/openmrs/openmrs-esm-core/pull/1373) by @denniskigen  
- **O3-4707**: Update visit context when active visit is created or ended [#1360](https://github.com/openmrs/openmrs-esm-core/pull/1360) by @chibongho  
- Add extra guardrails around `displayedValidationMessages` [#1356](https://github.com/openmrs/openmrs-esm-core/pull/1356) by @ibacher  
- Add Zeroheight link to README [commit](https://github.com/openmrs/openmrs-esm-core/commit/May2)  

