### PR TITLE
(test) O3-5574: Complete missing assertion for location redirection

### DIFF
--- a/packages/apps/esm-login-app/src/login/login.test.tsx
+++ b/packages/apps/esm-login-app/src/login/login.test.tsx
@@ -14,6 +14,19 @@ import { mockConfig } from '../../__mocks__/config.mock';
 import renderWithRouter from '../test-helpers/render-with-router';
 import Login from './login.component';
 
+/*
+Mock the React Router 'useNavigate' hook so we can track and assert
+if the user is redirected to the correct route after a successful login.
+*/
+const mockNavigate = vi.fn();
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual<any>('react-router-dom');
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
 const mockGetSessionStore = vi.mocked(getSessionStore);
 const mockLogin = vi.mocked(refetchCurrentUser);
 const mockUseConfig = vi.mocked(useConfig);
@@ -126,14 +139,19 @@ describe('Login', () => {
     await waitFor(() => expect(refetchCurrentUser).toHaveBeenCalledWith('yoshi', 'no-tax-fraud'));
   });
 
-  // TODO: Complete the test
+  // TODO: Complete the test  - DONE
   it('sends the user to the location select page on login if there is more than one location', async () => {
     let refreshUser = (user: any) => {};
     mockLogin.mockImplementation(() => {
       refreshUser({
         display: 'my name',
       });
-      return Promise.resolve({ data: { authenticated: true } } as unknown as SessionStore);
+
+      /*
+        FIX: Changed 'data' to 'session' to match the actual response structure
+        expected by the login component (sessionStore.session.authenticated).
+      */
+      return Promise.resolve({ session: { authenticated: true } } as unknown as SessionStore);
     });
     mockUseSession.mockImplementation(() => {
       const [user, setUser] = useState();
@@ -151,11 +169,22 @@ describe('Login', () => {
 
     const user = userEvent.setup();
 
+    mockNavigate.mockClear(); // clear the navigate mock to ensure we're only checking for navigation caused by this test
+
     await user.type(screen.getByRole('textbox', { name: /Username/i }), 'yoshi');
     await user.click(screen.getByRole('button', { name: /Continue/i }));
     await screen.findByLabelText(/^password$/i);
     await user.type(screen.getByLabelText(/^password$/i), 'no-tax-fraud');
     await user.click(screen.getByRole('button', { name: /log in/i }));
+
+    // Assert that the authentication API was called with the correct user credentials
+    await waitFor(() => expect(refetchCurrentUser).toHaveBeenCalledWith('yoshi', 'no-tax-fraud'));
+
+    /*
+      Assert that after successful authentication without a pre-selected location,
+      the user is properly redirected to the location picker page.
+    */
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith('/login/location'));
   });
 
   it('should render the both the username and password fields when the showPasswordOnSeparateScreen config is false', async () => {


### PR DESCRIPTION
# Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. Ensure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing#contributing-guidelines) label (such as `feat`, `fix`, or `chore`, among others). See existing PR titles for inspiration.

## If applicable

- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
This PR completes the missing assertions in the `login.test.tsx` file, specifically resolving the `// TODO: Complete the test` comment for the location selection redirection.

**Changes made:**
1. **Mocked `useNavigate`**: Added a `vi.hoisted` mock for `react-router-dom` to intercept and test the navigation behavior.
2. **Fixed Mock Data Structure**: Updated the mocked `refetchCurrentUser` response from `{ data: { authenticated: true } }` to `{ session: { authenticated: true } }` to correctly match how `login.component.tsx` validates the session.
3. **Added Assertions**: 
   - Verified that the `refetchCurrentUser` API is called with the correct mock credentials.
   - Verified that the user is correctly navigated to `/login/location` using `expect(mockNavigate).toHaveBeenCalledWith('/login/location')`.

## Screenshots
<img width="1522" height="705" alt="image" src="https://github.com/user-attachments/assets/5c33605d-f39e-4f7d-8eae-e723a236785a" />

## Related Issue
https://openmrs.atlassian.net/browse/O3-5574

## Other
N/A
