### PR TITLE
(fix) Render UserHasAccess children synchronously when session is alr…

### DIFF
--- a/packages/framework/esm-react-utils/src/UserHasAccess.test.tsx
+++ b/packages/framework/esm-react-utils/src/UserHasAccess.test.tsx
@@ -4,16 +4,22 @@ import React from 'react';
 import { Observable, type Subscriber } from 'rxjs';
 import type { LoggedInUser, Privilege, Role } from '@openmrs/esm-api';
 // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-import { getCurrentUser, userHasAccess } from '@openmrs/esm-api';
+import { getCurrentUser, sessionStore, userHasAccess } from '@openmrs/esm-api';
 import { UserHasAccess } from './UserHasAccess';
 
-// Mock getCurrentUser and userHasAccess
+// Mock getCurrentUser, userHasAccess, and sessionStore
 const mockGetCurrentUser = vi.fn();
 const mockUserHasAccess = vi.fn();
+const mockSessionStoreGetState = vi.fn().mockReturnValue({ loaded: false, session: null });
+const mockSessionStoreSubscribe = vi.fn().mockReturnValue(() => {});
 
 vi.mock('@openmrs/esm-api', () => ({
   getCurrentUser: (...args: Parameters<typeof getCurrentUser>) => mockGetCurrentUser(...args),
   userHasAccess: (...args: Parameters<typeof userHasAccess>) => mockUserHasAccess(...args),
+  sessionStore: {
+    getState: (...args: Parameters<typeof sessionStore.getState>) => mockSessionStoreGetState(...args),
+    subscribe: (...args: Parameters<typeof sessionStore.subscribe>) => mockSessionStoreSubscribe(...args),
+  },
 }));
 
 // Helper to create a mock user
@@ -45,6 +51,9 @@ function createMockUser(privileges: string[] = [], roles: string[] = []): Logged
 describe('UserHasAccess', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    // Default: session not yet loaded
+    mockSessionStoreGetState.mockReturnValue({ loaded: false, session: null });
+    mockSessionStoreSubscribe.mockReturnValue(() => {});
   });
 
   afterAll(() => {
@@ -99,6 +108,29 @@ describe('UserHasAccess', () => {
 
       expect(screen.getByText('First Child')).toBeInTheDocument();
       expect(screen.getByText('Second Child')).toBeInTheDocument();
+    });
+
+    it('should render children synchronously on first render when session is already loaded', () => {
+      // Simulates in-app navigation: session was loaded before this component mounted.
+      // Without the synchronous useState initializer, the first render would show null
+      // because useEffect hasn't fired yet, causing a visible flash on slow networks.
+      const user = createMockUser(['Edit Patients']);
+
+      mockSessionStoreGetState.mockReturnValue({
+        loaded: true,
+        session: { user, authenticated: true, sessionId: 'test-session' },
+      });
+      // Observable never emits — proves the initial render doesn't depend on it
+      mockGetCurrentUser.mockReturnValue(new Observable(() => {}));
+      mockUserHasAccess.mockReturnValue(true);
+
+      render(
+        <UserHasAccess privilege="Edit Patients">
+          <div>Protected Content</div>
+        </UserHasAccess>,
+      );
+
+      expect(screen.getByText('Protected Content')).toBeInTheDocument();
     });
   });
 

--- a/packages/framework/esm-react-utils/src/UserHasAccess.tsx
+++ b/packages/framework/esm-react-utils/src/UserHasAccess.tsx
@@ -1,12 +1,16 @@
 /** @module @category API */
-import type { LoggedInUser } from '@openmrs/esm-api';
-import { getCurrentUser, userHasAccess } from '@openmrs/esm-api';
+import type { LoggedInUser, SessionStore } from '@openmrs/esm-api';
+import { getCurrentUser, sessionStore, userHasAccess } from '@openmrs/esm-api';
 import React, { useEffect, useState } from 'react';
 
 export interface UserHasAccessProps {
   privilege: string | string[];
   fallback?: React.ReactNode;
   children?: React.ReactNode;
+}
+
+function getUserFromStore(state: SessionStore): LoggedInUser | null {
+  return state.loaded ? (state.session?.user ?? null) : null;
 }
 
 /**
@@ -38,9 +42,15 @@ export interface UserHasAccessProps {
  *   privileges.
  */
 export const UserHasAccess: React.FC<UserHasAccessProps> = ({ privilege, fallback, children }) => {
-  const [user, setUser] = useState<LoggedInUser | null>(null);
+  // Read the session store synchronously so that components which render after the
+  // session is already loaded (e.g. during in-app navigation) get the correct value
+  // on the very first render rather than flashing blank while useEffect fires.
+  const [user, setUser] = useState<LoggedInUser | null>(() => getUserFromStore(sessionStore.getState()));
 
   useEffect(() => {
+    // Re-sync in case the store changed between the render and this effect, then
+    // subscribe for future updates.
+    setUser(getUserFromStore(sessionStore.getState()));
     const subscription = getCurrentUser({
       includeAuthStatus: false,
     }).subscribe(setUser);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary

`UserHasAccess` previously initialised its user state to `null` and only  populated it inside a `useEffect` — meaning the **first render always returned null** even when the session was already loaded in `sessionStore`.

This caused two observable problems:

- **Flash of missing content during in-app navigation**: when a page transition renders a `UserHasAccess`-gated component after the session is already loaded, the component briefly shows nothing (or a fallback) until the effect fires.
- **Permanently hidden UI on slow/broken networks**: if the `getCurrentUser` observable never emits (e.g. the backend is unreachable), gated content is never shown — including buttons inside already-open modals that the user triggered themselves.

Fix: read `sessionStore` synchronously as the lazy `useState` initialiser so the first render already has the correct user. `useEffect` re-syncs immediately and subscribes for future changes as before. A test is added that proves children render on the first render when the session is already loaded (the Observable never emits in that test).

## Screenshots

Logic change with no visual diff in isolation, but hopes to fix below issue:

Before:
<img width="1290" height="2796" alt="IMG_4913 2" src="https://github.com/user-attachments/assets/052d8dc9-c799-4d5e-8f7b-f28e900e755e" />

After: (simulated)
<img width="771" height="627" alt="Screenshot 2026-04-22 at 5 16 04 PM" src="https://github.com/user-attachments/assets/9ca2d0f6-199c-4e58-83ab-a2c2947a1842" />


## Related Issue

Related patient-chart PR:
https://github.com/openmrs/openmrs-esm-patient-chart/pull/3258

<!-- Add issue link if one exists, otherwise N/A -->
N/A

## Other

None