### PR TITLE
(fix) Recalculate layout on window move and focus change

### DIFF
--- a/packages/framework/esm-react-utils/src/useLayoutType.ts
+++ b/packages/framework/esm-react-utils/src/useLayoutType.ts
@@ -27,11 +27,24 @@ export function useLayoutType() {
   const [type, setType] = useState<LayoutType>(getLayout);
 
   useEffect(() => {
-    const handler = () => {
+    const handleLayoutChange = () => {
       setType(getLayout());
     };
-    window.addEventListener('resize', handler);
-    return () => window.removeEventListener('resize', handler);
+
+    // normal resize
+    window.addEventListener('resize', handleLayoutChange);
+
+    // tab moved to new window / focus change
+    window.addEventListener('focus', handleLayoutChange);
+
+    // visibility change (browser context switch)
+    document.addEventListener('visibilitychange', handleLayoutChange);
+
+    return () => {
+      window.removeEventListener('resize', handleLayoutChange);
+      window.removeEventListener('focus', handleLayoutChange);
+      document.removeEventListener('visibilitychange', handleLayoutChange);
+    };
   }, []);
 
   return type;


### PR DESCRIPTION
## Problem
When an OpenMRS tab is moved to a new window, the app layout does not update
because a `resize` event is not always triggered.

## Solution
Extended the layout update logic to also react to:
- `window.focus`
- `document.visibilitychange`

This ensures layout recalculation when the browser context changes,
including when tabs are moved across windows.

## How to test
1. Open OpenMRS in a wide desktop window
2. Open another smaller window
3. Drag the OpenMRS tab to the smaller window
4. Layout updates correctly without manual refresh

## Notes
This is a frontend-only change with no breaking impact.
