### PR TITLE
(feat) O3-5623: Inject user location into displayExpression evaluator context

### DIFF
--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createGlobalStore } from '@openmrs/esm-state';
-import type { Session } from '@openmrs/esm-api';
+import { sessionStore, type Session } from '@openmrs/esm-api';
 import {
   attach,
   detach,
@@ -479,5 +479,70 @@ describe('getAssignedExtensions', () => {
     const result = getAssignedExtensions(slotName);
 
     expect(result[0].meta).toEqual(meta);
+  });
+
+  describe('displayExpression with user location', () => {
+    const locationUuid = '59b2d7d1-5b76-4b1b-a54c-0888ba1b2f4e';
+    const locationDisplay = 'Outpatient Clinic';
+
+    function setSession(session: Session | null) {
+      sessionStore.setState({ loaded: session != null, session });
+    }
+
+    afterEach(() => {
+      setSession(null);
+    });
+
+    it('includes an extension whose displayExpression matches userLocation', () => {
+      const slotName = getUniqueName('loc-slot-display');
+      const extensionName = getUniqueName('loc-ext-display');
+      registerExtension(
+        createMockExtension(extensionName, { displayExpression: `userLocation === '${locationDisplay}'` }),
+      );
+      attach(slotName, extensionName);
+      setSession({
+        authenticated: true,
+        sessionId: 's1',
+        sessionLocation: { uuid: locationUuid, display: locationDisplay, links: [] },
+      });
+
+      const result = getAssignedExtensions(slotName);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe(extensionName);
+    });
+
+    it('includes an extension whose displayExpression matches sessionLocationUuid', () => {
+      const slotName = getUniqueName('loc-slot-uuid');
+      const extensionName = getUniqueName('loc-ext-uuid');
+      registerExtension(
+        createMockExtension(extensionName, { displayExpression: `sessionLocationUuid === '${locationUuid}'` }),
+      );
+      attach(slotName, extensionName);
+      setSession({
+        authenticated: true,
+        sessionId: 's2',
+        sessionLocation: { uuid: locationUuid, display: locationDisplay, links: [] },
+      });
+
+      const result = getAssignedExtensions(slotName);
+
+      expect(result).toHaveLength(1);
+      expect(result[0].name).toBe(extensionName);
+    });
+
+    it('hides the extension when the session has no sessionLocation', () => {
+      const slotName = getUniqueName('loc-slot-none');
+      const extensionName = getUniqueName('loc-ext-none');
+      registerExtension(
+        createMockExtension(extensionName, { displayExpression: `userLocation === '${locationDisplay}'` }),
+      );
+      attach(slotName, extensionName);
+      setSession({ authenticated: true, sessionId: 's3' });
+
+      const result = getAssignedExtensions(slotName);
+
+      expect(result).toEqual([]);
+    });
   });
 });

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -348,9 +348,13 @@ function getAssignedExtensionsFromSlotData(
   const assignedIds = calculateAssignedIds(config, attachedIds);
   const extensions: Array<AssignedExtension> = [];
 
-  // Create context once for all extensions in this slot
   const slotState = internalState.slots[slotName]?.state;
-  const expressionContext = slotState && typeof slotState === 'object' ? { session, ...slotState } : { session };
+  const userLocation = session?.sessionLocation?.display ?? null;
+  const sessionLocationUuid = session?.sessionLocation?.uuid ?? null;
+  const expressionContext =
+    slotState && typeof slotState === 'object'
+      ? { session, ...slotState, userLocation, sessionLocationUuid }
+      : { session, userLocation, sessionLocationUuid };
 
   for (let id of assignedIds) {
     const { config: rawExtensionConfig } = getExtensionConfigFromStore(extensionConfigStoreState, slotName, id);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary

Adds `userLocation` (display string) and `sessionLocationUuid` to the variables map passed to `evaluateAsBoolean` in `getAssignedExtensionsFromSlotData`. Extension-slot `displayExpression` strings can now gate rendering on the user's current session location, in addition to `session` and slot-level state.

This is a small, location-focused slice of the context needed for the Dynamic EHR Custom Home Screen work (see [O3 Talk thread 48948](https://talk.openmrs.org/t/gsoc-2026-dynamic-ehr-custom-home-screen/48948)). It is complementary to #1682, which adds the role/privilege angle. Both touch the same `expressionContext` literal but do not overlap in keys.

**What changed**

- `packages/framework/esm-extensions/src/extensions.ts`: read `session?.sessionLocation` and expose `userLocation` + `sessionLocationUuid` on the per-slot `expressionContext` literal. Values coalesce to `null` (not `undefined`) so they satisfy `VariablesMap`. No new types are introduced; `Session` / `SessionLocation` from `@openmrs/esm-api` are reused.
- Reactivity is already wired: `sessionStore.subscribe` in the same file re-derives slot assignments when the session changes, so location-dependent extensions appear/disappear automatically as the user switches location.

**Tests**

Three new tests nested under the existing `getAssignedExtensions` describe block:

- Includes an extension whose `displayExpression` matches `userLocation`.
- Includes an extension whose `displayExpression` matches `sessionLocationUuid`.
- Hides the extension when the session has no `sessionLocation`.

All 39 tests in `@openmrs/esm-extensions` pass. Full workspace test + typecheck run green on pre-push (178/178).

## Screenshots

N/A: no UI changes. This PR only expands the variables map used by the `displayExpression` evaluator.

## Related Issue

- JIRA: https://openmrs.atlassian.net/browse/O3-5623
- Talk: https://talk.openmrs.org/t/gsoc-2026-dynamic-ehr-custom-home-screen/48948
- Related PR: #1682 (role/privilege context, complementary)

## Other

Test plan:

- [x] `yarn workspace @openmrs/esm-extensions typescript` passes
- [x] `yarn workspace @openmrs/esm-extensions test` passes (39/39)
- [x] Full monorepo pre-push test hook passes (178/178)
- [ ] Manual: register an extension with `displayExpression: "userLocation === 'Outpatient Clinic'"` and verify it renders only when the current session location matches
