### PR TITLE
Add Claude PR review caller workflow (pilot)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,11 +1,15 @@
 name: Claude PR Review
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, ready_for_review, reopened]
 
 jobs:
   review:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
     uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/claude-pr-review.yml@main
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -1,0 +1,23 @@
+name: Claude PR Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  review:
+    uses: openmrs/openmrs-contrib-gha-workflows/.github/workflows/claude-pr-review.yml@main
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+    with:
+      extra_instructions: |
+        This is a TypeScript/React OpenMRS frontend repository (part of OpenMRS 3.x microfrontend architecture). Pay particular attention to:
+
+        - i18n: user-facing strings must use the t() function from useTranslation, not hard-coded text. Flag hard-coded English strings in JSX, alerts, and toasts.
+        - Type safety: avoid `any` in new code; prefer specific types or `unknown` with type guards. Flag new uses of `any`.
+        - Data fetching: use SWR/React Query patterns consistent with the rest of the codebase; don't introduce ad-hoc fetch wrappers.
+        - Public exports: flag breaking changes to anything exported from index.ts or package entry points.
+        - Testing: use @testing-library/react idioms; avoid testing implementation details. Flag tests that mock OpenMRS framework primitives instead of using the official testing utilities.
+        - Performance: flag obvious re-render hazards (new object/array literals as hook deps, missing useMemo/useCallback on hot paths) but skip nits.
+
+        This package is the OpenMRS frontend framework runtime. Public API stability is paramount — treat any change to exported types, functions, or runtime behavior as a potential breaking change for every downstream microfrontend.


### PR DESCRIPTION
## Summary

Adds a thin caller workflow that invokes the reusable Claude PR review workflow in `openmrs/openmrs-contrib-gha-workflows`. Triggers on `[opened, ready_for_review, reopened]` (no `synchronize`) to avoid re-reviewing on every push during the pilot.

## Why

Part of a 10-repo pilot of AI-assisted PR review (see openmrs/openmrs-contrib-gha-workflows#36). We're evaluating Claude Code Action as a potential replacement for CodeRabbit, which has been hitting free-tier limits.

## Dependencies

⚠️  **Do not merge before openmrs/openmrs-contrib-gha-workflows#36 is merged.** This PR is opened as a draft until then; the caller pins the reusable workflow to `@main`.

## Cost guardrails (pilot)

- Model: `claude-sonnet-4-6` (cheaper of the two main options).
- Trigger: `[opened, ready_for_review, reopened]` only — explicitly excludes `synchronize`, so each PR gets one review per state-change, not one per push.
- Skips draft PRs.

## Test plan

- [ ] Merge openmrs/openmrs-contrib-gha-workflows#36.
- [ ] Mark this PR ready for review.
- [ ] Verify the next non-draft PR opened against this repo gets a Claude review comment.
- [ ] Compare review quality / signal-to-noise vs. CodeRabbit over the next 1–2 weeks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
