### PR TITLE
feat: added carbon icons to secondary text buttons

### DIFF
--- a/packages/apps/esm-login-app/src/change-password/change-password-link.extension.tsx
+++ b/packages/apps/esm-login-app/src/change-password/change-password-link.extension.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from 'react-i18next';
 import { Button, SwitcherItem } from '@carbon/react';
 import { PasswordIcon, showModal } from '@openmrs/esm-framework';
 import styles from './change-password.scss';
+import { ArrowRight } from '@carbon/react/icons';
 
 const ChangePasswordLink: React.FC = () => {
   const { t } = useTranslation();
@@ -12,7 +13,7 @@ const ChangePasswordLink: React.FC = () => {
       closeModal: () => dispose(),
       size: 'sm',
     });
-  }, []);  
+  }, []);
 
   return (
     <SwitcherItem aria-label={t('changePassword', 'ChangePassword')} className={styles.panelItemContainer}>
@@ -20,7 +21,7 @@ const ChangePasswordLink: React.FC = () => {
         <PasswordIcon size={20} />
         <p>{t('password', 'Password')}</p>
       </div>
-      <Button kind="ghost" onClick={launchChangePasswordModal}>
+      <Button kind="ghost" onClick={launchChangePasswordModal} renderIcon={ArrowRight}>
         {t('change', 'Change')}
       </Button>
     </SwitcherItem>

--- a/packages/apps/esm-login-app/src/change-password/change-password.modal.tsx
+++ b/packages/apps/esm-login-app/src/change-password/change-password.modal.tsx
@@ -17,6 +17,7 @@ import {
 import { showSnackbar } from '@openmrs/esm-framework';
 import { changeUserPassword } from './change-password.resource';
 import styles from './change-password-modal.scss';
+import { Edit, TrashCan, Save, ArrowRight } from '@carbon/react/icons';
 
 interface ChangePasswordModalProps {
   close(): () => void;

--- a/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
@@ -15,6 +15,7 @@ import { useDefaultLocation, useLocationCount } from './location-picker.resource
 import type { ConfigSchema } from '../config-schema';
 import type { LoginReferrer } from '../login/login.component';
 import styles from './location-picker.scss';
+import { Edit, TrashCan, Save } from '@carbon/react/icons';
 
 interface LocationPickerProps {
   hideWelcomeMessage?: boolean;
@@ -156,6 +157,7 @@ const LocationPickerView: React.FC<LocationPickerProps> = ({ hideWelcomeMessage,
               className={styles.confirmButton}
               kind="primary"
               type="submit"
+              renderIcon={Save}
               disabled={!activeLocation || !isLoginEnabled || isSubmitting}
             >
               {isSubmitting ? (

--- a/packages/apps/esm-login-app/src/location-picker/location-picker.test.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.test.tsx
@@ -22,6 +22,7 @@ import {
 import { mockConfig } from '../../__mocks__/config.mock';
 import renderWithRouter from '../test-helpers/render-with-router';
 import LocationPickerView from './location-picker-view.component';
+import { Edit, TrashCan, Save } from '@carbon/react/icons';
 
 const fistLocation = {
   uuid: 'uuid_1',

--- a/packages/apps/esm-login-app/src/login/login.component.tsx
+++ b/packages/apps/esm-login-app/src/login/login.component.tsx
@@ -15,6 +15,7 @@ import { type ConfigSchema } from '../config-schema';
 import Logo from '../logo.component';
 import Footer from '../footer.component';
 import styles from './login.scss';
+import { Edit, TrashCan, Save, ArrowRight } from '@carbon/react/icons';
 
 export interface LoginReferrer {
   referrer?: string;
@@ -204,8 +205,9 @@ const Login: React.FC = () => {
                   {showPasswordField ? (
                     <Button
                       type="submit"
+                      renderIcon={ArrowRight}
                       className={styles.continueButton}
-                      renderIcon={(props) => <ArrowRightIcon size={24} {...props} />}
+                      // renderIcon={(props) => <ArrowRightIcon size={24} {...props} />}
                       iconDescription={t('loginButtonIconDescription', 'Log in button')}
                       disabled={!isLoginEnabled || isLoggingIn}
                     >
@@ -219,7 +221,8 @@ const Login: React.FC = () => {
                     <Button
                       type="submit"
                       className={styles.continueButton}
-                      renderIcon={(props) => <ArrowRightIcon size={24} {...props} />}
+                      renderIcon={ArrowRight}
+                      // renderIcon={(props) => <ArrowRightIcon size={24} {...props} />}
                       iconDescription={t('continueToPassword', 'Continue to password')}
                       onClick={(evt) => {
                         evt.preventDefault();
@@ -248,7 +251,8 @@ const Login: React.FC = () => {
                   <Button
                     type="submit"
                     className={styles.continueButton}
-                    renderIcon={(props) => <ArrowRightIcon size={24} {...props} />}
+                    renderIcon={ArrowRight}
+                    // renderIcon={(props) => <ArrowRightIcon size={24} {...props} />}
                     iconDescription={t('loginButtonIconDescription', 'Log in button')}
                     disabled={!isLoginEnabled || isLoggingIn}
                   >

--- a/packages/apps/esm-offline-tools-app/src/components/overview-card.component.tsx
+++ b/packages/apps/esm-offline-tools-app/src/components/overview-card.component.tsx
@@ -4,6 +4,7 @@ import type { TileProps } from '@carbon/react';
 import { Button, Layer, Tile } from '@carbon/react';
 import { ArrowRightIcon, navigate } from '@openmrs/esm-framework';
 import styles from './overview-card.styles.scss';
+import { Edit, TrashCan, Save, ArrowRight } from '@carbon/react/icons';
 
 export interface OverviewCardProps extends TileProps {
   header: string;
@@ -22,7 +23,8 @@ const OverviewCard: React.FC<OverviewCardProps> = ({ header, viewLink, children 
           <Button
             className={styles.viewButton}
             kind="ghost"
-            renderIcon={(props) => <ArrowRightIcon size={16} {...props} />}
+            renderIcon={ArrowRight}
+            // renderIcon={(props) => <ArrowRightIcon size={16} {...props} />}
             size="sm"
             onClick={() => navigate({ to: `\${openmrsSpaBase}/${viewLink}` })}
           >


### PR DESCRIPTION
 Description
This PR standardizes secondary text buttons of the UI (OprnMRS-ems-core) frontend by replacing the icons with Carbon Design icons (e.g., pencil icon for "Edit") across relevant components.

# Changes
1. Added Carbon icons to secondary text buttons
2. Improved UI consistency with the O3 design system



# Requirements

- [ ] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## If applicable

- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

issue link
https://nankundal@atlassian.net/browser/MDP-7

