### PR TITLE
(feat) Add matchLocale framework function

### DIFF
--- a/.changeset/ten-impalas-report.md
+++ b/.changeset/ten-impalas-report.md
@@ -1,0 +1,6 @@
+---
+"@openmrs/esm-framework": minor
+"@openmrs/esm-utils": minor
+---
+
+(feat) Add matchLocale framework function

--- a/packages/framework/esm-framework/docs/functions/matchLocale.md
+++ b/packages/framework/esm-framework/docs/functions/matchLocale.md
@@ -1,0 +1,62 @@
+[O3 Framework](../API.md) / matchLocale
+
+# Function: matchLocale()
+
+> **matchLocale**(`requested`, `available`, `fallback?`): `undefined` \| `string`
+
+Defined in: [packages/framework/esm-utils/src/match-locale.ts:53](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-utils/src/match-locale.ts#L53)
+
+Resolves a requested locale against a list of available locales using the
+BCP 47 lookup algorithm (RFC 4647, §3.4).
+
+Tags are compared in canonical form via Intl.Locale, so casing and
+underscore-vs-hyphen differences in the inputs do not affect matching. The
+value returned is taken verbatim from `available`, preserving the caller's
+original casing.
+
+In addition to the truncation steps prescribed by RFC 4647, this function
+also performs prefix expansion at each level: when the requested tag is
+truncated to a more general range (e.g. `en` after stripping `en-CA`), any
+available locale whose canonical form begins with that range plus a hyphen
+(e.g. `en-US`, `en-GB`) is treated as a match. This is a relaxation of the
+strict lookup algorithm but typically reflects user intent — a user who
+asked for `en-CA` will usually accept `en-US` over a non-English fallback.
+
+Tags that fail to parse are skipped with a console warning; they never match
+and never throw.
+
+## Parameters
+
+### requested
+
+The locale the caller would like to use, or `null`/`undefined`
+  if no preference is known.
+
+`undefined` | `null` | `string`
+
+### available
+
+readonly `string`[]
+
+The list of locales the application supports.
+
+### fallback?
+
+`string`
+
+The value to return when no match is found. Defaults to
+  `undefined`.
+
+## Returns
+
+`undefined` \| `string`
+
+The matched locale from `available`, or `fallback` if nothing matches.
+
+## Example
+
+```ts
+matchLocale('en-CA', ['en-US', 'en-GB', 'fr-FR'], 'en-US'); // => 'en-US'
+matchLocale('fr-BE', ['en-US', 'fr-FR', 'de-DE'], 'en-US'); // => 'fr-FR'
+matchLocale('zh-Hant-TW', ['zh-Hant', 'zh-Hans', 'en'], 'en'); // => 'zh-Hant'
+```

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDateRangePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDateRangePickerProps.md
@@ -716,6 +716,16 @@ By default, this is determined by the user's locale.
 
 ***
 
+### size?
+
+> `optional` **size**: `"sm"` \| `"md"` \| `"lg"`
+
+Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx:36](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx#L36)
+
+Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option
+
+***
+
 ### slot?
 
 > `optional` **slot**: `null` \| `string`
@@ -812,6 +822,6 @@ or invalid via ARIA.
 
 > `optional` **value**: \[`DateInputValue`, `DateInputValue`\]
 
-Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx:36](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx#L36)
+Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx#L38)
 
 The value (controlled)

--- a/packages/framework/esm-framework/docs/variables/OpenmrsDateRangePicker.md
+++ b/packages/framework/esm-framework/docs/variables/OpenmrsDateRangePicker.md
@@ -4,6 +4,6 @@
 
 > `const` **OpenmrsDateRangePicker**: `ForwardRefExoticComponent`\<[`OpenmrsDateRangePickerProps`](../interfaces/OpenmrsDateRangePickerProps.md) & `RefAttributes`\<`HTMLDivElement`\>\>
 
-Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx:42](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx#L42)
+Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx#L44)
 
 A date range picker to enter or select a date and time range. Based on React Aria, but styled to look like Carbon.

--- a/packages/framework/esm-framework/mock-jest.tsx
+++ b/packages/framework/esm-framework/mock-jest.tsx
@@ -17,7 +17,7 @@ export * from '@openmrs/esm-state/mock';
 export * from '@openmrs/esm-styleguide/mock';
 export * from '@openmrs/esm-translations/mock';
 
-export { parseDate, formatDate, formatDatetime, formatTime, isOmrsDateToday } from '@openmrs/esm-utils';
+export { parseDate, formatDate, formatDatetime, formatTime, isOmrsDateToday, matchLocale } from '@openmrs/esm-utils';
 
 /* esm-globals */
 

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -18,7 +18,7 @@ export * from '@openmrs/esm-state/mock';
 export * from '@openmrs/esm-styleguide/mock';
 export * from '@openmrs/esm-translations/mock';
 
-export { parseDate, formatDate, formatDatetime, formatTime, isOmrsDateToday } from '@openmrs/esm-utils';
+export { parseDate, formatDate, formatDatetime, formatTime, isOmrsDateToday, matchLocale } from '@openmrs/esm-utils';
 
 /* esm-globals */
 

--- a/packages/framework/esm-utils/src/get-locale.ts
+++ b/packages/framework/esm-utils/src/get-locale.ts
@@ -4,7 +4,7 @@
  */
 export function getLocale() {
   let language = window.i18next.language;
-  language = language.replace('_', '-'); // just in case
+  language = language.replaceAll('_', '-'); // just in case
   // Hack for `ht` until all browsers update their unicode support with ht to fr mapping.
   // See https://unicode-org.atlassian.net/browse/CLDR-14956
   if (language === 'ht') {

--- a/packages/framework/esm-utils/src/index.ts
+++ b/packages/framework/esm-utils/src/index.ts
@@ -3,6 +3,7 @@ export * from './age-helpers';
 export * from './dates';
 export * from './get-locale';
 export * from './is-online';
+export * from './match-locale';
 export * from './patient-helpers';
 export * from './shallowEqual';
 export * from './storage';

--- a/packages/framework/esm-utils/src/match-locale.test.ts
+++ b/packages/framework/esm-utils/src/match-locale.test.ts
@@ -32,54 +32,54 @@ describe('matchLocale', () => {
     });
 
     it('returns the original casing from `available`, not the canonical form', () => {
-      expect(matchLocale('en-us', ['en-US'], undefined)).toBe('en-US');
-      expect(matchLocale('EN-US', ['en-us'], undefined)).toBe('en-us');
+      expect(matchLocale('en-us', ['en-US'])).toBe('en-US');
+      expect(matchLocale('EN-US', ['en-us'])).toBe('en-us');
     });
 
     it('matches the first occurrence when an available locale appears multiple times', () => {
-      expect(matchLocale('en', ['en', 'en-US', 'en'], undefined)).toBe('en');
+      expect(matchLocale('en', ['en', 'en-US', 'en'])).toBe('en');
     });
   });
 
   describe('canonicalization', () => {
     it('treats underscore-separated tags as equivalent to hyphen-separated tags', () => {
-      expect(matchLocale('en_GB', ['en-GB'], undefined)).toBe('en-GB');
-      expect(matchLocale('en-GB', ['en_GB'], undefined)).toBe('en_GB');
+      expect(matchLocale('en_GB', ['en-GB'])).toBe('en-GB');
+      expect(matchLocale('en-GB', ['en_GB'])).toBe('en_GB');
     });
 
     it('is case-insensitive across language, script, and region subtags', () => {
-      expect(matchLocale('ZH-hant-tw', ['zh-Hant'], undefined)).toBe('zh-Hant');
+      expect(matchLocale('ZH-hant-tw', ['zh-Hant'])).toBe('zh-Hant');
     });
 
     it('canonicalizes script casing for matching (Latn vs latn)', () => {
-      expect(matchLocale('sr-latn-rs', ['sr-Latn'], undefined)).toBe('sr-Latn');
+      expect(matchLocale('sr-latn-rs', ['sr-Latn'])).toBe('sr-Latn');
     });
   });
 
   describe('truncation', () => {
     it('strips a region subtag to match a language-only available locale', () => {
-      expect(matchLocale('en-CA', ['en'], undefined)).toBe('en');
+      expect(matchLocale('en-CA', ['en'])).toBe('en');
     });
 
     it('strips a region from a script+region tag, leaving the script', () => {
-      expect(matchLocale('zh-Hant-TW', ['zh-Hant'], undefined)).toBe('zh-Hant');
+      expect(matchLocale('zh-Hant-TW', ['zh-Hant'])).toBe('zh-Hant');
     });
 
     it('strips a single-letter extension singleton along with its trailing subtag', () => {
       // `en-US-x-private` → `en-US-x` → strip singleton → `en-US` → `en`.
-      expect(matchLocale('en-US-x-private', ['en'], undefined)).toBe('en');
+      expect(matchLocale('en-US-x-private', ['en'])).toBe('en');
     });
   });
 
   describe('prefix expansion', () => {
     it('expands a language-only request to a regional variant', () => {
-      expect(matchLocale('en', ['en-US', 'en-GB'], undefined)).toBe('en-US');
+      expect(matchLocale('en', ['en-US', 'en-GB'])).toBe('en-US');
     });
 
     it('falls through truncation steps before expanding', () => {
       // `fr-BE` → no exact, no `fr-BE-…` prefix → truncate to `fr` →
       // no exact `fr` → expand to `fr-FR`.
-      expect(matchLocale('fr-BE', ['fr-FR'], undefined)).toBe('fr-FR');
+      expect(matchLocale('fr-BE', ['fr-FR'])).toBe('fr-FR');
     });
 
     it('does not match across language families', () => {
@@ -111,39 +111,39 @@ describe('matchLocale', () => {
 
   describe('ht → fr-HT fallback', () => {
     it('falls back to fr-HT when `ht` is requested and no Haitian Creole locale is available', () => {
-      expect(matchLocale('ht', ['fr-HT', 'en-US'], undefined)).toBe('fr-HT');
+      expect(matchLocale('ht', ['fr-HT', 'en-US'])).toBe('fr-HT');
     });
 
     it('falls back from `ht-HT` to `fr-HT`', () => {
-      expect(matchLocale('ht-HT', ['fr-HT', 'en-US'], undefined)).toBe('fr-HT');
+      expect(matchLocale('ht-HT', ['fr-HT', 'en-US'])).toBe('fr-HT');
     });
 
     it('falls back from `ht-Latn-HT` to `fr-HT`', () => {
-      expect(matchLocale('ht-Latn-HT', ['fr-HT', 'en-US'], undefined)).toBe('fr-HT');
+      expect(matchLocale('ht-Latn-HT', ['fr-HT', 'en-US'])).toBe('fr-HT');
     });
 
     it('continues truncating to plain `fr` when `fr-HT` is not available', () => {
-      expect(matchLocale('ht', ['fr', 'en-US'], undefined)).toBe('fr');
+      expect(matchLocale('ht', ['fr', 'en-US'])).toBe('fr');
     });
 
     it('expands the post-remap `fr-HT` candidate to any available `fr-*` variant', () => {
       // Truncate `ht` → remap to `fr-HT` → no exact `fr-HT` and no `fr-HT-…` →
       // truncate to `fr` → no exact `fr`, but prefix `fr-` matches `fr-FR`.
-      expect(matchLocale('ht', ['fr-FR'], undefined)).toBe('fr-FR');
+      expect(matchLocale('ht', ['fr-FR'])).toBe('fr-FR');
     });
 
     it('prefers an available `ht` locale over the French fallback', () => {
-      expect(matchLocale('ht', ['ht', 'fr-HT'], undefined)).toBe('ht');
+      expect(matchLocale('ht', ['ht', 'fr-HT'])).toBe('ht');
     });
 
     it('prefers an available `ht-HT` locale over the French fallback', () => {
-      expect(matchLocale('ht-HT', ['ht-HT', 'fr-HT'], undefined)).toBe('ht-HT');
+      expect(matchLocale('ht-HT', ['ht-HT', 'fr-HT'])).toBe('ht-HT');
     });
 
     it('uses the `ht` prefix expansion before falling back to French', () => {
       // Requested `ht-Latn-HT` truncates to `ht`; prefix expansion finds `ht-HT`
       // before the loop ever sees the `ht` → `fr-HT` remap.
-      expect(matchLocale('ht-Latn-HT', ['ht-HT', 'fr-HT'], undefined)).toBe('ht-HT');
+      expect(matchLocale('ht-Latn-HT', ['ht-HT', 'fr-HT'])).toBe('ht-HT');
     });
 
     it('returns the fallback when neither Haitian Creole nor French is available', () => {
@@ -163,7 +163,7 @@ describe('matchLocale', () => {
     });
 
     it('skips invalid entries in `available` and warns about each', () => {
-      expect(matchLocale('en-US', ['not-a-locale!', 'en-US'], undefined)).toBe('en-US');
+      expect(matchLocale('en-US', ['not-a-locale!', 'en-US'])).toBe('en-US');
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid available locale tag'));
     });
 
@@ -173,7 +173,7 @@ describe('matchLocale', () => {
     });
 
     it('does not warn when all inputs are valid', () => {
-      matchLocale('en-US', ['en-US'], undefined);
+      matchLocale('en-US', ['en-US']);
       expect(warnSpy).not.toHaveBeenCalled();
     });
   });

--- a/packages/framework/esm-utils/src/match-locale.test.ts
+++ b/packages/framework/esm-utils/src/match-locale.test.ts
@@ -1,0 +1,180 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { matchLocale } from './match-locale';
+
+describe('matchLocale', () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  describe('examples from the spec', () => {
+    it('falls back to en-US when en-CA is requested but only other English variants exist', () => {
+      expect(matchLocale('en-CA', ['en-US', 'en-GB', 'fr-FR'], 'en-US')).toBe('en-US');
+    });
+
+    it('matches the language family when the region differs', () => {
+      expect(matchLocale('fr-BE', ['en-US', 'fr-FR', 'de-DE'], 'en-US')).toBe('fr-FR');
+    });
+
+    it('truncates a script subtag to find a script-only match', () => {
+      expect(matchLocale('zh-Hant-TW', ['zh-Hant', 'zh-Hans', 'en'], 'en')).toBe('zh-Hant');
+    });
+  });
+
+  describe('exact matching', () => {
+    it('returns the exact match when one is present', () => {
+      expect(matchLocale('en-US', ['fr-FR', 'en-US', 'de-DE'], 'fr-FR')).toBe('en-US');
+    });
+
+    it('returns the original casing from `available`, not the canonical form', () => {
+      expect(matchLocale('en-us', ['en-US'], undefined)).toBe('en-US');
+      expect(matchLocale('EN-US', ['en-us'], undefined)).toBe('en-us');
+    });
+
+    it('matches the first occurrence when an available locale appears multiple times', () => {
+      expect(matchLocale('en', ['en', 'en-US', 'en'], undefined)).toBe('en');
+    });
+  });
+
+  describe('canonicalization', () => {
+    it('treats underscore-separated tags as equivalent to hyphen-separated tags', () => {
+      expect(matchLocale('en_GB', ['en-GB'], undefined)).toBe('en-GB');
+      expect(matchLocale('en-GB', ['en_GB'], undefined)).toBe('en_GB');
+    });
+
+    it('is case-insensitive across language, script, and region subtags', () => {
+      expect(matchLocale('ZH-hant-tw', ['zh-Hant'], undefined)).toBe('zh-Hant');
+    });
+
+    it('canonicalizes script casing for matching (Latn vs latn)', () => {
+      expect(matchLocale('sr-latn-rs', ['sr-Latn'], undefined)).toBe('sr-Latn');
+    });
+  });
+
+  describe('truncation', () => {
+    it('strips a region subtag to match a language-only available locale', () => {
+      expect(matchLocale('en-CA', ['en'], undefined)).toBe('en');
+    });
+
+    it('strips a region from a script+region tag, leaving the script', () => {
+      expect(matchLocale('zh-Hant-TW', ['zh-Hant'], undefined)).toBe('zh-Hant');
+    });
+
+    it('strips a single-letter extension singleton along with its trailing subtag', () => {
+      // `en-US-x-private` → `en-US-x` → strip singleton → `en-US` → `en`.
+      expect(matchLocale('en-US-x-private', ['en'], undefined)).toBe('en');
+    });
+  });
+
+  describe('prefix expansion', () => {
+    it('expands a language-only request to a regional variant', () => {
+      expect(matchLocale('en', ['en-US', 'en-GB'], undefined)).toBe('en-US');
+    });
+
+    it('falls through truncation steps before expanding', () => {
+      // `fr-BE` → no exact, no `fr-BE-…` prefix → truncate to `fr` →
+      // no exact `fr` → expand to `fr-FR`.
+      expect(matchLocale('fr-BE', ['fr-FR'], undefined)).toBe('fr-FR');
+    });
+
+    it('does not match across language families', () => {
+      expect(matchLocale('fr-BE', ['en-US', 'de-DE'], 'en-US')).toBe('en-US');
+    });
+  });
+
+  describe('fallback handling', () => {
+    it('returns the fallback when no match is found', () => {
+      expect(matchLocale('ja', ['en-US', 'fr-FR'], 'en-US')).toBe('en-US');
+    });
+
+    it('returns undefined when no fallback is provided and no match is found', () => {
+      expect(matchLocale('ja', ['en-US', 'fr-FR'], undefined)).toBeUndefined();
+    });
+
+    it('returns the fallback when `available` is empty', () => {
+      expect(matchLocale('en-US', [], 'fallback-tag')).toBe('fallback-tag');
+    });
+
+    it('returns the fallback when `requested` is null', () => {
+      expect(matchLocale(null, ['en-US'], 'en-US')).toBe('en-US');
+    });
+
+    it('returns the fallback when `requested` is undefined', () => {
+      expect(matchLocale(undefined, ['en-US'], 'en-US')).toBe('en-US');
+    });
+  });
+
+  describe('ht → fr-HT fallback', () => {
+    it('falls back to fr-HT when `ht` is requested and no Haitian Creole locale is available', () => {
+      expect(matchLocale('ht', ['fr-HT', 'en-US'], undefined)).toBe('fr-HT');
+    });
+
+    it('falls back from `ht-HT` to `fr-HT`', () => {
+      expect(matchLocale('ht-HT', ['fr-HT', 'en-US'], undefined)).toBe('fr-HT');
+    });
+
+    it('falls back from `ht-Latn-HT` to `fr-HT`', () => {
+      expect(matchLocale('ht-Latn-HT', ['fr-HT', 'en-US'], undefined)).toBe('fr-HT');
+    });
+
+    it('continues truncating to plain `fr` when `fr-HT` is not available', () => {
+      expect(matchLocale('ht', ['fr', 'en-US'], undefined)).toBe('fr');
+    });
+
+    it('expands the post-remap `fr-HT` candidate to any available `fr-*` variant', () => {
+      // Truncate `ht` → remap to `fr-HT` → no exact `fr-HT` and no `fr-HT-…` →
+      // truncate to `fr` → no exact `fr`, but prefix `fr-` matches `fr-FR`.
+      expect(matchLocale('ht', ['fr-FR'], undefined)).toBe('fr-FR');
+    });
+
+    it('prefers an available `ht` locale over the French fallback', () => {
+      expect(matchLocale('ht', ['ht', 'fr-HT'], undefined)).toBe('ht');
+    });
+
+    it('prefers an available `ht-HT` locale over the French fallback', () => {
+      expect(matchLocale('ht-HT', ['ht-HT', 'fr-HT'], undefined)).toBe('ht-HT');
+    });
+
+    it('uses the `ht` prefix expansion before falling back to French', () => {
+      // Requested `ht-Latn-HT` truncates to `ht`; prefix expansion finds `ht-HT`
+      // before the loop ever sees the `ht` → `fr-HT` remap.
+      expect(matchLocale('ht-Latn-HT', ['ht-HT', 'fr-HT'], undefined)).toBe('ht-HT');
+    });
+
+    it('returns the fallback when neither Haitian Creole nor French is available', () => {
+      expect(matchLocale('ht-HT', ['en-US', 'de-DE'], 'en-US')).toBe('en-US');
+    });
+  });
+
+  describe('invalid input', () => {
+    it('returns the fallback and warns when `requested` is not a valid tag', () => {
+      expect(matchLocale('not a locale', ['en-US'], 'en-US')).toBe('en-US');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid requested locale tag'));
+    });
+
+    it('returns the fallback and warns when `requested` is an empty string', () => {
+      expect(matchLocale('', ['en-US'], 'en-US')).toBe('en-US');
+      expect(warnSpy).toHaveBeenCalled();
+    });
+
+    it('skips invalid entries in `available` and warns about each', () => {
+      expect(matchLocale('en-US', ['not-a-locale!', 'en-US'], undefined)).toBe('en-US');
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('invalid available locale tag'));
+    });
+
+    it('still returns the fallback when every available entry is invalid', () => {
+      expect(matchLocale('en-US', ['!!!', '@@@'], 'fallback')).toBe('fallback');
+      expect(warnSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not warn when all inputs are valid', () => {
+      matchLocale('en-US', ['en-US'], undefined);
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/framework/esm-utils/src/match-locale.ts
+++ b/packages/framework/esm-utils/src/match-locale.ts
@@ -9,7 +9,7 @@ function canonicalize(tag: string): string | undefined {
     return undefined;
   }
 
-  const normalized = tag.replace('_', '-');
+  const normalized = tag.replaceAll('_', '-');
 
   try {
     return new Intl.Locale(normalized).toString();

--- a/packages/framework/esm-utils/src/match-locale.ts
+++ b/packages/framework/esm-utils/src/match-locale.ts
@@ -1,0 +1,118 @@
+/**
+ * Returns a canonical BCP 47 representation of `tag`, or `undefined` if it is not a
+ * structurally valid tag. Underscores are accepted as a separator and normalized to
+ * hyphens before canonicalization to accommodate locale strings that originate from
+ * Java-style identifiers (e.g. `en_GB`).
+ */
+function canonicalize(tag: string): string | undefined {
+  if (typeof tag !== 'string' || tag.trim().length === 0) {
+    return undefined;
+  }
+
+  const normalized = tag.replace('_', '-');
+
+  try {
+    return new Intl.Locale(normalized).toString();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Resolves a requested locale against a list of available locales using the
+ * BCP 47 lookup algorithm (RFC 4647, §3.4).
+ *
+ * Tags are compared in canonical form via {@link Intl.Locale}, so casing and
+ * underscore-vs-hyphen differences in the inputs do not affect matching. The
+ * value returned is taken verbatim from `available`, preserving the caller's
+ * original casing.
+ *
+ * In addition to the truncation steps prescribed by RFC 4647, this function
+ * also performs prefix expansion at each level: when the requested tag is
+ * truncated to a more general range (e.g. `en` after stripping `en-CA`), any
+ * available locale whose canonical form begins with that range plus a hyphen
+ * (e.g. `en-US`, `en-GB`) is treated as a match. This is a relaxation of the
+ * strict lookup algorithm but typically reflects user intent — a user who
+ * asked for `en-CA` will usually accept `en-US` over a non-English fallback.
+ *
+ * Tags that fail to parse are skipped with a console warning; they never match
+ * and never throw.
+ *
+ * @param requested - The locale the caller would like to use, or `null`/`undefined`
+ *   if no preference is known.
+ * @param available - The list of locales the application supports.
+ * @param fallback - The value to return when no match is found. Defaults to
+ *   `undefined`.
+ * @returns The matched locale from `available`, or `fallback` if nothing matches.
+ *
+ * @example
+ * matchLocale('en-CA', ['en-US', 'en-GB', 'fr-FR'], 'en-US'); // => 'en-US'
+ * matchLocale('fr-BE', ['en-US', 'fr-FR', 'de-DE'], 'en-US'); // => 'fr-FR'
+ * matchLocale('zh-Hant-TW', ['zh-Hant', 'zh-Hans', 'en'], 'en'); // => 'zh-Hant'
+ */
+export function matchLocale(
+  requested: string | null | undefined,
+  available: ReadonlyArray<string>,
+  fallback?: string,
+): string | undefined {
+  if (requested == null) {
+    return fallback;
+  }
+
+  const requestedCanonical = canonicalize(requested);
+  if (!requestedCanonical) {
+    console.warn(`matchLocale: invalid requested locale tag: ${JSON.stringify(requested)}`);
+    return fallback;
+  }
+
+  const pool: Array<{ canonical: string; original: string }> = [];
+  for (const entry of available) {
+    const canonical = canonicalize(entry);
+    if (!canonical) {
+      console.warn(`matchLocale: skipping invalid available locale tag: ${JSON.stringify(entry)}`);
+      continue;
+    }
+    pool.push({ canonical, original: entry });
+  }
+
+  let candidate = requestedCanonical;
+  while (candidate) {
+    const exact = pool.find((p) => p.canonical === candidate);
+    if (exact) {
+      return exact.original;
+    }
+
+    const prefix = candidate + '-';
+    const prefixed = pool.find((p) => p.canonical.startsWith(prefix));
+    if (prefixed) {
+      return prefixed.original;
+    }
+
+    // Once the truncation chain has exhausted every `ht` option, retry the
+    // lookup with `fr-HT`. This mirrors the `ht` → `fr-HT` workaround in
+    // `get-locale.ts`: Haitian Creole content is typically registered under
+    // `fr-HT` because of incomplete browser Intl support for `ht`, so a caller
+    // asking for `ht` needs to find it there.
+    if (candidate === 'ht') {
+      candidate = 'fr-HT';
+      continue;
+    }
+
+    // RFC 4647 §3.4 step 4: strip the trailing subtag.
+    const lastDash = candidate.lastIndexOf('-');
+    if (lastDash === -1) {
+      break;
+    }
+    candidate = candidate.slice(0, lastDash);
+
+    // RFC 4647 §3.4 step 5: a trailing single-letter subtag is an extension
+    // singleton (e.g. `-x-` for private use, `-u-` for Unicode extensions) and
+    // is not meaningful on its own, so strip it together with its separator.
+    const tailDash = candidate.lastIndexOf('-');
+    if (tailDash !== -1 && candidate.length - tailDash === 2) {
+      candidate = candidate.slice(0, tailDash);
+    }
+  }
+
+  return fallback;
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->
matchLocale() implements the Lookup algorithm described in RFC 4647 to select the "best matching" locale against a supplied locale list. This is the algorithm the [Intl](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl) objects use to support locale lookup. It ensures, for example, that if I'm in the `en` locale and there are translations available for `en-GB`, but not plain `en` then `en-GB` is matched and that if I'm in the `en-GB` and `en` is available, `en` is matched.

This implementation has one non-standard addition to the general algorithm which is that the `ht` locale will fallback to `fr-HT`.

While locales are canonicalized for comparison, this method guarantees that it returns matches as the user specified.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
