### PR TITLE
(fix) Honor the invalid prop in OpenmrsDatePicker mocks

### DIFF
--- a/packages/framework/esm-framework/mock-jest.tsx
+++ b/packages/framework/esm-framework/mock-jest.tsx
@@ -111,7 +111,7 @@ export const navigateAndLaunchWorkspace = jest.fn();
 export const useWorkspaces = jest.fn();
 export const useWorkspace2Context = jest.fn();
 
-export const OpenmrsDatePicker = jest.fn(({ id, labelText, value, onChange, isInvalid, invalidText }) => (
+export const OpenmrsDatePicker = jest.fn(({ id, labelText, value, onChange, invalid, isInvalid, invalidText }) => (
   <>
     <label htmlFor={id}>{labelText}</label>
     <input
@@ -120,39 +120,41 @@ export const OpenmrsDatePicker = jest.fn(({ id, labelText, value, onChange, isIn
       value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
       onChange={(evt) => onChange?.(dayjs(evt.target.value).toDate())}
     />
-    {isInvalid && <span>{invalidText}</span>}
+    {(invalid || isInvalid) && <span>{invalidText}</span>}
   </>
 ));
 
-export const OpenmrsDateRangePicker = jest.fn(({ id, labelText, value = [], onChange, isInvalid, invalidText }) => {
-  const [inputValue, setInputValue] = useState(() => {
-    const [start, end] = value;
-    const formattedStart = start ? dayjs(start).format('DD/MM/YYYY') : 'dd/mm/yyyy';
-    const formattedEnd = end ? dayjs(end).format('DD/MM/YYYY') : 'dd/mm/yyyy';
-    return `${formattedStart}–${formattedEnd}`;
-  });
+export const OpenmrsDateRangePicker = jest.fn(
+  ({ id, labelText, value = [], onChange, invalid, isInvalid, invalidText }) => {
+    const [inputValue, setInputValue] = useState(() => {
+      const [start, end] = value;
+      const formattedStart = start ? dayjs(start).format('DD/MM/YYYY') : 'dd/mm/yyyy';
+      const formattedEnd = end ? dayjs(end).format('DD/MM/YYYY') : 'dd/mm/yyyy';
+      return `${formattedStart}–${formattedEnd}`;
+    });
 
-  const handleChange = (e) => {
-    const raw = e.target.value;
-    setInputValue(raw);
+    const handleChange = (e) => {
+      const raw = e.target.value;
+      setInputValue(raw);
 
-    const [startStr, endStr] = raw.split('–');
-    const start = dayjs(startStr, 'DD/MM/YYYY', true);
-    const end = dayjs(endStr, 'DD/MM/YYYY', true);
+      const [startStr, endStr] = raw.split('–');
+      const start = dayjs(startStr, 'DD/MM/YYYY', true);
+      const end = dayjs(endStr, 'DD/MM/YYYY', true);
 
-    if (start.isValid() && end.isValid()) {
-      onChange?.([start.toDate(), end.toDate()]);
-    }
-  };
+      if (start.isValid() && end.isValid()) {
+        onChange?.([start.toDate(), end.toDate()]);
+      }
+    };
 
-  return (
-    <div>
-      <label htmlFor={id}>{labelText}</label>
-      <input id={id} type="text" value={inputValue} onChange={handleChange} />
-      {isInvalid && <span>{invalidText}</span>}
-    </div>
-  );
-});
+    return (
+      <div>
+        <label htmlFor={id}>{labelText}</label>
+        <input id={id} type="text" value={inputValue} onChange={handleChange} />
+        {(invalid || isInvalid) && <span>{invalidText}</span>}
+      </div>
+    );
+  },
+);
 
 /* esm-utils */
 export {

--- a/packages/framework/esm-framework/mock.tsx
+++ b/packages/framework/esm-framework/mock.tsx
@@ -112,7 +112,7 @@ export const navigateAndLaunchWorkspace = vi.fn();
 export const useWorkspaces = vi.fn();
 export const useWorkspace2Context = vi.fn();
 
-export const OpenmrsDatePicker = vi.fn(({ id, labelText, value, onChange, isInvalid, invalidText }) => (
+export const OpenmrsDatePicker = vi.fn(({ id, labelText, value, onChange, invalid, isInvalid, invalidText }) => (
   <>
     <label htmlFor={id}>{labelText}</label>
     <input
@@ -121,39 +121,41 @@ export const OpenmrsDatePicker = vi.fn(({ id, labelText, value, onChange, isInva
       value={value ? dayjs(value).format('DD/MM/YYYY') : ''}
       onChange={(evt) => onChange?.(dayjs(evt.target.value).toDate())}
     />
-    {isInvalid && <span>{invalidText}</span>}
+    {(invalid || isInvalid) && <span>{invalidText}</span>}
   </>
 ));
 
-export const OpenmrsDateRangePicker = vi.fn(({ id, labelText, value = [], onChange, isInvalid, invalidText }) => {
-  const [inputValue, setInputValue] = useState(() => {
-    const [start, end] = value;
-    const formattedStart = start ? dayjs(start).format('DD/MM/YYYY') : 'dd/mm/yyyy';
-    const formattedEnd = end ? dayjs(end).format('DD/MM/YYYY') : 'dd/mm/yyyy';
-    return `${formattedStart}–${formattedEnd}`;
-  });
+export const OpenmrsDateRangePicker = vi.fn(
+  ({ id, labelText, value = [], onChange, invalid, isInvalid, invalidText }) => {
+    const [inputValue, setInputValue] = useState(() => {
+      const [start, end] = value;
+      const formattedStart = start ? dayjs(start).format('DD/MM/YYYY') : 'dd/mm/yyyy';
+      const formattedEnd = end ? dayjs(end).format('DD/MM/YYYY') : 'dd/mm/yyyy';
+      return `${formattedStart}–${formattedEnd}`;
+    });
 
-  const handleChange = (e) => {
-    const raw = e.target.value;
-    setInputValue(raw);
+    const handleChange = (e) => {
+      const raw = e.target.value;
+      setInputValue(raw);
 
-    const [startStr, endStr] = raw.split('–');
-    const start = dayjs(startStr, 'DD/MM/YYYY', true);
-    const end = dayjs(endStr, 'DD/MM/YYYY', true);
+      const [startStr, endStr] = raw.split('–');
+      const start = dayjs(startStr, 'DD/MM/YYYY', true);
+      const end = dayjs(endStr, 'DD/MM/YYYY', true);
 
-    if (start.isValid() && end.isValid()) {
-      onChange?.([start.toDate(), end.toDate()]);
-    }
-  };
+      if (start.isValid() && end.isValid()) {
+        onChange?.([start.toDate(), end.toDate()]);
+      }
+    };
 
-  return (
-    <div>
-      <label htmlFor={id}>{labelText}</label>
-      <input id={id} type="text" value={inputValue} onChange={handleChange} />
-      {isInvalid && <span>{invalidText}</span>}
-    </div>
-  );
-});
+    return (
+      <div>
+        <label htmlFor={id}>{labelText}</label>
+        <input id={id} type="text" value={inputValue} onChange={handleChange} />
+        {(invalid || isInvalid) && <span>{invalidText}</span>}
+      </div>
+    );
+  },
+);
 
 /* esm-utils */
 export {


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/docs/frontend-modules/contributing.en-US#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.
- [x] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary

The `OpenmrsDatePicker` and `OpenmrsDateRangePicker` mocks in `mock.tsx` and `mock-jest.tsx` only render `invalidText` when the `isInvalid` prop is set. The real components accept both `invalid` and `isInvalid` (they compute `invalid || isInvalid`), and consumers across the ecosystem typically pass `invalid`. As a result, the error text never renders in consumer tests, making it impossible to assert on date picker validation error messages. This came up in openmrs/openmrs-esm-patient-chart#3035, where a test could not assert on a date picker validation error.

This PR updates both mocks to render the error text when either prop is truthy, mirroring the real components. The date range picker mock in each file was rewrapped by Prettier because the parameter list exceeded the maximum line width after adding the new prop.

The storybook mocks do not stub the date pickers, so no changes were needed there.

## Screenshots

## Related Issue

## Other
