### PR TITLE
(chore) Bump ace-builds and configure for webpack 5 compatibility

### DIFF
--- a/packages/apps/esm-implementer-tools-app/package.json
+++ b/packages/apps/esm-implementer-tools-app/package.json
@@ -53,9 +53,9 @@
   "devDependencies": {
     "@openmrs/esm-framework": "workspace:*",
     "@openmrs/webpack-config": "workspace:*",
-    "ace-builds": "^1.4.14",
+    "ace-builds": "^1.43.3",
     "react": "^18.3.1",
-    "react-ace": "^9.5.0",
+    "react-ace": "^14.0.1",
     "react-dom": "^18.3.1",
     "react-i18next": "^11.18.6",
     "rxjs": "^6.5.3",

--- a/packages/apps/esm-implementer-tools-app/src/configuration/json-editor/json-editor.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/json-editor/json-editor.component.tsx
@@ -1,12 +1,21 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { Button } from '@carbon/react';
-import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import AceEditor from 'react-ace';
-import 'ace-builds/src-noconflict/mode-json';
-import 'ace-builds/src-noconflict/theme-dracula';
+import { Button } from '@carbon/react';
+import { useTranslation } from 'react-i18next';
 import { clearConfigErrors, temporaryConfigStore, useStore } from '@openmrs/esm-framework/src/internal';
 import styles from './json-editor.scss';
+
+import 'ace-builds/src-noconflict/mode-json';
+import 'ace-builds/src-noconflict/theme-dracula';
+import ace from 'ace-builds/src-noconflict/ace';
+
+// Configure ace to bundle workers locally (webpack 5 asset modules)
+// Using new URL() syntax instead of deprecated file-loader or CDN for offline compatibility
+ace.config.setModuleUrl(
+  'ace/mode/json_worker',
+  new URL('ace-builds/src-noconflict/worker-json.js', import.meta.url).href,
+);
 
 export interface JsonEditorProps {
   /** A CSS value */
@@ -25,17 +34,17 @@ export default function JsonEditor({ height }: JsonEditorProps) {
     try {
       config = JSON.parse(editorValue);
     } catch (e) {
-      setError(e.message);
+      setError(e instanceof Error ? e.message : 'Invalid JSON');
       return;
     }
     setError('');
     clearConfigErrors();
     temporaryConfigStore.setState({ config });
-  }, [editorValue, temporaryConfigStore]);
+  }, [editorValue, temporaryConfig.config]);
 
   useEffect(() => {
     if (editorValue != JSON.stringify(temporaryConfig.config, null, 2)) {
-      setKey((k) => `${k}+`); // just keep appendingplus signs
+      setKey((k) => `${k}+`); // just keep appending plus signs
     }
   }, [temporaryConfig.config]);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3893,10 +3893,10 @@ __metadata:
     "@carbon/react": "npm:^1.92.1"
     "@openmrs/esm-framework": "workspace:*"
     "@openmrs/webpack-config": "workspace:*"
-    ace-builds: "npm:^1.4.14"
+    ace-builds: "npm:^1.43.3"
     lodash-es: "npm:^4.17.21"
     react: "npm:^18.3.1"
-    react-ace: "npm:^9.5.0"
+    react-ace: "npm:^14.0.1"
     react-dom: "npm:^18.3.1"
     react-i18next: "npm:^11.18.6"
     rxjs: "npm:^6.5.3"
@@ -8317,10 +8317,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ace-builds@npm:^1.4.13, ace-builds@npm:^1.4.14":
-  version: 1.11.2
-  resolution: "ace-builds@npm:1.11.2"
-  checksum: 10/e8a14af434b550a759e979e037e5aca5e0d30aa0f1b412866078d21176430cadedf4bb4908be4ec76f12eefff8afd051833a555882522300a5fafcd5385e1269
+"ace-builds@npm:^1.36.3, ace-builds@npm:^1.43.3":
+  version: 1.43.3
+  resolution: "ace-builds@npm:1.43.3"
+  checksum: 10/6c38d5292c31ea7ee678b93584578906ce9c56e2c3c3b74236dbeb1de01a1533b3512fa0efc6094e029fd0bf8f912d85e6df7bffe29ab2f791f108e3574d0312
   languageName: node
   linkType: hard
 
@@ -17954,7 +17954,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1"
   dependencies:
@@ -18107,19 +18107,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-ace@npm:^9.5.0":
-  version: 9.5.0
-  resolution: "react-ace@npm:9.5.0"
+"react-ace@npm:^14.0.1":
+  version: 14.0.1
+  resolution: "react-ace@npm:14.0.1"
   dependencies:
-    ace-builds: "npm:^1.4.13"
+    ace-builds: "npm:^1.36.3"
     diff-match-patch: "npm:^1.0.5"
     lodash.get: "npm:^4.4.2"
     lodash.isequal: "npm:^4.5.0"
-    prop-types: "npm:^15.7.2"
+    prop-types: "npm:^15.8.1"
   peerDependencies:
-    react: ^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0
-    react-dom: ^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0
-  checksum: 10/3ca31fd70ec4671ae76fa15a9cdf2e13c4941f4a11c64ffb06fcf869a4acf29feb826031d9fc6325c5ad81609e5e87735fd165cb734ccf7712ad9051299ed046
+    react: ^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    react-dom: ^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+  checksum: 10/2aa878b1ae33cee91ef76d86fcc990d05c71de9f8be985c0a10e453f68c97ca0ab91e09c0e87755a980012412ab5290f6bafe776c0548041982b8761e9dac600
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## If applicable

- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the [esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

## Summary
    
Upgrades ace-builds from 1.4.14 to 1.43.3 and react-ace from 9.5.0 to 14.0.1. Configures JSON worker to bundle locally using webpack 5's asset modules (new URL() syntax) for offline compatibility in healthcare environments. This approach avoids both CDN dependencies and the deprecated file-loader package.

Sources: https://github.com/ajaxorg/ace-builds/issues/211

## Screenshots

<img width="3578" height="1348" alt="CleanShot 2025-10-03 at 12 20 11@2x" src="https://github.com/user-attachments/assets/dd288467-5a60-4bb8-82ab-e4ec01888d3d" />

https://github.com/user-attachments/assets/17bfe27d-950f-4333-91f9-edcea95cf76c

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
