### PR TITLE
(feat) O3-4465: Update patient header test stubs with actual implementations

### DIFF
--- a/packages/framework/esm-framework/mock-jest.tsx
+++ b/packages/framework/esm-framework/mock-jest.tsx
@@ -68,25 +68,92 @@ export const unsetLeftNav = jest.fn();
 export const ResponsiveWrapper = jest.fn(({ children }) => <>{children}</>);
 export const ErrorState = jest.fn(() => <div>Error State</div>);
 
-export const CustomOverflowMenu = jest.fn(({ menuTitle, children }) => (
-  <div>
-    <button>{menuTitle}</button>
-    {children}
+export { CustomOverflowMenu, CustomOverflowMenuItem } from '@openmrs/esm-styleguide/src/public';
+export const PatientBannerActionsMenu = jest.fn(
+  ({ patient, patientUuid, actionsSlotName, additionalActionsSlotState }) => {
+    const [menuIsOpen, setMenuIsOpen] = React.useState(false);
+    return (
+      <div data-testid="patient-banner-actions-menu">
+        <button aria-expanded={menuIsOpen} aria-haspopup="true" onClick={() => setMenuIsOpen(!menuIsOpen)}>
+          <span>Actions</span>
+        </button>
+        {menuIsOpen && (
+          <div role="menu">
+            <div data-extension-slot={actionsSlotName} data-patient-uuid={patientUuid} />
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+export const PatientBannerContactDetails = jest.fn(({ patientId, deceased }) => (
+  <div data-testid="patient-banner-contact-details" data-patient-id={patientId} data-deceased={deceased}>
+    <div>
+      <p>Patient Lists (0)</p>
+      <ul>
+        <li>--</li>
+      </ul>
+    </div>
+    <div>
+      <p>Address</p>
+      <ul>
+        <li>--</li>
+      </ul>
+    </div>
+    <div>
+      <p>Contact Details</p>
+      <ul>
+        <li>--</li>
+      </ul>
+    </div>
   </div>
 ));
-export const CustomOverflowMenuItem = jest.fn(({ itemText, ...props }) => (
-  <button role="menuitem" {...props}>
-    {itemText}
-  </button>
-));
-export const PatientBannerActionsMenu = jest.fn(() => <div>Patient Banner Actions Menu</div>);
-export const PatientBannerContactDetails = jest.fn(() => <div>Patient Banner Contact Details</div>);
-export const PatientBannerPatientInfo = jest.fn(() => <div>Patient Banner Patient Info</div>);
-export const PatientBannerPatientIdentifiers = jest.fn(() => <div>Patient Banner Patient Identifier</div>);
-export const PatientBannerToggleContactDetailsButton = jest.fn(() => (
-  <div>Patient Banner Toggle Contact Details Button</div>
-));
-export const PatientPhoto = jest.fn(() => <div>Patient Photo</div>);
+export const PatientBannerPatientInfo = jest.fn(({ patient, renderedFrom }) => {
+  const name = patient?.name?.[0]
+    ? `${patient.name[0].given?.join(' ') || ''} ${patient.name[0].family || ''}`.trim()
+    : 'Unknown';
+  const genderMap = { male: 'Male', female: 'Female', other: 'Other', unknown: 'Unknown' };
+  const gender = patient?.gender ? genderMap[patient.gender.toLowerCase()] || patient.gender : 'Unknown';
+
+  return (
+    <div data-testid="patient-banner-patient-info">
+      <div>
+        <span>{name}</span>
+        <div>
+          <span>{gender}</span>
+        </div>
+      </div>
+      <div>{patient?.birthDate && <span>{patient.birthDate}</span>}</div>
+    </div>
+  );
+});
+export const PatientBannerPatientIdentifiers = jest.fn(({ identifiers, showIdentifierLabel }) => {
+  if (!identifiers || identifiers.length === 0) {
+    return null;
+  }
+
+  return (
+    <div data-testid="patient-banner-identifiers">
+      {identifiers.map((identifier, index) => (
+        <span key={index}>
+          {showIdentifierLabel && identifier.type?.text && <span>{identifier.type.text}: </span>}
+          <span>{identifier.value}</span>
+        </span>
+      ))}
+    </div>
+  );
+});
+export { PatientBannerToggleContactDetailsButton } from '@openmrs/esm-styleguide/src/public';
+export const PatientPhoto = jest.fn(({ patientUuid, patientName, alt }) => {
+  const altText = alt || `Avatar for ${patientName}`;
+  return (
+    <div data-testid="patient-photo" aria-label={altText}>
+      <div>
+        <span>{patientName?.charAt(0)?.toUpperCase()}</span>
+      </div>
+    </div>
+  );
+});
 export const usePatientPhoto = jest.fn(() => ({
   isLoading: true,
   data: null,

--- a/packages/framework/esm-framework/mock-jest.tsx
+++ b/packages/framework/esm-framework/mock-jest.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef, useId } from 'react';
+import React, { useState } from 'react';
 import { NEVER } from 'rxjs';
 import type {} from '@openmrs/esm-globals';
 import * as utils from '@openmrs/esm-utils';
@@ -76,17 +76,8 @@ export {
   PatientBannerPatientInfo,
   PatientBannerPatientIdentifiers,
   PatientBannerToggleContactDetailsButton,
+  PatientPhoto,
 } from '@openmrs/esm-styleguide/src/public';
-export const PatientPhoto = jest.fn(({ patientUuid, patientName, alt }) => {
-  const altText = alt || `Avatar for ${patientName}`;
-  return (
-    <div data-testid="patient-photo" aria-label={altText}>
-      <div>
-        <span>{patientName?.charAt(0)?.toUpperCase()}</span>
-      </div>
-    </div>
-  );
-});
 export const usePatientPhoto = jest.fn(() => ({
   isLoading: true,
   data: null,

--- a/packages/framework/esm-framework/mock-jest.tsx
+++ b/packages/framework/esm-framework/mock-jest.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useCallback, useRef, useId } from 'react';
 import { NEVER } from 'rxjs';
 import type {} from '@openmrs/esm-globals';
 import * as utils from '@openmrs/esm-utils';
@@ -68,80 +68,15 @@ export const unsetLeftNav = jest.fn();
 export const ResponsiveWrapper = jest.fn(({ children }) => <>{children}</>);
 export const ErrorState = jest.fn(() => <div>Error State</div>);
 
-export { CustomOverflowMenu, CustomOverflowMenuItem } from '@openmrs/esm-styleguide/src/public';
-export const PatientBannerActionsMenu = jest.fn(({ patient, patientUuid }) => (
-  <div data-testid="patient-banner-actions-menu">
-    <button aria-label="Actions">Actions</button>
-  </div>
-));
-export const PatientBannerContactDetails = jest.fn(({ patientId, deceased, address, telecom }) => (
-  <div data-testid="patient-banner-contact-details" data-patient-id={patientId} data-deceased={deceased}>
-    <div>
-      <p>Address</p>
-      {address && address.length > 0 ? (
-        <ul>
-          {address.map((addr, index) => (
-            <li key={index}>
-              {[addr.city, addr.state, addr.postalCode, addr.country].filter(Boolean).join(', ') || 'N/A'}
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p>No address on file</p>
-      )}
-    </div>
-    <div>
-      <p>Contact Details</p>
-      {telecom && telecom.length > 0 ? (
-        <ul>
-          {telecom.map((contact, index) => (
-            <li key={index}>
-              {contact.system}: {contact.value}
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p>No contact details on file</p>
-      )}
-    </div>
-  </div>
-));
-export const PatientBannerPatientInfo = jest.fn(({ patient, renderedFrom }) => {
-  const name = patient?.name?.[0]
-    ? `${patient.name[0].given?.join(' ') || ''} ${patient.name[0].family || ''}`.trim()
-    : 'Unknown';
-  const genderMap = { male: 'Male', female: 'Female', other: 'Other', unknown: 'Unknown' };
-  const gender = patient?.gender ? genderMap[patient.gender.toLowerCase()] || patient.gender : 'Unknown';
-
-  return (
-    <div data-testid="patient-banner-patient-info">
-      <div>
-        <span>{name}</span>
-        <div>
-          <span>{gender}</span>
-        </div>
-      </div>
-      <div>{patient?.birthDate && <span>{patient.birthDate}</span>}</div>
-    </div>
-  );
-});
-export const PatientBannerPatientIdentifiers = jest.fn(({ identifiers, showIdentifierLabel }) => {
-  if (!identifiers || identifiers.length === 0) {
-    return null;
-  }
-
-  return (
-    <div data-testid="patient-banner-identifiers">
-      {identifiers.map((identifier, index) => (
-        <span key={index}>
-          {showIdentifierLabel && identifier.type?.text && <span>{identifier.type.text}: </span>}
-          <span>{identifier.value}</span>
-        </span>
-      ))}
-    </div>
-  );
-});
-export { PatientBannerToggleContactDetailsButton } from '@openmrs/esm-styleguide/src/public';
+export {
+  CustomOverflowMenu,
+  CustomOverflowMenuItem,
+  PatientBannerActionsMenu,
+  PatientBannerContactDetails,
+  PatientBannerPatientInfo,
+  PatientBannerPatientIdentifiers,
+  PatientBannerToggleContactDetailsButton,
+} from '@openmrs/esm-styleguide/src/public';
 export const PatientPhoto = jest.fn(({ patientUuid, patientName, alt }) => {
   const altText = alt || `Avatar for ${patientName}`;
   return (

--- a/packages/framework/esm-framework/mock-jest.tsx
+++ b/packages/framework/esm-framework/mock-jest.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { NEVER } from 'rxjs';
 import type {} from '@openmrs/esm-globals';
 import * as utils from '@openmrs/esm-utils';
@@ -69,42 +69,40 @@ export const ResponsiveWrapper = jest.fn(({ children }) => <>{children}</>);
 export const ErrorState = jest.fn(() => <div>Error State</div>);
 
 export { CustomOverflowMenu, CustomOverflowMenuItem } from '@openmrs/esm-styleguide/src/public';
-export const PatientBannerActionsMenu = jest.fn(
-  ({ patient, patientUuid, actionsSlotName, additionalActionsSlotState }) => {
-    const [menuIsOpen, setMenuIsOpen] = React.useState(false);
-    return (
-      <div data-testid="patient-banner-actions-menu">
-        <button aria-expanded={menuIsOpen} aria-haspopup="true" onClick={() => setMenuIsOpen(!menuIsOpen)}>
-          <span>Actions</span>
-        </button>
-        {menuIsOpen && (
-          <div role="menu">
-            <div data-extension-slot={actionsSlotName} data-patient-uuid={patientUuid} />
-          </div>
-        )}
-      </div>
-    );
-  },
-);
-export const PatientBannerContactDetails = jest.fn(({ patientId, deceased }) => (
+export const PatientBannerActionsMenu = jest.fn(({ patient, patientUuid }) => (
+  <div data-testid="patient-banner-actions-menu">
+    <button aria-label="Actions">Actions</button>
+  </div>
+));
+export const PatientBannerContactDetails = jest.fn(({ patientId, deceased, address, telecom }) => (
   <div data-testid="patient-banner-contact-details" data-patient-id={patientId} data-deceased={deceased}>
     <div>
-      <p>Patient Lists (0)</p>
-      <ul>
-        <li>--</li>
-      </ul>
-    </div>
-    <div>
       <p>Address</p>
-      <ul>
-        <li>--</li>
-      </ul>
+      {address && address.length > 0 ? (
+        <ul>
+          {address.map((addr, index) => (
+            <li key={index}>
+              {[addr.city, addr.state, addr.postalCode, addr.country].filter(Boolean).join(', ') || 'N/A'}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No address on file</p>
+      )}
     </div>
     <div>
       <p>Contact Details</p>
-      <ul>
-        <li>--</li>
-      </ul>
+      {telecom && telecom.length > 0 ? (
+        <ul>
+          {telecom.map((contact, index) => (
+            <li key={index}>
+              {contact.system}: {contact.value}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No contact details on file</p>
+      )}
     </div>
   </div>
 ));

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -69,25 +69,92 @@ export const unsetLeftNav = vi.fn();
 export const ResponsiveWrapper = vi.fn(({ children }) => <>{children}</>);
 export const ErrorState = vi.fn(() => <div>Error State</div>);
 
-export const CustomOverflowMenu = vi.fn(({ menuTitle, children }) => (
-  <div>
-    <button>{menuTitle}</button>
-    {children}
+export { CustomOverflowMenu, CustomOverflowMenuItem } from '@openmrs/esm-styleguide/src/public';
+export const PatientBannerActionsMenu = vi.fn(
+  ({ patient, patientUuid, actionsSlotName, additionalActionsSlotState }) => {
+    const [menuIsOpen, setMenuIsOpen] = React.useState(false);
+    return (
+      <div data-testid="patient-banner-actions-menu">
+        <button aria-expanded={menuIsOpen} aria-haspopup="true" onClick={() => setMenuIsOpen(!menuIsOpen)}>
+          <span>Actions</span>
+        </button>
+        {menuIsOpen && (
+          <div role="menu">
+            <div data-extension-slot={actionsSlotName} data-patient-uuid={patientUuid} />
+          </div>
+        )}
+      </div>
+    );
+  },
+);
+export const PatientBannerContactDetails = vi.fn(({ patientId, deceased }) => (
+  <div data-testid="patient-banner-contact-details" data-patient-id={patientId} data-deceased={deceased}>
+    <div>
+      <p>Patient Lists (0)</p>
+      <ul>
+        <li>--</li>
+      </ul>
+    </div>
+    <div>
+      <p>Address</p>
+      <ul>
+        <li>--</li>
+      </ul>
+    </div>
+    <div>
+      <p>Contact Details</p>
+      <ul>
+        <li>--</li>
+      </ul>
+    </div>
   </div>
 ));
-export const CustomOverflowMenuItem = vi.fn(({ itemText, ...props }) => (
-  <button role="menuitem" {...props}>
-    {itemText}
-  </button>
-));
-export const PatientBannerActionsMenu = vi.fn(() => <div>Patient Banner Actions Menu</div>);
-export const PatientBannerContactDetails = vi.fn(() => <div>Patient Banner Contact Details</div>);
-export const PatientBannerPatientInfo = vi.fn(() => <div>Patient Banner Patient Info</div>);
-export const PatientBannerPatientIdentifiers = vi.fn(() => <div>Patient Banner Patient Identifier</div>);
-export const PatientBannerToggleContactDetailsButton = vi.fn(() => (
-  <div>Patient Banner Toggle Contact Details Button</div>
-));
-export const PatientPhoto = vi.fn(() => <div>Patient Photo</div>);
+export const PatientBannerPatientInfo = vi.fn(({ patient, renderedFrom }) => {
+  const name = patient?.name?.[0]
+    ? `${patient.name[0].given?.join(' ') || ''} ${patient.name[0].family || ''}`.trim()
+    : 'Unknown';
+  const genderMap = { male: 'Male', female: 'Female', other: 'Other', unknown: 'Unknown' };
+  const gender = patient?.gender ? genderMap[patient.gender.toLowerCase()] || patient.gender : 'Unknown';
+
+  return (
+    <div data-testid="patient-banner-patient-info">
+      <div>
+        <span>{name}</span>
+        <div>
+          <span>{gender}</span>
+        </div>
+      </div>
+      <div>{patient?.birthDate && <span>{patient.birthDate}</span>}</div>
+    </div>
+  );
+});
+export const PatientBannerPatientIdentifiers = vi.fn(({ identifiers, showIdentifierLabel }) => {
+  if (!identifiers || identifiers.length === 0) {
+    return null;
+  }
+
+  return (
+    <div data-testid="patient-banner-identifiers">
+      {identifiers.map((identifier, index) => (
+        <span key={index}>
+          {showIdentifierLabel && identifier.type?.text && <span>{identifier.type.text}: </span>}
+          <span>{identifier.value}</span>
+        </span>
+      ))}
+    </div>
+  );
+});
+export { PatientBannerToggleContactDetailsButton } from '@openmrs/esm-styleguide/src/public';
+export const PatientPhoto = vi.fn(({ patientUuid, patientName, alt }) => {
+  const altText = alt || `Avatar for ${patientName}`;
+  return (
+    <div data-testid="patient-photo" aria-label={altText}>
+      <div>
+        <span>{patientName?.charAt(0)?.toUpperCase()}</span>
+      </div>
+    </div>
+  );
+});
 export const usePatientPhoto = vi.fn(() => ({
   isLoading: true,
   data: null,

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useCallback, useRef, useId } from 'react';
 import dayjs from 'dayjs';
 import { NEVER } from 'rxjs';
 import { vi } from 'vitest';
@@ -69,80 +69,15 @@ export const unsetLeftNav = vi.fn();
 export const ResponsiveWrapper = vi.fn(({ children }) => <>{children}</>);
 export const ErrorState = vi.fn(() => <div>Error State</div>);
 
-export { CustomOverflowMenu, CustomOverflowMenuItem } from '@openmrs/esm-styleguide/src/public';
-export const PatientBannerActionsMenu = vi.fn(({ patient, patientUuid }) => (
-  <div data-testid="patient-banner-actions-menu">
-    <button aria-label="Actions">Actions</button>
-  </div>
-));
-export const PatientBannerContactDetails = vi.fn(({ patientId, deceased, address, telecom }) => (
-  <div data-testid="patient-banner-contact-details" data-patient-id={patientId} data-deceased={deceased}>
-    <div>
-      <p>Address</p>
-      {address && address.length > 0 ? (
-        <ul>
-          {address.map((addr, index) => (
-            <li key={index}>
-              {[addr.city, addr.state, addr.postalCode, addr.country].filter(Boolean).join(', ') || 'N/A'}
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p>No address on file</p>
-      )}
-    </div>
-    <div>
-      <p>Contact Details</p>
-      {telecom && telecom.length > 0 ? (
-        <ul>
-          {telecom.map((contact, index) => (
-            <li key={index}>
-              {contact.system}: {contact.value}
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <p>No contact details on file</p>
-      )}
-    </div>
-  </div>
-));
-export const PatientBannerPatientInfo = vi.fn(({ patient, renderedFrom }) => {
-  const name = patient?.name?.[0]
-    ? `${patient.name[0].given?.join(' ') || ''} ${patient.name[0].family || ''}`.trim()
-    : 'Unknown';
-  const genderMap = { male: 'Male', female: 'Female', other: 'Other', unknown: 'Unknown' };
-  const gender = patient?.gender ? genderMap[patient.gender.toLowerCase()] || patient.gender : 'Unknown';
-
-  return (
-    <div data-testid="patient-banner-patient-info">
-      <div>
-        <span>{name}</span>
-        <div>
-          <span>{gender}</span>
-        </div>
-      </div>
-      <div>{patient?.birthDate && <span>{patient.birthDate}</span>}</div>
-    </div>
-  );
-});
-export const PatientBannerPatientIdentifiers = vi.fn(({ identifiers, showIdentifierLabel }) => {
-  if (!identifiers || identifiers.length === 0) {
-    return null;
-  }
-
-  return (
-    <div data-testid="patient-banner-identifiers">
-      {identifiers.map((identifier, index) => (
-        <span key={index}>
-          {showIdentifierLabel && identifier.type?.text && <span>{identifier.type.text}: </span>}
-          <span>{identifier.value}</span>
-        </span>
-      ))}
-    </div>
-  );
-});
-export { PatientBannerToggleContactDetailsButton } from '@openmrs/esm-styleguide/src/public';
+export {
+  CustomOverflowMenu,
+  CustomOverflowMenuItem,
+  PatientBannerActionsMenu,
+  PatientBannerContactDetails,
+  PatientBannerPatientInfo,
+  PatientBannerPatientIdentifiers,
+  PatientBannerToggleContactDetailsButton,
+} from '@openmrs/esm-styleguide/src/public';
 export const PatientPhoto = vi.fn(({ patientUuid, patientName, alt }) => {
   const altText = alt || `Avatar for ${patientName}`;
   return (

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef, useId } from 'react';
+import React, { useState } from 'react';
 import dayjs from 'dayjs';
 import { NEVER } from 'rxjs';
 import { vi } from 'vitest';
@@ -77,17 +77,8 @@ export {
   PatientBannerPatientInfo,
   PatientBannerPatientIdentifiers,
   PatientBannerToggleContactDetailsButton,
+  PatientPhoto,
 } from '@openmrs/esm-styleguide/src/public';
-export const PatientPhoto = vi.fn(({ patientUuid, patientName, alt }) => {
-  const altText = alt || `Avatar for ${patientName}`;
-  return (
-    <div data-testid="patient-photo" aria-label={altText}>
-      <div>
-        <span>{patientName?.charAt(0)?.toUpperCase()}</span>
-      </div>
-    </div>
-  );
-});
 export const usePatientPhoto = vi.fn(() => ({
   isLoading: true,
   data: null,

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import dayjs from 'dayjs';
 import { NEVER } from 'rxjs';
 import { vi } from 'vitest';
@@ -70,42 +70,40 @@ export const ResponsiveWrapper = vi.fn(({ children }) => <>{children}</>);
 export const ErrorState = vi.fn(() => <div>Error State</div>);
 
 export { CustomOverflowMenu, CustomOverflowMenuItem } from '@openmrs/esm-styleguide/src/public';
-export const PatientBannerActionsMenu = vi.fn(
-  ({ patient, patientUuid, actionsSlotName, additionalActionsSlotState }) => {
-    const [menuIsOpen, setMenuIsOpen] = React.useState(false);
-    return (
-      <div data-testid="patient-banner-actions-menu">
-        <button aria-expanded={menuIsOpen} aria-haspopup="true" onClick={() => setMenuIsOpen(!menuIsOpen)}>
-          <span>Actions</span>
-        </button>
-        {menuIsOpen && (
-          <div role="menu">
-            <div data-extension-slot={actionsSlotName} data-patient-uuid={patientUuid} />
-          </div>
-        )}
-      </div>
-    );
-  },
-);
-export const PatientBannerContactDetails = vi.fn(({ patientId, deceased }) => (
+export const PatientBannerActionsMenu = vi.fn(({ patient, patientUuid }) => (
+  <div data-testid="patient-banner-actions-menu">
+    <button aria-label="Actions">Actions</button>
+  </div>
+));
+export const PatientBannerContactDetails = vi.fn(({ patientId, deceased, address, telecom }) => (
   <div data-testid="patient-banner-contact-details" data-patient-id={patientId} data-deceased={deceased}>
     <div>
-      <p>Patient Lists (0)</p>
-      <ul>
-        <li>--</li>
-      </ul>
-    </div>
-    <div>
       <p>Address</p>
-      <ul>
-        <li>--</li>
-      </ul>
+      {address && address.length > 0 ? (
+        <ul>
+          {address.map((addr, index) => (
+            <li key={index}>
+              {[addr.city, addr.state, addr.postalCode, addr.country].filter(Boolean).join(', ') || 'N/A'}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No address on file</p>
+      )}
     </div>
     <div>
       <p>Contact Details</p>
-      <ul>
-        <li>--</li>
-      </ul>
+      {telecom && telecom.length > 0 ? (
+        <ul>
+          {telecom.map((contact, index) => (
+            <li key={index}>
+              {contact.system}: {contact.value}
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p>No contact details on file</p>
+      )}
     </div>
   </div>
 ));


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## If applicable

- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the esm-framework mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx) and [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx)) to reflect any API changes.

## Summary

This PR updates test stubs for patient header subcomponents to use more of the actual component implementations while maintaining proper test isolation by stubbing network calls.

### Test Strategy

The updated mocks follow the principle described in the issue: **"finding a good balance between stubbing away functionality that should be mocked anyway (like network calls), whilst maintaining most of the rendering logic of the actual components under test."**


## Screenshots

N/A - This PR only updates test infrastructure, no UI changes.

## Related Issue

https://issues.openmrs.org/browse/O3-4465

## Other


