### PR TITLE
(docs) O3-5096: Update E2E test documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,12 +181,12 @@ cp example.env .env
 By default, tests run against a local backend at http://localhost:8080/openmrs. To test local changes, make sure your dev server is running before executing tests. For example, to test local changes to the Login app, run:
 
 ```bash
-yarn start --sources packages/apps/esm-login-app
+yarn start --sources packages/apps/esm-login-app # or any other app in the packages/apps directory
 ```
 
-To test against a remote instance (such as the OpenMRS refapp hosted on dev3.openmrs.org, update the E2E_BASE_URL environment variable in your .env file:
+To test against a remote instance (such as the OpenMRS refapp hosted on dev3.openmrs.org), update the `E2E_BASE_URL` environment variable in your .env file:
 
-```
+```env
 E2E_BASE_URL=https://dev3.openmrs.org/openmrs
 ```
 
@@ -196,7 +196,7 @@ To run E2E tests:
 yarn test-e2e
 ```
 
-This will run all the E2E tests (files in the e2e directory with the *.spec.ts extension) in headless mode. That means no browser UI will be visible.
+This will run all the E2E tests (files in the e2e/specs directory with the `*.spec.ts` extension) in headless mode. That means no browser UI will be visible.
 
 To run tests in headed mode (shows the browser while tests run) use:
 
@@ -219,7 +219,7 @@ yarn test-e2e --headed --ui
 To run a specific test file:
 
 ```bash
-yarn test-e2e <test-name>
+yarn test-e2e <test-name> # for example, yarn test-e2e login.spec.ts
 ```
 
 Read the [e2e testing guide](https://openmrs.atlassian.net/wiki/spaces/docs/pages/150962731/Testing+Frontend+Modules+O3) to learn more about End-to-End tests in this project.

--- a/README.md
+++ b/README.md
@@ -169,31 +169,60 @@ By default, `turbo` will cache test runs. This means that re-running tests witho
 yarn turbo run test --force
 ```
 
-#### E2E tests
+#### Running End-to-End (E2E) tests
 
-To run E2E tests locally, follow these steps:
-
-##### Start the Development Server
-
-Begin by spinning up a development server for the frontend module that you want to test. Ensure the server is running before proceeding.
-
-##### Set Up Environment Variables
-
-Copy the example environment variables into a new .env file by running the following command:
+Before running the E2E tests, you need to set up the test environment. Install Playwright browsers and setup the default test environment variables by running the following commands:
 
 ```bash
+npx playwright install
 cp example.env .env
 ```
 
-##### Execute Tests
-
-Run the tests with the following command:
+By default, tests run against a local backend at http://localhost:8080/openmrs. To test local changes, make sure your dev server is running before executing tests. For example, to test local changes to the Login app, run:
 
 ```bash
-yarn test-e2e --ui --headed
+yarn start --sources packages/apps/esm-login-app
 ```
 
-Read the [e2e testing guide](https://openmrs.atlassian.net/wiki/spaces/docs/pages/150962731/Testing+Frontend+Modules+O3#End-to-end-testing-with-Playwright) to learn more about End-to-End tests.
+To test against a remote instance (such as the OpenMRS refapp hosted on dev3.openmrs.org, update the E2E_BASE_URL environment variable in your .env file:
+
+```
+E2E_BASE_URL=https://dev3.openmrs.org/openmrs
+```
+
+To run E2E tests:
+
+```bash
+yarn test-e2e
+```
+
+This will run all the E2E tests (files in the e2e directory with the *.spec.ts extension) in headless mode. That means no browser UI will be visible.
+
+To run tests in headed mode (shows the browser while tests run) use:
+
+```bash
+yarn test-e2e --headed
+```
+
+To run tests in Playwright's UI mode (interactive debugger), use:
+
+```bash
+yarn test-e2e --ui
+```
+
+You'll most often want to run tests in both headed and UI mode:
+
+```bash
+yarn test-e2e --headed --ui
+```
+
+To run a specific test file:
+
+```bash
+yarn test-e2e <test-name>
+```
+
+Read the [e2e testing guide](https://openmrs.atlassian.net/wiki/spaces/docs/pages/150962731/Testing+Frontend+Modules+O3) to learn more about End-to-End tests in this project.
 
 ### Linking the framework
 

--- a/markdown_link_check_config.json
+++ b/markdown_link_check_config.json
@@ -13,6 +13,9 @@
     },
     {
       "pattern": "^https://www.npmjs.com/package/@openmrs/"
+    },
+    {
+      "pattern": "^http://localhost"
     }
   ],
   "retryOn429": true,


### PR DESCRIPTION
# Requirements

* [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [[conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines)](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## If applicable

* [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
* [ ] My work includes tests or is validated by existing tests.
* [ ] I have updated the [[esm-framework mock](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx)](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) to reflect any API changes I have made.

---

## Summary

This PR updates the **E2E testing section** in the `esm-core` README to provide clearer guidance on how to run and debug end-to-end tests.
It clarifies the difference between running tests in **headed mode** and **UI mode**, consolidates duplicated commands, and improves overall readability for contributors setting up Playwright tests.

---

## Screenshots

*N/A — no UI changes.*

---

## Related Issue

[https://openmrs.atlassian.net/browse/O3-5096](https://openmrs.atlassian.net/browse/O3-5096)

---

## Other

Minor documentation-only update — no code or configuration changes.