### PR TITLE
(fix) O3-4552: Fix Firefox back button issue with hash URLs

### DIFF
--- a/packages/framework/esm-navigation/src/history/history.ts
+++ b/packages/framework/esm-navigation/src/history/history.ts
@@ -4,7 +4,18 @@ import { navigate } from '../navigation/navigate';
 const historyKey = 'openmrs:history';
 
 function addToHistory(newLocation: string) {
+  // Don't add URLs ending with '#' to history as they cause issues with browser back button
+  // (they redirect to the non-# version, making back button appear broken)
+  if (newLocation.endsWith('#')) {
+    return;
+  }
+
   let history = JSON.parse(sessionStorage.getItem(historyKey) ?? '[]') || [];
+
+  if (history.length > 0 && history[history.length - 1] === newLocation) {
+    return;
+  }
+
   history.push(newLocation);
   const maxSize = 50;
   if (history.length > maxSize) {
@@ -27,16 +38,18 @@ export function setupHistory() {
 
   window.addEventListener('single-spa:routing-event', (evt: CustomEvent) => {
     const history = getHistory();
+    const currentUrl = window.location.href;
+
     if (evt.detail.originalEvent?.singleSpaTrigger == 'replaceState') {
       // handle redirect
-      history[history.length - 1] = window.location.href;
+      history[history.length - 1] = currentUrl;
       sessionStorage.setItem(historyKey, JSON.stringify(history));
-    } else if (!evt.detail.originalEvent?.singleSpa && history.includes(window.location.href)) {
+    } else if (!evt.detail.originalEvent?.singleSpa && history.includes(currentUrl)) {
       // handle back button (as best we can tell whether it was used or not)
-      goBackInHistory({ toUrl: window.location.href });
-    } else if (history[history.length - 1] !== window.location.href) {
+      goBackInHistory({ toUrl: currentUrl, skipNavigation: true });
+    } else if (history[history.length - 1] !== currentUrl) {
       // handle normal navigation
-      addToHistory(window.location.href);
+      addToHistory(currentUrl);
     }
   });
 }
@@ -49,19 +62,29 @@ export function getHistory(): Array<string> {
 }
 
 /**
- * Rolls back the history to the specified point and navigates to that URL.
+ * Rolls back the history to the specified point in the session history.
+ *
+ * This function has two use cases:
+ * 1. When called programmatically by app code (skipNavigation=false): Trims the history
+ *    AND navigates the browser to the specified URL.
+ * 2. When called after browser back button is pressed (skipNavigation=true): Only trims
+ *    the history since the browser has already navigated.
  *
  * @param toUrl: The URL in the history to navigate to. History after that index
  * will be deleted. If the URL is not found in the history, an error will be
  * thrown.
+ * @param skipNavigation: If true, skips the navigation step. Use true when the browser
+ * has already navigated (e.g., via back button). Defaults to false for programmatic calls.
  */
-export function goBackInHistory({ toUrl }: { toUrl: string }) {
+export function goBackInHistory({ toUrl, skipNavigation = false }: { toUrl: string; skipNavigation?: boolean }) {
   const history = getHistory();
   const toIndex = history.lastIndexOf(toUrl);
   if (toIndex != -1) {
     const newHistory = history.slice(0, toIndex + 1);
-    navigate({ to: history[toIndex] });
     sessionStorage.setItem(historyKey, JSON.stringify(newHistory));
+    if (!skipNavigation) {
+      navigate({ to: history[toIndex] });
+    }
   } else {
     throw new Error(`URL ${toUrl} not found in history; cannot go back to it.`);
   }

--- a/packages/framework/esm-navigation/src/navigation/navigate.test.ts
+++ b/packages/framework/esm-navigation/src/navigation/navigate.test.ts
@@ -66,4 +66,16 @@ describe('navigate', () => {
     expect(navigateToUrl).toHaveBeenCalledWith('/openmrs/spa/qux/page');
     expect(window.location.assign).not.toHaveBeenCalled();
   });
+
+  it('strips trailing hash from target URL to prevent Firefox back button issues', () => {
+    navigate({ to: '/openmrs/spa/home#' });
+    expect(navigateToUrl).toHaveBeenCalledWith('/openmrs/spa/home');
+    expect(window.location.assign).not.toHaveBeenCalled();
+  });
+
+  it('strips trailing hash from interpolated SPA path', () => {
+    navigate({ to: '${openmrsSpaBase}/home#' });
+    expect(navigateToUrl).toHaveBeenCalledWith('/openmrs/spa/home');
+    expect(window.location.assign).not.toHaveBeenCalled();
+  });
 });

--- a/packages/framework/esm-navigation/src/navigation/navigate.ts
+++ b/packages/framework/esm-navigation/src/navigation/navigate.ts
@@ -48,7 +48,9 @@ export interface NavigateOptions {
  */
 export function navigate({ to, templateParams }: NavigateOptions): void {
   const openmrsSpaBase = trimTrailingSlash(window.getOpenmrsSpaBase());
-  const target = interpolateUrl(to, templateParams).replace(window.location.origin, '');
+  let target = interpolateUrl(to, templateParams).replace(window.location.origin, '');
+  target = target.replace(/#$/, '');
+
   const isSpaPath = target.startsWith(openmrsSpaBase);
 
   if (isSpaPath) {


### PR DESCRIPTION
# Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## Summary
Fixes Firefox back button getting stuck when navigating between pages with trailing hash fragments (#).

## Screenshots

https://github.com/user-attachments/assets/a4fed052-f9ca-49d5-803b-78260ae3c3e5


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3-4552>

## Other
<!-- Anything not covered above -->
