### PR TITLE
(fix) O3-4996: Add horizontal alignment to top-nav-info-slot in navbar

### DIFF
--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.component.tsx
@@ -62,7 +62,7 @@ const HeaderItems: React.FC = () => {
           </div>
         </ConfigurableLink>
         <div className={styles.divider} />
-        <ExtensionSlot name="top-nav-info-slot" />
+        <ExtensionSlot name="top-nav-info-slot" className={styles.topNavInfoSlot} />
         <HeaderGlobalBar className={styles.headerGlobalBar}>
           <ExtensionSlot
             name="top-nav-actions-slot"

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.scss
@@ -41,6 +41,7 @@
   background-color: rgba(244, 244, 244, 0.4);
   margin-inline-start: layout.$spacing-04;
 }
+
 .topNavInfoSlot {
   display: flex;
   gap: layout.$spacing-03;

--- a/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.scss
+++ b/packages/apps/esm-primary-navigation-app/src/components/navbar/navbar.scss
@@ -41,3 +41,7 @@
   background-color: rgba(244, 244, 244, 0.4);
   margin-inline-start: layout.$spacing-04;
 }
+.topNavInfoSlot {
+  display: flex;
+  gap: layout.$spacing-03;
+}


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## For changes to apps

- [ ] My work conforms to the [**O3 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://om.rs/o3ui).

## If applicable

- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
The `top-nav-info-slot` extension slot currently lacks a flex container, causing multiple extensions to stack vertically instead of displaying side-by-side as intended. This implements flexbox layout with proper spacing to ensure extensions render horizontally in the navbar.

## Screenshots
### Issue
<img width="1788" height="45" alt="Screenshot from 2025-08-27 15-06-03" src="https://github.com/user-attachments/assets/983009f5-0443-40e8-95a4-8cdab9ee6706" />

### Fix
<img width="1792" height="50" alt="dndndnndddddddddddddddd" src="https://github.com/user-attachments/assets/5e28a6ff-0c70-4487-91f3-2f29ff6423a7" />

## Related Issue
https://openmrs.atlassian.net/browse/O3-4996

## Other
<!-- Anything not covered above -->
