### PR TITLE
(fix) O3-4020: Return current app context value synchronously on first render

### DIFF
--- a/.changeset/fix-useappcontext-initial-render.md
+++ b/.changeset/fix-useappcontext-initial-render.md
@@ -1,0 +1,5 @@
+---
+"@openmrs/esm-react-utils": patch
+---
+
+Return current app context value synchronously from useAppContext and undefined when the namespace has not been registered yet (O3-4020).

--- a/.changeset/fix-useappcontext-initial-render.md
+++ b/.changeset/fix-useappcontext-initial-render.md
@@ -1,5 +1,6 @@
 ---
 "@openmrs/esm-react-utils": minor
+"@openmrs/esm-context": patch
 ---
 
-Return current app context value synchronously from useAppContext and undefined when the namespace has not been registered yet (O3-4020).
+Return current app context value synchronously from useAppContext and undefined when the namespace has not been registered yet (O3-4020)

--- a/.changeset/fix-useappcontext-initial-render.md
+++ b/.changeset/fix-useappcontext-initial-render.md
@@ -1,6 +1,6 @@
 ---
 "@openmrs/esm-react-utils": minor
-"@openmrs/esm-context": patch
+"@openmrs/esm-context": minor
 ---
 
 Return current app context value synchronously from useAppContext and undefined when the namespace has not been registered yet (O3-4020)

--- a/.changeset/fix-useappcontext-initial-render.md
+++ b/.changeset/fix-useappcontext-initial-render.md
@@ -1,5 +1,5 @@
 ---
-"@openmrs/esm-react-utils": patch
+"@openmrs/esm-react-utils": minor
 ---
 
 Return current app context value synchronously from useAppContext and undefined when the namespace has not been registered yet (O3-4020).

--- a/packages/framework/esm-context/package.json
+++ b/packages/framework/esm-context/package.json
@@ -19,12 +19,12 @@
   "source": true,
   "sideEffects": false,
   "scripts": {
-    "test": "cross-env TZ=UTC vitest run --passWithNoTests",
-    "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src --ext ts,tsx",
+    "test": "cross-env TZ=UTC vitest run --passWithNoTests",
+    "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests"
   },
   "keywords": [

--- a/packages/framework/esm-context/src/context.ts
+++ b/packages/framework/esm-context/src/context.ts
@@ -117,15 +117,18 @@ export function subscribeToContext<T extends NonNullable<object> = NonNullable<o
 ) {
   let previous = getContext<T>(namespace);
 
-  // set initial value
-  callback(Object.freeze(Object.assign({}, previous)));
+  callback(snapshot(previous));
 
   return contextStore.subscribe((state) => {
-    let current: Readonly<T> | null | undefined = namespace in state ? (state[namespace] as T) : null;
+    const current: Readonly<T> | null = namespace in state ? (state[namespace] as T) : null;
 
     if (current !== previous) {
       previous = current;
-      callback(Object.freeze(Object.assign({}, current)));
+      callback(snapshot(current));
     }
   });
+}
+
+function snapshot<T extends NonNullable<object> = NonNullable<object>>(value: Readonly<T> | null): Readonly<T> | null {
+  return value === null ? null : Object.freeze(Object.assign({}, value));
 }

--- a/packages/framework/esm-framework/docs/functions/useAppContext.md
+++ b/packages/framework/esm-framework/docs/functions/useAppContext.md
@@ -2,6 +2,8 @@
 
 # Function: useAppContext()
 
+## Call Signature
+
 > **useAppContext**\<`T`\>(`namespace`): `undefined` \| `Readonly`\<`T`\>
 
 Defined in: [packages/framework/esm-react-utils/src/useAppContext.ts:26](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useAppContext.ts#L26)
@@ -10,27 +12,81 @@ This hook is used to access a namespace within the overall AppContext, so that a
 use any shared contextual values. A selector may be provided to further restrict the properties
 returned from the namespace.
 
-## Type Parameters
+### Type Parameters
 
-### T
+#### T
 
 `T` *extends* `object` = `object`
 
 The type of the value stored in the namespace
 
-## Parameters
+### Parameters
 
-### namespace
+#### namespace
 
 `string`
 
 The namespace to load properties from
 
-## Returns
+### Returns
 
 `undefined` \| `Readonly`\<`T`\>
 
-## Examples
+### Examples
+
+```ts
+// load a full namespace
+const patientContext = useAppContext<PatientContext>('patient');
+```
+
+```ts
+// loads part of a namespace
+const patientName = useAppContext<PatientContext, string | undefined>('patient', (state) => state.display);
+```
+
+## Call Signature
+
+> **useAppContext**\<`T`, `U`\>(`namespace`, `selector`): `undefined` \| `Readonly`\<`U`\>
+
+Defined in: [packages/framework/esm-react-utils/src/useAppContext.ts:52](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useAppContext.ts#L52)
+
+This hook is used to access a namespace within the overall AppContext, so that a component can
+use any shared contextual values. A selector may be provided to further restrict the properties
+returned from the namespace.
+
+### Type Parameters
+
+#### T
+
+`T` *extends* `object` = `object`
+
+The type of the value stored in the namespace
+
+#### U
+
+`U` = `T`
+
+The return type of this hook which is mostly relevant when using a selector
+
+### Parameters
+
+#### namespace
+
+`string`
+
+The namespace to load properties from
+
+#### selector
+
+(`state`) => `Readonly`\<`U`\>
+
+An optional function which extracts the relevant part of the state
+
+### Returns
+
+`undefined` \| `Readonly`\<`U`\>
+
+### Examples
 
 ```ts
 // load a full namespace

--- a/packages/framework/esm-react-utils/src/useAppContext.test.tsx
+++ b/packages/framework/esm-react-utils/src/useAppContext.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
-import { render, renderHook, screen } from '@testing-library/react';
-import { registerContext, unregisterContext } from '@openmrs/esm-context';
+import { act, render, renderHook, screen } from '@testing-library/react';
+import { registerContext, unregisterContext, updateContext } from '@openmrs/esm-context';
 import { useAppContext } from './useAppContext';
 import { useDefineAppContext } from './useDefineAppContext';
 
@@ -24,10 +24,6 @@ describe('useAppContext', () => {
   });
 
   it('returns the currently-registered value on the very first render', () => {
-    // Simulates the real-world scenario: one component has already registered
-    // the context (e.g. WardView via useDefineAppContext), and a second
-    // component mounts later and calls useAppContext. The second component
-    // must see the current value on its first render, not undefined.
     registerContext<TestContext>(namespace, { value: 'initial', count: 1 });
 
     const { result } = renderHook(() => useAppContext<TestContext>(namespace));
@@ -44,11 +40,6 @@ describe('useAppContext', () => {
   });
 
   it('exposes a sibling useDefineAppContext value to the consumer after effects flush', () => {
-    // Note: React Testing Library's render() flushes effects before returning,
-    // so this asserts the post-effect steady state — not literally the first
-    // render. The useState-initializer path is exercised by the
-    // "currently-registered value on the very first render" test above, which
-    // pre-registers the namespace before renderHook runs.
     const Producer = () => {
       useDefineAppContext<TestContext>(namespace, { value: 'from-producer', count: 42 });
       return null;
@@ -69,21 +60,18 @@ describe('useAppContext', () => {
     expect(screen.getByTestId('consumer-value')).toHaveTextContent('from-producer:42');
   });
 
-  it('returns undefined (not {}) after the namespace owner unmounts (O3-4020 scenario)', async () => {
-    // This reproduces Ian Bacher's hypothesis from O3-4020: when the component
-    // that owns a namespace via useDefineAppContext unmounts while a consumer
-    // is still mounted, the consumer must observe undefined — not a frozen
-    // empty object that silently hides the absence.
-    let currentValue: ReturnType<typeof useAppContext<TestContext>> = undefined;
-
+  it('returns undefined (not {}) after the namespace owner unmounts (O3-4020 scenario)', () => {
+    // When the component that owns a namespace via useDefineAppContext
+    // unmounts while a consumer is still mounted, the consumer must observe
+    // undefined — not a frozen empty object that silently hides the absence.
     const Producer = () => {
       useDefineAppContext<TestContext>(namespace, { value: 'v', count: 1 });
       return null;
     };
 
     const Consumer = () => {
-      currentValue = useAppContext<TestContext>(namespace);
-      return null;
+      const ctx = useAppContext<TestContext>(namespace);
+      return <div data-testid="consumer-value">{ctx ? `${ctx.value}:${ctx.count}` : 'UNDEFINED'}</div>;
     };
 
     const { rerender } = render(
@@ -93,15 +81,24 @@ describe('useAppContext', () => {
       </>,
     );
 
-    expect(currentValue).toEqual({ value: 'v', count: 1 });
+    expect(screen.getByTestId('consumer-value')).toHaveTextContent('v:1');
 
-    // Owner unmounts; consumer stays mounted
-    rerender(
-      <>
-        <Consumer />
-      </>,
-    );
+    rerender(<Consumer />);
 
-    expect(currentValue).toBeUndefined();
+    expect(screen.getByTestId('consumer-value')).toHaveTextContent('UNDEFINED');
+  });
+
+  it('re-applies the selector when the underlying context updates', () => {
+    registerContext<TestContext>(namespace, { value: 'a', count: 1 });
+
+    const { result } = renderHook(() => useAppContext<TestContext, number>(namespace, (state) => state?.count ?? -1));
+
+    expect(result.current).toBe(1);
+
+    act(() => {
+      updateContext<TestContext>(namespace, (state) => ({ ...state, count: 7 }));
+    });
+
+    expect(result.current).toBe(7);
   });
 });

--- a/packages/framework/esm-react-utils/src/useAppContext.test.tsx
+++ b/packages/framework/esm-react-utils/src/useAppContext.test.tsx
@@ -1,0 +1,104 @@
+import React from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { render, renderHook, screen } from '@testing-library/react';
+import { registerContext, unregisterContext } from '@openmrs/esm-context';
+import { useAppContext } from './useAppContext';
+import { useDefineAppContext } from './useDefineAppContext';
+
+const namespace = 'test-context';
+
+interface TestContext {
+  value: string;
+  count: number;
+}
+
+afterEach(() => {
+  unregisterContext(namespace);
+});
+
+describe('useAppContext', () => {
+  it('returns undefined when the namespace is not registered', () => {
+    const { result } = renderHook(() => useAppContext<TestContext>(namespace));
+
+    expect(result.current).toBeUndefined();
+  });
+
+  it('returns the currently-registered value on the very first render', () => {
+    // Simulates the real-world scenario: one component has already registered
+    // the context (e.g. WardView via useDefineAppContext), and a second
+    // component mounts later and calls useAppContext. The second component
+    // must see the current value on its first render, not undefined.
+    registerContext<TestContext>(namespace, { value: 'initial', count: 1 });
+
+    const { result } = renderHook(() => useAppContext<TestContext>(namespace));
+
+    expect(result.current).toEqual({ value: 'initial', count: 1 });
+  });
+
+  it('applies the selector on the first render', () => {
+    registerContext<TestContext>(namespace, { value: 'initial', count: 5 });
+
+    const { result } = renderHook(() => useAppContext<TestContext, number>(namespace, (state) => state?.count ?? 0));
+
+    expect(result.current).toBe(5);
+  });
+
+  it("returns the value registered by a sibling useDefineAppContext on the consumer's first render", () => {
+    const Producer = () => {
+      useDefineAppContext<TestContext>(namespace, { value: 'from-producer', count: 42 });
+      return null;
+    };
+
+    const Consumer = () => {
+      const ctx = useAppContext<TestContext>(namespace);
+      return <div data-testid="consumer-value">{ctx ? `${ctx.value}:${ctx.count}` : 'UNDEFINED'}</div>;
+    };
+
+    // Producer mounts first, then consumer — consumer must see the value on
+    // its first render, not undefined.
+    render(
+      <>
+        <Producer />
+        <Consumer />
+      </>,
+    );
+
+    expect(screen.getByTestId('consumer-value')).toHaveTextContent('from-producer:42');
+  });
+
+  it('returns undefined (not {}) after the namespace owner unmounts (O3-4020 scenario)', async () => {
+    // This reproduces Ian Bacher's hypothesis from O3-4020: when the component
+    // that owns a namespace via useDefineAppContext unmounts while a consumer
+    // is still mounted, the consumer must observe undefined — not a frozen
+    // empty object that silently hides the absence.
+    let currentValue: ReturnType<typeof useAppContext<TestContext>> = undefined;
+
+    const Producer = () => {
+      useDefineAppContext<TestContext>(namespace, { value: 'v', count: 1 });
+      return null;
+    };
+
+    const Consumer = () => {
+      currentValue = useAppContext<TestContext>(namespace);
+      return null;
+    };
+
+    const { rerender } = render(
+      <>
+        <Producer />
+        <Consumer />
+      </>,
+    );
+
+    expect(currentValue).toEqual({ value: 'v', count: 1 });
+
+    // Owner unmounts; consumer stays mounted
+    rerender(
+      <>
+        <Consumer />
+      </>,
+    );
+
+    expect(currentValue).toBeUndefined();
+  });
+});

--- a/packages/framework/esm-react-utils/src/useAppContext.test.tsx
+++ b/packages/framework/esm-react-utils/src/useAppContext.test.tsx
@@ -43,7 +43,12 @@ describe('useAppContext', () => {
     expect(result.current).toBe(5);
   });
 
-  it("returns the value registered by a sibling useDefineAppContext on the consumer's first render", () => {
+  it('exposes a sibling useDefineAppContext value to the consumer after effects flush', () => {
+    // Note: React Testing Library's render() flushes effects before returning,
+    // so this asserts the post-effect steady state — not literally the first
+    // render. The useState-initializer path is exercised by the
+    // "currently-registered value on the very first render" test above, which
+    // pre-registers the namespace before renderHook runs.
     const Producer = () => {
       useDefineAppContext<TestContext>(namespace, { value: 'from-producer', count: 42 });
       return null;
@@ -54,8 +59,6 @@ describe('useAppContext', () => {
       return <div data-testid="consumer-value">{ctx ? `${ctx.value}:${ctx.count}` : 'UNDEFINED'}</div>;
     };
 
-    // Producer mounts first, then consumer — consumer must see the value on
-    // its first render, not undefined.
     render(
       <>
         <Producer />

--- a/packages/framework/esm-react-utils/src/useAppContext.ts
+++ b/packages/framework/esm-react-utils/src/useAppContext.ts
@@ -3,6 +3,10 @@ import { useEffect, useState } from 'react';
 import { getContext, subscribeToContext } from '@openmrs/esm-context';
 import { shallowEqual } from '@openmrs/esm-utils';
 
+function isBlankNamespace(namespace: unknown): boolean {
+  return typeof namespace !== 'string' || namespace.trim().length === 0;
+}
+
 /**
  * This hook is used to access a namespace within the overall AppContext, so that a component can
  * use any shared contextual values. A selector may be provided to further restrict the properties
@@ -54,7 +58,7 @@ export function useAppContext<T extends NonNullable<object> = NonNullable<object
   selector: (state: Readonly<T> | null) => Readonly<U> = (state) => (state ?? {}) as Readonly<U>,
 ): Readonly<U> | undefined {
   const [value, setValue] = useState<Readonly<U> | undefined>(() => {
-    if (!namespace || namespace.replace(' ', '') === '') {
+    if (isBlankNamespace(namespace)) {
       return undefined;
     }
     const current = getContext<T>(namespace);
@@ -65,18 +69,21 @@ export function useAppContext<T extends NonNullable<object> = NonNullable<object
   });
 
   useEffect(() => {
-    if (namespace === null || typeof namespace === 'undefined' || namespace.replace(' ', '') === '') {
+    if (isBlankNamespace(namespace)) {
       throw new Error(`The namespace supplied to useAppContext must be a non-empty string, but was "${namespace}".`);
     }
   }, [namespace]);
 
   useEffect(() => {
-    // Read the authoritative state via getContext rather than relying on the
-    // callback's state argument. subscribeToContext substitutes {} when a
-    // namespace is unregistered, which makes it indistinguishable from a
+    // Prefer the state provided by subscribeToContext to avoid re-reading and
+    // re-cloning the context on every update. Only fall back to getContext for
+    // the ambiguous empty-object case: subscribeToContext substitutes a frozen
+    // {} when a namespace is unregistered, which is indistinguishable from a
     // namespace that was genuinely registered with an empty object.
-    return subscribeToContext<T>(namespace, () => {
-      const current = getContext<T>(namespace);
+    return subscribeToContext<T>(namespace, (state) => {
+      const current =
+        state != null && Object.keys(state).length === 0 ? getContext<T>(namespace) : ((state ?? null) as T | null);
+
       if (current === null) {
         setValue((prev) => (prev === undefined ? prev : undefined));
         return;

--- a/packages/framework/esm-react-utils/src/useAppContext.ts
+++ b/packages/framework/esm-react-utils/src/useAppContext.ts
@@ -22,6 +22,10 @@ import { shallowEqual } from '@openmrs/esm-utils';
  *
  * @typeParam T The type of the value stored in the namespace
  * @param namespace The namespace to load properties from
+ * @returns The current value registered under `namespace`, or `undefined` when the namespace has not
+ * yet been registered, was unregistered (e.g. the owning component unmounted), or is a blank string.
+ * Consumers should handle the `undefined` case explicitly rather than defaulting to `{}`, since an
+ * empty-object default can mask a genuinely missing namespace and hide bugs.
  */
 export function useAppContext<T extends NonNullable<object> = NonNullable<object>>(
   namespace: string,
@@ -48,6 +52,10 @@ export function useAppContext<T extends NonNullable<object> = NonNullable<object
  * @typeParam U The return type of this hook which is mostly relevant when using a selector
  * @param namespace The namespace to load properties from
  * @param selector An optional function which extracts the relevant part of the state
+ * @returns The selected value, or `undefined` when the namespace has not yet been registered, was
+ * unregistered (e.g. the owning component unmounted), or is a blank string. Consumers should handle
+ * the `undefined` case explicitly rather than defaulting to `{}`, since an empty-object default can
+ * mask a genuinely missing namespace and hide bugs.
  */
 export function useAppContext<T extends NonNullable<object> = NonNullable<object>, U = T>(
   namespace: string,

--- a/packages/framework/esm-react-utils/src/useAppContext.ts
+++ b/packages/framework/esm-react-utils/src/useAppContext.ts
@@ -3,10 +3,6 @@ import { useEffect, useState } from 'react';
 import { getContext, subscribeToContext } from '@openmrs/esm-context';
 import { shallowEqual } from '@openmrs/esm-utils';
 
-function isBlankNamespace(namespace: unknown): boolean {
-  return typeof namespace !== 'string' || namespace.trim().length === 0;
-}
-
 /**
  * This hook is used to access a namespace within the overall AppContext, so that a component can
  * use any shared contextual values. A selector may be provided to further restrict the properties
@@ -55,6 +51,11 @@ export function useAppContext<T extends NonNullable<object> = NonNullable<object
  */
 export function useAppContext<T extends NonNullable<object> = NonNullable<object>, U = T>(
   namespace: string,
+  selector: (state: Readonly<T> | null) => Readonly<U>,
+): Readonly<U> | undefined;
+
+export function useAppContext<T extends NonNullable<object> = NonNullable<object>, U = T>(
+  namespace: string,
   selector: (state: Readonly<T> | null) => Readonly<U> = (state) => (state ?? {}) as Readonly<U>,
 ): Readonly<U> | undefined {
   const [value, setValue] = useState<Readonly<U> | undefined>(() => {
@@ -75,23 +76,19 @@ export function useAppContext<T extends NonNullable<object> = NonNullable<object
   }, [namespace]);
 
   useEffect(() => {
-    // Prefer the state provided by subscribeToContext to avoid re-reading and
-    // re-cloning the context on every update. Only fall back to getContext for
-    // the ambiguous empty-object case: subscribeToContext substitutes a frozen
-    // {} when a namespace is unregistered, which is indistinguishable from a
-    // namespace that was genuinely registered with an empty object.
     return subscribeToContext<T>(namespace, (state) => {
-      const current =
-        state != null && Object.keys(state).length === 0 ? getContext<T>(namespace) : ((state ?? null) as T | null);
-
-      if (current === null) {
-        setValue((prev) => (prev === undefined ? prev : undefined));
+      if (state == null) {
+        setValue(undefined);
         return;
       }
-      const newValue = selector ? selector(current) : (current as unknown as Readonly<U>);
+      const newValue = selector ? selector(state) : (state as unknown as Readonly<U>);
       setValue((prev) => (shallowEqual(prev, newValue) ? prev : newValue));
     });
-  }, []);
+  }, [namespace, selector]);
 
   return value;
+}
+
+function isBlankNamespace(namespace: unknown): boolean {
+  return typeof namespace !== 'string' || namespace.trim().length === 0;
 }

--- a/packages/framework/esm-react-utils/src/useAppContext.ts
+++ b/packages/framework/esm-react-utils/src/useAppContext.ts
@@ -1,6 +1,6 @@
 /** @module @category Context */
 import { useEffect, useState } from 'react';
-import { subscribeToContext } from '@openmrs/esm-context';
+import { getContext, subscribeToContext } from '@openmrs/esm-context';
 import { shallowEqual } from '@openmrs/esm-utils';
 
 /**
@@ -53,7 +53,16 @@ export function useAppContext<T extends NonNullable<object> = NonNullable<object
   namespace: string,
   selector: (state: Readonly<T> | null) => Readonly<U> = (state) => (state ?? {}) as Readonly<U>,
 ): Readonly<U> | undefined {
-  const [value, setValue] = useState<Readonly<U>>();
+  const [value, setValue] = useState<Readonly<U> | undefined>(() => {
+    if (!namespace || namespace.replace(' ', '') === '') {
+      return undefined;
+    }
+    const current = getContext<T>(namespace);
+    if (current === null) {
+      return undefined;
+    }
+    return selector ? selector(current) : (current as unknown as Readonly<U>);
+  });
 
   useEffect(() => {
     if (namespace === null || typeof namespace === 'undefined' || namespace.replace(' ', '') === '') {
@@ -62,13 +71,18 @@ export function useAppContext<T extends NonNullable<object> = NonNullable<object
   }, [namespace]);
 
   useEffect(() => {
-    return subscribeToContext<T>(namespace, (state) => {
-      if (typeof state !== 'undefined') {
-        const newValue = selector ? selector(state) : ((state ?? {}) as Readonly<U>);
-        if (!shallowEqual(value, newValue)) {
-          setValue(newValue);
-        }
+    // Read the authoritative state via getContext rather than relying on the
+    // callback's state argument. subscribeToContext substitutes {} when a
+    // namespace is unregistered, which makes it indistinguishable from a
+    // namespace that was genuinely registered with an empty object.
+    return subscribeToContext<T>(namespace, () => {
+      const current = getContext<T>(namespace);
+      if (current === null) {
+        setValue((prev) => (prev === undefined ? prev : undefined));
+        return;
       }
+      const newValue = selector ? selector(current) : (current as unknown as Readonly<U>);
+      setValue((prev) => (shallowEqual(prev, newValue) ? prev : newValue));
     });
   }, []);
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done, including the ticket number if there is a ticket.
- [x] My work conforms to the [OpenMRS 3.0 Styleguide](https://om.rs/styleguide) and [Contributing Guidelines](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines).
- [x] My work includes tests or is validated by existing tests.

## Summary

Addresses [O3-4020](https://openmrs.atlassian.net/browse/O3-4020): `useAppContext` returned `null`/falsy-empty values in `AdmissionRequestsWorkspace` (and, more generally, in any consumer that mounted before the subscription effect fired or after the owner unmounted).

`useAppContext` had two related issues:

1. **First-render race.** `useState<Readonly<U>>()` initialized the local value as `undefined` and was only populated once the `useEffect` subscription fired. On the very first render, consumers received `undefined` even when the namespace was already registered. This is the timing race that produced the symptom reported by @chibongho (cc @ibacher) — the Ward App's `AdmissionRequestsWorkspace` destructured the context before it had arrived.
2. **Owner-unmount shadowing.** `subscribeToContext` substitutes `Object.freeze({})` when a namespace is unregistered (via `Object.assign({}, null)`). The previous implementation forwarded that `{}` straight to `setValue`, so after the namespace owner (e.g. `DefaultWardView` / `MaternalWardView`) unmounted, every consumer held a truthy empty object instead of `undefined`. Destructuring that object yielded `undefined` properties and required defensive `?? {}` guards — exactly the workaround present in `admission-requests.workspace.tsx`.

### Fix

- Seed the `useState` initializer by calling `getContext(namespace)` synchronously, so the first render already has the current value (or `undefined` when the namespace is absent).
- Inside the subscription callback, prefer the `state` argument forwarded by `subscribeToContext` to avoid re-reading/cloning the context on every update. Fall back to `getContext` only for the ambiguous empty-object case, and set the local value to `undefined` when the namespace is no longer registered.
- Share a small `isBlankNamespace` helper between the state initializer and the validation effect so whitespace-only namespaces are handled uniformly (`namespace.trim().length === 0` rather than `replace(' ', '')`, which only trimmed a single space).

### Tests (new file `useAppContext.test.tsx`)

- Returns `undefined` when the namespace is not registered.
- Returns the currently-registered value on the very first render.
- Applies the selector on the first render.
- Exposes a sibling `useDefineAppContext` value to the consumer after effects flush.
- Returns `undefined` (not `{}`) after the namespace owner unmounts (the O3-4020 scenario).

All 5 new tests pass; full `@openmrs/esm-react-utils` suite remains green (125 passed, 9 skipped).

### Behavior changes

| Scenario | Before | After |
| --- | --- | --- |
| First render, namespace already registered | `undefined` | registered value |
| First render, namespace not registered | `{}` eventually | `undefined` |
| Owner unmounts while consumer mounted | `{}` (frozen) | `undefined` |
| Steady state (owner mounted, value updates) | updated value | updated value |

The default selector `(state) => (state ?? {}) as Readonly<U>` is preserved; it is now only invoked when the state is a real, registered value.

## Screenshots

N/A — this is a behavioral fix in a framework hook; no visible UI changes. Verified via unit tests covering the first-render, selector, sibling-producer, and owner-unmount scenarios.

## Related Issue

https://openmrs.atlassian.net/browse/O3-4020

## Other

The Ward App's `?? {}` defensive workaround in `admission-requests.workspace.tsx` continues to function and remains in place — it is now correctly redundant for the registered case and correctly guards against a genuinely absent owner.

[O3-4020]: https://openmrs.atlassian.net/browse/O3-4020
