### PR TITLE
(fix) Add missing workspace translation and fix extraction

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-scripts-prepend-node-path=true

--- a/packages/framework/esm-framework/docs/interfaces/FeatureFlagDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/FeatureFlagDefinition.md
@@ -2,7 +2,7 @@
 
 # Interface: FeatureFlagDefinition
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:300
+Defined in: packages/framework/esm-globals/dist/types.d.ts:296
 
 A definition of a feature flag extracted from the routes.json
 
@@ -12,7 +12,7 @@ A definition of a feature flag extracted from the routes.json
 
 > **description**: `string`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:306
+Defined in: packages/framework/esm-globals/dist/types.d.ts:302
 
 An explanation of what the flag does, which will be displayed in the Implementer Tools
 
@@ -22,7 +22,7 @@ An explanation of what the flag does, which will be displayed in the Implementer
 
 > **flagName**: `string`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:302
+Defined in: packages/framework/esm-globals/dist/types.d.ts:298
 
 A code-friendly name for the flag, which will be used to reference it in code
 
@@ -32,6 +32,6 @@ A code-friendly name for the flag, which will be used to reference it in code
 
 > **label**: `string`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:304
+Defined in: packages/framework/esm-globals/dist/types.d.ts:300
 
 A human-friendly name which will be displayed in the Implementer Tools

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
@@ -2,7 +2,7 @@
 
 # Interface: OpenmrsAppRoutes
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:309
+Defined in: packages/framework/esm-globals/dist/types.d.ts:305
 
 This interface describes the format of the routes provided by an app
 
@@ -12,7 +12,7 @@ This interface describes the format of the routes provided by an app
 
 > `optional` **backendDependencies**: `Record`\<`string`, `string`\>
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:313
+Defined in: packages/framework/esm-globals/dist/types.d.ts:309
 
 A list of backend modules necessary for this frontend module and the corresponding required versions.
 
@@ -22,7 +22,7 @@ A list of backend modules necessary for this frontend module and the correspondi
 
 > `optional` **extensions**: [`ExtensionDefinition`](../type-aliases/ExtensionDefinition.md)[]
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:327
+Defined in: packages/framework/esm-globals/dist/types.d.ts:323
 
 An array of all extensions supported by this frontend module. Extensions can be mounted in extension slots, either via declarations in this file or configuration.
 
@@ -32,7 +32,7 @@ An array of all extensions supported by this frontend module. Extensions can be 
 
 > `optional` **featureFlags**: [`FeatureFlagDefinition`](FeatureFlagDefinition.md)[]
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:329
+Defined in: packages/framework/esm-globals/dist/types.d.ts:325
 
 An array of all feature flags for any beta-stage features this module provides.
 
@@ -42,7 +42,7 @@ An array of all feature flags for any beta-stage features this module provides.
 
 > `optional` **modals**: [`ModalDefinition`](../type-aliases/ModalDefinition.md)[]
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:331
+Defined in: packages/framework/esm-globals/dist/types.d.ts:327
 
 An array of all modals supported by this frontend module. Modals can be launched by name.
 
@@ -52,7 +52,7 @@ An array of all modals supported by this frontend module. Modals can be launched
 
 > `optional` **optionalBackendDependencies**: `object`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:315
+Defined in: packages/framework/esm-globals/dist/types.d.ts:311
 
 A list of backend modules that may enable optional functionality in this frontend module if available and the corresponding required versions.
 
@@ -68,7 +68,7 @@ The name of the backend dependency and either the required version or an object 
 
 > `optional` **pages**: [`PageDefinition`](../type-aliases/PageDefinition.md)[]
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:325
+Defined in: packages/framework/esm-globals/dist/types.d.ts:321
 
 An array of all pages supported by this frontend module. Pages are automatically mounted based on a route.
 
@@ -78,7 +78,7 @@ An array of all pages supported by this frontend module. Pages are automatically
 
 > `optional` **version**: `string`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:311
+Defined in: packages/framework/esm-globals/dist/types.d.ts:307
 
 The version of this frontend module.
 
@@ -88,7 +88,7 @@ The version of this frontend module.
 
 > `optional` **workspaceGroups**: [`WorkspaceGroupDefinition`](WorkspaceGroupDefinition.md)[]
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:335
+Defined in: packages/framework/esm-globals/dist/types.d.ts:331
 
 An array of all workspace groups supported by this frontend module.
 
@@ -98,6 +98,6 @@ An array of all workspace groups supported by this frontend module.
 
 > `optional` **workspaces**: [`WorkspaceDefinition`](../type-aliases/WorkspaceDefinition.md)[]
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:333
+Defined in: packages/framework/esm-globals/dist/types.d.ts:329
 
 An array of all workspaces supported by this frontend module. Workspaces can be launched by name.

--- a/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
+++ b/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
@@ -2,7 +2,7 @@
 
 # Interface: ResourceLoader()\<T\>
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:342
+Defined in: packages/framework/esm-globals/dist/types.d.ts:338
 
 ## Type Parameters
 
@@ -12,7 +12,7 @@ Defined in: packages/framework/esm-globals/dist/types.d.ts:342
 
 > **ResourceLoader**(): `Promise`\<`T`\>
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:343
+Defined in: packages/framework/esm-globals/dist/types.d.ts:339
 
 ## Returns
 

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceGroupDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceGroupDefinition.md
@@ -2,7 +2,7 @@
 
 # Interface: WorkspaceGroupDefinition
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:287
+Defined in: packages/framework/esm-globals/dist/types.d.ts:283
 
 ## Properties
 
@@ -10,7 +10,7 @@ Defined in: packages/framework/esm-globals/dist/types.d.ts:287
 
 > `optional` **members**: `string`[]
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:295
+Defined in: packages/framework/esm-globals/dist/types.d.ts:291
 
 List of workspace names which are part of the workspace group.
 
@@ -20,6 +20,6 @@ List of workspace names which are part of the workspace group.
 
 > **name**: `string`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:291
+Defined in: packages/framework/esm-globals/dist/types.d.ts:287
 
 Name of the workspace group. This is used to launch the workspace group

--- a/packages/framework/esm-framework/docs/type-aliases/ExtensionDefinition.md
+++ b/packages/framework/esm-framework/docs/type-aliases/ExtensionDefinition.md
@@ -14,19 +14,9 @@ A definition of an extension as extracted from an app's routes.json
 
 > **component**: `string`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:214
+Defined in: packages/framework/esm-globals/dist/types.d.ts:210
 
 The name of the component exported by this frontend module.
-
-***
-
-### displayExpression?
-
-> `optional` **displayExpression**: `string`
-
-Defined in: packages/framework/esm-globals/dist/types.d.ts:200
-
-The expression that determines whether the extension is displayed.
 
 ***
 
@@ -34,7 +24,7 @@ The expression that determines whether the extension is displayed.
 
 > `optional` **featureFlag**: `string`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:204
+Defined in: packages/framework/esm-globals/dist/types.d.ts:200
 
 If supplied, the extension will only be rendered when this feature flag is enabled.
 
@@ -44,7 +34,7 @@ If supplied, the extension will only be rendered when this feature flag is enabl
 
 > `optional` **meta**: `object`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:208
+Defined in: packages/framework/esm-globals/dist/types.d.ts:204
 
 Meta describes any properties that are passed down to the extension when it is loaded
 

--- a/packages/framework/esm-framework/docs/type-aliases/ModalDefinition.md
+++ b/packages/framework/esm-framework/docs/type-aliases/ModalDefinition.md
@@ -4,7 +4,7 @@
 
 > **ModalDefinition** = `object`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:219
+Defined in: packages/framework/esm-globals/dist/types.d.ts:215
 
 A definition of a modal as extracted from an app's routes.json
 
@@ -14,7 +14,7 @@ A definition of a modal as extracted from an app's routes.json
 
 > **component**: `string`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:227
+Defined in: packages/framework/esm-globals/dist/types.d.ts:223
 
 The name of the component exported by this frontend module.
 
@@ -24,6 +24,6 @@ The name of the component exported by this frontend module.
 
 > **name**: `string`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:223
+Defined in: packages/framework/esm-globals/dist/types.d.ts:219
 
 The name of this modal. This is used to launch the modal.

--- a/packages/framework/esm-framework/docs/type-aliases/NameUse.md
+++ b/packages/framework/esm-framework/docs/type-aliases/NameUse.md
@@ -4,4 +4,4 @@
 
 > **NameUse** = `"usual"` \| `"official"` \| `"temp"` \| `"nickname"` \| `"anonymous"` \| `"old"` \| `"maiden"`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:345
+Defined in: packages/framework/esm-globals/dist/types.d.ts:341

--- a/packages/framework/esm-framework/docs/type-aliases/OpenmrsRoutes.md
+++ b/packages/framework/esm-framework/docs/type-aliases/OpenmrsRoutes.md
@@ -4,7 +4,7 @@
 
 > **OpenmrsRoutes** = `Record`\<`string`, [`OpenmrsAppRoutes`](../interfaces/OpenmrsAppRoutes.md)\>
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:341
+Defined in: packages/framework/esm-globals/dist/types.d.ts:337
 
 This interfaces describes the format of the overall routes.json loaded by the app shell.
 Basically, this is the same as the app routes, with each routes definition keyed by the app's name

--- a/packages/framework/esm-framework/docs/type-aliases/WorkspaceDefinition.md
+++ b/packages/framework/esm-framework/docs/type-aliases/WorkspaceDefinition.md
@@ -4,7 +4,7 @@
 
 > **WorkspaceDefinition** = `object`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:233
+Defined in: packages/framework/esm-globals/dist/types.d.ts:229
 
 A definition of a workspace as extracted from an app's routes.json
 
@@ -14,7 +14,7 @@ A definition of a workspace as extracted from an app's routes.json
 
 > `optional` **canHide**: `boolean`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:249
+Defined in: packages/framework/esm-globals/dist/types.d.ts:245
 
 ***
 
@@ -22,7 +22,7 @@ Defined in: packages/framework/esm-globals/dist/types.d.ts:249
 
 > `optional` **canMaximize**: `boolean`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:250
+Defined in: packages/framework/esm-globals/dist/types.d.ts:246
 
 ***
 
@@ -30,7 +30,7 @@ Defined in: packages/framework/esm-globals/dist/types.d.ts:250
 
 > **component**: `string`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:285
+Defined in: packages/framework/esm-globals/dist/types.d.ts:281
 
 The name of the component exported by this frontend module.
 
@@ -40,7 +40,7 @@ The name of the component exported by this frontend module.
 
 > **groups**: `string`[]
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:281
+Defined in: packages/framework/esm-globals/dist/types.d.ts:277
 
 Workspaces can open either independently or as part of a "workspace group". A
 "workspace group" groups related workspaces together, so that only one is visible
@@ -68,7 +68,7 @@ name, the entire workspace group will close, and the new workspace will launch i
 
 > **name**: `string`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:237
+Defined in: packages/framework/esm-globals/dist/types.d.ts:233
 
 The name of this workspace. This is used to launch the workspace.
 
@@ -78,7 +78,7 @@ The name of this workspace. This is used to launch the workspace.
 
 > `optional` **preferredWindowSize**: [`WorkspaceWindowState`](WorkspaceWindowState.md)
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:260
+Defined in: packages/framework/esm-globals/dist/types.d.ts:256
 
 Launches the workspace in the preferred size, it defaults to the 'narrow' width
 
@@ -88,7 +88,7 @@ Launches the workspace in the preferred size, it defaults to the 'narrow' width
 
 > **title**: `string`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:242
+Defined in: packages/framework/esm-globals/dist/types.d.ts:238
 
 The title of the workspace. This will be looked up as a key in the translations of the module
 defining the workspace.
@@ -99,7 +99,7 @@ defining the workspace.
 
 > **type**: `string`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:248
+Defined in: packages/framework/esm-globals/dist/types.d.ts:244
 
 The type of the workspace. Only one of each "type" of workspace is allowed to be open at a
 time. The default is "form". If the right sidebar is in use, then the type determines which
@@ -111,7 +111,7 @@ right sidebar icon corresponds to the workspace.
 
 > `optional` **width**: `"narrow"` \| `"wider"` \| `"extra-wide"`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:256
+Defined in: packages/framework/esm-globals/dist/types.d.ts:252
 
 Controls the width of the workspace. The default is "narrow" and this should only be
 changed to "wider" if the workspace itself has internal navigation, like the form editor.

--- a/packages/framework/esm-framework/docs/type-aliases/WorkspaceWindowState.md
+++ b/packages/framework/esm-framework/docs/type-aliases/WorkspaceWindowState.md
@@ -4,4 +4,4 @@
 
 > **WorkspaceWindowState** = `"maximized"` \| `"hidden"` \| `"normal"`
 
-Defined in: packages/framework/esm-globals/dist/types.d.ts:229
+Defined in: packages/framework/esm-globals/dist/types.d.ts:225

--- a/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
+++ b/packages/framework/esm-styleguide/src/workspaces/workspaces.ts
@@ -1,5 +1,6 @@
 /** @module @category Workspace */
 import { useMemo, type ReactNode } from 'react';
+import type { StoreApi } from 'zustand/vanilla';
 import {
   getWorkspaceGroupRegistration,
   getWorkspaceRegistration,
@@ -10,7 +11,6 @@ import { navigate } from '@openmrs/esm-navigation';
 import { getGlobalStore, createGlobalStore } from '@openmrs/esm-state';
 import { getCoreTranslation } from '@openmrs/esm-translations';
 import { useStore } from '@openmrs/esm-react-utils';
-import type { StoreApi } from 'zustand/vanilla';
 
 export interface CloseWorkspaceOptions {
   /**

--- a/packages/framework/esm-translations/custom-i18next-parser-lexer.mjs
+++ b/packages/framework/esm-translations/custom-i18next-parser-lexer.mjs
@@ -7,12 +7,18 @@ export default class ObjectLexer extends BaseLexer {
 
   // `content` is literally just the text content of the file. We use a
   // regex matcher to extract the key-value pairs.
+  // Supports single quotes, double quotes, and backticks, including escaped quotes.
   extract(content) {
-    const regex = /(?<=\s*)(\w+)\s*:\s*'([^']+)'/g;
-    let keys = []
+    const regex = /(\w+)\s*:\s*(?:"((?:[^"\\]|\\.)*)"|'((?:[^'\\]|\\.)*)'|`((?:[^`\\]|\\.)*)`)/g;
+    let keys = [];
     let match;
     while ((match = regex.exec(content)) !== null) {
-      keys.push({ key: match[1], defaultValue: match[2] });
+      const key = match[1];
+      // The value is in one of groups 2, 3, or 4 depending on quote type
+      const rawValue = match[2] || match[3] || match[4];
+      // Unescape any escaped characters
+      const defaultValue = rawValue.replace(/\\(.)/g, '$1');
+      keys.push({ key, defaultValue });
     }
     return keys;
   }

--- a/packages/framework/esm-translations/src/translations.ts
+++ b/packages/framework/esm-translations/src/translations.ts
@@ -27,7 +27,8 @@ const workspaceTranslations = {
   maximize: 'Maximize',
   minimize: 'Minimize',
   openAnyway: 'Open anyway',
-  unsavedChangesInOpenedWorkspace: `You may have unsaved changes in the opened workspace. Do you want to discard these changes?`,
+  unsavedChangesInOpenedWorkspace:
+    'You may have unsaved changes in the opened workspace. Do you want to discard these changes?',
   unsavedChangesInWorkspace:
     'There may be unsaved changes in "{{workspaceName}}". Please save them before opening another workspace.',
   unsavedChangesTitleText: 'Unsaved changes',

--- a/packages/framework/esm-translations/translations/en.json
+++ b/packages/framework/esm-translations/translations/en.json
@@ -15,7 +15,7 @@
   "Clinic": "Clinic",
   "close": "Close",
   "closeAllOpenedWorkspaces": "Discard changes in {{count}} workspaces",
-  "closingAllWorkspacesPromptBody": "There are unsaved changes in the following workspaces. Do you want to discard changes in the following workspaces? {{workspaceNames}}",
+  "closingAllWorkspacesPromptBody": "There may be unsaved changes in the following workspaces. Do you want to discard changes in the following workspaces? {{workspaceNames}}",
   "closingAllWorkspacesPromptTitle": "You have unsaved changes",
   "confirm": "Confirm",
   "contactAdministratorIfIssuePersists": "Contact your system administrator if the problem persists.",
@@ -57,6 +57,7 @@
   "stateProvince": "State",
   "toggleDevTools": "Toggle dev tools",
   "unknown": "Unknown",
+  "unsavedChangesInOpenedWorkspace": "You may have unsaved changes in the opened workspace. Do you want to discard these changes?",
   "unsavedChangesInWorkspace": "There may be unsaved changes in \"{{workspaceName}}\". Please save them before opening another workspace.",
   "unsavedChangesTitleText": "Unsaved changes",
   "workspaceHeader": "Workspace header"


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## If applicable

- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary

This PR makes the following changes:

- Fix `unsavedChangesInOpenedWorkspace` not being extracted by using single quotes instead of backticks. The value uses backticks (`), but the [custom lexer regex](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-translations/custom-i18next-parser-lexer.mjs#L11) only matches single quotes. Keys with backticks or double quotes are skipped during extraction.
- Add missing `unsavedChangesInOpenedWorkspace` key to `en.json`.
- Update `closingAllWorkspacesPromptBody` to match current source text.
- Tangential: Remove `scripts-prepend-node-path=true` from .npmrc to fix a deprecation warning.

## Screenshots

With french translation added by hand for testing:

<img width="3580" height="2086" alt="CleanShot 2025-10-01 at 01 15 45@2x" src="https://github.com/user-attachments/assets/dae64dc4-80ff-40d8-b02c-5b1b5273059c" />

This screenshot reveals the other bug reported by Bradley where both the discard and cancel buttons incorrectly use the same french translation ("Annuler"). That should be fixed upstream in Transifex.

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
