### PR TITLE
(fix) Add esm-patient-task-list-app to the e2e Docker environment

### DIFF
--- a/e2e/support/github/run-e2e-docker-env.sh
+++ b/e2e/support/github/run-e2e-docker-env.sh
@@ -238,6 +238,7 @@ jq -n \
     "@openmrs/esm-patient-programs-app": "next",
     "@openmrs/esm-patient-registration-app": "next",
     "@openmrs/esm-patient-search-app": "next",
+    "@openmrs/esm-patient-task-list-app": "next",
     "@openmrs/esm-patient-tests-app": "next",
     "@openmrs/esm-patient-vitals-app": "next",
     "@openmrs/esm-service-queues-app": "next",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary

`@openmrs/esm-patient-task-list-app` was added to `openmrs-esm-patient-chart` in [#3202](https://github.com/openmrs/openmrs-esm-patient-chart/pull/3202), and e2e tests for it were ported in [#3303](https://github.com/openmrs/openmrs-esm-patient-chart/pull/3303). However, the package was never added to the `spa-assemble-config.json` built by `run-e2e-docker-env.sh`, so the task list workspace button never appeared in the test environment. This caused all task-list e2e tests to time out waiting for the button.

## Screenshots

## Related Issue

## Other
