### PR TITLE
(feat) Prevent the shared SWR cache being torn down when a decorated component unmounts

### DIFF
--- a/.changeset/fix-swr-shared-cache-teardown.md
+++ b/.changeset/fix-swr-shared-cache-teardown.md
@@ -1,0 +1,5 @@
+---
+"@openmrs/esm-react-utils": patch
+---
+
+Prevent the shared SWR cache from being torn down when a decorated component unmounts. Every component decorated with `openmrsComponentDecorator` mounts its own `<SWRConfig>` over one shared cache; SWR deletes that cache's global state when the first such boundary unmounts, crashing still-mounted components ("undefined is not iterable"). The cache is now pre-initialized so the framework module owns its lifecycle.

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.swr-cache.test.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.swr-cache.test.tsx
@@ -1,0 +1,102 @@
+import React, { useReducer, useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import useSWR from 'swr';
+import { openmrsComponentDecorator } from './openmrsComponentDecorator';
+
+// Regression test for the shared-SWR-cache lifecycle crash.
+//
+// Every component decorated by `openmrsComponentDecorator` mounts its own
+// `<SWRConfig>` over a single shared cache. SWR ties that cache's global state
+// to the first `<SWRConfig>` to initialize it, deleting it when that boundary
+// unmounts. So before the fix, unmounting the first-mounted decorated component
+// while another is still mounted wiped the shared state, and the survivor threw
+// "undefined is not iterable" on its next render (caught by the decorator's
+// error boundary, which then renders "An error has occurred").
+
+function decorate(featureName: string, Inner: React.ComponentType) {
+  return openmrsComponentDecorator({
+    moduleName: featureName.toLowerCase(),
+    featureName,
+    strictMode: false,
+    throwErrorsToConsole: false,
+    disableTranslations: true,
+  })(Inner);
+}
+
+function Widget({ id }: { id: string }) {
+  // Touch SWR so this component reads the shared SWRGlobalState on every render.
+  useSWR(`widget-${id}`, () => Promise.resolve(id));
+  const [count, bump] = useReducer((n) => n + 1, 0);
+  return (
+    <button type="button" onClick={bump}>
+      {id}-{count}
+    </button>
+  );
+}
+
+describe('openmrsComponentDecorator shared SWR cache lifecycle', () => {
+  it('keeps a still-mounted decorated component working after a sibling decorated component unmounts', async () => {
+    const user = userEvent.setup();
+
+    // `A` renders first, so it is the first `<SWRConfig>` to initialize the
+    // shared cache (the boundary that owned SWR's deleter before the fix).
+    const A = decorate('A', () => <Widget id="A" />);
+    const B = decorate('B', () => <Widget id="B" />);
+
+    function Harness() {
+      const [showA, setShowA] = useState(true);
+      return (
+        <div>
+          {showA && <A />}
+          <B />
+          <button type="button" onClick={() => setShowA(false)}>
+            hide-a
+          </button>
+        </div>
+      );
+    }
+
+    render(<Harness />);
+
+    expect(await screen.findByRole('button', { name: 'A-0' })).toBeInTheDocument();
+    expect(await screen.findByRole('button', { name: 'B-0' })).toBeInTheDocument();
+
+    // Unmount the cache-owning component.
+    await user.click(screen.getByRole('button', { name: 'hide-a' }));
+    expect(screen.queryByRole('button', { name: 'A-0' })).not.toBeInTheDocument();
+
+    // Force the still-mounted component to re-render. Before the fix this threw
+    // and the decorator's error boundary replaced B with an error message.
+    await user.click(screen.getByRole('button', { name: 'B-0' }));
+
+    expect(await screen.findByRole('button', { name: 'B-1' })).toBeInTheDocument();
+    expect(screen.queryByText(/an error has occurred/i)).not.toBeInTheDocument();
+  });
+
+  it('shares cached data across separately decorated components (single global cache, #1397)', async () => {
+    const key = `shared-${Math.random()}`;
+
+    function Producer() {
+      const { data } = useSWR(key, () => Promise.resolve('shared-value'));
+      return <span>producer:{data ?? 'loading'}</span>;
+    }
+
+    // The consumer's own fetcher never resolves; if it renders the value, it can
+    // only have come from a cache shared with the producer.
+    function Consumer() {
+      const { data } = useSWR(key, () => new Promise<string>(() => {}));
+      return <span>consumer:{data ?? 'loading'}</span>;
+    }
+
+    const DecoratedProducer = decorate('Producer', Producer);
+    const DecoratedConsumer = decorate('Consumer', Consumer);
+
+    render(<DecoratedProducer />);
+    expect(await screen.findByText('producer:shared-value')).toBeInTheDocument();
+
+    render(<DecoratedConsumer />);
+    expect(await screen.findByText('consumer:shared-value')).toBeInTheDocument();
+  });
+});

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.swr-cache.test.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.swr-cache.test.tsx
@@ -71,7 +71,7 @@ describe('openmrsComponentDecorator shared SWR cache lifecycle', () => {
   });
 
   it('shares cached data across separately decorated components (single global cache, #1397)', async () => {
-    // Fixed key, unique within this file (the default cache persists across renders).
+    // Fixed key, unique within this file (the shared cache persists across renders).
     const key = 'swr-cache-sharing-test';
 
     function Producer() {

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.swr-cache.test.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.swr-cache.test.tsx
@@ -76,7 +76,9 @@ describe('openmrsComponentDecorator shared SWR cache lifecycle', () => {
   });
 
   it('shares cached data across separately decorated components (single global cache, #1397)', async () => {
-    const key = `shared-${Math.random()}`;
+    // A fixed key that no other test uses; the shared default cache persists
+    // across renders within this file, so the key only needs to be unique here.
+    const key = 'swr-cache-sharing-test';
 
     function Producer() {
       const { data } = useSWR(key, () => Promise.resolve('shared-value'));

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.swr-cache.test.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.swr-cache.test.tsx
@@ -5,15 +5,10 @@ import userEvent from '@testing-library/user-event';
 import useSWR from 'swr';
 import { openmrsComponentDecorator } from './openmrsComponentDecorator';
 
-// Regression test for the shared-SWR-cache lifecycle crash.
-//
-// Every component decorated by `openmrsComponentDecorator` mounts its own
-// `<SWRConfig>` over a single shared cache. SWR ties that cache's global state
-// to the first `<SWRConfig>` to initialize it, deleting it when that boundary
-// unmounts. So before the fix, unmounting the first-mounted decorated component
-// while another is still mounted wiped the shared state, and the survivor threw
-// "undefined is not iterable" on its next render (caught by the decorator's
-// error boundary, which then renders "An error has occurred").
+// Regression test for the shared-SWR-cache lifecycle crash: every decorated
+// component has its own `<SWRConfig>`, and SWR deletes a provider cache's state
+// when the first boundary to init it unmounts. Before the fix, that crashed any
+// still-mounted decorated component ("undefined is not iterable").
 
 function decorate(featureName: string, Inner: React.ComponentType) {
   return openmrsComponentDecorator({
@@ -76,8 +71,7 @@ describe('openmrsComponentDecorator shared SWR cache lifecycle', () => {
   });
 
   it('shares cached data across separately decorated components (single global cache, #1397)', async () => {
-    // A fixed key that no other test uses; the shared default cache persists
-    // across renders within this file, so the key only needs to be unique here.
+    // Fixed key, unique within this file (the default cache persists across renders).
     const key = 'swr-cache-sharing-test';
 
     function Producer() {

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
@@ -1,6 +1,6 @@
 import React, { type ComponentType, type ErrorInfo, Suspense } from 'react';
 import { I18nextProvider } from 'react-i18next';
-import { type Cache, SWRConfig, type SWRConfiguration } from 'swr';
+import { SWRConfig, type SWRConfiguration } from 'swr';
 import type {} from '@openmrs/esm-globals';
 import { openmrsFetch, OpenmrsFetchError } from '@openmrs/esm-api';
 import { type ComponentConfig, type ExtensionData } from '@openmrs/esm-extensions';
@@ -11,8 +11,6 @@ const defaultOpts = {
   throwErrorsToConsole: true,
   disableTranslations: false,
 };
-
-const swrCache: Cache = new Map();
 
 // Read more about the available config options here: https://swr.vercel.app/docs/api#configuration
 const defaultSwrConfig: SWRConfiguration = {
@@ -27,6 +25,18 @@ const defaultSwrConfig: SWRConfiguration = {
   revalidateOnFocus: false,
   revalidateOnReconnect: false,
   refreshInterval: 0,
+  // NOTE: deliberately no `provider`. SWR's default cache is already a single
+  // shared instance per swr module, which (because swr is a module-federation
+  // singleton) is shared across every app and extension — so we get one global
+  // cache for free. Do NOT reintroduce a custom `provider: () => sharedMap`
+  // here: SWR ties a provider cache's global state to the lifecycle of the
+  // first `<SWRConfig>` boundary that initializes it (its unmount runs
+  // `SWRGlobalState.delete(cache)`). Since every decorated component mounts its
+  // own `<SWRConfig>`, the first to mount would own that deleter; when it
+  // unmounts while others are still mounted (e.g. navigating the patient chart
+  // or closing a workspace) it wipes the shared state and the survivors crash
+  // on their next render with "undefined is not iterable". The default cache
+  // has no per-boundary owner, so it is never torn down.
   shouldRetryOnError: (error) => {
     if (error instanceof OpenmrsFetchError) {
       const status = error.response.status;
@@ -46,7 +56,6 @@ const defaultSwrConfig: SWRConfiguration = {
 
     return true;
   },
-  provider: () => swrCache,
 };
 
 export interface ComponentDecoratorOptions {
@@ -54,7 +63,10 @@ export interface ComponentDecoratorOptions {
   featureName: string;
   disableTranslations?: boolean;
   strictMode?: boolean;
-  swrConfig?: Partial<Omit<SWRConfiguration, 'fetcher'>>;
+  // `provider` is intentionally omitted: a custom cache provider must not be set
+  // per decorated component (see the note on `defaultSwrConfig` above). `fetcher`
+  // is fixed to `openmrsFetch`.
+  swrConfig?: Partial<Omit<SWRConfiguration, 'fetcher' | 'provider'>>;
 }
 
 export interface OpenmrsReactComponentProps {

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
@@ -1,6 +1,7 @@
 import React, { type ComponentType, type ErrorInfo, Suspense } from 'react';
 import { I18nextProvider } from 'react-i18next';
-import { SWRConfig, type SWRConfiguration } from 'swr';
+import { type Cache, SWRConfig, type SWRConfiguration } from 'swr';
+import { initCache } from 'swr/_internal';
 import type {} from '@openmrs/esm-globals';
 import { openmrsFetch, OpenmrsFetchError } from '@openmrs/esm-api';
 import { type ComponentConfig, type ExtensionData } from '@openmrs/esm-extensions';
@@ -11,6 +12,15 @@ const defaultOpts = {
   throwErrorsToConsole: true,
   disableTranslations: false,
 };
+
+// One global SWR cache shared by every decorated component, the same regardless
+// of module-federation load order (see #1397). It is pre-initialized here so its
+// SWRGlobalState is owned by this (singleton) module, not by the first
+// `<SWRConfig>` that mounts. Otherwise that boundary's unmount would run
+// `SWRGlobalState.delete(swrCache)` and the other still-mounted decorated
+// components would crash on their next render ("undefined is not iterable").
+const swrCache: Cache = new Map();
+initCache(swrCache);
 
 // Read more about the available config options here: https://swr.vercel.app/docs/api#configuration
 const defaultSwrConfig: SWRConfiguration = {
@@ -25,11 +35,6 @@ const defaultSwrConfig: SWRConfiguration = {
   revalidateOnFocus: false,
   revalidateOnReconnect: false,
   refreshInterval: 0,
-  // No custom `provider`: a provider cache is deleted from SWRGlobalState when
-  // the first `<SWRConfig>` to initialize it unmounts, which crashes the other
-  // decorated components still mounted ("undefined is not iterable"). SWR's
-  // default cache has no per-boundary owner and is already global (swr is a
-  // singleton), so don't reintroduce a `provider` here.
   shouldRetryOnError: (error) => {
     if (error instanceof OpenmrsFetchError) {
       const status = error.response.status;
@@ -49,6 +54,7 @@ const defaultSwrConfig: SWRConfiguration = {
 
     return true;
   },
+  provider: () => swrCache,
 };
 
 export interface ComponentDecoratorOptions {

--- a/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
+++ b/packages/framework/esm-react-utils/src/openmrsComponentDecorator.tsx
@@ -25,18 +25,11 @@ const defaultSwrConfig: SWRConfiguration = {
   revalidateOnFocus: false,
   revalidateOnReconnect: false,
   refreshInterval: 0,
-  // NOTE: deliberately no `provider`. SWR's default cache is already a single
-  // shared instance per swr module, which (because swr is a module-federation
-  // singleton) is shared across every app and extension — so we get one global
-  // cache for free. Do NOT reintroduce a custom `provider: () => sharedMap`
-  // here: SWR ties a provider cache's global state to the lifecycle of the
-  // first `<SWRConfig>` boundary that initializes it (its unmount runs
-  // `SWRGlobalState.delete(cache)`). Since every decorated component mounts its
-  // own `<SWRConfig>`, the first to mount would own that deleter; when it
-  // unmounts while others are still mounted (e.g. navigating the patient chart
-  // or closing a workspace) it wipes the shared state and the survivors crash
-  // on their next render with "undefined is not iterable". The default cache
-  // has no per-boundary owner, so it is never torn down.
+  // No custom `provider`: a provider cache is deleted from SWRGlobalState when
+  // the first `<SWRConfig>` to initialize it unmounts, which crashes the other
+  // decorated components still mounted ("undefined is not iterable"). SWR's
+  // default cache has no per-boundary owner and is already global (swr is a
+  // singleton), so don't reintroduce a `provider` here.
   shouldRetryOnError: (error) => {
     if (error instanceof OpenmrsFetchError) {
       const status = error.response.status;
@@ -63,9 +56,7 @@ export interface ComponentDecoratorOptions {
   featureName: string;
   disableTranslations?: boolean;
   strictMode?: boolean;
-  // `provider` is intentionally omitted: a custom cache provider must not be set
-  // per decorated component (see the note on `defaultSwrConfig` above). `fetcher`
-  // is fixed to `openmrsFetch`.
+  // `provider` omitted deliberately (see defaultSwrConfig); `fetcher` is fixed.
   swrConfig?: Partial<Omit<SWRConfiguration, 'fetcher' | 'provider'>>;
 }
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary

`openmrsComponentDecorator` wraps every decorated component in its own `<SWRConfig>` that points at a single module-level cache (`swrCache`, added in #1397 to give one global SWR cache regardless of module-federation load order).

SWR ties a provider cache's global state to the lifecycle of the **first** `<SWRConfig>` boundary that initializes it: that boundary's unmount runs `SWRGlobalState.delete(cache)`. Because every decorated component, extension, and workspace mounts its own `<SWRConfig>` over the one shared cache, whichever mounts first owns that deleter. When it unmounts while others are still mounted (routine on a busy page, e.g. navigating the patient chart or closing a workspace), the shared state is removed — the survivors' next render calls `SWRGlobalState.get(cache)`, which now returns `undefined`, and destructuring that throws `TypeError: undefined is not iterable`. The single-spa error boundary then replaces the page with "An error has occurred".

This is a **single-instance lifecycle bug**: it reproduces with one `swr/_internal` instance and no module federation (see the regression test). It is distinct from the separate multi-instance case — a cache registered in one `swr/_internal` instance being read from another — which `singleton: true` is there to prevent.

This is the cause of the intermittent patient-chart e2e failures (a different chart spec fails each run, e.g. `visit-context-navigation`, `drug-orders`, `attachments`, always a chart page timing out because it was replaced by the error boundary).

### Fix

Keep #1397's single shared cache, but **pre-initialize it once at module load** (`initCache(swrCache)`). That transfers ownership of the cache's `SWRGlobalState` from the first `<SWRConfig>` boundary to this (singleton) framework module: every `<SWRConfig>` then takes SWR's "already initialized" path and none of them registers the deleting cleanup, so the shared state is never torn down. This preserves #1397's guarantee of one global cache regardless of load order (and leaves the global `mutate()` behavior unchanged); it does **not** revert to SWR's default cache.

`ComponentDecoratorOptions['swrConfig']` is also tightened to omit `provider` (alongside the already-omitted `fetcher`), so a caller can't accidentally swap in a different cache provider per component. No current caller passes one.

### Tests

Adds `openmrsComponentDecorator.swr-cache.test.tsx`:
- a regression test that mounts two decorated components over the shared cache, unmounts the first (the owner), re-renders the survivor, and asserts it keeps working (fails without the fix, passes with it);
- a test confirming cached data is still shared across separately decorated components.

## Screenshots

## Related Issue

## Other

This deliberately keeps the single-global-cache design from #1397 (which was introduced to fix data-consistency problems with SWR's default cache under module federation, see #1395 / #774). The only change is to stop binding that cache's lifecycle to a component boundary. Thanks @ibacher for catching that an earlier revision, which dropped the provider, would have reintroduced the #1397 problem.

Because the crash is intermittent (it depends on component mount order), the patient-chart e2e passing once on this PR isn't conclusive by itself; the failing specs can be run repeatedly (this branch vs. `main` as a control) to show the crash rate going to zero.
