### PR TITLE
(feat) O3-5763: Add shared VisitSummary component to esm-styleguide

### DIFF
--- a/packages/framework/esm-styleguide/mock-jest.tsx
+++ b/packages/framework/esm-styleguide/mock-jest.tsx
@@ -201,6 +201,8 @@ export const DiagnosisTags = jest.fn(({ diagnoses }: { diagnoses: Array<Diagnosi
   </>
 ));
 
+export const VisitSummary = jest.fn(() => <div>Visit Summary</div>);
+
 export const Workspace2 = jest.fn(({ title, children }) => (
   <div>
     <h1>{title}</h1>

--- a/packages/framework/esm-styleguide/mock.tsx
+++ b/packages/framework/esm-styleguide/mock.tsx
@@ -202,6 +202,8 @@ export const DiagnosisTags = vi.fn(({ diagnoses }: { diagnoses: Array<Diagnosis>
   </>
 ));
 
+export const VisitSummary = vi.fn(() => <div>Visit Summary</div>);
+
 export const Workspace2 = vi.fn(({ title, children }) => (
   <div>
     <h1>{title}</h1>

--- a/packages/framework/esm-styleguide/src/internal.ts
+++ b/packages/framework/esm-styleguide/src/internal.ts
@@ -22,6 +22,7 @@ export * from './patient-banner';
 export * from './patient-photo';
 export * from './pictograms/pictograms';
 export * from './responsive-wrapper';
+export * from './visit-summary';
 export * from './snackbars';
 export * from './snackbars/snackbar.component';
 export * from './spinner';

--- a/packages/framework/esm-styleguide/src/public.ts
+++ b/packages/framework/esm-styleguide/src/public.ts
@@ -24,6 +24,7 @@ export * from './patient-banner';
 export * from './patient-photo';
 export * from './pictograms/pictograms';
 export * from './responsive-wrapper';
+export * from './visit-summary';
 export { showSnackbar, type SnackbarDescriptor, type SnackbarType, type SnackbarMeta } from './snackbars';
 export { showToast, type ToastDescriptor, type ToastType, type ToastNotificationMeta } from './toasts';
 export * from './workspaces/public';

--- a/packages/framework/esm-styleguide/src/visit-summary/index.ts
+++ b/packages/framework/esm-styleguide/src/visit-summary/index.ts
@@ -1,0 +1,1 @@
+export { default as VisitSummary } from './visit-summary.component';

--- a/packages/framework/esm-styleguide/src/visit-summary/medications-summary.component.tsx
+++ b/packages/framework/esm-styleguide/src/visit-summary/medications-summary.component.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { capitalize } from 'lodash-es';
+import { Tag, Tooltip } from '@carbon/react';
+import { useTranslation } from 'react-i18next';
+import { formatDate } from '@openmrs/esm-utils';
+import { EmptyCard } from '../empty-card';
+import { type OrderItem } from './types';
+import styles from './visit-detail-overview.module.scss';
+
+interface MedicationSummaryProps {
+  medications: Array<OrderItem>;
+  drugOrderTypeUUID: string;
+}
+
+const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications, drugOrderTypeUUID }) => {
+  const { t } = useTranslation();
+
+  const isDiscontinued = (order: OrderItem['order']) => {
+    if (!order?.dateStopped) {
+      return false;
+    }
+
+    return new Date(order.dateStopped) < new Date();
+  };
+
+  const drugOrders = medications?.filter((medication) => {
+    return medication?.order?.orderType?.uuid === drugOrderTypeUUID;
+  });
+
+  if (drugOrders.length === 0) {
+    return (
+      <EmptyCard displayText={t('medications__lower', 'medications')} headerTitle={t('medications', 'Medications')} />
+    );
+  }
+
+  return (
+    <div className={styles.medicationRecord}>
+      {drugOrders.map(
+        (medication, index) =>
+          (medication?.order?.dose != null || medication?.order?.dosingInstructions) && (
+            <React.Fragment key={index}>
+              <div className={styles.medicationContainer}>
+                <div>
+                  <p className={styles.bodyLong01}>
+                    <strong>{capitalize(medication?.order?.drug?.display)}</strong>{' '}
+                    {medication?.order?.drug?.strength && (
+                      <>&mdash; {medication?.order?.drug?.strength?.toLowerCase()}</>
+                    )}{' '}
+                    {medication?.order?.doseUnits?.display && (
+                      <>&mdash; {medication?.order?.doseUnits?.display?.toLowerCase()}</>
+                    )}{' '}
+                    {isDiscontinued(medication.order) && (
+                      <Tooltip align="right" label={<>{formatDate(new Date(medication.order.dateStopped as Date))}</>}>
+                        <Tag type="gray" className={styles.tag}>
+                          {t('discontinued', 'Discontinued')}
+                        </Tag>
+                      </Tooltip>
+                    )}
+                  </p>
+                  <p className={styles.bodyLong01}>
+                    {medication?.order?.dose != null ? (
+                      <>
+                        <span className={styles.label01}> {t('dose', 'Dose').toUpperCase()} </span>{' '}
+                        <span className={styles.dosage}>
+                          {medication?.order?.dose} {medication?.order?.doseUnits?.display?.toLowerCase()}
+                        </span>{' '}
+                        {medication.order?.route?.display && (
+                          <span>&mdash; {medication?.order?.route?.display?.toLowerCase()} </span>
+                        )}
+                        {medication?.order?.frequency?.display && (
+                          <>
+                            {medication.order?.route?.display ? <>&mdash; </> : null}
+                            {medication?.order?.frequency?.display?.toLowerCase()}{' '}
+                          </>
+                        )}
+                        {medication?.order?.duration != null && (
+                          <>
+                            &mdash;{' '}
+                            {t('orderDurationAndUnit', 'for {{duration}} {{durationUnit}}', {
+                              duration: medication?.order?.duration,
+                              durationUnit: medication?.order?.durationUnits?.display?.toLowerCase(),
+                            })}
+                          </>
+                        )}
+                        {medication?.order?.duration == null && (
+                          <>&mdash; {t('orderIndefiniteDuration', 'Indefinite duration')}</>
+                        )}
+                        {medication?.order?.numRefills != null && medication?.order?.numRefills !== 0 && (
+                          <span>
+                            <span className={styles.label01}> &mdash; {t('refills', 'Refills').toUpperCase()}</span>{' '}
+                            {medication?.order?.numRefills}
+                          </span>
+                        )}
+                        {medication?.order?.dosingInstructions && (
+                          <span> &mdash; {medication?.order?.dosingInstructions?.toLocaleLowerCase()}</span>
+                        )}
+                      </>
+                    ) : (
+                      <>
+                        <span className={styles.label01}>
+                          {t('dosingInstructions', 'Dosing Instructions').toUpperCase()}{' '}
+                        </span>
+                        <span className={styles.dosage}>{medication?.order?.dosingInstructions}</span>
+                        {medication?.order?.duration != null && (
+                          <span>
+                            {' '}
+                            &mdash;{' '}
+                            {t('orderDurationAndUnit', 'for {{duration}} {{durationUnit}}', {
+                              duration: medication?.order?.duration,
+                              durationUnit: medication?.order?.durationUnits?.display?.toLowerCase(),
+                            })}
+                          </span>
+                        )}
+                        {medication?.order?.numRefills != null && medication?.order?.numRefills !== 0 && (
+                          <span>
+                            <span className={styles.label01}> &mdash; {t('refills', 'Refills').toUpperCase()}</span>{' '}
+                            {medication?.order?.numRefills}
+                          </span>
+                        )}
+                      </>
+                    )}
+                  </p>
+                  <p className={styles.bodyLong01}>
+                    {medication?.order?.orderReasonNonCoded ? (
+                      <span>
+                        <span className={styles.label01}>{t('indication', 'Indication').toUpperCase()}</span>{' '}
+                        {medication?.order?.orderReasonNonCoded}
+                      </span>
+                    ) : null}
+                    {medication?.order?.orderReasonNonCoded && medication?.order?.quantity != null && <>&mdash;</>}
+                    {medication?.order?.quantity != null ? (
+                      <span>
+                        <span className={styles.label01}> {t('quantity', 'Quantity').toUpperCase()}</span>{' '}
+                        {medication?.order?.quantity}
+                      </span>
+                    ) : null}
+                    {medication?.order?.dateStopped ? (
+                      <span className={styles.bodyShort01}>
+                        <span className={styles.label01}>
+                          {medication?.order?.quantity != null ? ` — ` : ''} {t('endDate', 'End date').toUpperCase()}
+                        </span>{' '}
+                        {formatDate(new Date(medication?.order?.dateStopped))}
+                      </span>
+                    ) : null}
+                  </p>
+                </div>
+              </div>
+
+              <p className={styles.metadata}>
+                <div className={styles.startDateColumn}>
+                  <span>{formatDate(new Date(medication.order.dateActivated))}</span> &middot;{' '}
+                  <span>{medication.order.orderer?.display ?? '--'}</span>
+                </div>
+              </p>
+            </React.Fragment>
+          ),
+      )}
+    </div>
+  );
+};
+
+export default MedicationSummary;

--- a/packages/framework/esm-styleguide/src/visit-summary/medications-summary.component.tsx
+++ b/packages/framework/esm-styleguide/src/visit-summary/medications-summary.component.tsx
@@ -23,7 +23,7 @@ const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications, drug
     return new Date(order.dateStopped) < new Date();
   };
 
-  const drugOrders = medications?.filter((medication) => {
+  const drugOrders = medications.filter((medication) => {
     return medication?.order?.orderType?.uuid === drugOrderTypeUUID;
   });
 
@@ -36,9 +36,9 @@ const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications, drug
   return (
     <div className={styles.medicationRecord}>
       {drugOrders.map(
-        (medication, index) =>
+        (medication) =>
           (medication?.order?.dose != null || medication?.order?.dosingInstructions) && (
-            <React.Fragment key={index}>
+            <React.Fragment key={medication.order.uuid}>
               <div className={styles.medicationContainer}>
                 <div>
                   <p className={styles.bodyLong01}>
@@ -58,7 +58,30 @@ const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications, drug
                     )}
                   </p>
                   <p className={styles.bodyLong01}>
-                    {medication?.order?.dose != null ? (
+                    {medication?.order?.dose == null ? (
+                      <>
+                        <span className={styles.label01}>
+                          {t('dosingInstructions', 'Dosing Instructions').toUpperCase()}{' '}
+                        </span>
+                        <span className={styles.dosage}>{medication?.order?.dosingInstructions}</span>
+                        {medication?.order?.duration != null && (
+                          <span>
+                            {' '}
+                            &mdash;{' '}
+                            {t('orderDurationAndUnit', 'for {{duration}} {{durationUnit}}', {
+                              duration: medication?.order?.duration,
+                              durationUnit: medication?.order?.durationUnits?.display?.toLowerCase(),
+                            })}
+                          </span>
+                        )}
+                        {medication?.order?.numRefills != null && medication?.order?.numRefills !== 0 && (
+                          <span>
+                            <span className={styles.label01}> &mdash; {t('refills', 'Refills').toUpperCase()}</span>{' '}
+                            {medication?.order?.numRefills}
+                          </span>
+                        )}
+                      </>
+                    ) : (
                       <>
                         <span className={styles.label01}> {t('dose', 'Dose').toUpperCase()} </span>{' '}
                         <span className={styles.dosage}>
@@ -95,29 +118,6 @@ const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications, drug
                           <span> &mdash; {medication?.order?.dosingInstructions?.toLocaleLowerCase()}</span>
                         )}
                       </>
-                    ) : (
-                      <>
-                        <span className={styles.label01}>
-                          {t('dosingInstructions', 'Dosing Instructions').toUpperCase()}{' '}
-                        </span>
-                        <span className={styles.dosage}>{medication?.order?.dosingInstructions}</span>
-                        {medication?.order?.duration != null && (
-                          <span>
-                            {' '}
-                            &mdash;{' '}
-                            {t('orderDurationAndUnit', 'for {{duration}} {{durationUnit}}', {
-                              duration: medication?.order?.duration,
-                              durationUnit: medication?.order?.durationUnits?.display?.toLowerCase(),
-                            })}
-                          </span>
-                        )}
-                        {medication?.order?.numRefills != null && medication?.order?.numRefills !== 0 && (
-                          <span>
-                            <span className={styles.label01}> &mdash; {t('refills', 'Refills').toUpperCase()}</span>{' '}
-                            {medication?.order?.numRefills}
-                          </span>
-                        )}
-                      </>
                     )}
                   </p>
                   <p className={styles.bodyLong01}>
@@ -128,16 +128,16 @@ const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications, drug
                       </span>
                     ) : null}
                     {medication?.order?.orderReasonNonCoded && medication?.order?.quantity != null && <>&mdash;</>}
-                    {medication?.order?.quantity != null ? (
+                    {medication?.order?.quantity != null && (
                       <span>
                         <span className={styles.label01}> {t('quantity', 'Quantity').toUpperCase()}</span>{' '}
                         {medication?.order?.quantity}
                       </span>
-                    ) : null}
+                    )}
                     {medication?.order?.dateStopped ? (
                       <span className={styles.bodyShort01}>
                         <span className={styles.label01}>
-                          {medication?.order?.quantity != null ? ` — ` : ''} {t('endDate', 'End date').toUpperCase()}
+                          {medication?.order?.quantity != null && ` — `} {t('endDate', 'End date').toUpperCase()}
                         </span>{' '}
                         {formatDate(new Date(medication?.order?.dateStopped))}
                       </span>
@@ -146,12 +146,12 @@ const MedicationSummary: React.FC<MedicationSummaryProps> = ({ medications, drug
                 </div>
               </div>
 
-              <p className={styles.metadata}>
+              <div className={styles.metadata}>
                 <div className={styles.startDateColumn}>
                   <span>{formatDate(new Date(medication.order.dateActivated))}</span> &middot;{' '}
                   <span>{medication.order.orderer?.display ?? '--'}</span>
                 </div>
-              </p>
+              </div>
             </React.Fragment>
           ),
       )}

--- a/packages/framework/esm-styleguide/src/visit-summary/notes-summary.component.tsx
+++ b/packages/framework/esm-styleguide/src/visit-summary/notes-summary.component.tsx
@@ -18,8 +18,8 @@ const NotesSummary: React.FC<NotesSummaryProps> = ({ notes }) => {
 
   return (
     <>
-      {notes.map((note: Note, index) => (
-        <div className={styles.notesContainer} key={index}>
+      {notes.map((note: Note) => (
+        <div className={styles.notesContainer} key={note.id}>
           <p className={classNames(styles.noteText, styles.bodyLong01)}>{note.note}</p>
           <p className={styles.metadata}>
             {note.time} {note.provider.name ? <span>&middot; {note.provider.name} </span> : null}

--- a/packages/framework/esm-styleguide/src/visit-summary/notes-summary.component.tsx
+++ b/packages/framework/esm-styleguide/src/visit-summary/notes-summary.component.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import classNames from 'classnames';
+import { useTranslation } from 'react-i18next';
+import type { Note } from './types';
+import { EmptyCard } from '../empty-card';
+import styles from './visit-detail-overview.module.scss';
+
+interface NotesSummaryProps {
+  notes: Array<Note>;
+}
+
+const NotesSummary: React.FC<NotesSummaryProps> = ({ notes }) => {
+  const { t } = useTranslation();
+
+  if (notes.length === 0) {
+    return <EmptyCard displayText={t('notes__lower', 'notes')} headerTitle={t('notes', 'Notes')} />;
+  }
+
+  return (
+    <>
+      {notes.map((note: Note, index) => (
+        <div className={styles.notesContainer} key={index}>
+          <p className={classNames(styles.noteText, styles.bodyLong01)}>{note.note}</p>
+          <p className={styles.metadata}>
+            {note.time} {note.provider.name ? <span>&middot; {note.provider.name} </span> : null}
+            {note.provider.role ? <span>&middot; {note.provider.role}</span> : null}
+          </p>
+        </div>
+      ))}
+    </>
+  );
+};
+
+export default NotesSummary;

--- a/packages/framework/esm-styleguide/src/visit-summary/tests-summary.component.tsx
+++ b/packages/framework/esm-styleguide/src/visit-summary/tests-summary.component.tsx
@@ -6,9 +6,9 @@ type FilteredResultsFilter = (data: [{ encounter?: { reference?: string } }]) =>
 
 const TestsSummary = ({ patientUuid, encounters = [] }: { patientUuid: string; encounters: Array<Encounter> }) => {
   const filter = React.useMemo<FilteredResultsFilter>(() => {
-    const encounterIds = encounters.map((e) => `Encounter/${e.uuid}`);
+    const encounterIds = new Set(encounters.map((e) => `Encounter/${e.uuid}`));
     return ([entry]) => {
-      return encounterIds.includes(entry.encounter?.reference ?? '');
+      return encounterIds.has(entry.encounter?.reference ?? '');
     };
   }, [encounters]);
 

--- a/packages/framework/esm-styleguide/src/visit-summary/tests-summary.component.tsx
+++ b/packages/framework/esm-styleguide/src/visit-summary/tests-summary.component.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { ExtensionSlot } from '@openmrs/esm-react-utils';
+import { type Encounter } from '@openmrs/esm-emr-api';
+
+type FilteredResultsFilter = (data: [{ encounter?: { reference?: string } }]) => boolean;
+
+const TestsSummary = ({ patientUuid, encounters = [] }: { patientUuid: string; encounters: Array<Encounter> }) => {
+  const filter = React.useMemo<FilteredResultsFilter>(() => {
+    const encounterIds = encounters.map((e) => `Encounter/${e.uuid}`);
+    return ([entry]) => {
+      return encounterIds.includes(entry.encounter?.reference ?? '');
+    };
+  }, [encounters]);
+
+  return <ExtensionSlot name="test-results-filtered-overview-slot" state={{ filter, patientUuid }} />;
+};
+
+export default TestsSummary;

--- a/packages/framework/esm-styleguide/src/visit-summary/types.ts
+++ b/packages/framework/esm-styleguide/src/visit-summary/types.ts
@@ -1,0 +1,65 @@
+import { type OpenmrsResource } from '@openmrs/esm-api';
+
+export interface Order {
+  uuid: string;
+  action?: string | null;
+  autoExpireDate?: Date | null;
+  dateActivated: string;
+  dateStopped?: Date | null;
+  fulfillerStatus?: string | null;
+  dose: number;
+  dosingInstructions: string | null;
+  dosingType?: 'org.openmrs.FreeTextDosingInstructions' | 'org.openmrs.SimpleDosingInstructions';
+  doseUnits: {
+    uuid: string;
+    display: string;
+  };
+  drug: {
+    uuid: string;
+    name: string;
+    strength: string;
+    display: string;
+  };
+  duration: number;
+  durationUnits: {
+    uuid: string;
+    display: string;
+  };
+  frequency: {
+    uuid: string;
+    display: string;
+  };
+  numRefills: number;
+  orderNumber: string;
+  orderReason: string | null;
+  orderReasonNonCoded: string | null;
+  orderer: OpenmrsResource;
+  orderType: {
+    uuid: string;
+    display: string;
+  };
+  route: {
+    uuid: string;
+    display: string;
+  };
+  quantity: number;
+  quantityUnits: OpenmrsResource;
+}
+
+export interface Note {
+  concept: OpenmrsResource;
+  note: string;
+  provider: {
+    name: string;
+    role: string;
+  };
+  time: string;
+}
+
+export interface OrderItem {
+  order: Order;
+  provider: {
+    name: string;
+    role: string;
+  };
+}

--- a/packages/framework/esm-styleguide/src/visit-summary/types.ts
+++ b/packages/framework/esm-styleguide/src/visit-summary/types.ts
@@ -47,6 +47,7 @@ export interface Order {
 }
 
 export interface Note {
+  id: string;
   concept: OpenmrsResource;
   note: string;
   provider: {

--- a/packages/framework/esm-styleguide/src/visit-summary/useEncountersByVisit.ts
+++ b/packages/framework/esm-styleguide/src/visit-summary/useEncountersByVisit.ts
@@ -1,0 +1,18 @@
+import { restBaseUrl } from '@openmrs/esm-api';
+import { useOpenmrsFetchAll } from '@openmrs/esm-react-utils';
+import { type Encounter } from '@openmrs/esm-emr-api';
+
+interface UseEncountersByVisitResult {
+  encounters: Array<Encounter> | undefined;
+  isLoading: boolean;
+  error: Error | undefined;
+}
+
+export function useEncountersByVisit(patientUuid: string, visitUuid: string): UseEncountersByVisitResult {
+  const customRepresentation =
+    'custom:(uuid,encounterType:(uuid,display),encounterProviders:(provider:(person:(display))),encounterDatetime,visit:(uuid))';
+  const url = `${restBaseUrl}/encounter?patient=${patientUuid}&order=desc&visit=${visitUuid}&v=${customRepresentation}`;
+  const { data: encounters, isLoading, error } = useOpenmrsFetchAll<Encounter>(url);
+
+  return { encounters, isLoading, error };
+}

--- a/packages/framework/esm-styleguide/src/visit-summary/visit-detail-overview.module.scss
+++ b/packages/framework/esm-styleguide/src/visit-summary/visit-detail-overview.module.scss
@@ -1,0 +1,258 @@
+@use '@carbon/colors';
+@use '@carbon/layout';
+@use '@carbon/type';
+@use '@openmrs/esm-styleguide/src/vars' as *;
+
+.visitType {
+  @include type.type-style('heading-compact-02');
+  color: $text-02;
+  margin-bottom: 5px;
+}
+
+.date {
+  @include type.type-style('body-compact-01');
+  color: $text-02;
+  padding-right: 0.625rem;
+}
+
+.dateLabel {
+  padding-right: 0.313rem;
+}
+
+.displayFlex {
+  display: flex;
+  align-items: center;
+  justify-content: left;
+}
+
+.container {
+  background-color: $ui-background;
+  border: 1px solid $grey-2;
+  padding: layout.$spacing-05;
+  margin: layout.$spacing-05 0 layout.$spacing-05;
+  width: 100%;
+}
+
+.tabs > :global(.cds--tab-content) {
+  padding: 0 0 !important;
+}
+
+.tabList {
+  position: sticky;
+  top: 3rem;
+  z-index: 10;
+  background-color: $ui-01;
+  box-shadow: inset 0 -2px 0 0 $ui-03;
+}
+
+.tab {
+  height: 2.5rem;
+
+  &:active,
+  &:focus {
+    outline: none !important;
+  }
+
+  &:global(.cds--tabs__nav-item--selected) {
+    border-bottom-color: var(--brand-03);
+  }
+}
+
+.header {
+  .visitInfo {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+}
+
+.header::after {
+  content: '';
+  display: block;
+  width: layout.$spacing-07;
+  padding-top: 0.188rem;
+  border-bottom: 0.375rem solid var(--brand-03);
+}
+
+.toggleButtons {
+  margin: 0 layout.$spacing-05;
+  height: layout.$spacing-08;
+}
+
+.toggle {
+  border: 1px solid colors.$blue-30;
+
+  &:hover {
+    background-color: $color-blue-10;
+  }
+
+  &:active,
+  &:focus {
+    box-shadow: none;
+    background-color: $color-blue-10;
+  }
+
+  &:first-of-type {
+    border-radius: layout.$spacing-02 0 0 layout.$spacing-02;
+  }
+
+  &:last-of-type {
+    border-radius: 0 layout.$spacing-02 layout.$spacing-02 0;
+  }
+}
+
+.emptyStateContainer {
+  text-align: center;
+  margin: layout.$spacing-05 0;
+}
+
+.observation {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  grid-gap: layout.$spacing-03;
+  margin: layout.$spacing-05 layout.$spacing-05 0 0;
+}
+
+.observation > span {
+  align-self: center;
+}
+
+.flexSections {
+  display: flex;
+}
+
+.desktopTabs {
+  button {
+    height: layout.$spacing-07;
+  }
+}
+
+.tabletTabs {
+  button {
+    height: layout.$spacing-09;
+  }
+}
+
+.tabContent {
+  border-top: 1px solid $ui-03;
+  padding: layout.$spacing-05 0;
+  width: 70%;
+}
+
+.medicationRecord {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+
+  .bodyLong01 {
+    gap: layout.$spacing-02;
+    margin: layout.$spacing-02 0;
+  }
+}
+
+.medicationContainer {
+  background-color: $ui-01;
+  padding: layout.$spacing-05;
+  width: 100% !important;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+}
+
+.medicationContainer > div {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  width: 100%;
+}
+
+.medicationContainer p {
+  margin: layout.$spacing-02 0;
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.dosage {
+  @include type.type-style('heading-compact-01');
+}
+
+.toggleSwitch {
+  display: flex;
+  flex-direction: row;
+  justify-content: flex-end;
+  margin-bottom: layout.$spacing-02;
+}
+
+.toggleSwitch div {
+  width: 30%;
+}
+
+.noteText {
+  background-color: $ui-01;
+  padding: layout.$spacing-05;
+  width: 100% !important;
+  white-space: pre-wrap;
+}
+
+.metadata {
+  @include type.type-style('label-01');
+  color: $text-02;
+  margin: layout.$spacing-03 0 layout.$spacing-05;
+}
+
+.observationsEmptyState {
+  margin-top: layout.$spacing-06;
+}
+
+.loader {
+  margin: 0 auto;
+}
+
+.notesContainer {
+  margin-bottom: layout.$spacing-07;
+}
+
+.visitDetailOverviewActions {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
+}
+
+.loadMoreButton {
+  :global(.cds--inline-loading) {
+    min-height: layout.$spacing-05 !important;
+  }
+
+  :global(.cds--inline-loading__text) {
+    font-size: unset !important;
+  }
+}
+
+.label01 {
+  @include type.type-style('label-01');
+}
+
+.tag {
+  margin: 0 layout.$spacing-02 0 !important;
+  text-transform: uppercase;
+}
+
+.text02 {
+  color: colors.$gray-70;
+}
+
+.bodyLong01 {
+  @include type.type-style('body-01');
+}
+
+// Overriding styles for RTL support
+html[dir='rtl'] {
+  .header {
+    .visitInfo {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+    }
+  }
+}

--- a/packages/framework/esm-styleguide/src/visit-summary/visit-summary.component.tsx
+++ b/packages/framework/esm-styleguide/src/visit-summary/visit-summary.component.tsx
@@ -1,0 +1,172 @@
+import React, { useMemo } from 'react';
+import classNames from 'classnames';
+import { useTranslation } from 'react-i18next';
+import { Tab, TabList, TabPanel, TabPanels, Tabs } from '@carbon/react';
+import { Extension, ExtensionSlot, useAssignedExtensions } from '@openmrs/esm-react-utils';
+import { formatTime, parseDate } from '@openmrs/esm-utils';
+import { type Diagnosis, type Visit } from '@openmrs/esm-emr-api';
+import { DiagnosisTags } from '../diagnosis-tags/diagnosis-tags.component';
+import type { Note, Order, OrderItem } from './types';
+import MedicationSummary from './medications-summary.component';
+import NotesSummary from './notes-summary.component';
+import TestsSummary from './tests-summary.component';
+import VisitTimeline from './visit-timeline.component';
+import styles from './visit-summary.module.scss';
+
+interface VisitSummaryProps {
+  visit: Visit;
+  patientUuid: string;
+  /** Concept UUIDs whose observations are rendered as visit notes. */
+  notesConceptUuids?: Array<string>;
+  /** Order type UUID used to filter drug orders in the medications tab. */
+  drugOrderTypeUUID: string;
+  /** When true, tabs with no data are disabled. */
+  disableEmptyTabs?: boolean;
+}
+
+const visitSummaryPanelSlot = 'visit-summary-panels';
+const visitSummaryCompletedFormsSlot = 'visit-summary-completed-forms-slot';
+
+const VisitSummary: React.FC<VisitSummaryProps> = ({
+  visit,
+  patientUuid,
+  notesConceptUuids = [],
+  drugOrderTypeUUID,
+  disableEmptyTabs,
+}) => {
+  const { t } = useTranslation();
+  const extensions = useAssignedExtensions(visitSummaryPanelSlot);
+  const completedFormsExtensions = useAssignedExtensions(visitSummaryCompletedFormsSlot);
+
+  const [diagnoses, notes, medications]: [Array<Diagnosis>, Array<Note>, Array<OrderItem>] = useMemo(() => {
+    // Medication Tab
+    const medications: Array<OrderItem> = [];
+    // Diagnoses in a Visit
+    const diagnoses: Array<Diagnosis> = [];
+    // Notes Tab
+    const notes: Array<Note> = [];
+
+    visit?.encounters?.forEach((enc) => {
+      const provider = {
+        name: enc.encounterProviders?.[0]?.provider?.person?.display ?? '',
+        role: enc.encounterProviders?.[0]?.encounterRole?.display ?? '',
+      };
+
+      enc.orders?.forEach((order: Order) => {
+        medications.push({ order, provider });
+      });
+
+      // Check if there is a diagnosis associated with this encounter
+      const validDiagnoses = enc.diagnoses?.filter((diagnosis) => !diagnosis.voided) ?? [];
+      diagnoses.push(...validDiagnoses);
+
+      // Check for Visit Diagnoses and Notes
+      enc.obs?.forEach((obs) => {
+        if (obs.concept && notesConceptUuids?.includes(obs.concept.uuid)) {
+          // Putting all notes in a single array.
+          notes.push({
+            note: obs.value as string, // TODO: add better typing check
+            provider,
+            time: enc.encounterDatetime ? formatTime(parseDate(enc.encounterDatetime)) : '',
+            concept: obs.concept,
+          });
+        }
+      });
+    });
+
+    // Sort the diagnoses by rank, so that primary diagnoses come first
+    diagnoses.sort((a, b) => (a.rank ?? 0) - (b.rank ?? 0));
+
+    // Sort medications by dateActivated DESC (newest first) to align with backend ordering
+    medications.sort((a, b) => new Date(b.order.dateActivated).getTime() - new Date(a.order.dateActivated).getTime());
+
+    return [diagnoses, notes, medications];
+  }, [notesConceptUuids, visit?.encounters]);
+
+  const encounterIds = useMemo(() => visit?.encounters?.map((e) => `Encounter/${e.uuid}`) ?? [], [visit?.encounters]);
+
+  return (
+    <div className={styles.summaryContainer}>
+      <p className={styles.diagnosisLabel}>{t('diagnoses', 'Diagnoses')}</p>
+      <div className={styles.diagnosesList}>
+        {diagnoses.length > 0 ? (
+          <DiagnosisTags diagnoses={diagnoses} />
+        ) : (
+          <p className={classNames(styles.bodyLong01, styles.text02)} style={{ marginBottom: '0.5rem' }}>
+            {t('noDiagnosesFound', 'No diagnoses found')}
+          </p>
+        )}
+      </div>
+      <Tabs>
+        <TabList aria-label="Visit summary tabs" className={styles.tablist}>
+          <Tab className={classNames(styles.tab, styles.bodyLong01)} id="timeline-tab">
+            {t('timeline', 'Timeline')}
+          </Tab>
+          <Tab
+            className={classNames(styles.tab, styles.bodyLong01)}
+            id="notes-tab"
+            disabled={notes.length <= 0 && disableEmptyTabs}
+          >
+            {t('notes', 'Notes')}
+          </Tab>
+          <Tab className={styles.tab} id="tests-tab" disabled={encounterIds.length === 0 && disableEmptyTabs}>
+            {t('tests', 'Tests')}
+          </Tab>
+          <Tab className={styles.tab} id="medications-tab" disabled={medications.length <= 0 && disableEmptyTabs}>
+            {t('medications', 'Medications')}
+          </Tab>
+          {completedFormsExtensions?.map((extension, index) => (
+            <Tab
+              key={`completed-forms-${index}`}
+              className={styles.tab}
+              id={`${extension.meta.title || index}-completed-forms-tab`}
+            >
+              {t(extension.meta.title, {
+                ns: extension.moduleName,
+                defaultValue: extension.meta.title,
+              })}
+            </Tab>
+          ))}
+          {extensions?.map((extension, index) => (
+            <Tab key={index} className={styles.tab} id={`${extension.meta.title || index}-tab`}>
+              {t(extension.meta.title, {
+                ns: extension.moduleName,
+                defaultValue: extension.meta.title,
+              })}
+            </Tab>
+          ))}
+        </TabList>
+        {/* Wrap TabPanels so it is a single grid item: Carbon's TabPanels renders a Fragment, which would
+            otherwise place every TabPanel as a direct child of the summaryContainer grid and break the layout. */}
+        <div className={styles.tabPanels}>
+          <TabPanels>
+            <TabPanel>
+              <VisitTimeline visitUuid={visit.uuid} patientUuid={patientUuid} />
+            </TabPanel>
+            <TabPanel>
+              <NotesSummary notes={notes} />
+            </TabPanel>
+            <TabPanel>
+              <TestsSummary patientUuid={patientUuid} encounters={visit?.encounters ?? []} />
+            </TabPanel>
+            <TabPanel>
+              <MedicationSummary medications={medications} drugOrderTypeUUID={drugOrderTypeUUID} />
+            </TabPanel>
+            <ExtensionSlot name={visitSummaryCompletedFormsSlot}>
+              <TabPanel>
+                <Extension state={{ patientUuid, visit }} />
+              </TabPanel>
+            </ExtensionSlot>
+            <ExtensionSlot name={visitSummaryPanelSlot}>
+              <TabPanel>
+                <Extension state={{ patientUuid, visit }} />
+              </TabPanel>
+            </ExtensionSlot>
+          </TabPanels>
+        </div>
+      </Tabs>
+    </div>
+  );
+};
+
+export default VisitSummary;

--- a/packages/framework/esm-styleguide/src/visit-summary/visit-summary.component.tsx
+++ b/packages/framework/esm-styleguide/src/visit-summary/visit-summary.component.tsx
@@ -65,7 +65,8 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({
         if (obs.concept && notesConceptUuids?.includes(obs.concept.uuid)) {
           // Putting all notes in a single array.
           notes.push({
-            note: obs.value as string, // TODO: add better typing check
+            id: obs.uuid, // obs values are typed as unknown; visit notes are free-text string observations.
+            note: obs.value as string,
             provider,
             time: enc.encounterDatetime ? formatTime(parseDate(enc.encounterDatetime)) : '',
             concept: obs.concept,
@@ -116,11 +117,7 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({
             {t('medications', 'Medications')}
           </Tab>
           {completedFormsExtensions?.map((extension, index) => (
-            <Tab
-              key={`completed-forms-${index}`}
-              className={styles.tab}
-              id={`${extension.meta.title || index}-completed-forms-tab`}
-            >
+            <Tab key={extension.id} className={styles.tab} id={`${extension.meta.title || index}-completed-forms-tab`}>
               {t(extension.meta.title, {
                 ns: extension.moduleName,
                 defaultValue: extension.meta.title,
@@ -128,7 +125,7 @@ const VisitSummary: React.FC<VisitSummaryProps> = ({
             </Tab>
           ))}
           {extensions?.map((extension, index) => (
-            <Tab key={index} className={styles.tab} id={`${extension.meta.title || index}-tab`}>
+            <Tab key={extension.id} className={styles.tab} id={`${extension.meta.title || index}-tab`}>
               {t(extension.meta.title, {
                 ns: extension.moduleName,
                 defaultValue: extension.meta.title,

--- a/packages/framework/esm-styleguide/src/visit-summary/visit-summary.module.scss
+++ b/packages/framework/esm-styleguide/src/visit-summary/visit-summary.module.scss
@@ -1,0 +1,76 @@
+@use '@carbon/colors';
+@use '@carbon/layout';
+@use '@carbon/type';
+@use '@openmrs/esm-styleguide/src/vars' as *;
+
+.diagnosisLabel {
+  @include type.type-style('heading-compact-01');
+  color: $text-02;
+  margin-top: 5px;
+}
+
+.diagnosesList {
+  display: flex;
+  flex-flow: row wrap;
+  padding-bottom: layout.$spacing-03;
+  margin: 0 layout.$spacing-05;
+  border-bottom: 1px solid $ui-03;
+}
+
+.summaryContainer {
+  background-color: $ui-background;
+  display: grid;
+  grid-template-columns: max-content auto;
+  padding: layout.$spacing-05;
+
+  :global(.cds--tabs) {
+    min-height: 13rem;
+  }
+}
+
+.tabPanels {
+  min-width: 0;
+}
+
+.tab {
+  outline: 0;
+  outline-offset: 0;
+  min-height: 2rem !important;
+
+  &:active,
+  &:focus {
+    outline: layout.$spacing-01 solid var(--brand-03) !important;
+  }
+
+  &[aria-selected='true'] {
+    border-left: 3px solid var(--brand-03);
+    border-bottom: none;
+    font-weight: 600;
+    margin-left: 0 !important;
+  }
+
+  &[aria-selected='false'] {
+    border-bottom: none;
+    border-left: layout.$spacing-01 solid $ui-03;
+    margin-left: 0 !important;
+  }
+}
+
+.tablist {
+  :global(.cds--tab--list) {
+    flex-direction: column;
+    max-height: fit-content;
+  }
+
+  > button :global(.cds--tabs .cds--tabs__nav-link) {
+    border-bottom: none;
+  }
+}
+
+.text02 {
+  color: colors.$gray-70;
+}
+
+.bodyLong01 {
+  @include type.type-style('body-01');
+}

--- a/packages/framework/esm-styleguide/src/visit-summary/visit-summary.test.tsx
+++ b/packages/framework/esm-styleguide/src/visit-summary/visit-summary.test.tsx
@@ -1,0 +1,74 @@
+import React from 'react';
+import type { i18n } from 'i18next';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { useConfig } from '@openmrs/esm-react-utils';
+import { type Visit } from '@openmrs/esm-emr-api';
+import VisitSummary from './visit-summary.component';
+
+// esm-utils date helpers read window.i18next.language (see datepicker.test.tsx).
+window.i18next = { language: 'en' } as i18n;
+
+// Timeline tab fetches encounters of its own; keep it deterministic.
+vi.mock('./useEncountersByVisit', () => ({
+  useEncountersByVisit: () => ({ encounters: [], isLoading: false, error: undefined }),
+}));
+
+const mockUseConfig = vi.mocked(useConfig);
+
+const drugOrderTypeUUID = 'drug-order-type-uuid';
+const notesConceptUuids = ['note-concept-uuid'];
+
+const visitWithData = {
+  uuid: 'visit-uuid',
+  encounters: [
+    {
+      uuid: 'enc-1',
+      encounterDatetime: '2026-06-22T13:07:00.000+0000',
+      encounterProviders: [
+        { provider: { person: { display: 'Dr James Cook' } }, encounterRole: { display: 'Clinician' } },
+      ],
+      diagnoses: [{ uuid: 'dx-1', display: 'Malaria', rank: 1, voided: false }],
+      obs: [{ uuid: 'obs-1', concept: { uuid: 'note-concept-uuid', display: 'Note' }, value: 'Patient seems unwell' }],
+      orders: [],
+    },
+  ],
+} as unknown as Visit;
+
+const emptyVisit = { uuid: 'visit-empty', encounters: [] } as unknown as Visit;
+
+const renderSummary = (visit: Visit) =>
+  render(
+    <VisitSummary
+      visit={visit}
+      patientUuid="patient-uuid"
+      notesConceptUuids={notesConceptUuids}
+      drugOrderTypeUUID={drugOrderTypeUUID}
+    />,
+  );
+
+describe('VisitSummary', () => {
+  beforeEach(() => {
+    mockUseConfig.mockReturnValue({ diagnosisTags: { primaryColor: 'blue', secondaryColor: 'green' } });
+  });
+
+  it('renders the diagnoses section and the visit summary tabs', () => {
+    renderSummary(visitWithData);
+
+    expect(screen.getByText('Diagnoses')).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /timeline/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /notes/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /tests/i })).toBeInTheDocument();
+    expect(screen.getByRole('tab', { name: /medications/i })).toBeInTheDocument();
+  });
+
+  it('renders diagnosis tags parsed from the visit encounters', () => {
+    renderSummary(visitWithData);
+    expect(screen.getByText('Malaria')).toBeInTheDocument();
+  });
+
+  it('shows the empty diagnoses message when the visit has no diagnoses', () => {
+    renderSummary(emptyVisit);
+    expect(screen.getByText('No diagnoses found')).toBeInTheDocument();
+  });
+});

--- a/packages/framework/esm-styleguide/src/visit-summary/visit-timeline.component.tsx
+++ b/packages/framework/esm-styleguide/src/visit-summary/visit-timeline.component.tsx
@@ -5,6 +5,7 @@ import { SkeletonText } from '@carbon/react';
 import { formatDate } from '@openmrs/esm-utils';
 import { CardHeader } from '../cards';
 import { EmptyCard } from '../empty-card';
+import { ErrorState } from '../error-state';
 import { useEncountersByVisit } from './useEncountersByVisit';
 import styles from './visit-timeline.module.scss';
 
@@ -13,9 +14,9 @@ interface VisitTimelineProps {
   visitUuid: string;
 }
 
-function VisitTimeline({ patientUuid, visitUuid }: VisitTimelineProps) {
+function VisitTimeline({ patientUuid, visitUuid }: Readonly<VisitTimelineProps>) {
   const { t } = useTranslation();
-  const { encounters, isLoading } = useEncountersByVisit(patientUuid, visitUuid);
+  const { encounters, isLoading, error } = useEncountersByVisit(patientUuid, visitUuid);
 
   if (isLoading) {
     return (
@@ -29,8 +30,8 @@ function VisitTimeline({ patientUuid, visitUuid }: VisitTimelineProps) {
           </span>
         </p>
         <div className={styles.timelineEntries}>
-          {Array.from({ length: 3 }).map((_, index) => (
-            <p className={styles.timelineEntry} key={index}>
+          {['skeleton-1', 'skeleton-2', 'skeleton-3'].map((key) => (
+            <div className={styles.timelineEntry} key={key}>
               <div className={styles.timelineDot} />
               <SkeletonText className={styles.skeleton} />
               <span>&middot;</span>
@@ -39,12 +40,16 @@ function VisitTimeline({ patientUuid, visitUuid }: VisitTimelineProps) {
               <SkeletonText className={styles.skeleton} />
               <span>&mdash;</span>
               <SkeletonText className={styles.skeleton} />
-            </p>
+            </div>
           ))}
           <div className={styles.timelineLine} />
         </div>
       </div>
     );
+  }
+
+  if (error) {
+    return <ErrorState error={error} headerTitle={t('timeline', 'Timeline')} />;
   }
 
   if (encounters?.length === 0) {
@@ -65,18 +70,18 @@ function VisitTimeline({ patientUuid, visitUuid }: VisitTimelineProps) {
       </p>
       <div className={styles.timelineEntries}>
         {encounters?.map((encounter) => (
-          <p className={styles.timelineEntry} key={encounter.uuid}>
+          <div className={styles.timelineEntry} key={encounter.uuid}>
             <div className={styles.timelineDot} />
             <span className={styles.encounterType}>{encounter.encounterType?.display}</span>
             <span>&middot;</span>
-            {!encounter.encounterProviders?.length ? (
-              <span>{t('noProvider', 'No provider')}</span>
-            ) : (
+            {encounter.encounterProviders?.length ? (
               <span>
                 {encounter.encounterProviders
                   .map((encounterProvider) => encounterProvider.provider?.person?.display)
                   .join(', ')}
               </span>
+            ) : (
+              <span>{t('noProvider', 'No provider')}</span>
             )}
             <span>&middot;</span>{' '}
             <span>
@@ -86,7 +91,7 @@ function VisitTimeline({ patientUuid, visitUuid }: VisitTimelineProps) {
                   })
                 : ''}
             </span>
-          </p>
+          </div>
         ))}
         <div className={styles.timelineLine} />
       </div>

--- a/packages/framework/esm-styleguide/src/visit-summary/visit-timeline.component.tsx
+++ b/packages/framework/esm-styleguide/src/visit-summary/visit-timeline.component.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import dayjs from 'dayjs';
+import { useTranslation } from 'react-i18next';
+import { SkeletonText } from '@carbon/react';
+import { formatDate } from '@openmrs/esm-utils';
+import { CardHeader } from '../cards';
+import { EmptyCard } from '../empty-card';
+import { useEncountersByVisit } from './useEncountersByVisit';
+import styles from './visit-timeline.module.scss';
+
+interface VisitTimelineProps {
+  patientUuid: string;
+  visitUuid: string;
+}
+
+function VisitTimeline({ patientUuid, visitUuid }: VisitTimelineProps) {
+  const { t } = useTranslation();
+  const { encounters, isLoading } = useEncountersByVisit(patientUuid, visitUuid);
+
+  if (isLoading) {
+    return (
+      <div className={styles.visitTimeline}>
+        <CardHeader title={t('timeline', 'Timeline')}>{null}</CardHeader>
+        <p className={styles.timelineHeader}>
+          <span>{t('encounter', 'Encounter')}</span> <span>&middot;</span>
+          <span>{t('provider', 'Provider')}</span> <span>&middot;</span>{' '}
+          <span>
+            {t('timeStarted', 'Time started')} <span>&mdash;</span> {t('timeCompleted', 'Time completed')}{' '}
+          </span>
+        </p>
+        <div className={styles.timelineEntries}>
+          {Array.from({ length: 3 }).map((_, index) => (
+            <p className={styles.timelineEntry} key={index}>
+              <div className={styles.timelineDot} />
+              <SkeletonText className={styles.skeleton} />
+              <span>&middot;</span>
+              <SkeletonText className={styles.skeleton} />
+              <span>&middot;</span>
+              <SkeletonText className={styles.skeleton} />
+              <span>&mdash;</span>
+              <SkeletonText className={styles.skeleton} />
+            </p>
+          ))}
+          <div className={styles.timelineLine} />
+        </div>
+      </div>
+    );
+  }
+
+  if (encounters?.length === 0) {
+    return (
+      <EmptyCard
+        displayText={t('encountersForThisVisit', 'encounters for this visit')}
+        headerTitle={t('timeline', 'Timeline')}
+      />
+    );
+  }
+
+  return (
+    <div className={styles.visitTimeline}>
+      <p className={styles.timelineHeader}>
+        <span>{t('encounter', 'Encounter')}</span> <span>&middot;</span>
+        <span>{t('provider', 'Provider')}</span> <span>&middot;</span>
+        <span>{t('timeStarted', 'Time started')}</span>
+      </p>
+      <div className={styles.timelineEntries}>
+        {encounters?.map((encounter) => (
+          <p className={styles.timelineEntry} key={encounter.uuid}>
+            <div className={styles.timelineDot} />
+            <span className={styles.encounterType}>{encounter.encounterType?.display}</span>
+            <span>&middot;</span>
+            {!encounter.encounterProviders?.length ? (
+              <span>{t('noProvider', 'No provider')}</span>
+            ) : (
+              <span>
+                {encounter.encounterProviders
+                  .map((encounterProvider) => encounterProvider.provider?.person?.display)
+                  .join(', ')}
+              </span>
+            )}
+            <span>&middot;</span>{' '}
+            <span>
+              {encounter.encounterDatetime
+                ? formatDate(new Date(encounter.encounterDatetime), {
+                    time: dayjs(encounter.encounterDatetime).isSame(dayjs(), 'day') ? 'for today' : true,
+                  })
+                : ''}
+            </span>
+          </p>
+        ))}
+        <div className={styles.timelineLine} />
+      </div>
+    </div>
+  );
+}
+
+export default VisitTimeline;

--- a/packages/framework/esm-styleguide/src/visit-summary/visit-timeline.module.scss
+++ b/packages/framework/esm-styleguide/src/visit-summary/visit-timeline.module.scss
@@ -1,0 +1,60 @@
+@use '@carbon/colors';
+@use '@carbon/layout';
+@use '@carbon/type';
+
+.visitTimeline {
+  border: 1px solid colors.$gray-20;
+  background-color: colors.$white;
+  padding-top: layout.$spacing-05;
+}
+
+.timelineHeader {
+  padding: 0 layout.$spacing-10;
+  @include type.type-style('helper-text-01');
+  display: flex;
+  gap: layout.$spacing-03;
+}
+
+.timelineEntries {
+  margin: 0 layout.$spacing-08;
+  margin-top: layout.$spacing-04;
+  display: flex;
+  flex-direction: column;
+  gap: layout.$spacing-05;
+  margin-bottom: layout.$spacing-05;
+  position: relative;
+}
+
+.timelineEntry {
+  display: flex;
+  gap: layout.$spacing-03;
+  align-items: center;
+}
+
+.encounterType {
+  font-weight: 700;
+}
+
+.timelineDot {
+  height: 8px;
+  width: 8px;
+  background-color: colors.$blue-30;
+  border-radius: 50%;
+  display: inline-block;
+  margin-right: layout.$spacing-03;
+  z-index: 10;
+}
+
+.timelineLine {
+  position: absolute;
+  border-left: 1px solid colors.$blue-20;
+  height: 100%;
+  left: 3.4px;
+  top: 4px;
+  z-index: 9;
+}
+
+.skeleton {
+  width: 5% !important; // using hardcoded px values could be a bad idea.
+  margin-bottom: 0 !important;
+}


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
Adds a shared, props-based `VisitSummary` to `@openmrs/esm-styleguide` (exported via `@openmrs/esm-framework`) so apps outside the patient chart — e.g. Service Queues, can render the standard visit summary without depending on `@openmrs/esm-patient-common-lib`. This is the base the [patient-chart](https://github.com/openmrs/openmrs-esm-patient-chart/pull/3414) and [service-queues](https://github.com/openmrs/openmrs-esm-patient-management/pull/2598) PRs build on.

## Screenshots

## Related Issue
[O3-5763](https://issues.openmrs.org/browse/O3-5763)

## Other
Merge order: **core -> patient-chart <-> queue**.

[O3-5763]: https://openmrs.atlassian.net/browse/O3-5763?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ