### PR TITLE
(feat) Add support to invoke develop with package name

### DIFF
--- a/.changeset/early-pumas-mate.md
+++ b/.changeset/early-pumas-mate.md
@@ -1,0 +1,5 @@
+---
+"openmrs": minor
+---
+
+(feat) Add support to invoke develop with package name

--- a/packages/tooling/openmrs/src/cli.test.ts
+++ b/packages/tooling/openmrs/src/cli.test.ts
@@ -20,6 +20,7 @@ import {
   isPortAvailable,
   mergeImportmapAndRoutes,
   proxyImportmapAndRoutes,
+  resolvePackages,
   runProject,
   trimEnd,
 } from './utils';
@@ -48,6 +49,7 @@ beforeEach(() => {
     routes: { type: 'inline', value: '{}' },
     watchedRoutesPaths: {},
   });
+  vi.mocked(resolvePackages).mockResolvedValue([]);
   vi.mocked(runProject).mockResolvedValue({
     importMap: {},
     routes: {},
@@ -94,6 +96,27 @@ describe('develop command', () => {
   it('defaults api-url to /openmrs/', async () => {
     const parsed = await createCli(['develop']).parseAsync();
     expect(parsed.apiUrl).toBe('/openmrs/');
+  });
+
+  it('defaults sources to undefined (no default)', async () => {
+    const parsed = await createCli(['develop']).parseAsync();
+    expect(parsed.sources).toBeUndefined();
+  });
+
+  it('defaults packages to an empty array', async () => {
+    const parsed = await createCli(['develop']).parseAsync();
+    expect(parsed.packages).toEqual([]);
+  });
+
+  it('accepts multiple --packages flags', async () => {
+    const parsed = await createCli([
+      'develop',
+      '--packages',
+      '@openmrs/app-a',
+      '--packages',
+      '@openmrs/app-b',
+    ]).parseAsync();
+    expect(parsed.packages).toEqual(['@openmrs/app-a', '@openmrs/app-b']);
   });
 });
 

--- a/packages/tooling/openmrs/src/cli.ts
+++ b/packages/tooling/openmrs/src/cli.ts
@@ -7,8 +7,10 @@ import {
   getAvailablePort,
   getImportmapAndRoutes,
   isPortAvailable,
+  logFail,
   mergeImportmapAndRoutes,
   proxyImportmapAndRoutes,
+  resolvePackages,
   runProject,
   trimEnd,
 } from './utils';
@@ -86,8 +88,15 @@ export function buildCli(y: Argv) {
           string: true,
         })
         .option('sources', {
-          default: ['.'],
-          describe: 'Runs the projects from the provided source directories. Can be used multiple times.',
+          describe:
+            'Runs the projects from the provided source directories. Can be used multiple times. Defaults to the current directory if neither --sources nor --packages is specified.',
+          type: 'array',
+          string: true,
+        })
+        .option('packages', {
+          default: [],
+          describe:
+            'Runs the projects by package name, resolved from the current workspace. Can be used multiple times.',
           type: 'array',
           string: true,
         })
@@ -132,6 +141,30 @@ export function buildCli(y: Argv) {
         port = args.port;
       }
 
+      let resolvedFromPackages: string[] = [];
+      if (args.packages.length > 0) {
+        try {
+          resolvedFromPackages = await resolvePackages(args.packages);
+        } catch (e) {
+          logFail((e as Error).message);
+          process.exit(1);
+        }
+      }
+
+      const explicitSources = args.sources ?? [];
+      const combined = [...explicitSources, ...resolvedFromPackages];
+
+      // De-duplicate by resolved absolute path
+      const seen = new Set<string>();
+      const deduplicated = combined.filter((s) => {
+        const abs = resolve(s);
+        if (seen.has(abs)) return false;
+        seen.add(abs);
+        return true;
+      });
+
+      const sources = deduplicated.length > 0 ? deduplicated : ['.'];
+
       runCommand('runDevelop', {
         configUrls: args['config-url'],
         configFiles: args['config-file'],
@@ -140,7 +173,7 @@ export function buildCli(y: Argv) {
         ...proxyImportmapAndRoutes(
           await mergeImportmapAndRoutes(
             await getImportmapAndRoutes(args.importmap, args.routes, port),
-            await runProject(port, args.sources, args['use-rspack']),
+            await runProject(port, sources, args['use-rspack']),
             args.backend,
             args.spaPath,
           ),

--- a/packages/tooling/openmrs/src/utils/importmap.ts
+++ b/packages/tooling/openmrs/src/utils/importmap.ts
@@ -1,7 +1,7 @@
 import { createRequire } from 'node:module';
 import { glob } from 'glob';
 import { URL } from 'url';
-import { basename, resolve } from 'path';
+import { resolve } from 'path';
 import { existsSync, readFileSync } from 'fs';
 import { exec } from 'child_process';
 import { logFail, logInfo, logWarn } from './logger';
@@ -59,7 +59,7 @@ async function fetchRemoteImportmap(fetchUrl: string) {
   const m = await res.json();
 
   if (typeof m === 'object' && m !== null && 'imports' in m && typeof m.imports === 'object' && m.imports !== null) {
-    const imports = m.imports;
+    const imports = m.imports as Record<string, unknown>;
     Object.keys(imports).forEach((key) => {
       const url = imports[key];
 
@@ -166,9 +166,9 @@ export async function runProject(
 }> {
   const baseDir = process.cwd();
   const sourceDirectories = await matchAny(baseDir, sourceDirectoryPatterns);
-  const importMap = {};
-  const routes = {};
-  const watchedRoutesPaths = {};
+  const importMap: Record<string, string> = {};
+  const routes: Record<string, unknown> = {};
+  const watchedRoutesPaths: Record<string, string> = {};
   const devServerReadyPromises: Array<Promise<void>> = [];
 
   // Track the starting port, which is one more than the last used port

--- a/packages/tooling/openmrs/src/utils/index.ts
+++ b/packages/tooling/openmrs/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from './config';
 export * from './helpers';
 export * from './importmap';
 export * from './logger';
+export * from './packages';
 export * from './port';
 export * from './untar';
 export * from './types';

--- a/packages/tooling/openmrs/src/utils/packages.test.ts
+++ b/packages/tooling/openmrs/src/utils/packages.test.ts
@@ -1,0 +1,209 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('glob', () => ({
+  glob: vi.fn(),
+}));
+
+vi.mock('fs', () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+}));
+
+vi.mock('./logger', () => ({
+  logInfo: vi.fn(),
+  logWarn: vi.fn(),
+  logFail: vi.fn(),
+}));
+
+import { glob } from 'glob';
+import { existsSync, readFileSync } from 'node:fs';
+import { resolvePackages } from './packages';
+
+const mockGlob = vi.mocked(glob);
+const mockExistsSync = vi.mocked(existsSync);
+const mockReadFileSync = vi.mocked(readFileSync);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+// Helper to set up a consistent filesystem mock from a map of path -> JSON content.
+// Paths not in the map are treated as non-existent.
+function mockFs(files: Record<string, object>) {
+  mockExistsSync.mockImplementation((p) => String(p) in files);
+  mockReadFileSync.mockImplementation((p) => {
+    const content = files[String(p)];
+    if (content === undefined) {
+      throw new Error(`ENOENT: ${p}`);
+    }
+    return JSON.stringify(content);
+  });
+}
+
+describe('resolvePackages', () => {
+  describe('monorepo with workspaces (array form)', () => {
+    it('resolves a single package name to its workspace directory', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/repo');
+
+      mockFs({
+        '/repo/package.json': { name: 'root', workspaces: ['packages/*'] },
+        '/repo/packages/app-a/package.json': { name: '@openmrs/app-a' },
+        '/repo/packages/app-b/package.json': { name: '@openmrs/app-b' },
+      });
+      mockGlob.mockResolvedValue(['packages/app-a', 'packages/app-b']);
+
+      const result = await resolvePackages(['@openmrs/app-a']);
+      expect(result).toEqual(['/repo/packages/app-a']);
+    });
+
+    it('resolves multiple package names', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/repo');
+
+      mockFs({
+        '/repo/package.json': { name: 'root', workspaces: ['packages/*'] },
+        '/repo/packages/app-a/package.json': { name: '@openmrs/app-a' },
+        '/repo/packages/app-b/package.json': { name: '@openmrs/app-b' },
+      });
+      mockGlob.mockResolvedValue(['packages/app-a', 'packages/app-b']);
+
+      const result = await resolvePackages(['@openmrs/app-a', '@openmrs/app-b']);
+      expect(result).toEqual(['/repo/packages/app-a', '/repo/packages/app-b']);
+    });
+
+    it('handles multiple workspace patterns', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/repo');
+
+      mockFs({
+        '/repo/package.json': { name: 'root', workspaces: ['packages/apps/*', 'packages/libs/*'] },
+        '/repo/packages/apps/login/package.json': { name: '@openmrs/esm-login-app' },
+        '/repo/packages/libs/utils/package.json': { name: '@openmrs/esm-utils' },
+      });
+      // glob is called once per pattern
+      mockGlob.mockResolvedValueOnce(['packages/apps/login']).mockResolvedValueOnce(['packages/libs/utils']);
+
+      const result = await resolvePackages(['@openmrs/esm-login-app']);
+      expect(result).toEqual(['/repo/packages/apps/login']);
+      expect(mockGlob).toHaveBeenCalledTimes(2);
+    });
+
+    it('skips workspace directories without a package.json', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/repo');
+
+      mockFs({
+        '/repo/package.json': { name: 'root', workspaces: ['packages/*'] },
+        '/repo/packages/app-a/package.json': { name: '@openmrs/app-a' },
+        // packages/orphan has no package.json
+      });
+      mockGlob.mockResolvedValue(['packages/app-a', 'packages/orphan']);
+
+      const result = await resolvePackages(['@openmrs/app-a']);
+      expect(result).toEqual(['/repo/packages/app-a']);
+    });
+  });
+
+  describe('monorepo with workspaces (object form)', () => {
+    it('resolves packages when workspaces uses the { packages: [...] } form', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/repo');
+
+      mockFs({
+        '/repo/package.json': { name: 'root', workspaces: { packages: ['packages/*'] } },
+        '/repo/packages/app-a/package.json': { name: '@openmrs/app-a' },
+      });
+      mockGlob.mockResolvedValue(['packages/app-a']);
+
+      const result = await resolvePackages(['@openmrs/app-a']);
+      expect(result).toEqual(['/repo/packages/app-a']);
+    });
+  });
+
+  describe('workspace root discovery from subdirectory', () => {
+    it('finds workspace root when cwd is inside a workspace package', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/repo/packages/app-a');
+
+      mockFs({
+        '/repo/packages/app-a/package.json': { name: '@openmrs/app-a' },
+        '/repo/package.json': { name: 'root', workspaces: ['packages/*'] },
+        '/repo/packages/app-b/package.json': { name: '@openmrs/app-b' },
+      });
+      mockGlob.mockResolvedValue(['packages/app-a', 'packages/app-b']);
+
+      const result = await resolvePackages(['@openmrs/app-b']);
+      expect(result).toEqual(['/repo/packages/app-b']);
+    });
+  });
+
+  describe('single package (no workspaces)', () => {
+    it('resolves when the cwd package.json name matches', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/projects/lab-app');
+
+      mockFs({
+        '/projects/lab-app/package.json': { name: '@openmrs/esm-laboratory-app' },
+      });
+
+      const result = await resolvePackages(['@openmrs/esm-laboratory-app']);
+      expect(result).toEqual(['/projects/lab-app']);
+    });
+  });
+
+  describe('error handling', () => {
+    it('throws when a requested package is not found', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/repo');
+
+      mockFs({
+        '/repo/package.json': { name: 'root', workspaces: ['packages/*'] },
+        '/repo/packages/app-a/package.json': { name: '@openmrs/app-a' },
+      });
+      mockGlob.mockResolvedValue(['packages/app-a']);
+
+      await expect(resolvePackages(['@openmrs/nonexistent'])).rejects.toThrow(
+        'Could not resolve the following package(s)',
+      );
+    });
+
+    it('lists the unresolved package names in the error', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/repo');
+
+      mockFs({
+        '/repo/package.json': { name: 'root', workspaces: ['packages/*'] },
+        '/repo/packages/app-a/package.json': { name: '@openmrs/app-a' },
+      });
+      mockGlob.mockResolvedValue(['packages/app-a']);
+
+      await expect(resolvePackages(['@openmrs/nonexistent'])).rejects.toThrow('@openmrs/nonexistent');
+    });
+
+    it('includes available packages in the error message', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/repo');
+
+      mockFs({
+        '/repo/package.json': { name: 'root', workspaces: ['packages/*'] },
+        '/repo/packages/app-a/package.json': { name: '@openmrs/app-a' },
+      });
+      mockGlob.mockResolvedValue(['packages/app-a']);
+
+      await expect(resolvePackages(['@openmrs/nonexistent'])).rejects.toThrow('@openmrs/app-a');
+    });
+
+    it('reports when no packages are found at all', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/empty');
+
+      mockExistsSync.mockReturnValue(false);
+
+      await expect(resolvePackages(['@openmrs/anything'])).rejects.toThrow(
+        'No packages were found in the current directory',
+      );
+    });
+
+    it('throws for a mix of found and not-found packages', async () => {
+      vi.spyOn(process, 'cwd').mockReturnValue('/repo');
+
+      mockFs({
+        '/repo/package.json': { name: 'root', workspaces: ['packages/*'] },
+        '/repo/packages/app-a/package.json': { name: '@openmrs/app-a' },
+      });
+      mockGlob.mockResolvedValue(['packages/app-a']);
+
+      await expect(resolvePackages(['@openmrs/app-a', '@openmrs/missing'])).rejects.toThrow('@openmrs/missing');
+    });
+  });
+});

--- a/packages/tooling/openmrs/src/utils/packages.ts
+++ b/packages/tooling/openmrs/src/utils/packages.ts
@@ -1,0 +1,112 @@
+import { glob } from 'glob';
+import { dirname, resolve } from 'path';
+import { existsSync, readFileSync } from 'fs';
+import { logInfo } from './logger';
+import type { PackageJson } from './types';
+
+function readPackageJson(pkgPath: string): PackageJson {
+  return JSON.parse(readFileSync(pkgPath, 'utf8'));
+}
+
+function getWorkspacePatterns(pkg: PackageJson): Array<string> | null {
+  const workspaces = Array.isArray(pkg.workspaces) ? pkg.workspaces : pkg.workspaces?.packages ?? null;
+  return workspaces && workspaces.length > 0 ? workspaces : null;
+}
+
+/**
+ * Walk up the directory tree from startDir looking for a package.json
+ * with a workspaces field, which indicates a monorepo root.
+ */
+function findWorkspaceRoot(startDir: string): string | null {
+  let dir = startDir;
+  for (;;) {
+    const pkgPath = resolve(dir, 'package.json');
+    if (existsSync(pkgPath)) {
+      const pkg = readPackageJson(pkgPath);
+      if (getWorkspacePatterns(pkg)) {
+        return dir;
+      }
+    }
+    const parent = dirname(dir);
+    if (parent === dir) {
+      return null;
+    }
+    dir = parent;
+  }
+}
+
+/**
+ * Resolve package names to their source directories.
+ *
+ * First checks the current directory's package.json for a direct match,
+ * which handles single-package repos efficiently. If any requested
+ * packages remain unresolved, walks up the directory tree to find a
+ * workspace root and globs its workspace patterns to build a complete
+ * package map.
+ *
+ * @returns Absolute paths to the resolved package directories.
+ * @throws If any requested package name cannot be resolved, with a list
+ *   of available packages.
+ */
+export async function resolvePackages(packageNames: Array<string>): Promise<Array<string>> {
+  const cwd = process.cwd();
+  const packageMap = new Map<string, string>();
+
+  // Check the nearest package.json first (fast path for single-package repos)
+  const cwdPkgPath = resolve(cwd, 'package.json');
+  if (existsSync(cwdPkgPath)) {
+    const cwdPkg = readPackageJson(cwdPkgPath);
+    if (cwdPkg.name) {
+      packageMap.set(cwdPkg.name, cwd);
+    }
+  }
+
+  // If all requested packages are already resolved, skip workspace discovery
+  if (!packageNames.every((name) => packageMap.has(name))) {
+    const workspaceRoot = findWorkspaceRoot(cwd);
+
+    if (workspaceRoot) {
+      const rootPkg = readPackageJson(resolve(workspaceRoot, 'package.json'));
+      const patterns = getWorkspacePatterns(rootPkg)!;
+
+      const results = await Promise.all(patterns.map((pattern) => glob(pattern, { cwd: workspaceRoot })));
+      const workspaceDirs = results.flat();
+
+      for (const dir of workspaceDirs) {
+        const pkgPath = resolve(workspaceRoot, dir, 'package.json');
+        if (existsSync(pkgPath)) {
+          const pkg = readPackageJson(pkgPath);
+          if (pkg.name) {
+            packageMap.set(pkg.name, resolve(workspaceRoot, dir));
+          }
+        }
+      }
+    }
+  }
+
+  const resolved: Array<string> = [];
+  const notFound: Array<string> = [];
+
+  for (const name of packageNames) {
+    const dir = packageMap.get(name);
+    if (dir) {
+      logInfo(`Resolved package "${name}" to "${dir}"`);
+      resolved.push(dir);
+    } else {
+      notFound.push(name);
+    }
+  }
+
+  if (notFound.length > 0) {
+    const available = Array.from(packageMap.keys()).sort();
+    throw new Error(
+      `Could not resolve the following package(s):\n` +
+        notFound.map((n) => `  - ${n}`).join('\n') +
+        (available.length > 0
+          ? `\n\nAvailable packages:\n` + available.map((n) => `  - ${n}`).join('\n')
+          : '\n\nNo packages were found in the current directory.'),
+    );
+  }
+
+  return resolved;
+}

--- a/packages/tooling/openmrs/src/utils/types.ts
+++ b/packages/tooling/openmrs/src/utils/types.ts
@@ -4,6 +4,7 @@ export interface PackageJson {
   browser?: string;
   module?: string;
   main?: string;
+  workspaces?: Array<string> | { packages: Array<string> };
   'openmrs:develop'?: {
     command: string;
     url?: string;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->

This adds support for `openmrs develop --packages @openmrs/esm-some-app` in addition to existing support for using `--sources`. Packages are resolved either from the nearest package.json or from its workspace definition.

The main advantage here is that you can use this without needing the exact path to the sources, e.g. if switching between repos or the like.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

This feature is mostly inspired by `yarn workspace ...` and `yarn turbo filter=...` as being a more convenient way to refer to packages in monorepos, so I wanted the same thing for the CLI.
