### PR TITLE
(feat) O3-5027: Make login page configurable

### DIFF
--- a/packages/apps/esm-login-app/__mocks__/config.mock.ts
+++ b/packages/apps/esm-login-app/__mocks__/config.mock.ts
@@ -1,6 +1,11 @@
 import { type ConfigSchema } from '../src/config-schema';
 
 export const mockConfig: ConfigSchema = {
+  announcements: [],
+  background: {
+    image: '',
+    color: '',
+  },
   provider: {
     type: 'basic',
     loginUrl: '',

--- a/packages/apps/esm-login-app/src/config-schema.ts
+++ b/packages/apps/esm-login-app/src/config-schema.ts
@@ -105,9 +105,63 @@ export const configSchema = {
     _description:
       'Whether to show the password field on a separate screen. If false, the password field will be shown on the same screen.',
   },
+  background: {
+    _type: Type.Object,
+    _description:
+      'Customizes the login page background. Either a background image URL or a CSS color may be set. ' +
+      'If both are set, the image is used.',
+    image: {
+      _type: Type.String,
+      _default: '',
+      _description:
+        'URL to a background image. Relative paths are interpolated via ${openmrsBase} / ${openmrsSpaBase}.',
+      _validators: [validators.isUrl],
+    },
+    color: {
+      _type: Type.String,
+      _default: '',
+      _description: 'CSS color value (e.g. "#0066cc" or "rgb(0,102,204)"). Used when no image is set.',
+    },
+  },
+  announcements: {
+    _type: Type.Array,
+    _description:
+      'Message banners displayed above the login form, e.g. for planned downtime notices. ' +
+      'Each entry renders as a Carbon InlineNotification. `title` and `text` may be either ' +
+      'literal strings or translation keys.',
+    _elements: {
+      _type: Type.Object,
+      title: {
+        _type: Type.String,
+        _default: '',
+        _description: 'Optional title shown at the top of the banner. May be a translation key.',
+      },
+      text: {
+        _type: Type.String,
+        _required: true,
+        _description: 'Banner body text. May be a translation key.',
+      },
+      kind: {
+        _type: Type.String,
+        _default: 'info',
+        _description: 'The visual style of the banner. One of: info, warning, error, success.',
+        _validators: [validators.oneOf(['info', 'warning', 'error', 'success'])],
+      },
+    },
+    _default: [],
+  },
 };
 
 export interface ConfigSchema {
+  announcements: Array<{
+    title: string;
+    text: string;
+    kind: 'info' | 'warning' | 'error' | 'success';
+  }>;
+  background: {
+    image: string;
+    color: string;
+  };
   chooseLocation: {
     enabled: boolean;
     locationsPerRequest: number;

--- a/packages/apps/esm-login-app/src/login/login.component.tsx
+++ b/packages/apps/esm-login-app/src/login/login.component.tsx
@@ -1,10 +1,11 @@
-import React, { useState, useRef, useEffect, useCallback } from 'react';
+import React, { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { Button, InlineLoading, InlineNotification, PasswordInput, TextInput, Tile } from '@carbon/react';
 import {
   ArrowRightIcon,
   getCoreTranslation,
+  interpolateUrl,
   refetchCurrentUser,
   navigate as openmrsNavigate,
   useConfig,
@@ -21,7 +22,13 @@ export interface LoginReferrer {
 }
 
 const Login: React.FC = () => {
-  const { showPasswordOnSeparateScreen, provider: loginProvider, links: loginLinks } = useConfig<ConfigSchema>();
+  const {
+    announcements = [],
+    background = { image: '', color: '' },
+    showPasswordOnSeparateScreen,
+    provider: loginProvider,
+    links: loginLinks,
+  } = useConfig<ConfigSchema>();
   const isLoginEnabled = useConnectivity();
   const { t } = useTranslation();
   const { user } = useSession();
@@ -73,6 +80,20 @@ const Login: React.FC = () => {
 
   const changeUsername = useCallback((evt: React.ChangeEvent<HTMLInputElement>) => setUsername(evt.target.value), []);
   const changePassword = useCallback((evt: React.ChangeEvent<HTMLInputElement>) => setPassword(evt.target.value), []);
+
+  const containerStyle = useMemo<React.CSSProperties | undefined>(() => {
+    if (background.image) {
+      return {
+        backgroundImage: `url(${interpolateUrl(background.image)})`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+      };
+    }
+    if (background.color) {
+      return { backgroundColor: background.color };
+    }
+    return undefined;
+  }, [background]);
 
   const handleSubmit = useCallback(
     async (evt: React.FormEvent<HTMLFormElement>) => {
@@ -154,7 +175,21 @@ const Login: React.FC = () => {
 
   if (!loginProvider || loginProvider.type === 'basic') {
     return (
-      <div className={styles.container}>
+      <div className={styles.container} style={containerStyle} data-testid="login-container">
+        {announcements.length > 0 && (
+          <div className={styles.announcements}>
+            {announcements.map((announcement, i) => (
+              <InlineNotification
+                key={i}
+                kind={announcement.kind}
+                title={announcement.title ? t(announcement.title) : undefined}
+                subtitle={t(announcement.text)}
+                lowContrast
+                hideCloseButton
+              />
+            ))}
+          </div>
+        )}
         <Tile className={styles.loginCard}>
           {errorMessage && (
             <div className={styles.errorMessage}>

--- a/packages/apps/esm-login-app/src/login/login.component.tsx
+++ b/packages/apps/esm-login-app/src/login/login.component.tsx
@@ -182,7 +182,7 @@ const Login: React.FC = () => {
               <InlineNotification
                 key={i}
                 kind={announcement.kind}
-                title={announcement.title ? t(announcement.title) : undefined}
+                title={announcement.title ? t(announcement.title) : ''}
                 subtitle={t(announcement.text)}
                 lowContrast
                 hideCloseButton

--- a/packages/apps/esm-login-app/src/login/login.scss
+++ b/packages/apps/esm-login-app/src/login/login.scss
@@ -148,3 +148,11 @@
   position: absolute;
   pointer-events: none;
 }
+
+.announcements {
+  width: 23rem;
+  margin-bottom: layout.$spacing-07;
+  display: flex;
+  flex-direction: column;
+  gap: layout.$spacing-03;
+}

--- a/packages/apps/esm-login-app/src/login/login.test.tsx
+++ b/packages/apps/esm-login-app/src/login/login.test.tsx
@@ -296,4 +296,51 @@ describe('Login', () => {
 
     expect(usernameInput).toHaveFocus();
   });
+
+  it('does not render announcement banners by default', () => {
+    renderWithRouter(Login, {}, { route: '/login' });
+    expect(screen.queryByText(/Planned downtime/i)).not.toBeInTheDocument();
+  });
+
+  it('renders configured announcement banners stacked above the form', () => {
+    mockUseConfig.mockReturnValue({
+      ...mockConfig,
+      announcements: [
+        { title: '', text: 'Planned downtime tonight at 10pm', kind: 'warning' },
+        { title: 'Heads up', text: 'New release shipping Friday', kind: 'info' },
+      ],
+    });
+
+    renderWithRouter(Login, {}, { route: '/login' });
+
+    expect(screen.getByText('Planned downtime tonight at 10pm')).toBeInTheDocument();
+    expect(screen.getByText('New release shipping Friday')).toBeInTheDocument();
+    expect(screen.getByText('Heads up')).toBeInTheDocument();
+  });
+
+  it('interpolates relative background.image paths via interpolateUrl', () => {
+    mockUseConfig.mockReturnValue({
+      ...mockConfig,
+      background: { image: '${openmrsSpaBase}/assets/bg.jpg', color: '' },
+    });
+
+    renderWithRouter(Login, {}, { route: '/login' });
+    const root = screen.getByTestId('login-container');
+
+    expect(root.style.backgroundImage).toContain('/openmrs/spa/assets/bg.jpg');
+    expect(root.style.backgroundImage).not.toContain('${openmrsSpaBase}');
+  });
+
+  it('applies a background color when only background.color is configured', () => {
+    mockUseConfig.mockReturnValue({
+      ...mockConfig,
+      background: { image: '', color: '#0066cc' },
+    });
+
+    renderWithRouter(Login, {}, { route: '/login' });
+    const root = screen.getByTestId('login-container');
+
+    expect(root).toHaveStyle({ backgroundColor: '#0066cc' });
+    expect(root).toHaveStyle({ backgroundImage: '' });
+  });
 });


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->
Adds two new login-app config sections: `background` (image URL or CSS color) and `announcements` (array of Carbon InlineNotification banners with i18n-key support).

## Screenshots
<!-- Required if you are making UI changes. -->
https://github.com/user-attachments/assets/26a369b9-fd1f-4e01-b08d-0d9ad987f376

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
[O3-5027](https://issues.openmrs.org/browse/O3-5027)

## Other
<!-- Anything not covered above -->
Related PR #1460 

[O3-5027]: https://openmrs.atlassian.net/browse/O3-5027?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ