### PR TITLE
(fix) O3-5816: Stop LocationPicker crashing when no login locations are configured

### DIFF
--- a/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
@@ -119,11 +119,12 @@ const LocationPickerView: React.FC<LocationPickerProps> = ({ hideWelcomeMessage,
     if (isUpdateFlow) {
       return;
     }
-    if (defaultLocation && !isSubmitting && !hasNoLocations) {
+    if (isLoadingLocationCount) return;
+    if (defaultLocation && !isSubmitting) {
       setActiveLocation(defaultLocation);
       changeLocation(defaultLocation, true);
     }
-  }, [changeLocation, isSubmitting, defaultLocation, isUpdateFlow, hasNoLocations]);
+  }, [changeLocation, isSubmitting, defaultLocation, isUpdateFlow, isLoadingLocationCount]);
 
   const handleSubmit = useCallback(
     (evt: React.FormEvent<HTMLFormElement>) => {

--- a/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
@@ -119,12 +119,11 @@ const LocationPickerView: React.FC<LocationPickerProps> = ({ hideWelcomeMessage,
     if (isUpdateFlow) {
       return;
     }
-    if (isLoadingLocationCount) return;
     if (defaultLocation && !isSubmitting) {
       setActiveLocation(defaultLocation);
       changeLocation(defaultLocation, true);
     }
-  }, [changeLocation, isSubmitting, defaultLocation, isUpdateFlow, isLoadingLocationCount]);
+  }, [changeLocation, isSubmitting, defaultLocation, isUpdateFlow]);
 
   const handleSubmit = useCallback(
     (evt: React.FormEvent<HTMLFormElement>) => {

--- a/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
@@ -10,6 +10,7 @@ import {
   useConfig,
   useConnectivity,
   useSession,
+  WarningIcon,
 } from '@openmrs/esm-framework';
 import { useDefaultLocation, useLocationCount } from './location-picker.resource';
 import type { ConfigSchema } from '../config-schema';
@@ -60,6 +61,8 @@ const LocationPickerView: React.FC<LocationPickerProps> = ({ hideWelcomeMessage,
     [user],
   );
 
+  const hasNoLocations = !isLoadingLocationCount && locationCount === 0;
+
   const [activeLocation, setActiveLocation] = useState(() => {
     if (currentLocationUuid && hideWelcomeMessage) {
       return currentLocationUuid;
@@ -98,13 +101,11 @@ const LocationPickerView: React.FC<LocationPickerProps> = ({ hideWelcomeMessage,
     [state?.referrer, config.links.loginSuccess, updateDefaultLocation, searchParams],
   );
 
-  // Handle cases where the location picker is disabled, there is only one location, or there are no locations.
+  // Handle cases where the location picker is disabled or there is only one location.
   useEffect(() => {
     if (isLoadingLocationCount) return;
 
-    if (locationCount === 0) {
-      changeLocation();
-    } else if (locationCount === 1 || !chooseLocation.enabled) {
+    if (locationCount === 1 || (!chooseLocation.enabled && locationCount > 0)) {
       if (firstLocation?.resource?.id) {
         changeLocation(firstLocation.resource.id, true);
       } else {
@@ -118,11 +119,11 @@ const LocationPickerView: React.FC<LocationPickerProps> = ({ hideWelcomeMessage,
     if (isUpdateFlow) {
       return;
     }
-    if (defaultLocation && !isSubmitting) {
+    if (defaultLocation && !isSubmitting && !hasNoLocations) {
       setActiveLocation(defaultLocation);
       changeLocation(defaultLocation, true);
     }
-  }, [changeLocation, isSubmitting, defaultLocation, isUpdateFlow]);
+  }, [changeLocation, isSubmitting, defaultLocation, isUpdateFlow, hasNoLocations]);
 
   const handleSubmit = useCallback(
     (evt: React.FormEvent<HTMLFormElement>) => {
@@ -142,43 +143,62 @@ const LocationPickerView: React.FC<LocationPickerProps> = ({ hideWelcomeMessage,
       <form onSubmit={handleSubmit}>
         <div className={styles.locationCard}>
           <div className={styles.paddedContainer}>
-            <p className={styles.welcomeTitle}>
-              {t('welcome', 'Welcome')} {currentUser}
-            </p>
-            <p className={styles.welcomeMessage}>
-              {t(
-                'selectYourLocation',
-                'Select your location from the list below. Use the search bar to find your location.',
-              )}
-            </p>
+            {hasNoLocations ? (
+              <div className={styles.emptyStateContainer}>
+                <WarningIcon className={styles.emptyStateIcon} size={24} />
+                <p className={styles.emptyStateTitle}>{t('noLoginLocations', 'No login locations configured')}</p>
+                <p className={styles.emptyStateMessage}>
+                  {t(
+                    'noLoginLocationsMessage',
+                    'This installation has no login locations configured. Please contact your system administrator.',
+                  )}
+                </p>
+              </div>
+            ) : (
+              <>
+                <p className={styles.welcomeTitle}>
+                  {t('welcome', 'Welcome')} {currentUser}
+                </p>
+                <p className={styles.welcomeMessage}>
+                  {t(
+                    'selectYourLocation',
+                    'Select your location from the list below. Use the search bar to find your location.',
+                  )}
+                </p>
+              </>
+            )}
           </div>
-          <LocationPicker
-            selectedLocationUuid={activeLocation}
-            defaultLocationUuid={userProperties.defaultLocation}
-            locationTag={chooseLocation.useLoginLocationTag && 'Login Location'}
-            onChange={(locationUuid) => setActiveLocation(locationUuid)}
-          />
-          <div className={styles.footerContainer}>
-            <Checkbox
-              className={styles.savePreferenceCheckbox}
-              checked={savePreference}
-              id={checkboxId}
-              labelText={t('rememberLocationForFutureLogins', 'Remember my location for future logins')}
-              onChange={(_, { checked }) => setSavePreference(checked)}
+          {!hasNoLocations && (
+            <LocationPicker
+              selectedLocationUuid={activeLocation}
+              defaultLocationUuid={userProperties.defaultLocation}
+              locationTag={chooseLocation.useLoginLocationTag && 'Login Location'}
+              onChange={(locationUuid) => setActiveLocation(locationUuid)}
             />
-            <Button
-              className={styles.confirmButton}
-              kind="primary"
-              type="submit"
-              disabled={!activeLocation || !isLoginEnabled || isSubmitting}
-            >
-              {isSubmitting ? (
-                <InlineLoading className={styles.loader} description={t('submitting', 'Submitting')} />
-              ) : (
-                <span>{getCoreTranslation('confirm')}</span>
-              )}
-            </Button>
-          </div>
+          )}
+          {!hasNoLocations && (
+            <div className={styles.footerContainer}>
+              <Checkbox
+                className={styles.savePreferenceCheckbox}
+                checked={savePreference}
+                id={checkboxId}
+                labelText={t('rememberLocationForFutureLogins', 'Remember my location for future logins')}
+                onChange={(_, { checked }) => setSavePreference(checked)}
+              />
+              <Button
+                className={styles.confirmButton}
+                kind="primary"
+                type="submit"
+                disabled={!activeLocation || !isLoginEnabled || isSubmitting}
+              >
+                {isSubmitting ? (
+                  <InlineLoading className={styles.loader} description={t('submitting', 'Submitting') + '...'} />
+                ) : (
+                  <span>{getCoreTranslation('confirm')}</span>
+                )}
+              </Button>
+            </div>
+          )}
         </div>
       </form>
     </div>

--- a/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
@@ -191,7 +191,7 @@ const LocationPickerView: React.FC<LocationPickerProps> = ({ hideWelcomeMessage,
                   disabled={!activeLocation || !isLoginEnabled || isSubmitting}
                 >
                   {isSubmitting ? (
-                    <InlineLoading className={styles.loader} description={t('submitting', 'Submitting') + '...'} />
+                    <InlineLoading className={styles.loader} description={t('submitting', 'Submitting')} />
                   ) : (
                     <span>{getCoreTranslation('confirm')}</span>
                   )}

--- a/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker-view.component.tsx
@@ -144,7 +144,7 @@ const LocationPickerView: React.FC<LocationPickerProps> = ({ hideWelcomeMessage,
         <div className={styles.locationCard}>
           <div className={styles.paddedContainer}>
             {hasNoLocations ? (
-              <div className={styles.emptyStateContainer}>
+              <div className={styles.emptyStateContainer} role="status">
                 <WarningIcon className={styles.emptyStateIcon} size={24} />
                 <p className={styles.emptyStateTitle}>{t('noLoginLocations', 'No login locations configured')}</p>
                 <p className={styles.emptyStateMessage}>
@@ -169,35 +169,35 @@ const LocationPickerView: React.FC<LocationPickerProps> = ({ hideWelcomeMessage,
             )}
           </div>
           {!hasNoLocations && (
-            <LocationPicker
-              selectedLocationUuid={activeLocation}
-              defaultLocationUuid={userProperties.defaultLocation}
-              locationTag={chooseLocation.useLoginLocationTag && 'Login Location'}
-              onChange={(locationUuid) => setActiveLocation(locationUuid)}
-            />
-          )}
-          {!hasNoLocations && (
-            <div className={styles.footerContainer}>
-              <Checkbox
-                className={styles.savePreferenceCheckbox}
-                checked={savePreference}
-                id={checkboxId}
-                labelText={t('rememberLocationForFutureLogins', 'Remember my location for future logins')}
-                onChange={(_, { checked }) => setSavePreference(checked)}
+            <>
+              <LocationPicker
+                selectedLocationUuid={activeLocation}
+                defaultLocationUuid={userProperties.defaultLocation}
+                locationTag={chooseLocation.useLoginLocationTag && 'Login Location'}
+                onChange={(locationUuid) => setActiveLocation(locationUuid)}
               />
-              <Button
-                className={styles.confirmButton}
-                kind="primary"
-                type="submit"
-                disabled={!activeLocation || !isLoginEnabled || isSubmitting}
-              >
-                {isSubmitting ? (
-                  <InlineLoading className={styles.loader} description={t('submitting', 'Submitting') + '...'} />
-                ) : (
-                  <span>{getCoreTranslation('confirm')}</span>
-                )}
-              </Button>
-            </div>
+              <div className={styles.footerContainer}>
+                <Checkbox
+                  className={styles.savePreferenceCheckbox}
+                  checked={savePreference}
+                  id={checkboxId}
+                  labelText={t('rememberLocationForFutureLogins', 'Remember my location for future logins')}
+                  onChange={(_, { checked }) => setSavePreference(checked)}
+                />
+                <Button
+                  className={styles.confirmButton}
+                  kind="primary"
+                  type="submit"
+                  disabled={!activeLocation || !isLoginEnabled || isSubmitting}
+                >
+                  {isSubmitting ? (
+                    <InlineLoading className={styles.loader} description={t('submitting', 'Submitting') + '...'} />
+                  ) : (
+                    <span>{getCoreTranslation('confirm')}</span>
+                  )}
+                </Button>
+              </div>
+            </>
           )}
         </div>
       </form>

--- a/packages/apps/esm-login-app/src/location-picker/location-picker.scss
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.scss
@@ -92,3 +92,29 @@
   margin-inline-start: -(layout.$spacing-06);
   margin-inline-end: -(layout.$spacing-06);
 }
+
+.emptyStateContainer {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin-top: layout.$spacing-03;
+  padding: layout.$spacing-06;
+  text-align: center;
+}
+
+.emptyStateIcon {
+  color: $color-gray-70;
+  margin-bottom: layout.$spacing-03;
+}
+
+.emptyStateTitle {
+  @extend .bodyLong01;
+  font-weight: 600;
+  margin-bottom: layout.$spacing-03;
+}
+
+.emptyStateMessage {
+  @extend .bodyLong01;
+  color: $color-gray-70;
+  margin-bottom: layout.$spacing-05;
+}

--- a/packages/apps/esm-login-app/src/location-picker/location-picker.scss
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.scss
@@ -98,7 +98,6 @@
   flex-direction: column;
   align-items: center;
   margin-top: layout.$spacing-03;
-  padding: layout.$spacing-06;
   text-align: center;
 }
 
@@ -116,5 +115,4 @@
 .emptyStateMessage {
   @extend .bodyLong01;
   color: $color-gray-70;
-  margin-bottom: layout.$spacing-05;
 }

--- a/packages/apps/esm-login-app/src/location-picker/location-picker.test.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.test.tsx
@@ -1,6 +1,6 @@
+import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import React from 'react';
 import { screen, waitFor, render } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { SWRConfig } from 'swr';
@@ -39,6 +39,21 @@ const secondLocation = {
 
 const invalidLocationUuid = '2gf1b7d4-c865-4178-82b0-5932e51503d6';
 const userUuid = '90bd24b3-e700-46b0-a5ef-c85afdfededd';
+
+const mockZeroLocationsResponse = {
+  data: {
+    resourceType: 'Bundle',
+    type: 'searchset',
+    total: 0,
+    entry: [],
+  },
+} as FetchResponse<fhir.Bundle>;
+
+const regularUser: LoggedInUser = {
+  display: 'Regular User',
+  uuid: 'user-uuid',
+  userProperties: {},
+} as LoggedInUser;
 
 const mockOpenmrsFetch = vi.mocked(openmrsFetch);
 const mockUseConfig = vi.mocked(useConfig);
@@ -348,6 +363,44 @@ describe('LocationPickerView', () => {
       expect(mockSetUserProperties).not.toHaveBeenCalled();
     });
   });
+
+  describe('Zero login locations', () => {
+    const renderWithFreshCache = (props = {}) => {
+      return render(
+        <SWRConfig value={{ provider: () => new Map() }}>
+          <MemoryRouter>
+            <LocationPickerView {...props} />
+          </MemoryRouter>
+        </SWRConfig>,
+      );
+    };
+
+    it('shows an empty state and hides the picker, checkbox, and confirm button when no login locations exist', async () => {
+      mockUseSession.mockReturnValue({
+        user: regularUser,
+      } as Session);
+
+      mockOpenmrsFetch.mockImplementation(async (url) =>
+        String(url).includes('_count=1') ? mockZeroLocationsResponse : (mockLoginLocations as FetchResponse<unknown>),
+      );
+
+      renderWithFreshCache();
+
+      await waitFor(() => {
+        expect(screen.getByText('No login locations configured')).toBeInTheDocument();
+      });
+
+      expect(
+        screen.getByText(
+          'This installation has no login locations configured. Please contact your system administrator.',
+        ),
+      ).toBeInTheDocument();
+      expect(screen.queryByRole('button', { name: /confirm/i })).not.toBeInTheDocument();
+      expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+      expect(screen.queryByLabelText(/remember my location/i)).not.toBeInTheDocument();
+      expect(mockSetSessionLocation).not.toHaveBeenCalled();
+    });
+  });
 });
 
 describe('isSafeReturnUrl', () => {
@@ -465,139 +518,5 @@ describe('returnToUrl open-redirect protection', () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({ to: '/openmrs/spa/home' });
     });
-  });
-});
-
-const mockZeroLocationsResponse: FetchResponse<unknown> = {
-  data: {
-    resourceType: 'Bundle',
-    total: 0,
-    entry: [],
-  },
-} as FetchResponse<unknown>;
-
-const regularUser: LoggedInUser = {
-  display: 'Regular User',
-  uuid: 'user-uuid',
-  userProperties: {},
-} as LoggedInUser;
-
-describe('Zero login locations', () => {
-  beforeEach(() => {
-    mockUseConnectivity.mockReturnValue(true);
-    mockUseConfig.mockReturnValue(mockConfig);
-    mockSetSessionLocation.mockResolvedValue(undefined);
-    mockNavigate.mockClear();
-
-    mockOpenmrsFetch.mockImplementation(async (url) => {
-      if (String(url).includes('_count=1')) {
-        return mockZeroLocationsResponse;
-      }
-      return mockLoginLocations as FetchResponse<unknown>;
-    });
-  });
-
-  const renderWithFreshCache = (props = {}) => {
-    return render(
-      <SWRConfig value={{ provider: () => new Map() }}>
-        <MemoryRouter>
-          <LocationPickerView {...props} />
-        </MemoryRouter>
-      </SWRConfig>,
-    );
-  };
-
-  it('shows empty state message when no login locations exist', async () => {
-    mockUseSession.mockReturnValue({
-      user: regularUser,
-    } as Session);
-
-    renderWithFreshCache();
-
-    await waitFor(() => {
-      expect(screen.getByText('No login locations configured')).toBeInTheDocument();
-    });
-
-    expect(
-      screen.getByText(
-        'This installation has no login locations configured. Please contact your system administrator.',
-      ),
-    ).toBeInTheDocument();
-  });
-
-  it('does not render the confirm button when no locations exist', async () => {
-    mockUseSession.mockReturnValue({
-      user: regularUser,
-    } as Session);
-
-    renderWithFreshCache();
-
-    await waitFor(() => {
-      expect(screen.getByText('No login locations configured')).toBeInTheDocument();
-    });
-
-    expect(screen.queryByRole('button', { name: /confirm/i })).not.toBeInTheDocument();
-  });
-
-  it('does not render the location picker when no locations exist', async () => {
-    mockUseSession.mockReturnValue({
-      user: regularUser,
-    } as Session);
-
-    renderWithFreshCache();
-
-    await waitFor(() => {
-      expect(screen.getByText('No login locations configured')).toBeInTheDocument();
-    });
-
-    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
-  });
-
-  it('does not render the remember location checkbox when no locations exist', async () => {
-    mockUseSession.mockReturnValue({
-      user: regularUser,
-    } as Session);
-
-    renderWithFreshCache();
-
-    await waitFor(() => {
-      expect(screen.getByText('No login locations configured')).toBeInTheDocument();
-    });
-
-    expect(screen.queryByLabelText(/remember my location/i)).not.toBeInTheDocument();
-  });
-
-  it('does not call setSessionLocation when no locations exist', async () => {
-    mockUseSession.mockReturnValue({
-      user: regularUser,
-    } as Session);
-
-    renderWithFreshCache();
-
-    await waitFor(() => {
-      expect(screen.getByText('No login locations configured')).toBeInTheDocument();
-    });
-
-    expect(mockSetSessionLocation).not.toHaveBeenCalled();
-  });
-
-  it('does not auto-login with saved default when no login locations exist', async () => {
-    mockUseSession.mockReturnValue({
-      user: {
-        display: 'Saved Default User',
-        uuid: 'saved-user-uuid',
-        userProperties: {
-          defaultLocation: fistLocation.uuid,
-        },
-      } as LoggedInUser,
-    } as Session);
-
-    renderWithFreshCache();
-
-    await waitFor(() => {
-      expect(screen.getByText('No login locations configured')).toBeInTheDocument();
-    });
-
-    expect(mockSetSessionLocation).not.toHaveBeenCalled();
   });
 });

--- a/packages/apps/esm-login-app/src/location-picker/location-picker.test.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.test.tsx
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { screen, waitFor, render } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 import userEvent from '@testing-library/user-event';
 import {
   navigate,
@@ -462,5 +465,139 @@ describe('returnToUrl open-redirect protection', () => {
     await waitFor(() => {
       expect(mockNavigate).toHaveBeenCalledWith({ to: '/openmrs/spa/home' });
     });
+  });
+});
+
+const mockZeroLocationsResponse: FetchResponse<unknown> = {
+  data: {
+    resourceType: 'Bundle',
+    total: 0,
+    entry: [],
+  },
+} as FetchResponse<unknown>;
+
+const regularUser: LoggedInUser = {
+  display: 'Regular User',
+  uuid: 'user-uuid',
+  userProperties: {},
+} as LoggedInUser;
+
+describe('Zero login locations', () => {
+  beforeEach(() => {
+    mockUseConnectivity.mockReturnValue(true);
+    mockUseConfig.mockReturnValue(mockConfig);
+    mockSetSessionLocation.mockResolvedValue(undefined);
+    mockNavigate.mockClear();
+
+    mockOpenmrsFetch.mockImplementation(async (url) => {
+      if (String(url).includes('_count=1')) {
+        return mockZeroLocationsResponse;
+      }
+      return mockLoginLocations as FetchResponse<unknown>;
+    });
+  });
+
+  const renderWithFreshCache = (props = {}) => {
+    return render(
+      <SWRConfig value={{ provider: () => new Map() }}>
+        <MemoryRouter>
+          <LocationPickerView {...props} />
+        </MemoryRouter>
+      </SWRConfig>,
+    );
+  };
+
+  it('shows empty state message when no login locations exist', async () => {
+    mockUseSession.mockReturnValue({
+      user: regularUser,
+    } as Session);
+
+    renderWithFreshCache();
+
+    await waitFor(() => {
+      expect(screen.getByText('No login locations configured')).toBeInTheDocument();
+    });
+
+    expect(
+      screen.getByText(
+        'This installation has no login locations configured. Please contact your system administrator.',
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it('does not render the confirm button when no locations exist', async () => {
+    mockUseSession.mockReturnValue({
+      user: regularUser,
+    } as Session);
+
+    renderWithFreshCache();
+
+    await waitFor(() => {
+      expect(screen.getByText('No login locations configured')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('button', { name: /confirm/i })).not.toBeInTheDocument();
+  });
+
+  it('does not render the location picker when no locations exist', async () => {
+    mockUseSession.mockReturnValue({
+      user: regularUser,
+    } as Session);
+
+    renderWithFreshCache();
+
+    await waitFor(() => {
+      expect(screen.getByText('No login locations configured')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByRole('radio')).not.toBeInTheDocument();
+  });
+
+  it('does not render the remember location checkbox when no locations exist', async () => {
+    mockUseSession.mockReturnValue({
+      user: regularUser,
+    } as Session);
+
+    renderWithFreshCache();
+
+    await waitFor(() => {
+      expect(screen.getByText('No login locations configured')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByLabelText(/remember my location/i)).not.toBeInTheDocument();
+  });
+
+  it('does not call setSessionLocation when no locations exist', async () => {
+    mockUseSession.mockReturnValue({
+      user: regularUser,
+    } as Session);
+
+    renderWithFreshCache();
+
+    await waitFor(() => {
+      expect(screen.getByText('No login locations configured')).toBeInTheDocument();
+    });
+
+    expect(mockSetSessionLocation).not.toHaveBeenCalled();
+  });
+
+  it('does not auto-login with saved default when no login locations exist', async () => {
+    mockUseSession.mockReturnValue({
+      user: {
+        display: 'Saved Default User',
+        uuid: 'saved-user-uuid',
+        userProperties: {
+          defaultLocation: fistLocation.uuid,
+        },
+      } as LoggedInUser,
+    } as Session);
+
+    renderWithFreshCache();
+
+    await waitFor(() => {
+      expect(screen.getByText('No login locations configured')).toBeInTheDocument();
+    });
+
+    expect(mockSetSessionLocation).not.toHaveBeenCalled();
   });
 });

--- a/packages/apps/esm-login-app/src/location-picker/location-picker.test.tsx
+++ b/packages/apps/esm-login-app/src/location-picker/location-picker.test.tsx
@@ -49,12 +49,6 @@ const mockZeroLocationsResponse = {
   },
 } as FetchResponse<fhir.Bundle>;
 
-const regularUser: LoggedInUser = {
-  display: 'Regular User',
-  uuid: 'user-uuid',
-  userProperties: {},
-} as LoggedInUser;
-
 const mockOpenmrsFetch = vi.mocked(openmrsFetch);
 const mockUseConfig = vi.mocked(useConfig);
 const mockUseSession = vi.mocked(useSession);
@@ -365,6 +359,8 @@ describe('LocationPickerView', () => {
   });
 
   describe('Zero login locations', () => {
+    // useSwrImmutable keys on the URL; without a fresh cache, earlier tests' non-zero
+    // count stays cached and the empty state never renders.
     const renderWithFreshCache = (props = {}) => {
       return render(
         <SWRConfig value={{ provider: () => new Map() }}>
@@ -376,13 +372,7 @@ describe('LocationPickerView', () => {
     };
 
     it('shows an empty state and hides the picker, checkbox, and confirm button when no login locations exist', async () => {
-      mockUseSession.mockReturnValue({
-        user: regularUser,
-      } as Session);
-
-      mockOpenmrsFetch.mockImplementation(async (url) =>
-        String(url).includes('_count=1') ? mockZeroLocationsResponse : (mockLoginLocations as FetchResponse<unknown>),
-      );
+      mockOpenmrsFetch.mockResolvedValue(mockZeroLocationsResponse);
 
       renderWithFreshCache();
 

--- a/packages/apps/esm-login-app/translations/en.json
+++ b/packages/apps/esm-login-app/translations/en.json
@@ -24,6 +24,8 @@
   "logout": "Logout",
   "newPassword": "New password",
   "newPasswordRequired": "New password is required",
+  "noLoginLocations": "No login locations configured",
+  "noLoginLocationsMessage": "This installation has no login locations configured. Please contact your system administrator.",
   "oldPassword": "Old password",
   "oldPasswordRequired": "Old password is required",
   "openmrsLogo": "OpenMRS logo",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
On installs with zero login locations, the location picker crashes with `TypeError: can't access property "id", n is undefined`
[Screencast from 14-07-26 20:08:20.webm](https://github.com/user-attachments/assets/fc741d08-f76b-4e82-bd35-9c0580b50347)

## Description
I think the root cause was a `useEffect` in `location-picker-view.component.tsx` called `changeLocation()` with no arguments whenever `locationCount === 0`, passing undefined into `setSessionLocation`. This ran automatically on mount, independent of user interaction.

In this PR I have removed the `locationCount === 0` auto-redirect branch from the `useEffect` entirely, there's no valid location to redirect to, so the fix is to not attempt it, not to guard it more carefully
Added a locationCount > 0 guard to the single-location auto-select branch
Empty state (location-picker-view.component.tsx):

Shows "No login locations configured" with a message to contact the system administrator when `locationCount === 0`
Hides the welcome heading, `LocationPicker`, `checkbox`, and Confirm button

Testing
[Screencast from 21-07-26 18:31:45.webm](https://github.com/user-attachments/assets/c9759d20-6013-4087-921e-f6dd8fd8ec18)

## Screenshots
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/f26fae36-8a36-4e01-8c16-83107463bce5" />


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-5816

## Other
<!-- Anything not covered above -->

