### PR TITLE
(feat) O3-5522: Add hasPrivilege helper to extension display expression context

### DIFF
--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -396,37 +396,17 @@ describe('getAssignedExtensions — hasPrivilege helper', () => {
   const editOrders: PrivilegeEntry = { uuid: 'priv-1', name: 'Edit Orders', display: 'Edit Orders' };
   const viewReports: PrivilegeEntry = { uuid: 'priv-2', name: 'View Reports', display: 'View Reports' };
 
-
-    it('should hide extension when hasRole does not match user role', () => {
-      assertDisplayExpression("hasRole('Doctor')", [nurse], [], false);
-    });
-
-    it('should check inherited roles via allRoles', () => {
-      assertDisplayExpression(
-        "hasRole('Nurse')",
-        [],
-        [],
-        true,
-        [nurse],
-      );
-    });
-
-    it('should support OR logic across multiple roles', () => {
-      assertDisplayExpression("hasRole('Doctor') || hasRole('Nurse')", [nurse], [], true);
-    });
-  });
-
   describe('hasPrivilege() helper', () => {
     it('should show extension when hasPrivilege matches user privilege', () => {
-      assertDisplayExpression("hasPrivilege('Edit Orders')", [], [editOrders], true);
+      assertDisplayExpression("hasPrivilege('Edit Orders')", [editOrders], true);
     });
 
     it('should hide extension when hasPrivilege does not match', () => {
-      assertDisplayExpression("hasPrivilege('Edit Orders')", [], [viewReports], false);
+      assertDisplayExpression("hasPrivilege('Edit Orders')", [viewReports], false);
     });
 
     it('should return false gracefully when user has no privileges', () => {
-      assertDisplayExpression("hasPrivilege('Edit Orders')", [], [], false);
+      assertDisplayExpression("hasPrivilege('Edit Orders')", [], false);
     });
   });
 });

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -16,7 +16,6 @@ import {
 import type { ExtensionInfo, ExtensionInternalStore, ExtensionRegistration } from './store';
 import { getExtensionInternalStore } from './store';
 
-// Minimal mocking - only what we need for fine-grained control
 vi.mock('@openmrs/esm-api', () => ({
   sessionStore: createGlobalStore('mock-session-store', {
     loaded: false,
@@ -43,13 +42,11 @@ vi.mock('@openmrs/esm-globals', async (importOriginal) => {
   };
 });
 
-// Helper to create unique names for test isolation
 let nameCounter = 0;
 function getUniqueName(prefix: string = 'test'): string {
   return `${prefix}-${++nameCounter}`;
 }
 
-// Helper to create a mock extension registration
 function createMockExtension(name: string, overrides: Partial<ExtensionRegistration> = {}): ExtensionInfo {
   return {
     name,
@@ -69,7 +66,7 @@ function setSession(
   privileges: Array<PrivilegeEntry> = [],
   allRoles: Array<RoleEntry> = []
 ) {
-  (sessionStore as any).setState({
+  sessionStore.setState({
     loaded: true,
     session: {
       authenticated: true,
@@ -88,7 +85,7 @@ function setSession(
         locale: 'en',
         allowedLocales: ['en'],
       },
-    } as Session,
+    },
   });
 }
 
@@ -103,6 +100,10 @@ function getSlotState(slotName: string) {
   return getExtensionInternalStore().getState().slots[slotName];
 }
 
+/**
+ * Asserts that an extension with the given displayExpression is shown or hidden
+ * based on the current session state.
+ */
 function assertDisplayExpression(
   displayExpression: string,
   roles: Array<RoleEntry>,
@@ -151,6 +152,7 @@ describe('getExtensionRegistrationFrom', () => {
       slots: {},
       extensions: { 'test-extension': mockExtension },
     };
+
     expect(getExtensionRegistrationFrom(state, 'test-extension')).toBe(mockExtension);
   });
 
@@ -171,7 +173,8 @@ describe('getExtensionRegistrationFrom', () => {
 
 describe('getExtensionRegistration', () => {
   it('should return undefined for non-existent extension', () => {
-    expect(getExtensionRegistration('non-existent-extension-xyz')).toBeUndefined();
+    const result = getExtensionRegistration('non-existent-extension-xyz');
+    expect(result).toBeUndefined();
   });
 
   it('should return the extension registration for a registered extension', () => {
@@ -392,21 +395,46 @@ describe('getAssignedExtensions', () => {
   });
 });
 
-describe('getAssignedExtensions — hasPrivilege helper', () => {
+describe('getAssignedExtensions — hasRole and hasPrivilege helpers', () => {
+  const nurse: RoleEntry = { uuid: 'role-1', name: 'Nurse', display: 'Nurse' };
   const editOrders: PrivilegeEntry = { uuid: 'priv-1', name: 'Edit Orders', display: 'Edit Orders' };
   const viewReports: PrivilegeEntry = { uuid: 'priv-2', name: 'View Reports', display: 'View Reports' };
 
+  describe('hasRole() helper', () => {
+    it('should show extension when hasRole matches user role', () => {
+      assertDisplayExpression("hasRole('Nurse')", [nurse], [], true);
+    });
+
+    it('should hide extension when hasRole does not match user role', () => {
+      assertDisplayExpression("hasRole('Doctor')", [nurse], [], false);
+    });
+
+    it('should check inherited roles via allRoles', () => {
+      assertDisplayExpression(
+        "hasRole('Nurse')",
+        [],
+        [],
+        true,
+        [nurse],
+      );
+    });
+
+    it('should support OR logic across multiple roles', () => {
+      assertDisplayExpression("hasRole('Doctor') || hasRole('Nurse')", [nurse], [], true);
+    });
+  });
+
   describe('hasPrivilege() helper', () => {
     it('should show extension when hasPrivilege matches user privilege', () => {
-      assertDisplayExpression("hasPrivilege('Edit Orders')", [editOrders], true);
+      assertDisplayExpression("hasPrivilege('Edit Orders')", [], [editOrders], true);
     });
 
     it('should hide extension when hasPrivilege does not match', () => {
-      assertDisplayExpression("hasPrivilege('Edit Orders')", [viewReports], false);
+      assertDisplayExpression("hasPrivilege('Edit Orders')", [], [viewReports], false);
     });
 
     it('should return false gracefully when user has no privileges', () => {
-      assertDisplayExpression("hasPrivilege('Edit Orders')", [], false);
+      assertDisplayExpression("hasPrivilege('Edit Orders')", [], [], false);
     });
   });
 });

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -43,11 +43,13 @@ vi.mock('@openmrs/esm-globals', async (importOriginal) => {
   };
 });
 
+// Helper to create unique names for test isolation
 let nameCounter = 0;
 function getUniqueName(prefix: string = 'test'): string {
   return `${prefix}-${++nameCounter}`;
 }
 
+// Helper to create a mock extension registration
 function createMockExtension(name: string, overrides: Partial<ExtensionRegistration> = {}): ExtensionInfo {
   return {
     name,

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createGlobalStore } from '@openmrs/esm-state';
 import { sessionStore, userHasAccess } from '@openmrs/esm-api';
+import type { Privilege } from '@openmrs/esm-api';
 import {
   attach,
   detach,
@@ -436,7 +437,7 @@ describe('updateExtensionSlotState', () => {
 
 describe('getAssignedExtensions', () => {
   function setSession(
-    privileges: Array<{ uuid: string; name: string; display: string }> = [],
+    privileges: Array<Privilege> = [],
   ) {
     sessionStore.setState({
       loaded: true,
@@ -463,7 +464,7 @@ describe('getAssignedExtensions', () => {
 
   function assertDisplayExpression(
     displayExpression: string,
-    privileges: Array<{ uuid: string; name: string; display: string }>,
+    privileges: Array<Privilege>,
     expectVisible: boolean,
   ) {
     const slotName = getUniqueName('expr-slot');
@@ -534,12 +535,12 @@ describe('getAssignedExtensions', () => {
 
   describe('hasPrivilege', () => {
     it('should show extension when privilege matches', () => {
-      const editOrders = { uuid: 'priv-1', name: 'Edit Orders', display: 'Edit Orders' };
+      const editOrders: Privilege = { uuid: 'priv-1', name: 'Edit Orders', display: 'Edit Orders' };
       assertDisplayExpression("hasPrivilege('Edit Orders')", [editOrders], true);
     });
 
     it('should hide extension when privilege does not match', () => {
-      const viewReports = { uuid: 'priv-2', name: 'View Reports', display: 'View Reports' };
+      const viewReports: Privilege = { uuid: 'priv-2', name: 'View Reports', display: 'View Reports' };
       assertDisplayExpression("hasPrivilege('Edit Orders')", [viewReports], false);
     });
 

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -61,7 +61,11 @@ function createMockExtension(name: string, overrides: Partial<ExtensionRegistrat
 type RoleEntry = { uuid: string; name: string; display: string };
 type PrivilegeEntry = { uuid: string; name: string; display: string };
 
-function setSession(roles: Array<RoleEntry> = [], privileges: Array<PrivilegeEntry> = []) {
+function setSession(
+  roles: Array<RoleEntry> = [],
+  privileges: Array<PrivilegeEntry> = [],
+  allRoles: Array<RoleEntry> = []
+) {
   (sessionStore as any).setState({
     loaded: true,
     session: {
@@ -76,6 +80,7 @@ function setSession(roles: Array<RoleEntry> = [], privileges: Array<PrivilegeEnt
         person: { uuid: 'person-uuid' } as any,
         privileges,
         roles,
+        allRoles,
         retired: false,
         locale: 'en',
         allowedLocales: ['en'],

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -552,24 +552,6 @@ describe('getAssignedExtensions — hasRole and hasPrivilege helpers', () => {
   const editOrders = { uuid: 'priv-1', name: 'Edit Orders', display: 'Edit Orders' };
   const viewReports = { uuid: 'priv-2', name: 'View Reports', display: 'View Reports' };
 
-  describe('hasRole() helper', () => {
-    it('should show extension when hasRole matches user role', () => {
-      assertDisplayExpression("hasRole('Nurse')", [nurse], [], true);
-    });
-
-    it('should hide extension when hasRole does not match user role', () => {
-      assertDisplayExpression("hasRole('Doctor')", [nurse], [], false);
-    });
-
-    it('should check inherited roles via allRoles', () => {
-      assertDisplayExpression("hasRole('Nurse')", [], [], true, [nurse]);
-    });
-
-    it('should support OR logic across multiple roles', () => {
-      assertDisplayExpression("hasRole('Doctor') || hasRole('Nurse')", [nurse], [], true);
-    });
-  });
-
   describe('hasPrivilege() helper', () => {
     it('should show extension when hasPrivilege matches user privilege', () => {
       assertDisplayExpression("hasPrivilege('Edit Orders')", [], [editOrders], true);

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -61,70 +61,6 @@ function createMockExtension(name: string, overrides: Partial<ExtensionRegistrat
   };
 }
 
-type RoleEntry = { uuid: string; name: string; display: string };
-type PrivilegeEntry = { uuid: string; name: string; display: string };
-
-function setSession(
-  roles: Array<RoleEntry> = [],
-  privileges: Array<PrivilegeEntry> = [],
-  allRoles: Array<RoleEntry> = []
-) {
-  sessionStore.setState({
-    loaded: true,
-    session: {
-      authenticated: true,
-      sessionId: 'test-session',
-      user: {
-        uuid: 'user-uuid',
-        display: 'Test User',
-        username: 'testuser',
-        systemId: 'testuser',
-        userProperties: null,
-        person: { uuid: 'person-uuid' } as any,
-        privileges,
-        roles,
-        allRoles,
-        retired: false,
-        locale: 'en',
-        allowedLocales: ['en'],
-      },
-    },
-  });
-}
-
-function setupRegisteredExtension(
-  slotName: string,
-  extensionName: string,
-  overrides?: Partial<ExtensionRegistration>
-) {
-  const mockExtension = createMockExtension(extensionName, overrides);
-  registerExtension(mockExtension);
-  attach(slotName, extensionName);
-  return getAssignedExtensions(slotName);
-}
-
-function assertDisplayExpression(
-  displayExpression: string,
-  roles: Array<RoleEntry>,
-  privileges: Array<PrivilegeEntry>,
-  expectVisible: boolean,
-  allRoles: Array<RoleEntry> = roles
-) {
-  const slotName = getUniqueName('expr-slot');
-  const extensionName = getUniqueName('expr-ext');
-
-  setSession(roles, privileges, allRoles);
-  vi.mocked(userHasAccess).mockReturnValue(true);
-
-  const result = setupRegisteredExtension(slotName, extensionName, { displayExpression });
-
-  if (expectVisible) {
-    expect(result).toHaveLength(1);
-    expect(result[0].name).toBe(extensionName);
-  } else {
-    expect(result).toHaveLength(0);
-  }
-}
 
 describe('getExtensionNameFromId', () => {
   it('should extract the extension name from a simple ID', () => {
@@ -499,6 +435,56 @@ describe('updateExtensionSlotState', () => {
 });
 
 describe('getAssignedExtensions', () => {
+  function setSession(
+    privileges: Array<{ uuid: string; name: string; display: string }> = [],
+  ) {
+    sessionStore.setState({
+      loaded: true,
+      session: {
+        authenticated: true,
+        sessionId: 'test-session',
+        user: {
+          uuid: 'user-uuid',
+          display: 'Test User',
+          username: 'testuser',
+          systemId: 'testuser',
+          userProperties: null,
+          person: { uuid: 'person-uuid' } as any,
+          privileges,
+          roles: [],
+          allRoles: [],
+          retired: false,
+          locale: 'en',
+          allowedLocales: ['en'],
+        },
+      },
+    });
+  }
+
+  function assertDisplayExpression(
+    displayExpression: string,
+    privileges: Array<{ uuid: string; name: string; display: string }>,
+    expectVisible: boolean,
+  ) {
+    const slotName = getUniqueName('expr-slot');
+    const extensionName = getUniqueName('expr-ext');
+
+    setSession(privileges);
+    vi.mocked(userHasAccess).mockReturnValue(true);
+
+    const mockExtension = createMockExtension(extensionName, { displayExpression });
+    registerExtension(mockExtension);
+    attach(slotName, extensionName);
+    const result = getAssignedExtensions(slotName);
+
+    if (expectVisible) {
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe(extensionName);
+    } else {
+      expect(result).toHaveLength(0);
+    }
+  }
+
   it('should return an empty array for a slot with no registered extensions', () => {
     const slotName = getUniqueName('empty-slot');
 
@@ -545,24 +531,20 @@ describe('getAssignedExtensions', () => {
 
     expect(result[0].meta).toEqual(meta);
   });
-});
 
-describe('getAssignedExtensions — hasRole and hasPrivilege helpers', () => {
-  const nurse = { uuid: 'role-1', name: 'Nurse', display: 'Nurse' };
-  const editOrders = { uuid: 'priv-1', name: 'Edit Orders', display: 'Edit Orders' };
-  const viewReports = { uuid: 'priv-2', name: 'View Reports', display: 'View Reports' };
-
-  describe('hasPrivilege() helper', () => {
-    it('should show extension when hasPrivilege matches user privilege', () => {
-      assertDisplayExpression("hasPrivilege('Edit Orders')", [], [editOrders], true);
+  describe('hasPrivilege', () => {
+    it('should show extension when privilege matches', () => {
+      const editOrders = { uuid: 'priv-1', name: 'Edit Orders', display: 'Edit Orders' };
+      assertDisplayExpression("hasPrivilege('Edit Orders')", [editOrders], true);
     });
 
-    it('should hide extension when hasPrivilege does not match', () => {
-      assertDisplayExpression("hasPrivilege('Edit Orders')", [], [viewReports], false);
+    it('should hide extension when privilege does not match', () => {
+      const viewReports = { uuid: 'priv-2', name: 'View Reports', display: 'View Reports' };
+      assertDisplayExpression("hasPrivilege('Edit Orders')", [viewReports], false);
     });
 
-    it('should return false gracefully when user has no privileges', () => {
-      assertDisplayExpression("hasPrivilege('Edit Orders')", [], [], false);
+    it('should return false when no privileges exist', () => {
+      assertDisplayExpression("hasPrivilege('Edit Orders')", [], false);
     });
   });
 });

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -16,7 +16,6 @@ import {
 import type { ExtensionInfo, ExtensionInternalStore, ExtensionRegistration } from './store';
 import { getExtensionInternalStore } from './store';
 
-// Minimal mocking - only what we need for fine-grained control
 vi.mock('@openmrs/esm-api', () => ({
   sessionStore: createGlobalStore('mock-session-store', {
     loaded: false,
@@ -43,13 +42,11 @@ vi.mock('@openmrs/esm-globals', async (importOriginal) => {
   };
 });
 
-// Helper to create unique names for test isolation
 let nameCounter = 0;
 function getUniqueName(prefix: string = 'test'): string {
   return `${prefix}-${++nameCounter}`;
 }
 
-// Helper to create a mock extension registration
 function createMockExtension(name: string, overrides: Partial<ExtensionRegistration> = {}): ExtensionInfo {
   return {
     name,
@@ -61,10 +58,10 @@ function createMockExtension(name: string, overrides: Partial<ExtensionRegistrat
   };
 }
 
-function setSession(
-  roles: Array<{ uuid: string; name: string; display: string }> = [],
-  privileges: Array<{ uuid: string; name: string; display: string }> = [],
-) {
+type RoleEntry = { uuid: string; name: string; display: string };
+type PrivilegeEntry = { uuid: string; name: string; display: string };
+
+function setSession(roles: Array<RoleEntry> = [], privileges: Array<PrivilegeEntry> = []) {
   (sessionStore as any).setState({
     loaded: true,
     session: {
@@ -94,6 +91,36 @@ function setupRegisteredExtension(slotName: string, extensionName: string, overr
   return getAssignedExtensions(slotName);
 }
 
+function getSlotState(slotName: string) {
+  return getExtensionInternalStore().getState().slots[slotName];
+}
+
+/**
+ * Asserts that an extension with the given displayExpression is shown or hidden
+ * based on the current session state.
+ */
+function assertDisplayExpression(
+  displayExpression: string,
+  roles: Array<RoleEntry>,
+  privileges: Array<PrivilegeEntry>,
+  expectVisible: boolean,
+) {
+  const slotName = getUniqueName('expr-slot');
+  const extensionName = getUniqueName('expr-ext');
+
+  setSession(roles, privileges);
+  vi.mocked(userHasAccess).mockReturnValue(true);
+
+  const result = setupRegisteredExtension(slotName, extensionName, { displayExpression });
+
+  if (expectVisible) {
+    expect(result).toHaveLength(1);
+    expect(result[0].name).toBe(extensionName);
+  } else {
+    expect(result).toHaveLength(0);
+  }
+}
+
 describe('getExtensionNameFromId', () => {
   it('should extract the extension name from a simple ID', () => {
     expect(getExtensionNameFromId('foo')).toBe('foo');
@@ -115,137 +142,83 @@ describe('getExtensionNameFromId', () => {
 describe('getExtensionRegistrationFrom', () => {
   it('should return the extension registration if it exists', () => {
     const mockExtension = createMockExtension('test-extension');
-
     const state: ExtensionInternalStore = {
       slots: {},
-      extensions: {
-        'test-extension': mockExtension,
-      },
+      extensions: { 'test-extension': mockExtension },
     };
-
     expect(getExtensionRegistrationFrom(state, 'test-extension')).toBe(mockExtension);
   });
 
   it('should return undefined if the extension does not exist', () => {
-    const state: ExtensionInternalStore = {
-      slots: {},
-      extensions: {},
-    };
-
+    const state: ExtensionInternalStore = { slots: {}, extensions: {} };
     expect(getExtensionRegistrationFrom(state, 'non-existent')).toBeUndefined();
   });
 
   it('should handle extension IDs with # separator', () => {
     const mockExtension = createMockExtension('test-extension');
-
     const state: ExtensionInternalStore = {
       slots: {},
-      extensions: {
-        'test-extension': mockExtension,
-      },
+      extensions: { 'test-extension': mockExtension },
     };
-
     expect(getExtensionRegistrationFrom(state, 'test-extension#instance1')).toBe(mockExtension);
   });
 });
 
 describe('getExtensionRegistration', () => {
   it('should return undefined for non-existent extension', () => {
-    const result = getExtensionRegistration('non-existent-extension-xyz');
-    expect(result).toBeUndefined();
+    expect(getExtensionRegistration('non-existent-extension-xyz')).toBeUndefined();
   });
 
   it('should return the extension registration for a registered extension', () => {
     const extensionName = getUniqueName('registered-extension');
-    const mockExtension = createMockExtension(extensionName);
-
-    registerExtension(mockExtension);
-
-    const result = getExtensionRegistration(extensionName);
-    expect(result?.name).toBe(extensionName);
+    registerExtension(createMockExtension(extensionName));
+    expect(getExtensionRegistration(extensionName)?.name).toBe(extensionName);
   });
 
   it('should handle extension IDs with # separator', () => {
     const extensionName = getUniqueName('extension-with-hash');
-    const mockExtension = createMockExtension(extensionName);
-
-    registerExtension(mockExtension);
-
-    const result = getExtensionRegistration(`${extensionName}#instance1`);
-    expect(result?.name).toBe(extensionName);
+    registerExtension(createMockExtension(extensionName));
+    expect(getExtensionRegistration(`${extensionName}#instance1`)?.name).toBe(extensionName);
   });
 });
 
 describe('attach', () => {
   it('should attach an extension to a non-existent slot', () => {
     const slotName = getUniqueName('test-slot');
-    const extensionId = 'test-extension';
-
-    attach(slotName, extensionId);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName]).toBeDefined();
-    expect(state.slots[slotName].attachedIds).toContain(extensionId);
+    attach(slotName, 'test-extension');
+    expect(getSlotState(slotName).attachedIds).toContain('test-extension');
   });
 
   it('should attach an extension to an existing slot', () => {
     const slotName = getUniqueName('test-slot-existing');
-    const extensionId1 = 'extension-1';
-    const extensionId2 = 'extension-2';
-
-    attach(slotName, extensionId1);
-    attach(slotName, extensionId2);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].attachedIds).toContain(extensionId1);
-    expect(state.slots[slotName].attachedIds).toContain(extensionId2);
+    attach(slotName, 'extension-1');
+    attach(slotName, 'extension-2');
+    const { attachedIds } = getSlotState(slotName);
+    expect(attachedIds).toContain('extension-1');
+    expect(attachedIds).toContain('extension-2');
   });
 
   it('should allow attaching the same extension multiple times', () => {
     const slotName = getUniqueName('test-slot-duplicate');
-    const extensionId = 'duplicate-extension';
-
-    attach(slotName, extensionId);
-    attach(slotName, extensionId);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    // Both instances should be in the attachedIds array
-    const count = state.slots[slotName].attachedIds.filter((id) => id === extensionId).length;
+    attach(slotName, 'duplicate-extension');
+    attach(slotName, 'duplicate-extension');
+    const count = getSlotState(slotName).attachedIds.filter((id) => id === 'duplicate-extension').length;
     expect(count).toBe(2);
   });
 
   it('should handle extension IDs with # separator', () => {
     const slotName = getUniqueName('test-slot-with-hash');
-    const extensionId = 'extension#instance1';
-
-    attach(slotName, extensionId);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].attachedIds).toContain(extensionId);
+    attach(slotName, 'extension#instance1');
+    expect(getSlotState(slotName).attachedIds).toContain('extension#instance1');
   });
 
   it('should create a slot with the correct initial structure', () => {
     const slotName = getUniqueName('test-slot-structure');
-    const extensionId = 'test-extension';
-
-    attach(slotName, extensionId);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-    const slot = state.slots[slotName];
-
-    expect(slot).toEqual({
+    attach(slotName, 'test-extension');
+    expect(getSlotState(slotName)).toEqual({
       moduleName: undefined,
       name: slotName,
-      attachedIds: [extensionId],
+      attachedIds: ['test-extension'],
       config: null,
       state: undefined,
     });
@@ -255,233 +228,145 @@ describe('attach', () => {
 describe('detach', () => {
   it('should detach an extension from a slot', () => {
     const slotName = getUniqueName('test-slot-detach');
-    const extensionId = 'extension-to-detach';
-
-    attach(slotName, extensionId);
-    detach(slotName, extensionId);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].attachedIds).not.toContain(extensionId);
+    attach(slotName, 'extension-to-detach');
+    detach(slotName, 'extension-to-detach');
+    expect(getSlotState(slotName).attachedIds).not.toContain('extension-to-detach');
   });
 
   it('should not throw when detaching from a non-existent slot', () => {
-    const slotName = getUniqueName('non-existent-slot');
-
-    expect(() => detach(slotName, 'some-extension')).not.toThrow();
+    expect(() => detach(getUniqueName('non-existent-slot'), 'some-extension')).not.toThrow();
   });
 
   it('should not throw when detaching a non-attached extension', () => {
     const slotName = getUniqueName('test-slot-no-ext');
-
     attach(slotName, 'other-extension');
-
     expect(() => detach(slotName, 'non-attached-extension')).not.toThrow();
   });
 
   it('should only detach the specified extension', () => {
     const slotName = getUniqueName('test-slot-multi');
-    const ext1 = 'extension-1';
-    const ext2 = 'extension-2';
-
-    attach(slotName, ext1);
-    attach(slotName, ext2);
-    detach(slotName, ext1);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].attachedIds).not.toContain(ext1);
-    expect(state.slots[slotName].attachedIds).toContain(ext2);
+    attach(slotName, 'extension-1');
+    attach(slotName, 'extension-2');
+    detach(slotName, 'extension-1');
+    const { attachedIds } = getSlotState(slotName);
+    expect(attachedIds).not.toContain('extension-1');
+    expect(attachedIds).toContain('extension-2');
   });
 
   it('should not modify state when detaching from non-existent slot', () => {
-    const slotName = getUniqueName('non-existent-detach');
     const store = getExtensionInternalStore();
     const stateBefore = store.getState();
-
-    detach(slotName, 'some-extension');
-
-    const stateAfter = store.getState();
-    expect(stateAfter).toBe(stateBefore);
+    detach(getUniqueName('non-existent-detach'), 'some-extension');
+    expect(store.getState()).toBe(stateBefore);
   });
 
   it('should not modify state when detaching non-attached extension', () => {
     const slotName = getUniqueName('detach-non-attached');
-
     attach(slotName, 'existing-extension');
-
     const store = getExtensionInternalStore();
     const stateBefore = store.getState();
-
     detach(slotName, 'non-existent-extension');
-
-    const stateAfter = store.getState();
-    expect(stateAfter).toBe(stateBefore);
+    expect(store.getState()).toBe(stateBefore);
   });
 });
 
 describe('detachAll', () => {
   it('should detach all extensions from a slot', () => {
     const slotName = getUniqueName('test-slot-detach-all');
-
     attach(slotName, 'extension-1');
     attach(slotName, 'extension-2');
     attach(slotName, 'extension-3');
-
     detachAll(slotName);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].attachedIds).toEqual([]);
+    expect(getSlotState(slotName).attachedIds).toEqual([]);
   });
 
   it('should not throw when detaching all from a non-existent slot', () => {
-    const slotName = getUniqueName('non-existent-slot-all');
-
-    expect(() => detachAll(slotName)).not.toThrow();
+    expect(() => detachAll(getUniqueName('non-existent-slot-all'))).not.toThrow();
   });
 
   it('should handle detaching all from an empty slot', () => {
     const slotName = getUniqueName('test-slot-empty');
-
     attach(slotName, 'some-extension');
     detachAll(slotName);
     detachAll(slotName);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].attachedIds).toEqual([]);
+    expect(getSlotState(slotName).attachedIds).toEqual([]);
   });
 
   it('should not modify state when detaching all from non-existent slot', () => {
-    const slotName = getUniqueName('non-existent-all');
     const store = getExtensionInternalStore();
     const stateBefore = store.getState();
-
-    detachAll(slotName);
-
-    const stateAfter = store.getState();
-    expect(stateAfter).toBe(stateBefore);
+    detachAll(getUniqueName('non-existent-all'));
+    expect(store.getState()).toBe(stateBefore);
   });
 });
 
 describe('registerExtensionSlot', () => {
   it('should not crash when a slot is registered before the extensions that go in it', () => {
     const slotName = getUniqueName('mario-slot');
-
     attach(slotName, 'mario-hat');
     expect(() => registerExtensionSlot('mario-module', slotName)).not.toThrow();
   });
 
   it('should register a slot with module name', () => {
     const slotName = getUniqueName('slot-with-module');
-    const moduleName = 'test-module';
-
-    registerExtensionSlot(moduleName, slotName);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName]).toBeDefined();
-    expect(state.slots[slotName].moduleName).toBe(moduleName);
+    registerExtensionSlot('test-module', slotName);
+    expect(getSlotState(slotName)?.moduleName).toBe('test-module');
   });
 
   it('should register a slot with custom state', () => {
     const slotName = getUniqueName('slot-with-state');
     const customState = { foo: 'bar', count: 42 };
-
     registerExtensionSlot('test-module', slotName, customState);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].state).toEqual(customState);
+    expect(getSlotState(slotName).state).toEqual(customState);
   });
 
   it('should preserve attachedIds when registering an existing slot', () => {
     const slotName = getUniqueName('preserve-attached');
-    const extensionId = 'test-extension';
-
-    attach(slotName, extensionId);
+    attach(slotName, 'test-extension');
     registerExtensionSlot('test-module', slotName);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].attachedIds).toContain(extensionId);
+    expect(getSlotState(slotName).attachedIds).toContain('test-extension');
   });
 });
 
 describe('updateExtensionSlotState', () => {
   it('should update the full state when partial is false', () => {
     const slotName = getUniqueName('test-slot-state');
-
     registerExtensionSlot('test-module', slotName, { initial: 'state' });
-
     const newState = { updated: 'state', count: 1 };
     updateExtensionSlotState(slotName, newState, false);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].state).toEqual(newState);
-    expect(state.slots[slotName].state).not.toHaveProperty('initial');
+    const state = getSlotState(slotName).state;
+    expect(state).toEqual(newState);
+    expect(state).not.toHaveProperty('initial');
   });
 
   it('should merge state when partial is true', () => {
     const slotName = getUniqueName('test-slot-partial');
-
     registerExtensionSlot('test-module', slotName, { foo: 'bar', count: 1 });
-
-    const partialState = { count: 2, newProp: 'value' };
-    updateExtensionSlotState(slotName, partialState, true);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].state).toEqual({
-      foo: 'bar',
-      count: 2,
-      newProp: 'value',
-    });
+    updateExtensionSlotState(slotName, { count: 2, newProp: 'value' }, true);
+    expect(getSlotState(slotName).state).toEqual({ foo: 'bar', count: 2, newProp: 'value' });
   });
 
   it('should default partial to false when not specified', () => {
     const slotName = getUniqueName('test-slot-default');
-
     registerExtensionSlot('test-module', slotName, { foo: 'bar' });
-
-    const newState = { new: 'state' };
-    updateExtensionSlotState(slotName, newState);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].state).toEqual(newState);
-    expect(state.slots[slotName].state).not.toHaveProperty('foo');
+    updateExtensionSlotState(slotName, { new: 'state' });
+    const state = getSlotState(slotName).state;
+    expect(state).toEqual({ new: 'state' });
+    expect(state).not.toHaveProperty('foo');
   });
 });
 
 describe('getAssignedExtensions', () => {
   it('should return an empty array for a slot with no registered extensions', () => {
     const slotName = getUniqueName('empty-slot');
-
     attach(slotName, 'non-registered-extension');
-
-    const result = getAssignedExtensions(slotName);
-    expect(result).toEqual([]);
+    expect(getAssignedExtensions(slotName)).toEqual([]);
   });
 
   it('should return assigned extensions for a slot with registered extensions', () => {
     const slotName = getUniqueName('slot-with-extensions');
     const extensionName = getUniqueName('extension');
-
     const result = setupRegisteredExtension(slotName, extensionName);
-
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe(extensionName);
     expect(result[0].id).toBe(extensionName);
@@ -489,127 +374,53 @@ describe('getAssignedExtensions', () => {
 
   it('should return empty array for slot with no attached extensions', () => {
     const slotName = getUniqueName('empty-registered-slot');
-
     registerExtensionSlot('test-module', slotName);
-
-    const result = getAssignedExtensions(slotName);
-    expect(result).toEqual([]);
+    expect(getAssignedExtensions(slotName)).toEqual([]);
   });
 
   it('should include extension metadata', () => {
     const slotName = getUniqueName('slot-with-meta');
     const extensionName = getUniqueName('extension-meta');
     const meta = { version: '1.0', author: 'test' };
-
     const result = setupRegisteredExtension(slotName, extensionName, { meta });
-
     expect(result[0].meta).toEqual(meta);
   });
 });
 
 describe('getAssignedExtensions — hasRole and hasPrivilege helpers', () => {
+  const nurse: RoleEntry = { uuid: 'role-1', name: 'Nurse', display: 'Nurse' };
+  const editOrders: PrivilegeEntry = { uuid: 'priv-1', name: 'Edit Orders', display: 'Edit Orders' };
+  const viewReports: PrivilegeEntry = { uuid: 'priv-2', name: 'View Reports', display: 'View Reports' };
+
   describe('hasRole() helper', () => {
     it('should show extension when hasRole matches user role', () => {
-      const slotName = getUniqueName('role-slot-match');
-      const extensionName = getUniqueName('role-ext-match');
-
-      setSession([{ uuid: 'role-1', name: 'Nurse', display: 'Nurse' }], []);
-      vi.mocked(userHasAccess).mockReturnValue(true);
-
-      const result = setupRegisteredExtension(slotName, extensionName, {
-        displayExpression: "hasRole('Nurse')",
-      });
-
-      expect(result).toHaveLength(1);
-      expect(result[0].name).toBe(extensionName);
+      assertDisplayExpression("hasRole('Nurse')", [nurse], [], true);
     });
 
     it('should hide extension when hasRole does not match user role', () => {
-      const slotName = getUniqueName('role-slot-no-match');
-      const extensionName = getUniqueName('role-ext-no-match');
-
-      setSession([{ uuid: 'role-1', name: 'Nurse', display: 'Nurse' }], []);
-      vi.mocked(userHasAccess).mockReturnValue(true);
-
-      const result = setupRegisteredExtension(slotName, extensionName, {
-        displayExpression: "hasRole('Doctor')",
-      });
-
-      expect(result).toHaveLength(0);
+      assertDisplayExpression("hasRole('Doctor')", [nurse], [], false);
     });
 
     it('should return false gracefully when user has no roles', () => {
-      const slotName = getUniqueName('role-slot-empty');
-      const extensionName = getUniqueName('role-ext-empty');
-
-      setSession([], []);
-      vi.mocked(userHasAccess).mockReturnValue(true);
-
-      const result = setupRegisteredExtension(slotName, extensionName, {
-        displayExpression: "hasRole('Nurse')",
-      });
-
-      expect(result).toHaveLength(0);
+      assertDisplayExpression("hasRole('Nurse')", [], [], false);
     });
 
     it('should support OR logic across multiple roles', () => {
-      const slotName = getUniqueName('role-slot-or');
-      const extensionName = getUniqueName('role-ext-or');
-
-      setSession([{ uuid: 'role-1', name: 'Nurse', display: 'Nurse' }], []);
-      vi.mocked(userHasAccess).mockReturnValue(true);
-
-      const result = setupRegisteredExtension(slotName, extensionName, {
-        displayExpression: "hasRole('Doctor') || hasRole('Nurse')",
-      });
-
-      expect(result).toHaveLength(1);
-      expect(result[0].name).toBe(extensionName);
+      assertDisplayExpression("hasRole('Doctor') || hasRole('Nurse')", [nurse], [], true);
     });
   });
 
   describe('hasPrivilege() helper', () => {
     it('should show extension when hasPrivilege matches user privilege', () => {
-      const slotName = getUniqueName('priv-helper-slot-match');
-      const extensionName = getUniqueName('priv-helper-ext-match');
-
-      setSession([], [{ uuid: 'priv-1', name: 'Edit Orders', display: 'Edit Orders' }]);
-      vi.mocked(userHasAccess).mockReturnValue(true);
-
-      const result = setupRegisteredExtension(slotName, extensionName, {
-        displayExpression: "hasPrivilege('Edit Orders')",
-      });
-
-      expect(result).toHaveLength(1);
-      expect(result[0].name).toBe(extensionName);
+      assertDisplayExpression("hasPrivilege('Edit Orders')", [], [editOrders], true);
     });
 
     it('should hide extension when hasPrivilege does not match', () => {
-      const slotName = getUniqueName('priv-helper-slot-no-match');
-      const extensionName = getUniqueName('priv-helper-ext-no-match');
-
-      setSession([], [{ uuid: 'priv-2', name: 'View Reports', display: 'View Reports' }]);
-      vi.mocked(userHasAccess).mockReturnValue(true);
-
-      const result = setupRegisteredExtension(slotName, extensionName, {
-        displayExpression: "hasPrivilege('Edit Orders')",
-      });
-
-      expect(result).toHaveLength(0);
+      assertDisplayExpression("hasPrivilege('Edit Orders')", [], [viewReports], false);
     });
 
     it('should return false gracefully when user has no privileges', () => {
-      const slotName = getUniqueName('priv-helper-slot-empty');
-      const extensionName = getUniqueName('priv-helper-ext-empty');
-
-      setSession([], []);
-      vi.mocked(userHasAccess).mockReturnValue(true);
-
-      const result = setupRegisteredExtension(slotName, extensionName, {
-        displayExpression: "hasPrivilege('Edit Orders')",
-      });
-
-      expect(result).toHaveLength(0);
+      assertDisplayExpression("hasPrivilege('Edit Orders')", [], [], false);
     });
   });
 });

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createGlobalStore } from '@openmrs/esm-state';
-import type { Session } from '@openmrs/esm-api';
+import { type Session, sessionStore, userHasAccess } from '@openmrs/esm-api';
 import {
   attach,
   detach,
@@ -59,6 +59,39 @@ function createMockExtension(name: string, overrides: Partial<ExtensionRegistrat
     instances: [],
     ...overrides,
   };
+}
+
+function setSession(
+  roles: Array<{ uuid: string; name: string; display: string }> = [],
+  privileges: Array<{ uuid: string; name: string; display: string }> = [],
+) {
+  (sessionStore as any).setState({
+    loaded: true,
+    session: {
+      authenticated: true,
+      sessionId: 'test-session',
+      user: {
+        uuid: 'user-uuid',
+        display: 'Test User',
+        username: 'testuser',
+        systemId: 'testuser',
+        userProperties: null,
+        person: { uuid: 'person-uuid' } as any,
+        privileges,
+        roles,
+        retired: false,
+        locale: 'en',
+        allowedLocales: ['en'],
+      },
+    } as Session,
+  });
+}
+
+function setupRegisteredExtension(slotName: string, extensionName: string, overrides?: Partial<ExtensionRegistration>) {
+  const mockExtension = createMockExtension(extensionName, overrides);
+  registerExtension(mockExtension);
+  attach(slotName, extensionName);
+  return getAssignedExtensions(slotName);
 }
 
 describe('getExtensionNameFromId', () => {
@@ -447,11 +480,7 @@ describe('getAssignedExtensions', () => {
     const slotName = getUniqueName('slot-with-extensions');
     const extensionName = getUniqueName('extension');
 
-    const mockExtension = createMockExtension(extensionName);
-    registerExtension(mockExtension);
-    attach(slotName, extensionName);
-
-    const result = getAssignedExtensions(slotName);
+    const result = setupRegisteredExtension(slotName, extensionName);
 
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe(extensionName);
@@ -472,12 +501,115 @@ describe('getAssignedExtensions', () => {
     const extensionName = getUniqueName('extension-meta');
     const meta = { version: '1.0', author: 'test' };
 
-    const mockExtension = createMockExtension(extensionName, { meta });
-    registerExtension(mockExtension);
-    attach(slotName, extensionName);
-
-    const result = getAssignedExtensions(slotName);
+    const result = setupRegisteredExtension(slotName, extensionName, { meta });
 
     expect(result[0].meta).toEqual(meta);
+  });
+});
+
+describe('getAssignedExtensions — hasRole and hasPrivilege helpers', () => {
+  describe('hasRole() helper', () => {
+    it('should show extension when hasRole matches user role', () => {
+      const slotName = getUniqueName('role-slot-match');
+      const extensionName = getUniqueName('role-ext-match');
+
+      setSession([{ uuid: 'role-1', name: 'Nurse', display: 'Nurse' }], []);
+      vi.mocked(userHasAccess).mockReturnValue(true);
+
+      const result = setupRegisteredExtension(slotName, extensionName, {
+        displayExpression: "hasRole('Nurse')",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe(extensionName);
+    });
+
+    it('should hide extension when hasRole does not match user role', () => {
+      const slotName = getUniqueName('role-slot-no-match');
+      const extensionName = getUniqueName('role-ext-no-match');
+
+      setSession([{ uuid: 'role-1', name: 'Nurse', display: 'Nurse' }], []);
+      vi.mocked(userHasAccess).mockReturnValue(true);
+
+      const result = setupRegisteredExtension(slotName, extensionName, {
+        displayExpression: "hasRole('Doctor')",
+      });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should return false gracefully when user has no roles', () => {
+      const slotName = getUniqueName('role-slot-empty');
+      const extensionName = getUniqueName('role-ext-empty');
+
+      setSession([], []);
+      vi.mocked(userHasAccess).mockReturnValue(true);
+
+      const result = setupRegisteredExtension(slotName, extensionName, {
+        displayExpression: "hasRole('Nurse')",
+      });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should support OR logic across multiple roles', () => {
+      const slotName = getUniqueName('role-slot-or');
+      const extensionName = getUniqueName('role-ext-or');
+
+      setSession([{ uuid: 'role-1', name: 'Nurse', display: 'Nurse' }], []);
+      vi.mocked(userHasAccess).mockReturnValue(true);
+
+      const result = setupRegisteredExtension(slotName, extensionName, {
+        displayExpression: "hasRole('Doctor') || hasRole('Nurse')",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe(extensionName);
+    });
+  });
+
+  describe('hasPrivilege() helper', () => {
+    it('should show extension when hasPrivilege matches user privilege', () => {
+      const slotName = getUniqueName('priv-helper-slot-match');
+      const extensionName = getUniqueName('priv-helper-ext-match');
+
+      setSession([], [{ uuid: 'priv-1', name: 'Edit Orders', display: 'Edit Orders' }]);
+      vi.mocked(userHasAccess).mockReturnValue(true);
+
+      const result = setupRegisteredExtension(slotName, extensionName, {
+        displayExpression: "hasPrivilege('Edit Orders')",
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe(extensionName);
+    });
+
+    it('should hide extension when hasPrivilege does not match', () => {
+      const slotName = getUniqueName('priv-helper-slot-no-match');
+      const extensionName = getUniqueName('priv-helper-ext-no-match');
+
+      setSession([], [{ uuid: 'priv-2', name: 'View Reports', display: 'View Reports' }]);
+      vi.mocked(userHasAccess).mockReturnValue(true);
+
+      const result = setupRegisteredExtension(slotName, extensionName, {
+        displayExpression: "hasPrivilege('Edit Orders')",
+      });
+
+      expect(result).toHaveLength(0);
+    });
+
+    it('should return false gracefully when user has no privileges', () => {
+      const slotName = getUniqueName('priv-helper-slot-empty');
+      const extensionName = getUniqueName('priv-helper-ext-empty');
+
+      setSession([], []);
+      vi.mocked(userHasAccess).mockReturnValue(true);
+
+      const result = setupRegisteredExtension(slotName, extensionName, {
+        displayExpression: "hasPrivilege('Edit Orders')",
+      });
+
+      expect(result).toHaveLength(0);
+    });
   });
 });

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -16,6 +16,7 @@ import {
 import type { ExtensionInfo, ExtensionInternalStore, ExtensionRegistration } from './store';
 import { getExtensionInternalStore } from './store';
 
+// Minimal mocking - only what we need for fine-grained control
 vi.mock('@openmrs/esm-api', () => ({
   sessionStore: createGlobalStore('mock-session-store', {
     loaded: false,

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -100,20 +100,17 @@ function getSlotState(slotName: string) {
   return getExtensionInternalStore().getState().slots[slotName];
 }
 
-/**
- * Asserts that an extension with the given displayExpression is shown or hidden
- * based on the current session state.
- */
 function assertDisplayExpression(
   displayExpression: string,
   roles: Array<RoleEntry>,
   privileges: Array<PrivilegeEntry>,
   expectVisible: boolean,
+  allRoles: Array<RoleEntry> = roles,
 ) {
   const slotName = getUniqueName('expr-slot');
   const extensionName = getUniqueName('expr-ext');
 
-  setSession(roles, privileges);
+  setSession(roles, privileges, allRoles);
   vi.mocked(userHasAccess).mockReturnValue(true);
 
   const result = setupRegisteredExtension(slotName, extensionName, { displayExpression });
@@ -411,7 +408,8 @@ describe('getAssignedExtensions — hasRole and hasPrivilege helpers', () => {
         "hasRole('Nurse')",
         [],
         [],
-        true
+        true,
+        [nurse],
       );
     });
 

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -401,8 +401,13 @@ describe('getAssignedExtensions — hasRole and hasPrivilege helpers', () => {
       assertDisplayExpression("hasRole('Doctor')", [nurse], [], false);
     });
 
-    it('should return false gracefully when user has no roles', () => {
-      assertDisplayExpression("hasRole('Nurse')", [], [], false);
+    it('should check inherited roles via allRoles', () => {
+      assertDisplayExpression(
+        "hasRole('Nurse')",
+        [],
+        [],
+        true
+      );
     });
 
     it('should support OR logic across multiple roles', () => {

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -390,15 +390,10 @@ describe('getAssignedExtensions', () => {
   });
 });
 
-describe('getAssignedExtensions — hasRole and hasPrivilege helpers', () => {
-  const nurse: RoleEntry = { uuid: 'role-1', name: 'Nurse', display: 'Nurse' };
+describe('getAssignedExtensions — hasPrivilege helper', () => {
   const editOrders: PrivilegeEntry = { uuid: 'priv-1', name: 'Edit Orders', display: 'Edit Orders' };
   const viewReports: PrivilegeEntry = { uuid: 'priv-2', name: 'View Reports', display: 'View Reports' };
 
-  describe('hasRole() helper', () => {
-    it('should show extension when hasRole matches user role', () => {
-      assertDisplayExpression("hasRole('Nurse')", [nurse], [], true);
-    });
 
     it('should hide extension when hasRole does not match user role', () => {
       assertDisplayExpression("hasRole('Doctor')", [nurse], [], false);

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createGlobalStore } from '@openmrs/esm-state';
-import { type Session, sessionStore, userHasAccess } from '@openmrs/esm-api';
+import { sessionStore, userHasAccess } from '@openmrs/esm-api';
 import {
   attach,
   detach,
@@ -16,6 +16,7 @@ import {
 import type { ExtensionInfo, ExtensionInternalStore, ExtensionRegistration } from './store';
 import { getExtensionInternalStore } from './store';
 
+// Minimal mocking - only what we need for fine-grained control
 vi.mock('@openmrs/esm-api', () => ({
   sessionStore: createGlobalStore('mock-session-store', {
     loaded: false,
@@ -42,11 +43,13 @@ vi.mock('@openmrs/esm-globals', async (importOriginal) => {
   };
 });
 
+// Helper to create unique names for test isolation
 let nameCounter = 0;
 function getUniqueName(prefix: string = 'test'): string {
   return `${prefix}-${++nameCounter}`;
 }
 
+// Helper to create a mock extension registration
 function createMockExtension(name: string, overrides: Partial<ExtensionRegistration> = {}): ExtensionInfo {
   return {
     name,
@@ -89,27 +92,23 @@ function setSession(
   });
 }
 
-function setupRegisteredExtension(slotName: string, extensionName: string, overrides?: Partial<ExtensionRegistration>) {
+function setupRegisteredExtension(
+  slotName: string,
+  extensionName: string,
+  overrides?: Partial<ExtensionRegistration>
+) {
   const mockExtension = createMockExtension(extensionName, overrides);
   registerExtension(mockExtension);
   attach(slotName, extensionName);
   return getAssignedExtensions(slotName);
 }
 
-function getSlotState(slotName: string) {
-  return getExtensionInternalStore().getState().slots[slotName];
-}
-
-/**
- * Asserts that an extension with the given displayExpression is shown or hidden
- * based on the current session state.
- */
 function assertDisplayExpression(
   displayExpression: string,
   roles: Array<RoleEntry>,
   privileges: Array<PrivilegeEntry>,
   expectVisible: boolean,
-  allRoles: Array<RoleEntry> = roles,
+  allRoles: Array<RoleEntry> = roles
 ) {
   const slotName = getUniqueName('expr-slot');
   const extensionName = getUniqueName('expr-ext');
@@ -148,25 +147,36 @@ describe('getExtensionNameFromId', () => {
 describe('getExtensionRegistrationFrom', () => {
   it('should return the extension registration if it exists', () => {
     const mockExtension = createMockExtension('test-extension');
+
     const state: ExtensionInternalStore = {
       slots: {},
-      extensions: { 'test-extension': mockExtension },
+      extensions: {
+        'test-extension': mockExtension,
+      },
     };
 
     expect(getExtensionRegistrationFrom(state, 'test-extension')).toBe(mockExtension);
   });
 
   it('should return undefined if the extension does not exist', () => {
-    const state: ExtensionInternalStore = { slots: {}, extensions: {} };
+    const state: ExtensionInternalStore = {
+      slots: {},
+      extensions: {},
+    };
+
     expect(getExtensionRegistrationFrom(state, 'non-existent')).toBeUndefined();
   });
 
   it('should handle extension IDs with # separator', () => {
     const mockExtension = createMockExtension('test-extension');
+
     const state: ExtensionInternalStore = {
       slots: {},
-      extensions: { 'test-extension': mockExtension },
+      extensions: {
+        'test-extension': mockExtension,
+      },
     };
+
     expect(getExtensionRegistrationFrom(state, 'test-extension#instance1')).toBe(mockExtension);
   });
 });
@@ -179,54 +189,95 @@ describe('getExtensionRegistration', () => {
 
   it('should return the extension registration for a registered extension', () => {
     const extensionName = getUniqueName('registered-extension');
-    registerExtension(createMockExtension(extensionName));
-    expect(getExtensionRegistration(extensionName)?.name).toBe(extensionName);
+    const mockExtension = createMockExtension(extensionName);
+
+    registerExtension(mockExtension);
+
+    const result = getExtensionRegistration(extensionName);
+    expect(result?.name).toBe(extensionName);
   });
 
   it('should handle extension IDs with # separator', () => {
     const extensionName = getUniqueName('extension-with-hash');
-    registerExtension(createMockExtension(extensionName));
-    expect(getExtensionRegistration(`${extensionName}#instance1`)?.name).toBe(extensionName);
+    const mockExtension = createMockExtension(extensionName);
+
+    registerExtension(mockExtension);
+
+    const result = getExtensionRegistration(`${extensionName}#instance1`);
+    expect(result?.name).toBe(extensionName);
   });
 });
 
 describe('attach', () => {
   it('should attach an extension to a non-existent slot', () => {
     const slotName = getUniqueName('test-slot');
-    attach(slotName, 'test-extension');
-    expect(getSlotState(slotName).attachedIds).toContain('test-extension');
+    const extensionId = 'test-extension';
+
+    attach(slotName, extensionId);
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    expect(state.slots[slotName]).toBeDefined();
+    expect(state.slots[slotName].attachedIds).toContain(extensionId);
   });
 
   it('should attach an extension to an existing slot', () => {
     const slotName = getUniqueName('test-slot-existing');
-    attach(slotName, 'extension-1');
-    attach(slotName, 'extension-2');
-    const { attachedIds } = getSlotState(slotName);
-    expect(attachedIds).toContain('extension-1');
-    expect(attachedIds).toContain('extension-2');
+    const extensionId1 = 'extension-1';
+    const extensionId2 = 'extension-2';
+
+    attach(slotName, extensionId1);
+    attach(slotName, extensionId2);
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    expect(state.slots[slotName].attachedIds).toContain(extensionId1);
+    expect(state.slots[slotName].attachedIds).toContain(extensionId2);
   });
 
   it('should allow attaching the same extension multiple times', () => {
     const slotName = getUniqueName('test-slot-duplicate');
-    attach(slotName, 'duplicate-extension');
-    attach(slotName, 'duplicate-extension');
-    const count = getSlotState(slotName).attachedIds.filter((id) => id === 'duplicate-extension').length;
+    const extensionId = 'duplicate-extension';
+
+    attach(slotName, extensionId);
+    attach(slotName, extensionId);
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    // Both instances should be in the attachedIds array
+    const count = state.slots[slotName].attachedIds.filter((id) => id === extensionId).length;
     expect(count).toBe(2);
   });
 
   it('should handle extension IDs with # separator', () => {
     const slotName = getUniqueName('test-slot-with-hash');
-    attach(slotName, 'extension#instance1');
-    expect(getSlotState(slotName).attachedIds).toContain('extension#instance1');
+    const extensionId = 'extension#instance1';
+
+    attach(slotName, extensionId);
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    expect(state.slots[slotName].attachedIds).toContain(extensionId);
   });
 
   it('should create a slot with the correct initial structure', () => {
     const slotName = getUniqueName('test-slot-structure');
-    attach(slotName, 'test-extension');
-    expect(getSlotState(slotName)).toEqual({
+    const extensionId = 'test-extension';
+
+    attach(slotName, extensionId);
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+    const slot = state.slots[slotName];
+
+    expect(slot).toEqual({
       moduleName: undefined,
       name: slotName,
-      attachedIds: ['test-extension'],
+      attachedIds: [extensionId],
       config: null,
       state: undefined,
     });
@@ -236,145 +287,237 @@ describe('attach', () => {
 describe('detach', () => {
   it('should detach an extension from a slot', () => {
     const slotName = getUniqueName('test-slot-detach');
-    attach(slotName, 'extension-to-detach');
-    detach(slotName, 'extension-to-detach');
-    expect(getSlotState(slotName).attachedIds).not.toContain('extension-to-detach');
+    const extensionId = 'extension-to-detach';
+
+    attach(slotName, extensionId);
+    detach(slotName, extensionId);
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    expect(state.slots[slotName].attachedIds).not.toContain(extensionId);
   });
 
   it('should not throw when detaching from a non-existent slot', () => {
-    expect(() => detach(getUniqueName('non-existent-slot'), 'some-extension')).not.toThrow();
+    const slotName = getUniqueName('non-existent-slot');
+
+    expect(() => detach(slotName, 'some-extension')).not.toThrow();
   });
 
   it('should not throw when detaching a non-attached extension', () => {
     const slotName = getUniqueName('test-slot-no-ext');
+
     attach(slotName, 'other-extension');
+
     expect(() => detach(slotName, 'non-attached-extension')).not.toThrow();
   });
 
   it('should only detach the specified extension', () => {
     const slotName = getUniqueName('test-slot-multi');
-    attach(slotName, 'extension-1');
-    attach(slotName, 'extension-2');
-    detach(slotName, 'extension-1');
-    const { attachedIds } = getSlotState(slotName);
-    expect(attachedIds).not.toContain('extension-1');
-    expect(attachedIds).toContain('extension-2');
+    const ext1 = 'extension-1';
+    const ext2 = 'extension-2';
+
+    attach(slotName, ext1);
+    attach(slotName, ext2);
+    detach(slotName, ext1);
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    expect(state.slots[slotName].attachedIds).not.toContain(ext1);
+    expect(state.slots[slotName].attachedIds).toContain(ext2);
   });
 
   it('should not modify state when detaching from non-existent slot', () => {
+    const slotName = getUniqueName('non-existent-detach');
     const store = getExtensionInternalStore();
     const stateBefore = store.getState();
-    detach(getUniqueName('non-existent-detach'), 'some-extension');
-    expect(store.getState()).toBe(stateBefore);
+
+    detach(slotName, 'some-extension');
+
+    const stateAfter = store.getState();
+    expect(stateAfter).toBe(stateBefore);
   });
 
   it('should not modify state when detaching non-attached extension', () => {
     const slotName = getUniqueName('detach-non-attached');
+
     attach(slotName, 'existing-extension');
+
     const store = getExtensionInternalStore();
     const stateBefore = store.getState();
+
     detach(slotName, 'non-existent-extension');
-    expect(store.getState()).toBe(stateBefore);
+
+    const stateAfter = store.getState();
+    expect(stateAfter).toBe(stateBefore);
   });
 });
 
 describe('detachAll', () => {
   it('should detach all extensions from a slot', () => {
     const slotName = getUniqueName('test-slot-detach-all');
+
     attach(slotName, 'extension-1');
     attach(slotName, 'extension-2');
     attach(slotName, 'extension-3');
+
     detachAll(slotName);
-    expect(getSlotState(slotName).attachedIds).toEqual([]);
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    expect(state.slots[slotName].attachedIds).toEqual([]);
   });
 
   it('should not throw when detaching all from a non-existent slot', () => {
-    expect(() => detachAll(getUniqueName('non-existent-slot-all'))).not.toThrow();
+    const slotName = getUniqueName('non-existent-slot-all');
+
+    expect(() => detachAll(slotName)).not.toThrow();
   });
 
   it('should handle detaching all from an empty slot', () => {
     const slotName = getUniqueName('test-slot-empty');
+
     attach(slotName, 'some-extension');
     detachAll(slotName);
     detachAll(slotName);
-    expect(getSlotState(slotName).attachedIds).toEqual([]);
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    expect(state.slots[slotName].attachedIds).toEqual([]);
   });
 
   it('should not modify state when detaching all from non-existent slot', () => {
+    const slotName = getUniqueName('non-existent-all');
     const store = getExtensionInternalStore();
     const stateBefore = store.getState();
-    detachAll(getUniqueName('non-existent-all'));
-    expect(store.getState()).toBe(stateBefore);
+
+    detachAll(slotName);
+
+    const stateAfter = store.getState();
+    expect(stateAfter).toBe(stateBefore);
   });
 });
 
 describe('registerExtensionSlot', () => {
   it('should not crash when a slot is registered before the extensions that go in it', () => {
     const slotName = getUniqueName('mario-slot');
+
     attach(slotName, 'mario-hat');
     expect(() => registerExtensionSlot('mario-module', slotName)).not.toThrow();
   });
 
   it('should register a slot with module name', () => {
     const slotName = getUniqueName('slot-with-module');
-    registerExtensionSlot('test-module', slotName);
-    expect(getSlotState(slotName)?.moduleName).toBe('test-module');
+    const moduleName = 'test-module';
+
+    registerExtensionSlot(moduleName, slotName);
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    expect(state.slots[slotName]).toBeDefined();
+    expect(state.slots[slotName].moduleName).toBe(moduleName);
   });
 
   it('should register a slot with custom state', () => {
     const slotName = getUniqueName('slot-with-state');
     const customState = { foo: 'bar', count: 42 };
+
     registerExtensionSlot('test-module', slotName, customState);
-    expect(getSlotState(slotName).state).toEqual(customState);
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    expect(state.slots[slotName].state).toEqual(customState);
   });
 
   it('should preserve attachedIds when registering an existing slot', () => {
     const slotName = getUniqueName('preserve-attached');
-    attach(slotName, 'test-extension');
+    const extensionId = 'test-extension';
+
+    attach(slotName, extensionId);
     registerExtensionSlot('test-module', slotName);
-    expect(getSlotState(slotName).attachedIds).toContain('test-extension');
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    expect(state.slots[slotName].attachedIds).toContain(extensionId);
   });
 });
 
 describe('updateExtensionSlotState', () => {
   it('should update the full state when partial is false', () => {
     const slotName = getUniqueName('test-slot-state');
+
     registerExtensionSlot('test-module', slotName, { initial: 'state' });
+
     const newState = { updated: 'state', count: 1 };
     updateExtensionSlotState(slotName, newState, false);
-    const state = getSlotState(slotName).state;
-    expect(state).toEqual(newState);
-    expect(state).not.toHaveProperty('initial');
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    expect(state.slots[slotName].state).toEqual(newState);
+    expect(state.slots[slotName].state).not.toHaveProperty('initial');
   });
 
   it('should merge state when partial is true', () => {
     const slotName = getUniqueName('test-slot-partial');
+
     registerExtensionSlot('test-module', slotName, { foo: 'bar', count: 1 });
-    updateExtensionSlotState(slotName, { count: 2, newProp: 'value' }, true);
-    expect(getSlotState(slotName).state).toEqual({ foo: 'bar', count: 2, newProp: 'value' });
+
+    const partialState = { count: 2, newProp: 'value' };
+    updateExtensionSlotState(slotName, partialState, true);
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    expect(state.slots[slotName].state).toEqual({
+      foo: 'bar',
+      count: 2,
+      newProp: 'value',
+    });
   });
 
   it('should default partial to false when not specified', () => {
     const slotName = getUniqueName('test-slot-default');
+
     registerExtensionSlot('test-module', slotName, { foo: 'bar' });
-    updateExtensionSlotState(slotName, { new: 'state' });
-    const state = getSlotState(slotName).state;
-    expect(state).toEqual({ new: 'state' });
-    expect(state).not.toHaveProperty('foo');
+
+    const newState = { new: 'state' };
+    updateExtensionSlotState(slotName, newState);
+
+    const store = getExtensionInternalStore();
+    const state = store.getState();
+
+    expect(state.slots[slotName].state).toEqual(newState);
+    expect(state.slots[slotName].state).not.toHaveProperty('foo');
   });
 });
 
 describe('getAssignedExtensions', () => {
   it('should return an empty array for a slot with no registered extensions', () => {
     const slotName = getUniqueName('empty-slot');
+
     attach(slotName, 'non-registered-extension');
-    expect(getAssignedExtensions(slotName)).toEqual([]);
+
+    const result = getAssignedExtensions(slotName);
+    expect(result).toEqual([]);
   });
 
   it('should return assigned extensions for a slot with registered extensions', () => {
     const slotName = getUniqueName('slot-with-extensions');
     const extensionName = getUniqueName('extension');
-    const result = setupRegisteredExtension(slotName, extensionName);
+
+    const mockExtension = createMockExtension(extensionName);
+    registerExtension(mockExtension);
+    attach(slotName, extensionName);
+
+    const result = getAssignedExtensions(slotName);
+
     expect(result).toHaveLength(1);
     expect(result[0].name).toBe(extensionName);
     expect(result[0].id).toBe(extensionName);
@@ -382,23 +525,32 @@ describe('getAssignedExtensions', () => {
 
   it('should return empty array for slot with no attached extensions', () => {
     const slotName = getUniqueName('empty-registered-slot');
+
     registerExtensionSlot('test-module', slotName);
-    expect(getAssignedExtensions(slotName)).toEqual([]);
+
+    const result = getAssignedExtensions(slotName);
+    expect(result).toEqual([]);
   });
 
   it('should include extension metadata', () => {
     const slotName = getUniqueName('slot-with-meta');
     const extensionName = getUniqueName('extension-meta');
     const meta = { version: '1.0', author: 'test' };
-    const result = setupRegisteredExtension(slotName, extensionName, { meta });
+
+    const mockExtension = createMockExtension(extensionName, { meta });
+    registerExtension(mockExtension);
+    attach(slotName, extensionName);
+
+    const result = getAssignedExtensions(slotName);
+
     expect(result[0].meta).toEqual(meta);
   });
 });
 
 describe('getAssignedExtensions — hasRole and hasPrivilege helpers', () => {
-  const nurse: RoleEntry = { uuid: 'role-1', name: 'Nurse', display: 'Nurse' };
-  const editOrders: PrivilegeEntry = { uuid: 'priv-1', name: 'Edit Orders', display: 'Edit Orders' };
-  const viewReports: PrivilegeEntry = { uuid: 'priv-2', name: 'View Reports', display: 'View Reports' };
+  const nurse = { uuid: 'role-1', name: 'Nurse', display: 'Nurse' };
+  const editOrders = { uuid: 'priv-1', name: 'Edit Orders', display: 'Edit Orders' };
+  const viewReports = { uuid: 'priv-2', name: 'View Reports', display: 'View Reports' };
 
   describe('hasRole() helper', () => {
     it('should show extension when hasRole matches user role', () => {
@@ -410,13 +562,7 @@ describe('getAssignedExtensions — hasRole and hasPrivilege helpers', () => {
     });
 
     it('should check inherited roles via allRoles', () => {
-      assertDisplayExpression(
-        "hasRole('Nurse')",
-        [],
-        [],
-        true,
-        [nurse],
-      );
+      assertDisplayExpression("hasRole('Nurse')", [], [], true, [nurse]);
     });
 
     it('should support OR logic across multiple roles', () => {

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -351,10 +351,6 @@ function getAssignedExtensionsFromSlotData(
   // Create context once for all extensions in this slot
   const slotState = internalState.slots[slotName]?.state;
   const helpers = {
-    hasRole: (roleName: string) =>
-      session?.user?.roles?.some((r) => r.display === roleName) ||
-      session?.user?.allRoles?.some((r) => r.display === roleName) ||
-      false,
     hasPrivilege: (privName: string) => session?.user?.privileges?.some((p) => p.display === privName) ?? false,
   };
   const expressionContext =

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -353,7 +353,6 @@ function getAssignedExtensionsFromSlotData(
   const expressionContext = {
     session,
     ...(slotState && typeof slotState === 'object' ? slotState : {}),
-    hasRole: (roleName: string) => (session?.user?.allRoles ?? session?.user?.roles ?? []).some((r) => r?.display === roleName),
     hasPrivilege: (privName: string) => session?.user?.privileges?.some((p) => p.display === privName) ?? false,
   };
 

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -351,10 +351,14 @@ function getAssignedExtensionsFromSlotData(
   // Create context once for all extensions in this slot
   const slotState = internalState.slots[slotName]?.state;
   const helpers = {
-    hasPrivilege: (privName: string) => session?.user?.privileges?.some((p) => p.display === privName) ?? false,
+    hasRole: (roleName: string) =>
+    (session?.user?.allRoles ?? session?.user?.roles ?? [])
+      .some((r) => r?.display === roleName),
+    hasPrivilege: (privName: string) =>
+      session?.user?.privileges?.some((p) => p.display === privName) ?? false,
   };
   const expressionContext =
-    slotState && typeof slotState === 'object' ? { session, ...helpers, ...slotState } : { session, ...helpers };
+    slotState && typeof slotState === 'object' ? { session, ...slotState, ...helpers } : { session, ...helpers };
 
   for (let id of assignedIds) {
     const { config: rawExtensionConfig } = getExtensionConfigFromStore(extensionConfigStoreState, slotName, id);

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -351,9 +351,6 @@ function getAssignedExtensionsFromSlotData(
   // Create context once for all extensions in this slot
   const slotState = internalState.slots[slotName]?.state;
   const helpers = {
-    hasRole: (roleName: string) =>
-    (session?.user?.allRoles ?? session?.user?.roles ?? [])
-      .some((r) => r?.display === roleName),
     hasPrivilege: (privName: string) =>
       session?.user?.privileges?.some((p) => p.display === privName) ?? false,
   };

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -350,7 +350,12 @@ function getAssignedExtensionsFromSlotData(
 
   // Create context once for all extensions in this slot
   const slotState = internalState.slots[slotName]?.state;
-  const expressionContext = slotState && typeof slotState === 'object' ? { session, ...slotState } : { session };
+  const expressionContext = {
+    session,
+    ...(slotState && typeof slotState === 'object' ? slotState : {}),
+    hasRole: (roleName: string) => session?.user?.roles?.some((r) => r.display === roleName) ?? false,
+    hasPrivilege: (privName: string) => session?.user?.privileges?.some((p) => p.display === privName) ?? false,
+  };
 
   for (let id of assignedIds) {
     const { config: rawExtensionConfig } = getExtensionConfigFromStore(extensionConfigStoreState, slotName, id);

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -350,11 +350,15 @@ function getAssignedExtensionsFromSlotData(
 
   // Create context once for all extensions in this slot
   const slotState = internalState.slots[slotName]?.state;
-  const expressionContext = {
-    session,
-    ...(slotState && typeof slotState === 'object' ? slotState : {}),
+  const helpers = {
+    hasRole: (roleName: string) =>
+      session?.user?.roles?.some((r) => r.display === roleName) ||
+      session?.user?.allRoles?.some((r) => r.display === roleName) ||
+      false,
     hasPrivilege: (privName: string) => session?.user?.privileges?.some((p) => p.display === privName) ?? false,
   };
+  const expressionContext =
+    slotState && typeof slotState === 'object' ? { session, ...helpers, ...slotState } : { session, ...helpers };
 
   for (let id of assignedIds) {
     const { config: rawExtensionConfig } = getExtensionConfigFromStore(extensionConfigStoreState, slotName, id);

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -353,7 +353,7 @@ function getAssignedExtensionsFromSlotData(
   const expressionContext = {
     session,
     ...(slotState && typeof slotState === 'object' ? slotState : {}),
-    hasRole: (roleName: string) => session?.user?.roles?.some((r) => r.display === roleName) ?? false,
+    hasRole: (roleName: string) => (session?.user?.allRoles ?? session?.user?.roles ?? []).some((r) => r?.display === roleName),
     hasPrivilege: (privName: string) => session?.user?.privileges?.some((p) => p.display === privName) ?? false,
   };
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks to reflect any API changes.

## Summary
The extension `displayExpression` system supports arbitrary JavaScript expressions, but writing privilege-based conditions required verbose syntax:
```javascript
// Before — verbose and error-prone
"displayExpression": "session.user.privileges.some(p => p.display === 'Edit Orders')"
```

This PR adds a helper function to the expression evaluator context:

- `hasPrivilege(privName)` — returns true if the current user has the named privilege

Implementers can now write clean, readable conditions in `routes.json`:
```json
{ "displayExpression": "hasPrivilege('Edit Orders')" }
```

The helper uses optional chaining and returns a boolean, so existing extensions remain unaffected.

**Changed files:**
- `packages/framework/esm-extensions/src/extensions.ts`
- `packages/framework/esm-extensions/src/extensions.test.ts`

## Screenshots
Not applicable — framework logic with no UI changes.

## Related Issue
https://openmrs.atlassian.net/browse/O3-5522

## Other
This PR focuses on improving readability of privilege-based display conditions.