### PR TITLE
(fix) Restore pagination container text left padding

### DIFF
--- a/packages/framework/esm-styleguide/src/_overrides.scss
+++ b/packages/framework/esm-styleguide/src/_overrides.scss
@@ -337,6 +337,12 @@
   container: unset;
 }
 
+@media (min-width: 42rem) {
+  .cds--pagination .cds--pagination__left {
+    padding-inline-start: layout.$spacing-05;
+  }
+}
+
 .cds--pagination-nav__page:not(.cds--pagination-nav__page--direction) {
   &::after {
     @include brand-03(background-color);


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary

Carbon pagination's full left-side text was rendered flush against the table border. This made labels like `Items per page:` feel visually detached from the table content in data tables such as Bed allocation.

The existing styleguide override keeps `container: unset` on `.cds--pagination` to avoid Carbon's container-query arrow alignment issue. With that override in place, the left pagination section no longer receives the desktop/tablet inline padding that keeps it aligned with table content.

This PR restores the missing `padding-inline-start` for `.cds--pagination__left` at Carbon's medium breakpoint and above. The fix lives in the shared styleguide overrides so all table pagination instances using the full left-side pagination text get the same alignment.

## Screenshots

### Before
<img width="1656" height="870" alt="CleanShot 2026-05-28 at 22 51 07@2x" src="https://github.com/user-attachments/assets/7f862469-0739-41c9-a513-033e709334f4" />

### After
<img width="1664" height="856" alt="CleanShot 2026-05-28 at 23 06 12@2x" src="https://github.com/user-attachments/assets/6fa3e72f-0fb3-4efc-baaf-3ab598377005" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->


## Other
<!-- Anything not covered above -->
