### PR TITLE
(chore) Workspace2 is not longer experimental; deprecate currentVisit

### DIFF
--- a/packages/framework/esm-emr-api/src/visit-utils.ts
+++ b/packages/framework/esm-emr-api/src/visit-utils.ts
@@ -91,6 +91,9 @@ export function getVisitStore() {
  * import { setCurrentVisit } from '@openmrs/esm-framework';
  * setCurrentVisit('patient-uuid', 'visit-uuid');
  * ```
+ *
+ * @deprecated "current visit" is not well defined outside of the patient chart.
+ * Use `visitContext` in the patient chart instead.
  */
 export function setCurrentVisit(patientUuid: string, visitUuid: string) {
   getVisitStore().setState({ patientUuid, manuallySetVisitUuid: visitUuid });

--- a/packages/framework/esm-framework/docs/API.md
+++ b/packages/framework/esm-framework/docs/API.md
@@ -19,7 +19,7 @@
 - [PatientWithFullResponse](interfaces/PatientWithFullResponse.md)
 - [OnlyThePatient](interfaces/OnlyThePatient.md)
 - [getVisitStore](functions/getVisitStore.md)
-- [setCurrentVisit](functions/setCurrentVisit.md)
+- [~~setCurrentVisit~~](functions/setCurrentVisit.md)
 - [saveVisit](functions/saveVisit.md)
 - [updateVisit](functions/updateVisit.md)
 - [~~getVisitsForPatient~~](functions/getVisitsForPatient.md)

--- a/packages/framework/esm-framework/docs/functions/closeWorkspaceGroup2.md
+++ b/packages/framework/esm-framework/docs/functions/closeWorkspaceGroup2.md
@@ -4,9 +4,7 @@
 
 > **closeWorkspaceGroup2**(`discardUnsavedChanges?`): `Promise`\<`boolean`\>
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.ts:75](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.ts#L75)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.ts:73](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.ts#L73)
 
 Closes the workspace group that is currently opened. Note that only one workspace group
 may be opened at any given time

--- a/packages/framework/esm-framework/docs/functions/getRegisteredWorkspace2Names.md
+++ b/packages/framework/esm-framework/docs/functions/getRegisteredWorkspace2Names.md
@@ -4,7 +4,7 @@
 
 > **getRegisteredWorkspace2Names**(): `string`[]
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.ts:604](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.ts#L604)
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.ts:600](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.ts#L600)
 
 ## Returns
 

--- a/packages/framework/esm-framework/docs/functions/getVisitsForPatient.md
+++ b/packages/framework/esm-framework/docs/functions/getVisitsForPatient.md
@@ -4,7 +4,7 @@
 
 > **getVisitsForPatient**(`patientUuid`, `abortController`, `v?`): `Promise`\<[`FetchResponse`](../interfaces/FetchResponse.md)\<\{ `results`: [`Visit`](../interfaces/Visit.md)[]; \}\>\>
 
-Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:180](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L180)
+Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:183](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L183)
 
 ## Parameters
 

--- a/packages/framework/esm-framework/docs/functions/launchWorkspace2.md
+++ b/packages/framework/esm-framework/docs/functions/launchWorkspace2.md
@@ -4,9 +4,7 @@
 
 > **launchWorkspace2**\<`WorkspaceProps`, `WindowProps`, `GroupProp`\>(`workspaceName`, `workspaceProps`, `windowProps`, `groupProps`): `Promise`\<`boolean`\>
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.ts:135](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.ts#L135)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.ts:132](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.ts#L132)
 
 Attempts to launch the specified workspace with the given workspace props. This also implicitly opens
 the workspace window to which the workspace belongs (if it's not opened already),

--- a/packages/framework/esm-framework/docs/functions/launchWorkspaceGroup2.md
+++ b/packages/framework/esm-framework/docs/functions/launchWorkspaceGroup2.md
@@ -4,9 +4,7 @@
 
 > **launchWorkspaceGroup2**\<`GroupProps`\>(`groupName`, `groupProps`): `Promise`\<`boolean`\>
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.ts:32](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.ts#L32)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.ts:31](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.ts#L31)
 
 Attempts to launch the specified workspace group with the given group props. Note that only one workspace group
 may be opened at any given time. If a workspace group is already opened, calling `launchWorkspaceGroup2` with

--- a/packages/framework/esm-framework/docs/functions/saveVisit.md
+++ b/packages/framework/esm-framework/docs/functions/saveVisit.md
@@ -4,7 +4,7 @@
 
 > **saveVisit**(`payload`, `abortController`): `Promise`\<[`FetchResponse`](../interfaces/FetchResponse.md)\<[`Visit`](../interfaces/Visit.md)\>\>
 
-Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:134](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L134)
+Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:137](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L137)
 
 Creates a new visit by sending a POST request to the OpenMRS REST API.
 

--- a/packages/framework/esm-framework/docs/functions/setCurrentVisit.md
+++ b/packages/framework/esm-framework/docs/functions/setCurrentVisit.md
@@ -1,10 +1,10 @@
 [O3 Framework](../API.md) / setCurrentVisit
 
-# Function: setCurrentVisit()
+# Function: ~~setCurrentVisit()~~
 
 > **setCurrentVisit**(`patientUuid`, `visitUuid`): `void`
 
-Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:95](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L95)
+Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:98](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L98)
 
 Sets the current visit for a patient in the global visit store. This is used
 to manually specify which visit should be considered "active" for the given patient.
@@ -33,3 +33,8 @@ The UUID of the visit to set as the current visit.
 import { setCurrentVisit } from '@openmrs/esm-framework';
 setCurrentVisit('patient-uuid', 'visit-uuid');
 ```
+
+## Deprecated
+
+"current visit" is not well defined outside of the patient chart.
+Use `visitContext` in the patient chart instead.

--- a/packages/framework/esm-framework/docs/functions/updateVisit.md
+++ b/packages/framework/esm-framework/docs/functions/updateVisit.md
@@ -4,7 +4,7 @@
 
 > **updateVisit**(`uuid`, `payload`, `abortController`): `Promise`\<[`FetchResponse`](../interfaces/FetchResponse.md)\<[`Visit`](../interfaces/Visit.md)\>\>
 
-Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:162](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L162)
+Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:165](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L165)
 
 Updates an existing visit by sending a POST request to the OpenMRS REST API.
 

--- a/packages/framework/esm-framework/docs/functions/useVisit.md
+++ b/packages/framework/esm-framework/docs/functions/useVisit.md
@@ -4,7 +4,7 @@
 
 > **useVisit**(`patientUuid`, `representation`): [`VisitReturnType`](../interfaces/VisitReturnType.md)
 
-Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:51](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L51)
+Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:52](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L52)
 
 This React hook returns visit information if the patient UUID is not null. There are
 potentially two relevant visits at a time: "active" and "current".

--- a/packages/framework/esm-framework/docs/functions/useVisit.md
+++ b/packages/framework/esm-framework/docs/functions/useVisit.md
@@ -4,7 +4,7 @@
 
 > **useVisit**(`patientUuid`, `representation`): [`VisitReturnType`](../interfaces/VisitReturnType.md)
 
-Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:42](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L42)
+Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:51](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L51)
 
 This React hook returns visit information if the patient UUID is not null. There are
 potentially two relevant visits at a time: "active" and "current".

--- a/packages/framework/esm-framework/docs/functions/useWorkspace2Context.md
+++ b/packages/framework/esm-framework/docs/functions/useWorkspace2Context.md
@@ -4,7 +4,7 @@
 
 > **useWorkspace2Context**(): [`Workspace2DefinitionProps`](../interfaces/Workspace2DefinitionProps.md)\<`object`, `object`, `object`\>
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.ts:598](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.ts#L598)
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.ts:594](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.ts#L594)
 
 Returns the react Context containing props passed into a workspace.
 This hook MUST be called inside a child of <Workspace2>

--- a/packages/framework/esm-framework/docs/interfaces/VisitReturnType.md
+++ b/packages/framework/esm-framework/docs/interfaces/VisitReturnType.md
@@ -14,19 +14,26 @@ Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:16](https://gith
 
 ***
 
-### currentVisit
+### ~~currentVisit~~
 
 > **currentVisit**: `null` \| [`Visit`](Visit.md)
 
-Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L17)
+Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L22)
+
+#### Deprecated
+
+"current visit" is not well defined outside of the patient chart.
+Use `visitContext` in the patient chart instead.
 
 ***
 
-### currentVisitIsRetrospective
+### ~~currentVisitIsRetrospective~~
 
 > **currentVisitIsRetrospective**: `boolean`
 
-Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L18)
+Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:27](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L27)
+
+#### Deprecated
 
 ***
 
@@ -42,7 +49,7 @@ Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:13](https://gith
 
 > **isLoading**: `boolean`
 
-Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L19)
+Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:28](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L28)
 
 ***
 

--- a/packages/framework/esm-framework/docs/interfaces/VisitReturnType.md
+++ b/packages/framework/esm-framework/docs/interfaces/VisitReturnType.md
@@ -31,9 +31,12 @@ Use `visitContext` in the patient chart instead.
 
 > **currentVisitIsRetrospective**: `boolean`
 
-Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:27](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L27)
+Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:28](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L28)
 
 #### Deprecated
+
+"current visit" is not well defined outside of the patient chart.
+Use `visitContext` in the patient chart instead.
 
 ***
 
@@ -49,7 +52,7 @@ Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:13](https://gith
 
 > **isLoading**: `boolean`
 
-Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:28](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L28)
+Defined in: [packages/framework/esm-react-utils/src/useVisit.ts:29](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisit.ts#L29)
 
 ***
 

--- a/packages/framework/esm-framework/docs/interfaces/Workspace2DefinitionProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/Workspace2DefinitionProps.md
@@ -2,9 +2,7 @@
 
 # Interface: Workspace2DefinitionProps\<WorkspaceProps, WindowProps, GroupProps\>
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L21)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L18)
 
 ## Type Parameters
 
@@ -26,9 +24,7 @@ Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.compon
 
 > **groupProps**: `null` \| `GroupProps`
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:46](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L46)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:43](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L43)
 
 ***
 
@@ -36,9 +32,7 @@ Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.compon
 
 > **isRootWorkspace**: `boolean`
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:49](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L49)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:46](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L46)
 
 ***
 
@@ -46,9 +40,7 @@ Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.compon
 
 > **showActionMenu**: `boolean`
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L50)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L47)
 
 ***
 
@@ -56,9 +48,7 @@ Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.compon
 
 > **windowName**: `string`
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L48)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L45)
 
 ***
 
@@ -66,9 +56,7 @@ Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.compon
 
 > **windowProps**: `null` \| `WindowProps`
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L45)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:42](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L42)
 
 ***
 
@@ -76,9 +64,7 @@ Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.compon
 
 > **workspaceName**: `string`
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:47](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L47)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L44)
 
 ***
 
@@ -86,9 +72,7 @@ Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.compon
 
 > **workspaceProps**: `null` \| `WorkspaceProps`
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L44)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:41](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L41)
 
 ## Methods
 
@@ -96,9 +80,7 @@ Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.compon
 
 > **closeWorkspace**(`options?`): `Promise`\<`boolean`\>
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:42](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L42)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:39](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L39)
 
 closes the current workspace, along with its children.
 
@@ -132,9 +114,7 @@ a Promise that resolves to true if the workspace is closed, false otherwise.
 
 > **launchChildWorkspace**\<`Props`\>(`workspaceName`, `workspaceProps?`): `Promise`\<`void`\>
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:33](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L33)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:30](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L30)
 
 This function launches a child workspace. Unlike `launchWorkspace()`, this function is meant
 to be called from the a workspace, and it does not allow passing (or changing)

--- a/packages/framework/esm-framework/docs/type-aliases/Workspace2Definition.md
+++ b/packages/framework/esm-framework/docs/type-aliases/Workspace2Definition.md
@@ -4,9 +4,7 @@
 
 > **Workspace2Definition**\<`WorkspaceProps`, `WindowProps`, `GroupProps`\> = `React.FC`\<[`Workspace2DefinitionProps`](../interfaces/Workspace2DefinitionProps.md)\<`WorkspaceProps`, `WindowProps`, `GroupProps`\>\>
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:56](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L56)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:50](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L50)
 
 ## Type Parameters
 

--- a/packages/framework/esm-framework/docs/variables/ActionMenuButton2.md
+++ b/packages/framework/esm-framework/docs/variables/ActionMenuButton2.md
@@ -4,9 +4,7 @@
 
 > `const` **ActionMenuButton2**: `React.FC`\<`ActionMenuButtonProps2`\>
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/action-menu2/action-menu-button2.component.tsx:67](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/action-menu2/action-menu-button2.component.tsx#L67)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/action-menu2/action-menu-button2.component.tsx:66](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/action-menu2/action-menu-button2.component.tsx#L66)
 
 The ActionMenuButton2 component is used to render a button in the action menu of a workspace group.
 The button is associated with a specific workspace window, defined in routes.json of the app with the button.

--- a/packages/framework/esm-framework/docs/variables/Workspace2.md
+++ b/packages/framework/esm-framework/docs/variables/Workspace2.md
@@ -4,9 +4,7 @@
 
 > `const` **Workspace2**: `React.FC`\<`Workspace2Props`\>
 
-Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:69](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L69)
-
-**`Experimental`**
+Defined in: [packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx:62](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx#L62)
 
 The Workspace2 component is used as a top-level container to render
 its children as content within a workspace. When creating a workspace

--- a/packages/framework/esm-framework/docs/variables/getStartedVisit.md
+++ b/packages/framework/esm-framework/docs/variables/getStartedVisit.md
@@ -4,6 +4,6 @@
 
 > `const` **getStartedVisit**: `BehaviorSubject`\<`null` \| [`VisitItem`](../interfaces/VisitItem.md)\>
 
-Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:197](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L197)
+Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:200](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L200)
 
 ## Deprecated

--- a/packages/framework/esm-react-utils/src/useVisit.ts
+++ b/packages/framework/esm-react-utils/src/useVisit.ts
@@ -22,7 +22,8 @@ export interface VisitReturnType {
   currentVisit: Visit | null;
 
   /**
-   * @deprecated
+   * @deprecated "current visit" is not well defined outside of the patient chart.
+   * Use `visitContext` in the patient chart instead.
    */
   currentVisitIsRetrospective: boolean;
   isLoading: boolean;

--- a/packages/framework/esm-react-utils/src/useVisit.ts
+++ b/packages/framework/esm-react-utils/src/useVisit.ts
@@ -14,7 +14,16 @@ export interface VisitReturnType {
   mutate: () => void;
   isValidating: boolean;
   activeVisit: Visit | null;
+
+  /**
+   * @deprecated "current visit" is not well defined outside of the patient chart.
+   * Use `visitContext` in the patient chart instead.
+   */
   currentVisit: Visit | null;
+
+  /**
+   * @deprecated
+   */
   currentVisitIsRetrospective: boolean;
   isLoading: boolean;
 }

--- a/packages/framework/esm-styleguide/src/workspaces2/action-menu2/action-menu-button2.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces2/action-menu2/action-menu-button2.component.tsx
@@ -62,7 +62,6 @@ export interface ActionMenuButtonProps2 {
  * 2. restores the workspace window if it is opened and unfocused; or
  * 3. launches a workspace from within that window, if the window is not opened.
  *
- * @experimental
  */
 export const ActionMenuButton2: React.FC<ActionMenuButtonProps2> = ({
   icon: getIcon,

--- a/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces2/workspace2.component.tsx
@@ -15,9 +15,6 @@ interface Workspace2Props {
   hasUnsavedChanges?: boolean;
 }
 
-/**
- * @experimental
- */
 export interface Workspace2DefinitionProps<
   WorkspaceProps extends object = object,
   WindowProps extends object = object,
@@ -50,9 +47,6 @@ export interface Workspace2DefinitionProps<
   showActionMenu: boolean;
 }
 
-/**
- * @experimental
- */
 export type Workspace2Definition<
   WorkspaceProps extends object,
   WindowProps extends object,
@@ -64,7 +58,6 @@ export type Workspace2Definition<
  * its children as content within a workspace. When creating a workspace
  * component, `<Workspace2>` should be the top-level component returned,
  * wrapping all of the workspace content.
- * @experimental
  */
 export const Workspace2: React.FC<Workspace2Props> = ({ title, children, hasUnsavedChanges = false }) => {
   const layout = useLayoutType();

--- a/packages/framework/esm-styleguide/src/workspaces2/workspace2.ts
+++ b/packages/framework/esm-styleguide/src/workspaces2/workspace2.ts
@@ -23,7 +23,6 @@ import { type Workspace2DefinitionProps } from './workspace2.component';
  * the requested group is immediately opened.
  *
  * ** 2 sets of props are compatible if either one is nullish, or if they are shallow equal.
- * @experimental
  * @param groupName
  * @param groupProps
  * @returns a Promise that resolves to true if the specified workspace group with the specified group props
@@ -65,7 +64,6 @@ export async function launchWorkspaceGroup2<GroupProps extends object>(
 /**
  * Closes the workspace group that is currently opened. Note that only one workspace group
  * may be opened at any given time
- * @experimental
  * @param discardUnsavedChanges If true, then the workspace group is forced closed, with no prompt
  * for confirmation for unsaved changes in any opened workspace. This should be used sparingly
  * for clean-up purpose, ex: when exiting an app.
@@ -130,7 +128,6 @@ export async function closeWorkspaceGroup2(discardUnsavedChanges?: boolean) {
  * The "patient search" workspace in the queues and ward apps is another example.
  *
  * [^2] 2 sets of props are compatible if either one is nullish, or if they are shallow equal.
- * @experimental
  */
 export async function launchWorkspace2<
   WorkspaceProps extends object,
@@ -357,7 +354,6 @@ type PromptReason =
  * When the closing is explicit, it prompts for confirmation for affected workspaces with unsaved changes.
  * When the closing is implicit, it prompts for confirmation for all affected workspaces, regardless of
  * whether they have unsaved changes.
- * @experimental
  * @param promptReason
  * @returns a Promise that resolves to true if the user confirmed closing the workspaces; false otherwise.
  */


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->
Workspace v2 is no longer experimental; accordingly, we remove the `@experimental` tag.
"Current visit" is not well defined outside of the patient chart. We mark it as `@deprecated` and will remove it in a future release.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
