### PR TITLE
(fix) Remove doubled heading padding in EmptyCard and ErrorState

### DIFF
--- a/packages/framework/esm-framework/docs/functions/EmptyCardIllustration.md
+++ b/packages/framework/esm-framework/docs/functions/EmptyCardIllustration.md
@@ -4,7 +4,7 @@
 
 > **EmptyCardIllustration**(`__namedParameters`): `Element`
 
-Defined in: [packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx#L17)
+Defined in: [packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx#L16)
 
 ## Parameters
 

--- a/packages/framework/esm-framework/docs/interfaces/EmptyCardProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/EmptyCardProps.md
@@ -2,7 +2,7 @@
 
 # Interface: EmptyCardProps
 
-Defined in: [packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx#L8)
+Defined in: [packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx:7](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx#L7)
 
 ## Properties
 
@@ -10,7 +10,7 @@ Defined in: [packages/framework/esm-styleguide/src/empty-card/empty-card.compone
 
 > **displayText**: `string`
 
-Defined in: [packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx:10](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx#L10)
+Defined in: [packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx:9](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx#L9)
 
 The name of the type of item that would be displayed here if not empty. This must be a pre-translated string.
 
@@ -20,7 +20,7 @@ The name of the type of item that would be displayed here if not empty. This mus
 
 > **headerTitle**: `string`
 
-Defined in: [packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx:12](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx#L12)
+Defined in: [packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx:11](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx#L11)
 
 The title to use for this empty component. This must be a pre-translated string.
 
@@ -30,7 +30,7 @@ The title to use for this empty component. This must be a pre-translated string.
 
 > `optional` **launchForm**(): `void`
 
-Defined in: [packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx:14](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx#L14)
+Defined in: [packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx:13](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx#L13)
 
 A callback to invoke when the user tries to record a new item.
 

--- a/packages/framework/esm-framework/docs/type-aliases/ErrorCardProps.md
+++ b/packages/framework/esm-framework/docs/type-aliases/ErrorCardProps.md
@@ -4,4 +4,4 @@
 
 > **ErrorCardProps** = [`ErrorStateProps`](../interfaces/ErrorStateProps.md)
 
-Defined in: [packages/framework/esm-styleguide/src/error-state/error-state.component.tsx:30](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/error-state/error-state.component.tsx#L30)
+Defined in: [packages/framework/esm-styleguide/src/error-state/error-state.component.tsx:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/error-state/error-state.component.tsx#L34)

--- a/packages/framework/esm-framework/docs/variables/EmptyCard.md
+++ b/packages/framework/esm-framework/docs/variables/EmptyCard.md
@@ -4,6 +4,6 @@
 
 > `const` **EmptyCard**: `React.FC`\<[`EmptyCardProps`](../interfaces/EmptyCardProps.md)\>
 
-Defined in: [packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx:28](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx#L28)
+Defined in: [packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx:27](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx#L27)
 
 Re-usable card for displaying an empty state

--- a/packages/framework/esm-framework/docs/variables/ErrorCard.md
+++ b/packages/framework/esm-framework/docs/variables/ErrorCard.md
@@ -4,4 +4,4 @@
 
 > `const` **ErrorCard**: `FC`\<[`ErrorStateProps`](../interfaces/ErrorStateProps.md)\> = `ErrorState`
 
-Defined in: [packages/framework/esm-styleguide/src/error-state/error-state.component.tsx:29](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/error-state/error-state.component.tsx#L29)
+Defined in: [packages/framework/esm-styleguide/src/error-state/error-state.component.tsx:33](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/error-state/error-state.component.tsx#L33)

--- a/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx
+++ b/packages/framework/esm-styleguide/src/empty-card/empty-card.component.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { Button, Layer, Tile } from '@carbon/react';
 import { useLayoutType } from '@openmrs/esm-react-utils';
 import { getCoreTranslation } from '@openmrs/esm-translations';
-import { CardHeader } from '../cards';
 import styles from './empty-card.module.scss';
 
 export interface EmptyCardProps {
@@ -32,7 +31,9 @@ export const EmptyCard: React.FC<EmptyCardProps> = (props) => {
   return (
     <Layer className={styles.layer}>
       <Tile className={styles.tile}>
-        <CardHeader title={props.headerTitle} />
+        <div className={isTablet ? styles.tabletHeading : styles.desktopHeading}>
+          <h4>{props.headerTitle}</h4>
+        </div>
         <EmptyCardIllustration />
         <p className={styles.content}>
           {getCoreTranslation('emptyStateText', 'There are no {{displayText}} to display', {

--- a/packages/framework/esm-styleguide/src/empty-card/empty-card.module.scss
+++ b/packages/framework/esm-styleguide/src/empty-card/empty-card.module.scss
@@ -13,12 +13,32 @@
   margin-bottom: layout.$spacing-03;
 }
 
-.heading:after {
-  content: '';
-  display: block;
-  width: layout.$spacing-07;
-  padding-top: 0.188rem;
-  border-bottom: 0.375rem solid var(--brand-03);
+.desktopHeading {
+  h4 {
+    @include type.type-style('heading-compact-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeading {
+  h4 {
+    @include type.type-style('heading-03');
+    color: $text-02;
+  }
+}
+
+.desktopHeading,
+.tabletHeading {
+  text-align: left;
+  margin-bottom: layout.$spacing-05;
+
+  h4:after {
+    content: '';
+    display: block;
+    width: layout.$spacing-07;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid var(--brand-03);
+  }
 }
 
 .tile {

--- a/packages/framework/esm-styleguide/src/error-state/error-state.component.tsx
+++ b/packages/framework/esm-styleguide/src/error-state/error-state.component.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Layer, Tile } from '@carbon/react';
+import { useLayoutType } from '@openmrs/esm-react-utils';
 import { getCoreTranslation } from '@openmrs/esm-translations';
 import styles from './error-state.module.scss';
-import { CardHeader } from '../cards';
 
 export interface ErrorStateProps {
   /** The error that caused this error card to be rendered. Expected to be a failed fetch result. */
@@ -12,10 +12,14 @@ export interface ErrorStateProps {
 }
 
 export const ErrorState: React.FC<ErrorStateProps> = ({ error, headerTitle }) => {
+  const isTablet = useLayoutType() === 'tablet';
+
   return (
     <Layer>
       <Tile className={styles.tile}>
-        <CardHeader title={headerTitle} />
+        <div className={isTablet ? styles.tabletHeading : styles.desktopHeading}>
+          <h4>{headerTitle}</h4>
+        </div>
         <p className={styles.errorMessage}>
           {getCoreTranslation('error', 'Error')} {`${error?.response?.status}: `}
           {error?.response?.statusText}

--- a/packages/framework/esm-styleguide/src/error-state/error-state.module.scss
+++ b/packages/framework/esm-styleguide/src/error-state/error-state.module.scss
@@ -15,6 +15,34 @@
   color: $text-02;
 }
 
+.desktopHeading {
+  h4 {
+    @include type.type-style('heading-compact-02');
+    color: $text-02;
+  }
+}
+
+.tabletHeading {
+  h4 {
+    @include type.type-style('heading-03');
+    color: $text-02;
+  }
+}
+
+.desktopHeading,
+.tabletHeading {
+  text-align: left;
+  margin-bottom: layout.$spacing-05;
+
+  h4:after {
+    content: '';
+    display: block;
+    width: layout.$spacing-07;
+    padding-top: 0.188rem;
+    border-bottom: 0.375rem solid var(--brand-03);
+  }
+}
+
 .tile {
   text-align: center;
   border: 1px solid $ui-03;

--- a/packages/framework/esm-styleguide/src/error-state/error-state.test.tsx
+++ b/packages/framework/esm-styleguide/src/error-state/error-state.test.tsx
@@ -31,7 +31,7 @@ describe('ErrorState', () => {
 
     render(<ErrorState headerTitle="test" error={{}} />);
     // eslint-disable-next-line testing-library/no-node-access
-    expect(screen.getByRole('heading').parentElement?.getAttribute('class')).toContain('tabletHeader');
+    expect(screen.getByRole('heading').parentElement?.getAttribute('class')).toContain('tabletHeading');
   });
 
   it('should render desktop layout when layout type is not tablet', () => {
@@ -39,7 +39,7 @@ describe('ErrorState', () => {
 
     render(<ErrorState headerTitle="test" error={{}} />);
     // eslint-disable-next-line testing-library/no-node-access
-    expect(screen.getByRole('heading').parentElement?.getAttribute('class')).toContain('desktopHeader');
+    expect(screen.getByRole('heading').parentElement?.getAttribute('class')).toContain('desktopHeading');
   });
 
   it('should handle error with partial response data', () => {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary

Since the component harvest in #1526, `EmptyCard` and `ErrorState` render `CardHeader` inside a Carbon `Tile`. `CardHeader` carries its own padding and fixed height because it is designed to sit flush at the top of unpadded widget cards, while the `Tile` adds its default 16px padding on every side. Stacked together, the heading rendered 32px from the left edge with extra vertical bulk, so widgets that have migrated to `EmptyCard` (like Procedures) looked visibly different from the legacy `EmptyState` tiles still rendered by most patient chart widgets.

This PR restores the pre-harvest heading markup, a plain `h4` with the desktop/tablet heading styles, in both components. Empty and error tiles now match the legacy patient-common-lib `EmptyState` geometry exactly. Verified against a local patient chart, the migrated Procedures empty state and a legacy Attachments empty state both measure:

| | EmptyCard (Procedures) | Legacy EmptyState (Attachments) |
|---|---|---|
| Tile dimensions | 1238 × 231px | 1238 × 231px |
| Heading offset from tile edge | (16, 16) | (16, 16) |
| Tile top → illustration | 64px | 64px |

One legacy detail deliberately not restored: `text-transform: capitalize` on the heading. It title-cases every word of `headerTitle`, which is a pre-translated string, so callers should control casing.

## Screenshots

### Before

#### Note the extraneous padding around the `Procedures` heading

<img width="2554" height="1628" alt="CleanShot 2026-06-03 at 15 04 16@2x" src="https://github.com/user-attachments/assets/e8a5294a-db52-4851-9143-dd89110eb9fd" />

### After

<img width="2340" height="1630" alt="CleanShot 2026-06-03 at 15 03 54@2x" src="https://github.com/user-attachments/assets/84cfa96e-5232-4eb4-be84-f2d2c12b9ebb" />

## Related Issue

## Other
