### PR TITLE
(fix) O3-4924: Align expand animation and size prop with Carbon design system

### DIFF
--- a/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
@@ -163,7 +163,7 @@ describe('OpenmrsDateRangePicker', () => {
       const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" />);
       const wrapper = getInputsWrapper(container);
       expect(wrapper?.className).toContain('inputsWrapperMd');
-      expect(screen.getByRole('button')).toHaveClass('flatButtonMd');
+      expect(screen.getByRole('button').className).toContain('flatButtonMd');
     });
 
     it('should apply sm size classes when size="sm"', () => {
@@ -171,7 +171,7 @@ describe('OpenmrsDateRangePicker', () => {
       const wrapper = getInputsWrapper(container);
       expect(wrapper?.className).toContain('inputsWrapperSm');
       expect(wrapper?.className).not.toContain('inputsWrapperMd');
-      expect(screen.getByRole('button')).toHaveClass('flatButtonSm');
+      expect(screen.getByRole('button').className).toContain('flatButtonSm');
     });
 
     it('should apply md size classes when size="md"', () => {
@@ -179,7 +179,7 @@ describe('OpenmrsDateRangePicker', () => {
       const wrapper = getInputsWrapper(container);
       expect(wrapper?.className).toContain('inputsWrapperMd');
       expect(wrapper?.className).not.toContain('inputsWrapperSm');
-      expect(screen.getByRole('button')).toHaveClass('flatButtonMd');
+      expect(screen.getByRole('button').className).toContain('flatButtonMd');
     });
 
     it('should apply lg size classes when size="lg"', () => {
@@ -187,7 +187,7 @@ describe('OpenmrsDateRangePicker', () => {
       const wrapper = getInputsWrapper(container);
       expect(wrapper?.className).toContain('inputsWrapperLg');
       expect(wrapper?.className).not.toContain('inputsWrapperMd');
-      expect(screen.getByRole('button')).toHaveClass('flatButtonLg');
+      expect(screen.getByRole('button').className).toContain('flatButtonLg');
     });
     /* eslint-enable testing-library/no-container, testing-library/no-node-access */
   });

--- a/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
@@ -154,8 +154,6 @@ describe('OpenmrsDateRangePicker', () => {
   });
 
   describe('size prop', () => {
-    // CSS module class names are hashed at runtime; direct className inspection is the
-    // only way to assert which size modifier is applied.
     /* eslint-disable testing-library/no-container, testing-library/no-node-access */
     const getInputsWrapper = (container: HTMLElement) =>
       Array.from(container.querySelectorAll('div')).find((el) => el.className.includes('inputsWrapper')) ?? null;
@@ -163,28 +161,28 @@ describe('OpenmrsDateRangePicker', () => {
     it('should apply md size classes by default', () => {
       const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" />);
       const wrapper = getInputsWrapper(container)!;
-      expect(wrapper.className).toContain('inputsWrapperMd');
+      expect(wrapper).toHaveClass(styles.inputsWrapperMd);
       expect(screen.getByRole('button')).toHaveClass(styles.flatButtonMd);
     });
 
     it('should apply sm size classes when size="sm"', () => {
       const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="sm" />);
       const wrapper = getInputsWrapper(container)!;
-      expect(wrapper.className).toContain('inputsWrapperSm');
+      expect(wrapper).toHaveClass(styles.inputsWrapperSm);
       expect(screen.getByRole('button')).toHaveClass(styles.flatButtonSm);
     });
 
     it('should apply md size classes when size="md"', () => {
       const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="md" />);
       const wrapper = getInputsWrapper(container)!;
-      expect(wrapper.className).toContain('inputsWrapperMd');
+      expect(wrapper).toHaveClass(styles.inputsWrapperMd);
       expect(screen.getByRole('button')).toHaveClass(styles.flatButtonMd);
     });
 
     it('should apply lg size classes when size="lg"', () => {
       const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="lg" />);
       const wrapper = getInputsWrapper(container)!;
-      expect(wrapper.className).toContain('inputsWrapperLg');
+      expect(wrapper).toHaveClass(styles.inputsWrapperLg);
       expect(screen.getByRole('button')).toHaveClass(styles.flatButtonLg);
     });
     /* eslint-enable testing-library/no-container, testing-library/no-node-access */

--- a/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { useConfig } from '@openmrs/esm-react-utils/mock';
 import { OpenmrsDateRangePicker } from './index';
 import { DEFAULT_MIN_DATE_FLOOR } from './defaults';
+import styles from './datepicker.module.scss';
 
 describe('OpenmrsDateRangePicker', () => {
   beforeEach(() => {
@@ -163,28 +164,28 @@ describe('OpenmrsDateRangePicker', () => {
       const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" />);
       const wrapper = getInputsWrapper(container)!;
       expect(wrapper.className).toContain('inputsWrapperMd');
-      expect(screen.getByRole('button').className).toContain('flatButtonMd');
+      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonMd);
     });
 
     it('should apply sm size classes when size="sm"', () => {
       const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="sm" />);
       const wrapper = getInputsWrapper(container)!;
       expect(wrapper.className).toContain('inputsWrapperSm');
-      expect(screen.getByRole('button').className).toContain('flatButtonSm');
+      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonSm);
     });
 
     it('should apply md size classes when size="md"', () => {
       const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="md" />);
       const wrapper = getInputsWrapper(container)!;
       expect(wrapper.className).toContain('inputsWrapperMd');
-      expect(screen.getByRole('button').className).toContain('flatButtonMd');
+      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonMd);
     });
 
     it('should apply lg size classes when size="lg"', () => {
       const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="lg" />);
       const wrapper = getInputsWrapper(container)!;
       expect(wrapper.className).toContain('inputsWrapperLg');
-      expect(screen.getByRole('button').className).toContain('flatButtonLg');
+      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonLg);
     });
     /* eslint-enable testing-library/no-container, testing-library/no-node-access */
   });

--- a/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
@@ -161,32 +161,29 @@ describe('OpenmrsDateRangePicker', () => {
 
     it('should apply md size classes by default', () => {
       const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" />);
-      const wrapper = getInputsWrapper(container);
-      expect(wrapper?.className).toContain('inputsWrapperMd');
+      const wrapper = getInputsWrapper(container)!;
+      expect(wrapper.className).toContain('inputsWrapperMd');
       expect(screen.getByRole('button').className).toContain('flatButtonMd');
     });
 
     it('should apply sm size classes when size="sm"', () => {
       const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="sm" />);
-      const wrapper = getInputsWrapper(container);
-      expect(wrapper?.className).toContain('inputsWrapperSm');
-      expect(wrapper?.className).not.toContain('inputsWrapperMd');
+      const wrapper = getInputsWrapper(container)!;
+      expect(wrapper.className).toContain('inputsWrapperSm');
       expect(screen.getByRole('button').className).toContain('flatButtonSm');
     });
 
     it('should apply md size classes when size="md"', () => {
       const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="md" />);
-      const wrapper = getInputsWrapper(container);
-      expect(wrapper?.className).toContain('inputsWrapperMd');
-      expect(wrapper?.className).not.toContain('inputsWrapperSm');
+      const wrapper = getInputsWrapper(container)!;
+      expect(wrapper.className).toContain('inputsWrapperMd');
       expect(screen.getByRole('button').className).toContain('flatButtonMd');
     });
 
     it('should apply lg size classes when size="lg"', () => {
       const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="lg" />);
-      const wrapper = getInputsWrapper(container);
-      expect(wrapper?.className).toContain('inputsWrapperLg');
-      expect(wrapper?.className).not.toContain('inputsWrapperMd');
+      const wrapper = getInputsWrapper(container)!;
+      expect(wrapper.className).toContain('inputsWrapperLg');
       expect(screen.getByRole('button').className).toContain('flatButtonLg');
     });
     /* eslint-enable testing-library/no-container, testing-library/no-node-access */

--- a/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
@@ -152,6 +152,46 @@ describe('OpenmrsDateRangePicker', () => {
     });
   });
 
+  describe('size prop', () => {
+    // CSS module class names are hashed at runtime; direct className inspection is the
+    // only way to assert which size modifier is applied.
+    /* eslint-disable testing-library/no-container, testing-library/no-node-access */
+    const getInputsWrapper = (container: HTMLElement) =>
+      Array.from(container.querySelectorAll('div')).find((el) => el.className.includes('inputsWrapper')) ?? null;
+
+    it('should apply md size classes by default', () => {
+      const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" />);
+      const wrapper = getInputsWrapper(container);
+      expect(wrapper?.className).toContain('inputsWrapperMd');
+      expect(screen.getByRole('button')).toHaveClass('flatButtonMd');
+    });
+
+    it('should apply sm size classes when size="sm"', () => {
+      const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="sm" />);
+      const wrapper = getInputsWrapper(container);
+      expect(wrapper?.className).toContain('inputsWrapperSm');
+      expect(wrapper?.className).not.toContain('inputsWrapperMd');
+      expect(screen.getByRole('button')).toHaveClass('flatButtonSm');
+    });
+
+    it('should apply md size classes when size="md"', () => {
+      const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="md" />);
+      const wrapper = getInputsWrapper(container);
+      expect(wrapper?.className).toContain('inputsWrapperMd');
+      expect(wrapper?.className).not.toContain('inputsWrapperSm');
+      expect(screen.getByRole('button')).toHaveClass('flatButtonMd');
+    });
+
+    it('should apply lg size classes when size="lg"', () => {
+      const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="lg" />);
+      const wrapper = getInputsWrapper(container);
+      expect(wrapper?.className).toContain('inputsWrapperLg');
+      expect(wrapper?.className).not.toContain('inputsWrapperMd');
+      expect(screen.getByRole('button')).toHaveClass('flatButtonLg');
+    });
+    /* eslint-enable testing-library/no-container, testing-library/no-node-access */
+  });
+
   describe('calendar popover', () => {
     it('should open the calendar popover when the calendar button is clicked', async () => {
       const user = userEvent.setup();

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -114,6 +114,14 @@
   block-size: layout.$spacing-08;
 }
 
+.inputWrapperSm {
+  block-size: layout.$spacing-07;
+}
+
+.inputWrapperLg {
+  block-size: layout.$spacing-09;
+}
+
 // Range date picker inputs
 .inputsWrapper {
   display: flex;
@@ -121,6 +129,18 @@
   max-width: 15rem;
   margin-inline-start: 1rem;
   inline-size: 15rem;
+}
+
+.inputsWrapperSm {
+  block-size: layout.$spacing-07;
+}
+
+.inputsWrapperMd {
+  block-size: layout.$spacing-08;
+}
+
+.inputsWrapperLg {
+  block-size: layout.$spacing-09;
 }
 
 .dateInputWrapper {
@@ -154,20 +174,31 @@
 }
 
 // Used for calendar pop-over
-@keyframes fade-in-down {
+@keyframes expand-in {
   from {
     opacity: 0;
-    transform: translate3d(0, -20px, 0);
+    transform: scale(0.93);
   }
 
   to {
     opacity: 1;
-    transform: translate3d(0, 0, 0);
+    transform: scale(1);
   }
 }
 
+.popover {
+  transform-origin: top center;
+}
+
+// When the popover flips above the trigger (near bottom of viewport), anchor from the bottom
+.popover[data-placement='top'],
+.popover[data-placement='top-start'],
+.popover[data-placement='top-end'] {
+  transform-origin: bottom center;
+}
+
 .popover[data-entering] {
-  animation: fade-in-down motion.$duration-fast-02 motion.motion(entrance, productive);
+  animation: expand-in motion.$duration-fast-02 motion.motion(entrance, productive);
 
   @media screen and (prefers-reduced-motion: reduce) {
     animation: none;
@@ -221,6 +252,16 @@
 .flatButtonMd {
   height: layout.$spacing-08;
   width: layout.$spacing-08;
+}
+
+.flatButtonSm {
+  height: layout.$spacing-07;
+  width: layout.$spacing-07;
+}
+
+.flatButtonLg {
+  height: layout.$spacing-09;
+  width: layout.$spacing-09;
 }
 
 .monthYear {

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
@@ -151,32 +151,29 @@ describe('OpenmrsDatePicker', () => {
     /* eslint-disable testing-library/no-container, testing-library/no-node-access */
     it('should apply md size classes by default', () => {
       const { container } = render(<OpenmrsDatePicker aria-label="datepicker" />);
-      const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
-      expect(wrapper?.className).toContain('inputWrapperMd');
+      const wrapper = container.querySelector('.cds--date-picker-input__wrapper')!;
+      expect(wrapper.className).toContain('inputWrapperMd');
       expect(screen.getByRole('button').className).toContain('flatButtonMd');
     });
 
     it('should apply sm size classes when size="sm"', () => {
       const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="sm" />);
-      const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
-      expect(wrapper?.className).toContain('inputWrapperSm');
-      expect(wrapper?.className).not.toContain('inputWrapperMd');
+      const wrapper = container.querySelector('.cds--date-picker-input__wrapper')!;
+      expect(wrapper.className).toContain('inputWrapperSm');
       expect(screen.getByRole('button').className).toContain('flatButtonSm');
     });
 
     it('should apply md size classes when size="md"', () => {
       const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="md" />);
-      const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
-      expect(wrapper?.className).toContain('inputWrapperMd');
-      expect(wrapper?.className).not.toContain('inputWrapperSm');
+      const wrapper = container.querySelector('.cds--date-picker-input__wrapper')!;
+      expect(wrapper.className).toContain('inputWrapperMd');
       expect(screen.getByRole('button').className).toContain('flatButtonMd');
     });
 
     it('should apply lg size classes when size="lg"', () => {
       const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="lg" />);
-      const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
-      expect(wrapper?.className).toContain('inputWrapperLg');
-      expect(wrapper?.className).not.toContain('inputWrapperMd');
+      const wrapper = container.querySelector('.cds--date-picker-input__wrapper')!;
+      expect(wrapper.className).toContain('inputWrapperLg');
       expect(screen.getByRole('button').className).toContain('flatButtonLg');
     });
     /* eslint-enable testing-library/no-container, testing-library/no-node-access */

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
@@ -147,34 +147,32 @@ describe('OpenmrsDatePicker', () => {
   });
 
   describe('size prop', () => {
-    // CSS module class names are hashed at runtime; direct className inspection is the
-    // only way to assert which size modifier is applied.
     /* eslint-disable testing-library/no-container, testing-library/no-node-access */
     it('should apply md size classes by default', () => {
       const { container } = render(<OpenmrsDatePicker aria-label="datepicker" />);
       const wrapper = container.querySelector('.cds--date-picker-input__wrapper')!;
-      expect(wrapper.className).toContain('inputWrapperMd');
+      expect(wrapper).toHaveClass(styles.inputWrapperMd);
       expect(screen.getByRole('button')).toHaveClass(styles.flatButtonMd);
     });
 
     it('should apply sm size classes when size="sm"', () => {
       const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="sm" />);
       const wrapper = container.querySelector('.cds--date-picker-input__wrapper')!;
-      expect(wrapper.className).toContain('inputWrapperSm');
+      expect(wrapper).toHaveClass(styles.inputWrapperSm);
       expect(screen.getByRole('button')).toHaveClass(styles.flatButtonSm);
     });
 
     it('should apply md size classes when size="md"', () => {
       const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="md" />);
       const wrapper = container.querySelector('.cds--date-picker-input__wrapper')!;
-      expect(wrapper.className).toContain('inputWrapperMd');
+      expect(wrapper).toHaveClass(styles.inputWrapperMd);
       expect(screen.getByRole('button')).toHaveClass(styles.flatButtonMd);
     });
 
     it('should apply lg size classes when size="lg"', () => {
       const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="lg" />);
       const wrapper = container.querySelector('.cds--date-picker-input__wrapper')!;
-      expect(wrapper.className).toContain('inputWrapperLg');
+      expect(wrapper).toHaveClass(styles.inputWrapperLg);
       expect(screen.getByRole('button')).toHaveClass(styles.flatButtonLg);
     });
     /* eslint-enable testing-library/no-container, testing-library/no-node-access */

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
@@ -153,7 +153,7 @@ describe('OpenmrsDatePicker', () => {
       const { container } = render(<OpenmrsDatePicker aria-label="datepicker" />);
       const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
       expect(wrapper?.className).toContain('inputWrapperMd');
-      expect(screen.getByRole('button')).toHaveClass('flatButtonMd');
+      expect(screen.getByRole('button').className).toContain('flatButtonMd');
     });
 
     it('should apply sm size classes when size="sm"', () => {
@@ -161,7 +161,7 @@ describe('OpenmrsDatePicker', () => {
       const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
       expect(wrapper?.className).toContain('inputWrapperSm');
       expect(wrapper?.className).not.toContain('inputWrapperMd');
-      expect(screen.getByRole('button')).toHaveClass('flatButtonSm');
+      expect(screen.getByRole('button').className).toContain('flatButtonSm');
     });
 
     it('should apply md size classes when size="md"', () => {
@@ -169,7 +169,7 @@ describe('OpenmrsDatePicker', () => {
       const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
       expect(wrapper?.className).toContain('inputWrapperMd');
       expect(wrapper?.className).not.toContain('inputWrapperSm');
-      expect(screen.getByRole('button')).toHaveClass('flatButtonMd');
+      expect(screen.getByRole('button').className).toContain('flatButtonMd');
     });
 
     it('should apply lg size classes when size="lg"', () => {
@@ -177,7 +177,7 @@ describe('OpenmrsDatePicker', () => {
       const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
       expect(wrapper?.className).toContain('inputWrapperLg');
       expect(wrapper?.className).not.toContain('inputWrapperMd');
-      expect(screen.getByRole('button')).toHaveClass('flatButtonLg');
+      expect(screen.getByRole('button').className).toContain('flatButtonLg');
     });
     /* eslint-enable testing-library/no-container, testing-library/no-node-access */
   });

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
@@ -145,6 +145,43 @@ describe('OpenmrsDatePicker', () => {
     });
   });
 
+  describe('size prop', () => {
+    // CSS module class names are hashed at runtime; direct className inspection is the
+    // only way to assert which size modifier is applied.
+    /* eslint-disable testing-library/no-container, testing-library/no-node-access */
+    it('should apply md size classes by default', () => {
+      const { container } = render(<OpenmrsDatePicker aria-label="datepicker" />);
+      const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
+      expect(wrapper?.className).toContain('inputWrapperMd');
+      expect(screen.getByRole('button')).toHaveClass('flatButtonMd');
+    });
+
+    it('should apply sm size classes when size="sm"', () => {
+      const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="sm" />);
+      const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
+      expect(wrapper?.className).toContain('inputWrapperSm');
+      expect(wrapper?.className).not.toContain('inputWrapperMd');
+      expect(screen.getByRole('button')).toHaveClass('flatButtonSm');
+    });
+
+    it('should apply md size classes when size="md"', () => {
+      const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="md" />);
+      const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
+      expect(wrapper?.className).toContain('inputWrapperMd');
+      expect(wrapper?.className).not.toContain('inputWrapperSm');
+      expect(screen.getByRole('button')).toHaveClass('flatButtonMd');
+    });
+
+    it('should apply lg size classes when size="lg"', () => {
+      const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="lg" />);
+      const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
+      expect(wrapper?.className).toContain('inputWrapperLg');
+      expect(wrapper?.className).not.toContain('inputWrapperMd');
+      expect(screen.getByRole('button')).toHaveClass('flatButtonLg');
+    });
+    /* eslint-enable testing-library/no-container, testing-library/no-node-access */
+  });
+
   describe('calendar popover', () => {
     it('should open the calendar popover when the calendar button is clicked', async () => {
       const user = userEvent.setup();

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
@@ -7,6 +7,7 @@ import userEvent from '@testing-library/user-event';
 import { useConfig } from '@openmrs/esm-react-utils/mock';
 import { OpenmrsDatePicker } from './index';
 import { DEFAULT_MIN_DATE_FLOOR } from './defaults';
+import styles from './datepicker.module.scss';
 
 window.i18next = { language: 'en' } as i18n;
 
@@ -153,28 +154,28 @@ describe('OpenmrsDatePicker', () => {
       const { container } = render(<OpenmrsDatePicker aria-label="datepicker" />);
       const wrapper = container.querySelector('.cds--date-picker-input__wrapper')!;
       expect(wrapper.className).toContain('inputWrapperMd');
-      expect(screen.getByRole('button').className).toContain('flatButtonMd');
+      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonMd);
     });
 
     it('should apply sm size classes when size="sm"', () => {
       const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="sm" />);
       const wrapper = container.querySelector('.cds--date-picker-input__wrapper')!;
       expect(wrapper.className).toContain('inputWrapperSm');
-      expect(screen.getByRole('button').className).toContain('flatButtonSm');
+      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonSm);
     });
 
     it('should apply md size classes when size="md"', () => {
       const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="md" />);
       const wrapper = container.querySelector('.cds--date-picker-input__wrapper')!;
       expect(wrapper.className).toContain('inputWrapperMd');
-      expect(screen.getByRole('button').className).toContain('flatButtonMd');
+      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonMd);
     });
 
     it('should apply lg size classes when size="lg"', () => {
       const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="lg" />);
       const wrapper = container.querySelector('.cds--date-picker-input__wrapper')!;
       expect(wrapper.className).toContain('inputWrapperLg');
-      expect(screen.getByRole('button').className).toContain('flatButtonLg');
+      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonLg);
     });
     /* eslint-enable testing-library/no-container, testing-library/no-node-access */
   });

--- a/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx
@@ -129,7 +129,9 @@ export const OpenmrsDatePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, Openmr
                     id={hasVisibleLabel ? id : undefined}
                     ref={ref}
                     className={classNames('cds--date-picker-input__wrapper', styles.inputWrapper, {
+                      [styles.inputWrapperSm]: size === 'sm',
                       [styles.inputWrapperMd]: size === 'md' || !size || size.length === 0,
+                      [styles.inputWrapperLg]: size === 'lg',
                     })}
                   >
                     {(segment) => {
@@ -140,7 +142,13 @@ export const OpenmrsDatePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, Openmr
                       );
                     }}
                   </DatePickerInput>
-                  <Button className={classNames(styles.flatButton, styles.flatButtonMd)}>
+                  <Button
+                    className={classNames(styles.flatButton, {
+                      [styles.flatButtonSm]: size === 'sm',
+                      [styles.flatButtonMd]: size === 'md' || !size || size.length === 0,
+                      [styles.flatButtonLg]: size === 'lg',
+                    })}
+                  >
                     <DatePickerIcon />
                   </Button>
                 </Group>

--- a/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx
@@ -32,6 +32,8 @@ export interface OpenmrsDateRangePickerProps
   onChange?: (value: [Date | null | undefined, Date | null | undefined]) => void;
   /** Handler that is called when the value changes. Note that this provides types from @internationalized/date. */
   onChangeRaw?: (value: DateRange | null) => void;
+  /** Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option */
+  size?: 'sm' | 'md' | 'lg';
   /** The value (controlled) */
   value?: [DateInputValue, DateInputValue];
 }
@@ -55,6 +57,7 @@ export const OpenmrsDateRangePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, O
       minDate: rawMinDate,
       onChange,
       onChangeRaw,
+      size = 'md',
       value: rawValue,
       ...dateRangePickerProps
     },
@@ -144,7 +147,13 @@ export const OpenmrsDateRangePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, O
                 )}
 
                 <Group className={styles.inputGroup}>
-                  <div className={styles.inputsWrapper}>
+                  <div
+                    className={classNames(styles.inputsWrapper, {
+                      [styles.inputsWrapperSm]: size === 'sm',
+                      [styles.inputsWrapperMd]: size === 'md' || !size || size.length === 0,
+                      [styles.inputsWrapperLg]: size === 'lg',
+                    })}
+                  >
                     <DateInput
                       className={classNames(
                         'cds--date-picker-input__wrapper',
@@ -171,7 +180,13 @@ export const OpenmrsDateRangePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, O
                       {(segment) => <DateSegment className={styles.inputSegment} segment={segment} />}
                     </DateInput>
                   </div>
-                  <Button className={classNames(styles.flatButton, styles.flatButtonMd)}>
+                  <Button
+                    className={classNames(styles.flatButton, {
+                      [styles.flatButtonSm]: size === 'sm',
+                      [styles.flatButtonMd]: size === 'md' || !size || size.length === 0,
+                      [styles.flatButtonLg]: size === 'lg',
+                    })}
+                  >
                     <DatePickerIcon />
                   </Button>
                 </Group>


### PR DESCRIPTION

## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->
The date picker calendar was opening with a slide-from-above animation (translate3d) instead of Carbon's standard scale-expand animation. Also, the size prop was broken only md worked, and the range picker had no size prop at all.

## Screenshots
<!-- Required if you are making UI changes. -->

https://github.com/user-attachments/assets/fc954b10-eb2a-43c9-b4f7-41f709c273c1



## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-4924

## Other
<!-- Anything not covered above -->
