### PR TITLE
(chore) O3-5467: Fix strict-mode type errors in help component

### DIFF
--- a/packages/apps/esm-help-menu-app/src/help-menu/help.component.tsx
+++ b/packages/apps/esm-help-menu-app/src/help-menu/help.component.tsx
@@ -18,15 +18,18 @@ export default function HelpMenu() {
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent | TouchEvent) => {
-      if (
-        helpMenuButtonRef.current &&
-        !helpMenuButtonRef.current.contains(event.target instanceof Node ? event.target : null) &&
-        popupRef.current &&
-        !popupRef.current.contains(event.target instanceof Node ? event.target : null)
-      ) {
-        setHelpMenuOpen(false);
-      }
-    };
+    const target = event.target;
+
+    if (
+      target instanceof Node &&
+      helpMenuButtonRef.current &&
+      popupRef.current &&
+      !helpMenuButtonRef.current.contains(target) &&
+      !popupRef.current.contains(target)
+    ) {
+      setHelpMenuOpen(false);
+    }
+  };
 
     window.addEventListener(`mousedown`, handleClickOutside);
     window.addEventListener(`touchstart`, handleClickOutside);

--- a/packages/apps/esm-help-menu-app/src/help-menu/help.component.tsx
+++ b/packages/apps/esm-help-menu-app/src/help-menu/help.component.tsx
@@ -8,8 +8,8 @@ import styles from './help.styles.scss';
 export default function HelpMenu() {
   const { user } = useSession();
   const [helpMenuOpen, setHelpMenuOpen] = useState(false);
-  const helpMenuButtonRef = useRef(null);
-  const popupRef = useRef(null);
+  const helpMenuButtonRef = useRef<HTMLButtonElement>(null);
+  const popupRef = useRef<HTMLDivElement>(null);
   const helpMenuItems = useAssignedExtensions('help-menu-slot');
 
   const toggleHelpMenu = () => {
@@ -17,12 +17,12 @@ export default function HelpMenu() {
   };
 
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
       if (
         helpMenuButtonRef.current &&
-        !helpMenuButtonRef.current.contains(event.target) &&
+        !helpMenuButtonRef.current.contains(event.target instanceof Node ? event.target : null) &&
         popupRef.current &&
-        !popupRef.current.contains(event.target)
+        !popupRef.current.contains(event.target instanceof Node ? event.target : null)
       ) {
         setHelpMenuOpen(false);
       }


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number and uses a conventional commit label.

## If applicable

- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work is validated by existing tests.
- [ ] I have updated the esm-framework mocks (mock.tsx and mock-jest.tsx) to reflect any API changes.

---

## Summary

This PR resolves several TypeScript strict-mode errors in `help.component.tsx` within `esm-help-menu-app`, identified while evaluating strict compatibility for O3 app packages.

The changes ensure the component compiles successfully under `--strict` without affecting runtime behavior.

### Changes

**Untyped refs**
`useRef(null)` infers `MutableRefObject<null>` under strict mode, which prevents safe `.contains()` checks.
Fixed by adding explicit element types:

```ts
const buttonRef = useRef<HTMLButtonElement>(null);
const menuRef = useRef<HTMLDivElement>(null);
```
Incorrect event handler typing
handleClickOutside was typed as MouseEvent but registered on both mousedown and touchstart.
Since touchstart emits TouchEvent, strict mode reports a type mismatch.
Updated the handler signature to:

```ts
(event: MouseEvent | TouchEvent)
```

event.target typing
event.target is typed as EventTarget | null, while .contains() requires Node | null.
Resolved by safely casting:

```ts
const target = event.target as Node | null;
```

These changes allow the component to compile cleanly under strict TypeScript settings while preserving existing runtime behavior.

Screenshots

N/A — no UI changes.

Related Issue

https://issues.openmrs.org/browse/O3-5467

## Testing

The following checks were performed:

- `npx tsc --noEmit --strict` → 0 errors in `esm-help-menu-app`
- `yarn turbo run build --filter=@openmrs/esm-help-menu-app` → build succeeds
- `yarn workspace @openmrs/esm-help-menu-app test` → all tests passing

No runtime behaviour changes were introduced.