### PR TITLE
(fix) Render UI Editor extension overlays and stop leaking overlay containers

### DIFF
--- a/packages/apps/esm-implementer-tools-app/src/ui-editor/extension-overlay.component.test.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/ui-editor/extension-overlay.component.test.tsx
@@ -1,0 +1,49 @@
+// This component manages a portal container imperatively, so verifying its lifecycle requires
+// inspecting the DOM directly rather than via Testing Library queries.
+/* eslint-disable testing-library/no-node-access */
+import React from 'react';
+import { describe, expect, it } from 'vitest';
+import { render } from '@testing-library/react';
+import { ExtensionOverlay } from './extension-overlay.component';
+
+// ExtensionOverlay imperatively appends a portal container as a sibling of the host element. These
+// tests guard against leaking that container, which previously was never removed on unmount or when
+// the host element changed.
+describe('ExtensionOverlay', () => {
+  it('removes its injected overlay container on unmount', () => {
+    const parent = document.createElement('div');
+    const host = document.createElement('div');
+    parent.appendChild(host);
+    document.body.appendChild(parent);
+
+    const before = parent.childElementCount;
+
+    const { unmount } = render(
+      <ExtensionOverlay extensionName="my-ext" slotModuleName="@openmrs/mod" slotName="my-slot" domElement={host} />,
+    );
+    expect(parent.childElementCount).toBe(before + 1);
+
+    unmount();
+    expect(parent.childElementCount).toBe(before);
+  });
+
+  it('does not accumulate containers when the host element changes', () => {
+    const parent = document.createElement('div');
+    const hostA = document.createElement('div');
+    const hostB = document.createElement('div');
+    parent.append(hostA, hostB);
+    document.body.appendChild(parent);
+
+    const before = parent.childElementCount;
+
+    const { rerender } = render(
+      <ExtensionOverlay extensionName="my-ext" slotModuleName="@openmrs/mod" slotName="my-slot" domElement={hostA} />,
+    );
+    expect(parent.childElementCount).toBe(before + 1);
+
+    rerender(
+      <ExtensionOverlay extensionName="my-ext" slotModuleName="@openmrs/mod" slotName="my-slot" domElement={hostB} />,
+    );
+    expect(parent.childElementCount).toBe(before + 1);
+  });
+});

--- a/packages/apps/esm-implementer-tools-app/src/ui-editor/extension-overlay.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/ui-editor/extension-overlay.component.tsx
@@ -17,11 +17,18 @@ export function ExtensionOverlay({ extensionName, slotModuleName, slotName, domE
   const [overlayDomElement, setOverlayDomElement] = useState<HTMLElement>();
 
   useEffect(() => {
-    if (domElement) {
-      const newOverlayDomElement = document.createElement('div');
-      domElement.parentElement?.appendChild(newOverlayDomElement);
-      setOverlayDomElement(newOverlayDomElement);
+    if (!domElement?.parentElement) {
+      return;
     }
+
+    const newOverlayDomElement = document.createElement('div');
+    domElement.parentElement.appendChild(newOverlayDomElement);
+    setOverlayDomElement(newOverlayDomElement);
+
+    return () => {
+      newOverlayDomElement.remove();
+      setOverlayDomElement(undefined);
+    };
   }, [domElement]);
 
   return overlayDomElement ? (

--- a/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.test.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { type ExtensionInfo } from '@openmrs/esm-framework/src/internal';
+import { getExtensionOverlayTargets } from './ui-editor';
+
+// `extensions[name].instances` is an Array<ExtensionInstance> in the framework store. These tests
+// guard against regressing to an object-style traversal, which produced array indices as module
+// names and instance property names as slot names, so no overlay ever matched a real DOM node.
+const extensions = {
+  'nav-item': {
+    instances: [
+      { id: 'nav-item-0', slotName: 'top-nav-slot', slotModuleName: '@openmrs/esm-nav-app' },
+      { id: 'nav-item-1', slotName: 'side-nav-slot', slotModuleName: '@openmrs/esm-nav-app' },
+    ],
+  },
+  'patient-banner': {
+    instances: [{ id: 'patient-banner-0', slotName: 'patient-header-slot', slotModuleName: '@openmrs/esm-chart-app' }],
+  },
+} as unknown as Record<string, ExtensionInfo>;
+
+describe('getExtensionOverlayTargets', () => {
+  it('flattens the instances array into real slot, module, and id descriptors', () => {
+    const targets = getExtensionOverlayTargets(extensions);
+
+    expect(targets).toHaveLength(3);
+    expect(targets[0]).toMatchObject({
+      extensionName: 'nav-item',
+      slotName: 'top-nav-slot',
+      slotModuleName: '@openmrs/esm-nav-app',
+    });
+    expect(targets[0].extensionInstance.id).toBe('nav-item-0');
+    expect(targets[2]).toMatchObject({
+      extensionName: 'patient-banner',
+      slotName: 'patient-header-slot',
+      slotModuleName: '@openmrs/esm-chart-app',
+    });
+  });
+
+  it('does not surface array indices or instance property names (regression guard)', () => {
+    const targets = getExtensionOverlayTargets(extensions);
+
+    // Old object-traversal bug surfaced "0"/"1" as module names and "id"/"slotName"/"slotModuleName"
+    // as slot names, with an undefined instance id.
+    expect(targets.map((target) => target.slotModuleName)).not.toContain('0');
+    expect(targets.map((target) => target.slotName)).toEqual(
+      expect.not.arrayContaining(['id', 'slotName', 'slotModuleName']),
+    );
+    expect(targets.every((target) => typeof target.extensionInstance.id === 'string')).toBe(true);
+  });
+
+  it('returns an empty list when there are no extensions', () => {
+    expect(getExtensionOverlayTargets(undefined)).toEqual([]);
+    expect(getExtensionOverlayTargets({})).toEqual([]);
+  });
+});

--- a/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@carbon/react';
 import {
   CloseIcon,
+  type ExtensionInfo,
   getExtensionInternalStore,
   useStore,
   useStoreWithActions,
@@ -24,6 +25,32 @@ interface SlotOverlayProps {
   slotName: string;
   t: TFunction;
   colorScheme: 'blue' | 'green';
+}
+
+export interface ExtensionOverlayTarget {
+  extensionName: string;
+  slotModuleName: string;
+  slotName: string;
+  extensionInstance: ExtensionInfo['instances'][number];
+}
+
+/**
+ * Flattens `extensions[name].instances` into a flat list of overlay targets. `instances` is an
+ * `Array<ExtensionInstance>`, so it must be iterated directly. Treating it as a nested object (via
+ * `Object.entries`) yields array indices as the module name and instance property names as the slot
+ * name, so the generated selectors never match a real extension DOM node.
+ */
+export function getExtensionOverlayTargets(
+  extensions: Record<string, ExtensionInfo> | undefined,
+): Array<ExtensionOverlayTarget> {
+  return Object.entries(extensions ?? {}).flatMap(([extensionName, extensionInfo]) =>
+    (extensionInfo.instances ?? []).map((extensionInstance) => ({
+      extensionName,
+      slotModuleName: extensionInstance.slotModuleName,
+      slotName: extensionInstance.slotName,
+      extensionInstance,
+    })),
+  );
 }
 
 export default function UiEditor() {
@@ -67,25 +94,16 @@ export default function UiEditor() {
       .filter((x): x is NonNullable<typeof x> => Boolean(x));
   }, [slots]);
 
-  const extensionElements = useMemo(() => {
-    if (!extensions) {
-      return [];
-    }
-
-    return Object.entries(extensions).flatMap(([extensionName, extensionInfo]) =>
-      Object.entries(extensionInfo.instances).flatMap(([slotModuleName, bySlotName]) =>
-        Object.entries(bySlotName).map(([slotName, extensionInstance]) => ({
-          extensionName,
-          slotModuleName,
-          slotName,
-          extensionInstance,
-          element: document.querySelector(
-            `*[data-extension-slot-name="${slotName}"][data-extension-slot-module-name="${slotModuleName}"] *[data-extension-id="${extensionInstance.id}"]`,
-          ) as HTMLElement | null,
-        })),
-      ),
-    );
-  }, [extensions]);
+  const extensionElements = useMemo(
+    () =>
+      getExtensionOverlayTargets(extensions).map((target) => ({
+        ...target,
+        element: document.querySelector(
+          `*[data-extension-slot-name="${target.slotName}"][data-extension-slot-module-name="${target.slotModuleName}"] *[data-extension-id="${target.extensionInstance.id}"]`,
+        ) as HTMLElement | null,
+      })),
+    [extensions],
+  );
 
   return (
     <>


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui)) <!-- N/A: no visual design change; this restores intended overlay behaviour -->
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes. <!-- N/A: no framework API changes -->

## Summary

The Implementer Tools UI Editor rendered slot overlays but no **extension** overlays, even on pages with many extensions (for example the patient chart, which has dozens of `[data-extension-id]` nodes).

The overlay targets were computed by treating `extensions[name].instances` as a nested object. In the framework extension store that field is `Array<ExtensionInstance>`, so iterating it with `Object.entries` produced array indices (`"0"`) as module names and instance property names (`"id"`, `"slotName"`) as slot names, with an `undefined` instance id. The resulting `data-extension-*` selectors never matched a real DOM node, so no extension overlay rendered even when extensions were present. This PR iterates the instances array directly through a small `getExtensionOverlayTargets` helper that reads `slotName`, `slotModuleName`, and `id` from each instance. (The slot-overlay path was already correct, since `slots` genuinely is a `Record`.)

Fixing that surfaced a latent leak that had been masked while no overlays mounted: `ExtensionOverlay` appends a portal container to the host element's parent on mount but never removed it. With overlays now mounting, exiting the UI Editor or changing the host element orphaned empty sibling divs in the host application's DOM. This adds an effect cleanup that removes the container on unmount and when the host element changes.

Includes regression tests for the traversal helper (`getExtensionOverlayTargets`) and the overlay container lifecycle (no leak on unmount or host change).

## Screenshots

<!-- Pending: before/after of the UI Editor showing extension overlays now rendering on a page with extensions. -->

## Related Issue

<!-- None -->

## Other
