### PR TITLE
(feat) O3-5754: Update login location picker to use user-scoped endpoint

### DIFF
--- a/packages/apps/esm-login-app/src/login.resource.ts
+++ b/packages/apps/esm-login-app/src/login.resource.ts
@@ -1,5 +1,4 @@
 import { useEffect, useMemo } from 'react';
-import { useTranslation } from 'react-i18next';
 import useSwrInfinite, { type SWRInfiniteResponse } from 'swr/infinite';
 import useSwrImmutable from 'swr/immutable';
 import {
@@ -10,6 +9,7 @@ import {
   type FetchResponse,
   type Session,
   useDebounce,
+  useSession,
 } from '@openmrs/esm-framework';
 import type { LocationEntry, LocationResponse } from './types';
 
@@ -17,14 +17,14 @@ import type { LocationEntry, LocationResponse } from './types';
 type InfiniteKeyedMutator<T> = SWRInfiniteResponse<T extends (infer I)[] ? I : T>['mutate'];
 
 interface LoginLocationData {
-  error: Error;
+  error: Error | undefined;
   hasMore: boolean;
   isLoading: boolean;
   loadingNewData: boolean;
-  locations: Array<LocationEntry>;
+  locations: Array<LocationEntry> | null;
   mutate: InfiniteKeyedMutator<FetchResponse<LocationResponse>[]>;
   setPage: (size: number | ((_size: number) => number)) => Promise<FetchResponse<LocationResponse>[]>;
-  totalResults: number;
+  totalResults: number | null;
 }
 
 export function useLoginLocations(
@@ -32,10 +32,16 @@ export function useLoginLocations(
   searchQuery: string = '',
   useLoginLocationTag: boolean,
 ): LoginLocationData {
-  const { t } = useTranslation();
+  const { user } = useSession();
+  const userUuid = user?.uuid;
   const debouncedSearchQuery = useDebounce(searchQuery);
 
   function constructUrl(page: number, prevPageData: FetchResponse<LocationResponse>) {
+    // Wait until the user UUID is available before making any request.
+    if (!userUuid) {
+      return null;
+    }
+
     if (prevPageData) {
       const nextLink = prevPageData.data?.link?.find((link) => link.relation === 'next');
 
@@ -56,27 +62,21 @@ export function useLoginLocations(
       ).toString();
     }
 
-    let url = `${fhirBaseUrl}/Location?`;
-    let urlSearchParameters = new URLSearchParams();
-    urlSearchParameters.append('_summary', 'data');
-
-    if (count) {
-      urlSearchParameters.append('_count', '' + count);
-    }
-
-    if (page) {
-      urlSearchParameters.append('_getpagesoffset', '' + page * count);
-    }
+    // Use the user-scoped REST endpoint so the backend filters locations to
+    // only those assigned to this user (falling back to all Login Locations
+    // for users with no explicit mappings).
+    const urlSearchParameters = new URLSearchParams();
 
     if (useLoginLocationTag) {
-      urlSearchParameters.append('_tag', 'Login Location');
+      urlSearchParameters.append('tag', 'Login Location');
     }
 
-    if (typeof debouncedSearchQuery === 'string' && debouncedSearchQuery != '') {
-      urlSearchParameters.append('name:contains', debouncedSearchQuery);
+    if (typeof debouncedSearchQuery === 'string' && debouncedSearchQuery !== '') {
+      urlSearchParameters.append('q', debouncedSearchQuery);
     }
 
-    return url + urlSearchParameters.toString();
+    const queryString = urlSearchParameters.toString();
+    return `${restBaseUrl}/user/${userUuid}/location${queryString ? `?${queryString}` : ''}`;
   }
 
   const { data, isLoading, isValidating, setSize, error, mutate } = useSwrInfinite<

--- a/packages/apps/esm-login-app/src/login.resource.ts
+++ b/packages/apps/esm-login-app/src/login.resource.ts
@@ -76,7 +76,8 @@ export function useLoginLocations(
     }
 
     const queryString = urlSearchParameters.toString();
-    return `${restBaseUrl}/user/${userUuid}/location${queryString ? `?${queryString}` : ''}`;
+    const query = queryString ? '?' + queryString : '';
+    return `${restBaseUrl}/user/${userUuid}/location${query}`;
   }
 
   const { data, isLoading, isValidating, setSize, error, mutate } = useSwrInfinite<

--- a/packages/apps/esm-login-app/src/login/login.resource.test.ts
+++ b/packages/apps/esm-login-app/src/login/login.resource.test.ts
@@ -1,0 +1,113 @@
+import React from 'react';
+import { renderHook, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { openmrsFetch, useSession, type FetchResponse, type Session } from '@openmrs/esm-framework';
+import { SWRConfig } from 'swr';
+import { mockLoginLocations } from '../../__mocks__/locations.mock';
+import { useLoginLocations } from '../login.resource';
+
+const mockOpenmrsFetch = vi.mocked(openmrsFetch);
+const mockUseSession = vi.mocked(useSession);
+
+const userUuid = '90bd24b3-e700-46b0-a5ef-c85afdfededd';
+
+// Provide a fresh SWR cache for every test so results are never served from a
+// previous test's cache. Required because useSwrInfinite caches by URL key.
+const wrapper = ({ children }: { children: React.ReactNode }) =>
+  React.createElement(SWRConfig, { value: { provider: () => new Map() } }, children);
+
+describe('useLoginLocations', () => {
+  beforeEach(() => {
+    mockUseSession.mockReturnValue({
+      user: { uuid: userUuid, display: 'Test User', userProperties: {} },
+      authenticated: true,
+      sessionId: 'test-session-id',
+    } as Session);
+
+    mockOpenmrsFetch.mockResolvedValue(mockLoginLocations as FetchResponse<any>);
+  });
+
+  it('does not fetch until the user UUID is available', async () => {
+    mockUseSession.mockReturnValue({ authenticated: false, sessionId: '' } as Session);
+
+    const { result } = renderHook(() => useLoginLocations(50, '', true), { wrapper });
+
+    // isLoading stays false and no fetch is made because constructUrl returns null
+    expect(result.current.isLoading).toBe(false);
+    expect(mockOpenmrsFetch).not.toHaveBeenCalled();
+  });
+
+  it('calls the user-scoped REST endpoint with the correct user UUID', async () => {
+    const { result } = renderHook(() => useLoginLocations(50, '', true), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const calledUrl = mockOpenmrsFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain(`/ws/rest/v1/user/${userUuid}/location`);
+  });
+
+  it('appends the tag parameter when useLoginLocationTag is true', async () => {
+    const { result } = renderHook(() => useLoginLocations(50, '', true), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const calledUrl = mockOpenmrsFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('tag=Login+Location');
+  });
+
+  it('does not append the tag parameter when useLoginLocationTag is false', async () => {
+    const { result } = renderHook(() => useLoginLocations(50, '', false), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const calledUrl = mockOpenmrsFetch.mock.calls[0][0] as string;
+    expect(calledUrl).not.toContain('tag=');
+  });
+
+  it('appends the search query when a search term is provided', async () => {
+    const { result } = renderHook(() => useLoginLocations(50, 'outpatient', true), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const calledUrl = mockOpenmrsFetch.mock.calls[0][0] as string;
+    expect(calledUrl).toContain('q=outpatient');
+  });
+
+  it('does not append a search query when the search term is empty', async () => {
+    const { result } = renderHook(() => useLoginLocations(50, '', true), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const calledUrl = mockOpenmrsFetch.mock.calls[0][0] as string;
+    expect(calledUrl).not.toContain('q=');
+  });
+
+  it('returns the locations from the response', async () => {
+    const { result } = renderHook(() => useLoginLocations(50, '', true), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.locations).not.toBeNull();
+    });
+
+    expect(result.current.locations).toEqual(mockLoginLocations.data.entry);
+    expect(result.current.totalResults).toBe(4);
+  });
+
+  it('returns null for locations while the user UUID is unavailable', () => {
+    mockUseSession.mockReturnValue({ authenticated: false, sessionId: '' } as Session);
+
+    const { result } = renderHook(() => useLoginLocations(50, '', true), { wrapper });
+
+    expect(result.current.locations).toBeNull();
+  });
+});

--- a/packages/framework/esm-styleguide/src/location-picker/location-picker.resource.ts
+++ b/packages/framework/esm-styleguide/src/location-picker/location-picker.resource.ts
@@ -1,9 +1,9 @@
 import { useMemo } from 'react';
 import useSwrImmutable from 'swr/immutable';
 import useSwrInfinite from 'swr/infinite';
-import { type FetchResponse, fhirBaseUrl, openmrsFetch } from '@openmrs/esm-api';
+import { type FetchResponse, fhirBaseUrl, openmrsFetch, restBaseUrl } from '@openmrs/esm-api';
 import { type FHIRLocationResource } from '@openmrs/esm-emr-api';
-import { useDebounce } from '@openmrs/esm-react-utils';
+import { useDebounce, useSession } from '@openmrs/esm-react-utils';
 
 export interface LocationResponse {
   type: string;
@@ -73,8 +73,16 @@ export function useLocationByUuid(locationUuid?: string) {
  * @category API
  */
 export function useLocations(locationTag?: string, count: number = 0, searchQuery: string = ''): LoginLocationData {
+  const { user } = useSession();
+  const userUuid = user?.uuid;
   const debouncedSearchQuery = useDebounce(searchQuery);
+
   function constructUrl(page: number, prevPageData: FetchResponse<LocationResponse>) {
+    // Wait until the user UUID is available before making any request.
+    if (!userUuid) {
+      return null;
+    }
+
     if (prevPageData) {
       const nextLink = prevPageData.data?.link?.find((link) => link.relation === 'next');
 
@@ -95,27 +103,21 @@ export function useLocations(locationTag?: string, count: number = 0, searchQuer
       ).toString();
     }
 
-    let url = `${fhirBaseUrl}/Location?`;
-    let urlSearchParameters = new URLSearchParams();
-    urlSearchParameters.append('_summary', 'data');
-
-    if (count) {
-      urlSearchParameters.append('_count', '' + count);
-    }
-
-    if (page) {
-      urlSearchParameters.append('_getpagesoffset', '' + page * count);
-    }
+    // Use the user-scoped REST endpoint so the backend filters locations to
+    // only those assigned to this user (falling back to all Login Locations
+    // for users with no explicit mappings).
+    const urlSearchParameters = new URLSearchParams();
 
     if (locationTag) {
-      urlSearchParameters.append('_tag', locationTag);
+      urlSearchParameters.append('tag', locationTag);
     }
 
     if (typeof debouncedSearchQuery === 'string' && debouncedSearchQuery !== '') {
-      urlSearchParameters.append('name:contains', debouncedSearchQuery);
+      urlSearchParameters.append('q', debouncedSearchQuery);
     }
 
-    return url + urlSearchParameters.toString();
+    const queryString = urlSearchParameters.toString();
+    return `${restBaseUrl}/user/${userUuid}/location${queryString ? `?${queryString}` : ''}`;
   }
 
   const { data, isLoading, isValidating, setSize, error } = useSwrInfinite<FetchResponse<LocationResponse>, Error>(

--- a/packages/framework/esm-styleguide/src/location-picker/location-picker.resource.ts
+++ b/packages/framework/esm-styleguide/src/location-picker/location-picker.resource.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import useSwrImmutable from 'swr/immutable';
 import useSwrInfinite from 'swr/infinite';
-import { type FetchResponse, fhirBaseUrl, openmrsFetch, restBaseUrl } from '@openmrs/esm-api';
+import { type FetchResponse, openmrsFetch, restBaseUrl } from '@openmrs/esm-api';
 import { type FHIRLocationResource } from '@openmrs/esm-emr-api';
 import { useDebounce, useSession } from '@openmrs/esm-react-utils';
 

--- a/packages/framework/esm-styleguide/src/location-picker/location-picker.resource.ts
+++ b/packages/framework/esm-styleguide/src/location-picker/location-picker.resource.ts
@@ -117,7 +117,8 @@ export function useLocations(locationTag?: string, count: number = 0, searchQuer
     }
 
     const queryString = urlSearchParameters.toString();
-    return `${restBaseUrl}/user/${userUuid}/location${queryString ? `?${queryString}` : ''}`;
+    const query = queryString ? '?' + queryString : '';
+    return `${restBaseUrl}/user/${userUuid}/location${query}`;
   }
 
   const { data, isLoading, isValidating, setSize, error } = useSwrInfinite<FetchResponse<LocationResponse>, Error>(


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks to reflect any API changes.

## Summary
Replaces the generic `GET /ws/fhir2/R4/Location` call in the login location picker with a user-scoped endpoint `GET /ws/rest/v1/user/{uuid}/location`, so users only see locations relevant to them. The user UUID is sourced from `useSession()`. 
Fallback logic lives entirely server-side, so deployments without user-location mappings are unaffected.

## Screenshots
No UI changes.

## Related Issue
https://openmrs.atlassian.net/browse/O3-5754
https://openmrs.atlassian.net/browse/TRUNK-6669

## Other
⚠️ Draft — blocked on [TRUNK-6669](https://openmrs.atlassian.net/browse/TRUNK-6669). 
Backend endpoint not yet implemented. Ticket still at needs assessment stage

[TRUNK-6669]: https://openmrs.atlassian.net/browse/TRUNK-6669?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ