### PR TITLE
(chore) O3-5788: Upgrade webpack-bundle-analyzer to 5.3.0 to fix ws DoS vulnerability

### DIFF
--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -82,7 +82,7 @@
     "tar": "7.5.13",
     "typescript": "5.8.3",
     "webpack": "5.105.3",
-    "webpack-bundle-analyzer": "4.10.2",
+    "webpack-bundle-analyzer": "5.3.0",
     "webpack-cli": "6.0.1",
     "webpack-dev-server": "5.2.3",
     "webpack-stats-plugin": "1.1.3",

--- a/packages/tooling/rspack-config/package.json
+++ b/packages/tooling/rspack-config/package.json
@@ -42,7 +42,7 @@
     "style-loader": "3.3.4",
     "swc-loader": "0.2.7",
     "ts-checker-rspack-plugin": "1.1.4",
-    "webpack-bundle-analyzer": "4.10.2",
+    "webpack-bundle-analyzer": "5.3.0",
     "webpack-stats-plugin": "1.1.3"
   },
   "devDependencies": {

--- a/packages/tooling/webpack-config/package.json
+++ b/packages/tooling/webpack-config/package.json
@@ -41,7 +41,7 @@
     "style-loader": "3.3.4",
     "swc-loader": "0.2.7",
     "webpack": "5.105.3",
-    "webpack-bundle-analyzer": "4.10.2",
+    "webpack-bundle-analyzer": "5.3.0",
     "webpack-cli": "6.0.1",
     "webpack-stats-plugin": "1.1.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -523,7 +523,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@discoveryjs/json-ext@npm:^0.6.1":
+"@discoveryjs/json-ext@npm:^0.6.1, @discoveryjs/json-ext@npm:^0.6.3":
   version: 0.6.3
   resolution: "@discoveryjs/json-ext@npm:0.6.3"
   checksum: 10/6cb35ce92c8f1e9533250da9a893def63cce4f9a4f67677259bf11619d83858ca9c010171f49b22d83153b7b7ff65c39bbbf0edf4734d67e864de1044b7a943c
@@ -3592,7 +3592,7 @@ __metadata:
     swc-loader: "npm:0.2.7"
     ts-checker-rspack-plugin: "npm:1.1.4"
     typescript: "npm:^5.8.3"
-    webpack-bundle-analyzer: "npm:4.10.2"
+    webpack-bundle-analyzer: "npm:5.3.0"
     webpack-stats-plugin: "npm:1.1.3"
   languageName: unknown
   linkType: soft
@@ -3669,7 +3669,7 @@ __metadata:
     swc-loader: "npm:0.2.7"
     typescript: "npm:^5.8.3"
     webpack: "npm:5.105.3"
-    webpack-bundle-analyzer: "npm:4.10.2"
+    webpack-bundle-analyzer: "npm:5.3.0"
     webpack-cli: "npm:6.0.1"
     webpack-stats-plugin: "npm:1.1.3"
   languageName: unknown
@@ -9391,6 +9391,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^14.0.2":
+  version: 14.0.3
+  resolution: "commander@npm:14.0.3"
+  checksum: 10/dfa9ebe2a433d277de5cb0252d23b10a543d245d892db858d23b516336a835c50fd4f52bee4cd13c705cc8acb6f03dc632c73dd806f7d06d3353eb09953dd17a
+  languageName: node
+  linkType: hard
+
 "commander@npm:^6.0.0":
   version: 6.2.1
   resolution: "commander@npm:6.2.1"
@@ -11128,6 +11135,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"escape-string-regexp@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "escape-string-regexp@npm:5.0.0"
+  checksum: 10/20daabe197f3cb198ec28546deebcf24b3dbb1a5a269184381b3116d12f0532e06007f4bc8da25669d6a7f8efb68db0758df4cd981f57bc5b57f521a3e12c59e
+  languageName: node
+  linkType: hard
+
 "eslint-import-resolver-node@npm:^0.3.9":
   version: 0.3.9
   resolution: "eslint-import-resolver-node@npm:0.3.9"
@@ -12630,6 +12644,13 @@ __metadata:
   version: 2.0.2
   resolution: "html-escaper@npm:2.0.2"
   checksum: 10/034d74029dcca544a34fb6135e98d427acd73019796ffc17383eaa3ec2fe1c0471dcbbc8f8ed39e46e86d43ccd753a160631615e4048285e313569609b66d5b7
+  languageName: node
+  linkType: hard
+
+"html-escaper@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "html-escaper@npm:3.0.3"
+  checksum: 10/7795141912bd82f0ece3c65fa329cdf40cd0ea6c1b9c556ac88ff2212e878ddc55b64219709f5fcb252406fe420ae15e5bd5626e36c0215ff1054f9d601ca382
   languageName: node
   linkType: hard
 
@@ -15377,7 +15398,7 @@ __metadata:
     typescript: "npm:5.8.3"
     vitest: "npm:^4.1.2"
     webpack: "npm:5.105.3"
-    webpack-bundle-analyzer: "npm:4.10.2"
+    webpack-bundle-analyzer: "npm:5.3.0"
     webpack-cli: "npm:6.0.1"
     webpack-dev-server: "npm:5.2.3"
     webpack-stats-plugin: "npm:1.1.3"
@@ -18088,6 +18109,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"sirv@npm:^3.0.2":
+  version: 3.0.2
+  resolution: "sirv@npm:3.0.2"
+  dependencies:
+    "@polka/url": "npm:^1.0.0-next.24"
+    mrmime: "npm:^2.0.0"
+    totalist: "npm:^3.0.0"
+  checksum: 10/259617f4ab57664be6d963f5b27b38a6351d3e91ce70d6726985d087b40efd595fcf7f72ae010babf5e0acb63bcb3e3d6db8de34604da1011be6e28ee32aa15d
+  languageName: node
+  linkType: hard
+
 "slash@npm:3.0.0, slash@npm:^3.0.0":
   version: 3.0.0
   resolution: "slash@npm:3.0.0"
@@ -20002,6 +20034,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"webpack-bundle-analyzer@npm:5.3.0":
+  version: 5.3.0
+  resolution: "webpack-bundle-analyzer@npm:5.3.0"
+  dependencies:
+    "@discoveryjs/json-ext": "npm:^0.6.3"
+    acorn: "npm:^8.0.4"
+    acorn-walk: "npm:^8.0.0"
+    commander: "npm:^14.0.2"
+    escape-string-regexp: "npm:^5.0.0"
+    html-escaper: "npm:^3.0.3"
+    opener: "npm:^1.5.2"
+    picocolors: "npm:^1.0.0"
+    sirv: "npm:^3.0.2"
+    ws: "npm:^8.19.0"
+  bin:
+    webpack-bundle-analyzer: lib/bin/analyzer.js
+  checksum: 10/debed08160f10ea0890548907d530a7cef26ae049a5f650998ba85e71c1267a453ca0b262f121822ad08954b9241706455ade86dd05769c6a129a348f5cf4087
+  languageName: node
+  linkType: hard
+
 "webpack-cli@npm:6.0.1":
   version: 6.0.1
   resolution: "webpack-cli@npm:6.0.1"
@@ -20443,6 +20495,21 @@ __metadata:
     utf-8-validate:
       optional: true
   checksum: 10/26e4901e93abaf73af9f26a93707c95b4845e91a7a347ec8c569e6e9be7f9df066f6c2b817b2d685544e208207898a750b78461e6e8d810c11a370771450c31b
+  languageName: node
+  linkType: hard
+
+"ws@npm:^8.19.0":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
+  peerDependencies:
+    bufferutil: ^4.0.1
+    utf-8-validate: ">=5.0.2"
+  peerDependenciesMeta:
+    bufferutil:
+      optional: true
+    utf-8-validate:
+      optional: true
+  checksum: 10/088411956432c8f876158409d5a285cb9ad1382f593391f51d3a599bd0a5b277f876609ebd00fc3596321c4a4c9064d6fffe1ebad960e8ea7fd9ae25324f35c2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Requirements
- [x] This PR has a title that briefly describes the work done including the ticket number.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below.
- [x] My work includes tests or is validated by existing tests.

## Summary
`webpack-bundle-analyzer@4.10.2` (used in `openmrs`, `rspack-config`, `webpack-config`) pulls in `ws@7.5.10`, affected by [GHSA-96hv-2xvq-fx4p](https://github.com/advisories/GHSA-96hv-2xvq-fx4p). No `4.x` patch exists — bumped directly to `5.3.0`, which resolves `ws` to `8.21.0`. No breaking API changes between `4.x`/`5.x` per the [changelog](https://github.com/webpack/webpack-bundle-analyzer/blob/main/CHANGELOG.md).

## Screenshots
N/A

## Related Issue
https://issues.openmrs.org/browse/O3-5788

## Other
- Verified via `yarn why ws` and a working `yarn analyze` report in `esm-login-app`
- `@rspack/cli` (third-party) still pulls the vulnerable `4.10.2`/`ws@7.5.9` — out of scope, can't be fixed from this repo