### PR TITLE
(fix) Switch to using contenthash for shell files

### DIFF
--- a/packages/shell/esm-app-shell/rspack.config.js
+++ b/packages/shell/esm-app-shell/rspack.config.js
@@ -233,7 +233,7 @@ module.exports = (env, argv = []) => {
     entry: resolve(__dirname, 'src/index.ts'),
     output: {
       filename: isProd ? 'openmrs.[contenthash].js' : 'openmrs.js',
-      chunkFilename: '[chunkhash].js',
+      chunkFilename: '[contenthash].js',
       path: resolve(__dirname, outDir),
       publicPath: '',
       hashFunction: 'xxhash64',


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->

Purely for consistency (we use `[contenthash]` everywhere else). I'm not really convinced this buys us anything.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
