### PR TITLE
(fix) Align error handling mock with normalization behavior

### DIFF
--- a/packages/framework/esm-api/__mocks__/openmrs-esm-error-handling.mock.ts
+++ b/packages/framework/esm-api/__mocks__/openmrs-esm-error-handling.mock.ts
@@ -1,2 +1,29 @@
-export function createErrorHandler() {}
-export function reportError() {}
+export function createErrorHandler() {
+  return (error: unknown): never => {
+    reportError(error);
+  };
+}
+
+export function reportError(error: unknown): never {
+  if (error instanceof Error) {
+    throw error;
+  }
+
+  if (typeof error === 'string') {
+    throw new Error(error);
+  }
+
+  if (error === null) {
+    throw new Error("'null' was thrown as an error");
+  }
+
+  if (error === undefined) {
+    throw new Error("'undefined' was thrown as an error");
+  }
+
+  try {
+    throw new Error(`Object thrown as error: ${JSON.stringify(error)}`);
+  } catch {
+    throw new Error('Unknown non-Error value thrown');
+  }
+}


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done and follows the conventional commit format (`fix:`).


## If applicable

- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework mock to reflect any API changes I have made.  
      (Not applicable – no production API changes were introduced.)

## Summary
The existing esm-api error handling mock exported empty implementations for `createErrorHandler` and `reportError`, which allowed tests to pass without enforcing the error normalization behavior asserted by the test suite.

This change implements realistic mock behavior so that non-`Error` values are normalized and thrown consistently, aligning the mock with the expectations already validated by tests. This helps prevent false positives in tests and improves the reliability of the test environment without affecting production code.

## Screenshots
Not applicable (no UI changes).

## Related Issue
Not linked to a Jira ticket.

## Other
- Scope intentionally limited to the mock implementation only
- No production code or public APIs were changed
- Behavior matches existing test expectations to improve test correctness
