### PR TITLE
(fix) O3-5842: Match Carbon's control height in the date pickers

### DIFF
--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDatePickerProps.md
@@ -670,7 +670,7 @@ A placeholder date that influences the format of the placeholder shown when no v
 
 > `optional` **short**: `boolean`
 
-Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx:32](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx#L32)
+Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx:36](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx#L36)
 
 'true' to use the short version.
 
@@ -715,9 +715,11 @@ By default, this is determined by the user's locale.
 
 > `optional` **size**: `"sm"` \| `"md"` \| `"lg"`
 
-Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx:30](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx#L30)
+Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx#L34)
 
-Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option
+Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option.
+When omitted, the size is taken from the surrounding Carbon layout context, falling back to
+`md` when there is none.
 
 ***
 
@@ -803,6 +805,6 @@ or invalid via ARIA.
 
 > `optional` **value**: `DateInputValue`
 
-Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx#L34)
+Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx#L38)
 
 The value (controlled)

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsDateRangePickerProps.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsDateRangePickerProps.md
@@ -720,9 +720,11 @@ By default, this is determined by the user's locale.
 
 > `optional` **size**: `"sm"` \| `"md"` \| `"lg"`
 
-Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx:36](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx#L36)
+Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx:40](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx#L40)
 
-Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option
+Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option.
+When omitted, the size is taken from the surrounding Carbon layout context, falling back to
+`md` when there is none.
 
 ***
 
@@ -822,6 +824,6 @@ or invalid via ARIA.
 
 > `optional` **value**: \[`DateInputValue`, `DateInputValue`\]
 
-Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx:38](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx#L38)
+Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx:42](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx#L42)
 
 The value (controlled)

--- a/packages/framework/esm-framework/docs/variables/OpenmrsDatePicker.md
+++ b/packages/framework/esm-framework/docs/variables/OpenmrsDatePicker.md
@@ -4,6 +4,6 @@
 
 > `const` **OpenmrsDatePicker**: `ForwardRefExoticComponent`\<[`OpenmrsDatePickerProps`](../interfaces/OpenmrsDatePickerProps.md) & `RefAttributes`\<`HTMLDivElement`\>\>
 
-Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx:45](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx#L45)
+Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx#L48)
 
 A date picker component to select a single date. Based on React Aria, but styled to look like Carbon.

--- a/packages/framework/esm-framework/docs/variables/OpenmrsDateRangePicker.md
+++ b/packages/framework/esm-framework/docs/variables/OpenmrsDateRangePicker.md
@@ -4,6 +4,6 @@
 
 > `const` **OpenmrsDateRangePicker**: `ForwardRefExoticComponent`\<[`OpenmrsDateRangePickerProps`](../interfaces/OpenmrsDateRangePickerProps.md) & `RefAttributes`\<`HTMLDivElement`\>\>
 
-Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx#L44)
+Defined in: [packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx:48](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx#L48)
 
 A date range picker to enter or select a date and time range. Based on React Aria, but styled to look like Carbon.

--- a/packages/framework/esm-styleguide/src/datepicker/calendar-popover.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/calendar-popover.component.tsx
@@ -52,11 +52,11 @@ export const CalendarPopover = /*#__PURE__*/ forwardRef<HTMLDivElement, Calendar
       <AutoCloseDialog>
         <CalendarComponent {...calendarProps}>
           <header className={styles.header}>
-            <Button className={classNames(styles.flatButton, styles.flatButtonMd)} slot="previous">
+            <Button className={classNames(styles.flatButton, styles.calendarNavButton)} slot="previous">
               <ChevronLeftIcon size={16} />
             </Button>
             <MonthYear className={styles.monthYear} />
-            <Button className={classNames(styles.flatButton, styles.flatButtonMd)} slot="next">
+            <Button className={classNames(styles.flatButton, styles.calendarNavButton)} slot="next">
               <ChevronRightIcon size={16} />
             </Button>
           </header>

--- a/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
@@ -173,6 +173,23 @@ describe('OpenmrsDateRangePicker', () => {
       expect(inputGroup).toHaveClass(styles.inputGroup);
       expect(inputGroup.className).not.toMatch(/cds--layout--size-/);
     });
+
+    // See the note in datepicker.test.tsx: untyped JavaScript callers can pass anything, and none
+    // of it may reach the DOM as a `cds--layout--size-*` token.
+    it.each([
+      ['null', null],
+      ['an empty string', ''],
+      ['an unsupported step', 'xl'],
+      ['the wrong case', 'Md'],
+      ['a number', 40],
+      ['an object', {}],
+      ['a value that would inject a second class', 'md cds--layout--size-lg'],
+    ])('should render without a layout class when size is %s', (_label, size) => {
+      render(<OpenmrsDateRangePicker aria-label="datepicker" size={size as unknown as 'md'} />);
+      const [inputGroup] = screen.getAllByRole('group');
+      expect(inputGroup).toHaveClass(styles.inputGroup);
+      expect(inputGroup.className).not.toMatch(/cds--layout--size-/);
+    });
   });
 
   describe('calendar popover', () => {

--- a/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
@@ -157,7 +157,6 @@ describe('OpenmrsDateRangePicker', () => {
     // See the note in datepicker.test.tsx: the group owns both the height and the bottom border,
     // and gets its height from Carbon's layout size tokens via these classes.
     it.each([
-      [undefined, 'cds--layout--size-md'],
       ['sm' as const, 'cds--layout--size-sm'],
       ['md' as const, 'cds--layout--size-md'],
       ['lg' as const, 'cds--layout--size-lg'],
@@ -166,6 +165,13 @@ describe('OpenmrsDateRangePicker', () => {
       const [inputGroup] = screen.getAllByRole('group');
       expect(inputGroup).toHaveClass(styles.inputGroup);
       expect(inputGroup).toHaveClass(expectedClass);
+    });
+
+    it('should not set a layout class when no size is given', () => {
+      render(<OpenmrsDateRangePicker aria-label="datepicker" />);
+      const [inputGroup] = screen.getAllByRole('group');
+      expect(inputGroup).toHaveClass(styles.inputGroup);
+      expect(inputGroup.className).not.toMatch(/cds--layout--size-/);
     });
   });
 

--- a/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/date-range-picker.test.tsx
@@ -154,38 +154,19 @@ describe('OpenmrsDateRangePicker', () => {
   });
 
   describe('size prop', () => {
-    /* eslint-disable testing-library/no-container, testing-library/no-node-access */
-    const getInputsWrapper = (container: HTMLElement) =>
-      Array.from(container.querySelectorAll('div')).find((el) => el.className.includes('inputsWrapper')) ?? null;
-
-    it('should apply md size classes by default', () => {
-      const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" />);
-      const wrapper = getInputsWrapper(container)!;
-      expect(wrapper).toHaveClass(styles.inputsWrapperMd);
-      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonMd);
+    // See the note in datepicker.test.tsx: the group owns both the height and the bottom border,
+    // and gets its height from Carbon's layout size tokens via these classes.
+    it.each([
+      [undefined, 'cds--layout--size-md'],
+      ['sm' as const, 'cds--layout--size-sm'],
+      ['md' as const, 'cds--layout--size-md'],
+      ['lg' as const, 'cds--layout--size-lg'],
+    ])('should size the input group with the Carbon layout class for size=%s', (size, expectedClass) => {
+      render(<OpenmrsDateRangePicker aria-label="datepicker" size={size} />);
+      const [inputGroup] = screen.getAllByRole('group');
+      expect(inputGroup).toHaveClass(styles.inputGroup);
+      expect(inputGroup).toHaveClass(expectedClass);
     });
-
-    it('should apply sm size classes when size="sm"', () => {
-      const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="sm" />);
-      const wrapper = getInputsWrapper(container)!;
-      expect(wrapper).toHaveClass(styles.inputsWrapperSm);
-      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonSm);
-    });
-
-    it('should apply md size classes when size="md"', () => {
-      const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="md" />);
-      const wrapper = getInputsWrapper(container)!;
-      expect(wrapper).toHaveClass(styles.inputsWrapperMd);
-      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonMd);
-    });
-
-    it('should apply lg size classes when size="lg"', () => {
-      const { container } = render(<OpenmrsDateRangePicker aria-label="datepicker" size="lg" />);
-      const wrapper = getInputsWrapper(container)!;
-      expect(wrapper).toHaveClass(styles.inputsWrapperLg);
-      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonLg);
-    });
-    /* eslint-enable testing-library/no-container, testing-library/no-node-access */
   });
 
   describe('calendar popover', () => {

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -6,16 +6,36 @@
 @use '@carbon/styles/scss/utilities/box-shadow';
 @use '@carbon/styles/scss/utilities/component-reset';
 @use '@carbon/styles/scss/utilities/focus-outline' as focus;
+@use '@carbon/styles/scss/utilities/layout' as carbon-layout;
 @use '../vars' as *;
 
 // Text field for dates
+//
+// Carbon puts the control height and the 1px bottom border on the *same* border-box element
+// (see `.cds--text-input` / `.cds--date-picker__input`), so the border is included in the
+// height: an md input is 40px in total, not 40px plus a border. This group has to do the same,
+// otherwise it renders one pixel taller than every Carbon input beside it in a form row.
+//
+// The height itself comes from Carbon's layout size tokens (sm 32px / md 40px / lg 48px), read
+// from the `cds--layout--size-*` class the components set, which is exactly how Carbon's own
+// inputs are sized. That way we follow Carbon if those values ever change.
 .inputGroup {
+  @include carbon-layout.use('size', $default: 'md', $min: 'sm', $max: 'lg');
+
   align-items: center;
   background-color: var(--cds-field);
+  block-size: carbon-layout.size('height');
   border-block-end: 1px solid var(--cds-border-strong);
+  box-sizing: border-box;
   color: var(--cds-text-primary);
   display: flex;
   position: relative;
+
+  // The trigger button fills the group instead of defining its height.
+  & > .flatButton {
+    block-size: 100%;
+    inline-size: carbon-layout.size('height');
+  }
 
   &:focus-within,
   &.cds--focused {
@@ -98,6 +118,7 @@
 
 // Single date picker input
 .inputWrapper {
+  block-size: 100%;
   inline-size: 15rem;
   margin-left: layout.$spacing-05;
   min-width: layout.$spacing-13;
@@ -110,37 +131,14 @@
   @extend %readonlyPlaceholderDimming;
 }
 
-.inputWrapperMd {
-  block-size: layout.$spacing-08;
-}
-
-.inputWrapperSm {
-  block-size: layout.$spacing-07;
-}
-
-.inputWrapperLg {
-  block-size: layout.$spacing-09;
-}
-
 // Range date picker inputs
 .inputsWrapper {
+  block-size: 100%;
   display: flex;
   min-width: 10rem;
   max-width: 15rem;
   margin-inline-start: 1rem;
   inline-size: 15rem;
-}
-
-.inputsWrapperSm {
-  block-size: layout.$spacing-07;
-}
-
-.inputsWrapperMd {
-  block-size: layout.$spacing-08;
-}
-
-.inputsWrapperLg {
-  block-size: layout.$spacing-09;
 }
 
 .dateInputWrapper {
@@ -251,19 +249,11 @@
   --omrs-icon-fill: #{theme.$support-error};
 }
 
+// Used by the calendar's month navigation buttons; the input group's trigger button is sized
+// by the group itself.
 .flatButtonMd {
   height: layout.$spacing-08;
   width: layout.$spacing-08;
-}
-
-.flatButtonSm {
-  height: layout.$spacing-07;
-  width: layout.$spacing-07;
-}
-
-.flatButtonLg {
-  height: layout.$spacing-09;
-  width: layout.$spacing-09;
 }
 
 .monthYear {

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -16,9 +16,12 @@
 // height: an md input is 40px in total, not 40px plus a border. This group has to do the same,
 // otherwise it renders one pixel taller than every Carbon input beside it in a form row.
 //
-// The height itself comes from Carbon's layout size tokens (sm 32px / md 40px / lg 48px), read
-// from the `cds--layout--size-*` class the components set, which is exactly how Carbon's own
-// inputs are sized. That way we follow Carbon if those values ever change.
+// The height itself comes from Carbon's layout size tokens (sm 32px / md 40px / lg 48px), which is
+// exactly how Carbon's own inputs are sized, so we follow Carbon if those values ever change. The
+// step is taken from the surrounding layout context — either the `cds--layout--size-*` class the
+// components set when a `size` prop is given, or one on an ancestor — and falls back to `$default`
+// when there is none. `$min`/`$max` match `.cds--text-input`, so a context outside sm..lg clamps
+// the same way Carbon's inputs do.
 .inputGroup {
   @include carbon-layout.use('size', $default: 'md', $min: 'sm', $max: 'lg');
 

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.module.scss
@@ -249,9 +249,10 @@
   --omrs-icon-fill: #{theme.$support-error};
 }
 
-// Used by the calendar's month navigation buttons; the input group's trigger button is sized
-// by the group itself.
-.flatButtonMd {
+// The calendar popover's previous/next month buttons. These are a fixed 2.5rem square regardless
+// of the field size: the popover is not part of the field, so it does not scale with it. The
+// field's own trigger button is sized by `.inputGroup` above.
+.calendarNavButton {
   height: layout.$spacing-08;
   width: layout.$spacing-08;
 }

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
@@ -220,6 +220,25 @@ describe('OpenmrsDatePicker', () => {
       expect(inputGroup).toHaveClass(styles.inputGroup);
       expect(inputGroup.className).not.toMatch(/cds--layout--size-/);
     });
+
+    // The prop is typed, but the framework is consumed from untyped JavaScript, so the component
+    // has to survive whatever a caller actually passes. Nothing outside the three supported steps
+    // may reach the DOM as a `cds--layout--size-*` token: the group must stay unsized and inherit
+    // the layout context instead.
+    it.each([
+      ['null', null],
+      ['an empty string', ''],
+      ['an unsupported step', 'xl'],
+      ['the wrong case', 'Md'],
+      ['a number', 40],
+      ['an object', {}],
+      ['a value that would inject a second class', 'md cds--layout--size-lg'],
+    ])('should render without a layout class when size is %s', (_label, size) => {
+      render(<OpenmrsDatePicker aria-label="datepicker" size={size as unknown as 'md'} />);
+      const [inputGroup] = screen.getAllByRole('group');
+      expect(inputGroup).toHaveClass(styles.inputGroup);
+      expect(inputGroup.className).not.toMatch(/cds--layout--size-/);
+    });
   });
 
   describe('CSS class variants', () => {

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
@@ -194,39 +194,21 @@ describe('OpenmrsDatePicker', () => {
   });
 
   describe('size prop', () => {
-    /* eslint-disable testing-library/no-container, testing-library/no-node-access */
-    it('should apply md size classes by default', () => {
-      const { container } = render(<OpenmrsDatePicker aria-label="datepicker" />);
-      const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
-      expect(wrapper).not.toBeNull();
-      expect(wrapper).toHaveClass(styles.inputWrapperMd);
-      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonMd);
+    // The input group is the element that carries both the control height and the bottom border,
+    // and it takes that height from Carbon's layout size tokens through these classes, the same
+    // way `cds--text-input` does. Asserting on the class is the closest we can get in jsdom,
+    // which has no layout engine and so cannot report a rendered height.
+    it.each([
+      [undefined, 'cds--layout--size-md'],
+      ['sm' as const, 'cds--layout--size-sm'],
+      ['md' as const, 'cds--layout--size-md'],
+      ['lg' as const, 'cds--layout--size-lg'],
+    ])('should size the input group with the Carbon layout class for size=%s', (size, expectedClass) => {
+      render(<OpenmrsDatePicker aria-label="datepicker" size={size} />);
+      const [inputGroup] = screen.getAllByRole('group');
+      expect(inputGroup).toHaveClass(styles.inputGroup);
+      expect(inputGroup).toHaveClass(expectedClass);
     });
-
-    it('should apply sm size classes when size="sm"', () => {
-      const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="sm" />);
-      const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
-      expect(wrapper).not.toBeNull();
-      expect(wrapper).toHaveClass(styles.inputWrapperSm);
-      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonSm);
-    });
-
-    it('should apply md size classes when size="md"', () => {
-      const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="md" />);
-      const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
-      expect(wrapper).not.toBeNull();
-      expect(wrapper).toHaveClass(styles.inputWrapperMd);
-      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonMd);
-    });
-
-    it('should apply lg size classes when size="lg"', () => {
-      const { container } = render(<OpenmrsDatePicker aria-label="datepicker" size="lg" />);
-      const wrapper = container.querySelector('.cds--date-picker-input__wrapper');
-      expect(wrapper).not.toBeNull();
-      expect(wrapper).toHaveClass(styles.inputWrapperLg);
-      expect(screen.getByRole('button')).toHaveClass(styles.flatButtonLg);
-    });
-    /* eslint-enable testing-library/no-container, testing-library/no-node-access */
   });
 
   describe('CSS class variants', () => {

--- a/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/datepicker.test.tsx
@@ -196,10 +196,11 @@ describe('OpenmrsDatePicker', () => {
   describe('size prop', () => {
     // The input group is the element that carries both the control height and the bottom border,
     // and it takes that height from Carbon's layout size tokens through these classes, the same
-    // way `cds--text-input` does. Asserting on the class is the closest we can get in jsdom,
-    // which has no layout engine and so cannot report a rendered height.
+    // way `cds--text-input` does. Asserting on the class is the closest we can get here: happy-dom
+    // has no layout engine, so it cannot report a rendered height. The heights themselves
+    // (sm 32px / md 40px / lg 48px, matching Carbon's inputs) are only verifiable in a real
+    // browser.
     it.each([
-      [undefined, 'cds--layout--size-md'],
       ['sm' as const, 'cds--layout--size-sm'],
       ['md' as const, 'cds--layout--size-md'],
       ['lg' as const, 'cds--layout--size-lg'],
@@ -208,6 +209,16 @@ describe('OpenmrsDatePicker', () => {
       const [inputGroup] = screen.getAllByRole('group');
       expect(inputGroup).toHaveClass(styles.inputGroup);
       expect(inputGroup).toHaveClass(expectedClass);
+    });
+
+    // Without a size the group must carry no layout class at all, so that it inherits the
+    // surrounding Carbon layout context the way an unsized `TextInput` does. The `md` fallback
+    // then comes from `layout.use()`'s `$default` in the stylesheet, not from a class.
+    it('should not set a layout class when no size is given', () => {
+      render(<OpenmrsDatePicker aria-label="datepicker" />);
+      const [inputGroup] = screen.getAllByRole('group');
+      expect(inputGroup).toHaveClass(styles.inputGroup);
+      expect(inputGroup.className).not.toMatch(/cds--layout--size-/);
     });
   });
 

--- a/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx
@@ -5,7 +5,7 @@ import { Button, DatePicker, type DatePickerProps, FieldError, Group, Provider, 
 import { type CalendarDate } from '@internationalized/date';
 import { type DateInputValue, type DatePickerBaseProps } from './types';
 import { I18nWrapper } from './i18n-wrapper.component';
-import { dateToInternationalizedDate, internationalizedDateToDate } from './utils';
+import { dateToInternationalizedDate, getLayoutSizeClass, internationalizedDateToDate } from './utils';
 import { OpenmrsIntlLocaleContext, useDatepickerContext } from './hooks';
 import { DEFAULT_MIN_DATE_FLOOR } from './defaults';
 import { CalendarPopover } from './calendar-popover.component';
@@ -68,6 +68,7 @@ export const OpenmrsDatePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, Openmr
 
     const id = useId();
     const hasVisibleLabel = !!(labelText ?? label);
+    const layoutSizeClass = getLayoutSizeClass(size);
 
     // Warn in development if no accessible label is provided
     if (process.env.NODE_ENV !== 'production') {
@@ -124,15 +125,11 @@ export const OpenmrsDatePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, Openmr
                     {labelText ?? label}
                   </Label>
                 )}
-                <Group className={styles.inputGroup}>
+                <Group className={classNames(styles.inputGroup, layoutSizeClass)}>
                   <DatePickerInput
                     id={hasVisibleLabel ? id : undefined}
                     ref={ref}
-                    className={classNames('cds--date-picker-input__wrapper', styles.inputWrapper, {
-                      [styles.inputWrapperSm]: size === 'sm',
-                      [styles.inputWrapperMd]: size === 'md' || !size || size.length === 0,
-                      [styles.inputWrapperLg]: size === 'lg',
-                    })}
+                    className={classNames('cds--date-picker-input__wrapper', styles.inputWrapper)}
                   >
                     {(segment) => {
                       return segment.type !== 'era' ? (
@@ -142,13 +139,7 @@ export const OpenmrsDatePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, Openmr
                       );
                     }}
                   </DatePickerInput>
-                  <Button
-                    className={classNames(styles.flatButton, {
-                      [styles.flatButtonSm]: size === 'sm',
-                      [styles.flatButtonMd]: size === 'md' || !size || size.length === 0,
-                      [styles.flatButtonLg]: size === 'lg',
-                    })}
-                  >
+                  <Button className={styles.flatButton}>
                     <DatePickerIcon />
                   </Button>
                 </Group>

--- a/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/openmrs-date-picker.component.tsx
@@ -26,7 +26,11 @@ export interface OpenmrsDatePickerProps
   onChange?: (value: Date | null | undefined) => void;
   /** Handler that is called when the value changes. Note that this provides types from @internationalized/date. */
   onChangeRaw?: (value: DateValue | null) => void;
-  /** Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option */
+  /**
+   * Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option.
+   * When omitted, the size is taken from the surrounding Carbon layout context, falling back to
+   * `md` when there is none.
+   */
   size?: 'sm' | 'md' | 'lg';
   /** 'true' to use the short version. */
   short?: boolean;
@@ -36,7 +40,6 @@ export interface OpenmrsDatePickerProps
 
 const defaultProps: OpenmrsDatePickerProps = {
   short: false,
-  size: 'md',
 };
 
 /**

--- a/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx
@@ -19,7 +19,7 @@ import { type DateInputValue, type DatePickerBaseProps } from './types';
 import { I18nWrapper } from './i18n-wrapper.component';
 import { DatePickerIcon } from './date-picker-icon.component';
 import { CalendarPopover } from './calendar-popover.component';
-import { dateToInternationalizedDate, internationalizedDateToDate } from './utils';
+import { dateToInternationalizedDate, getLayoutSizeClass, internationalizedDateToDate } from './utils';
 import { DEFAULT_MIN_DATE_FLOOR } from './defaults';
 
 /** Properties for the OpenmrsDateRangePicker */
@@ -67,6 +67,7 @@ export const OpenmrsDateRangePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, O
 
     const id = useId();
     const hasVisibleLabel = !!(labelText ?? label);
+    const layoutSizeClass = getLayoutSizeClass(size);
 
     // Warn in development if no accessible label is provided
     if (process.env.NODE_ENV !== 'production') {
@@ -146,14 +147,8 @@ export const OpenmrsDateRangePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, O
                   </Label>
                 )}
 
-                <Group className={styles.inputGroup}>
-                  <div
-                    className={classNames(styles.inputsWrapper, {
-                      [styles.inputsWrapperSm]: size === 'sm',
-                      [styles.inputsWrapperMd]: size === 'md' || !size || size.length === 0,
-                      [styles.inputsWrapperLg]: size === 'lg',
-                    })}
-                  >
+                <Group className={classNames(styles.inputGroup, layoutSizeClass)}>
+                  <div className={styles.inputsWrapper}>
                     <DateInput
                       className={classNames(
                         'cds--date-picker-input__wrapper',
@@ -180,13 +175,7 @@ export const OpenmrsDateRangePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, O
                       {(segment) => <DateSegment className={styles.inputSegment} segment={segment} />}
                     </DateInput>
                   </div>
-                  <Button
-                    className={classNames(styles.flatButton, {
-                      [styles.flatButtonSm]: size === 'sm',
-                      [styles.flatButtonMd]: size === 'md' || !size || size.length === 0,
-                      [styles.flatButtonLg]: size === 'lg',
-                    })}
-                  >
+                  <Button className={styles.flatButton}>
                     <DatePickerIcon />
                   </Button>
                 </Group>

--- a/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx
+++ b/packages/framework/esm-styleguide/src/datepicker/openmrs-date-range-picker.component.tsx
@@ -32,7 +32,11 @@ export interface OpenmrsDateRangePickerProps
   onChange?: (value: [Date | null | undefined, Date | null | undefined]) => void;
   /** Handler that is called when the value changes. Note that this provides types from @internationalized/date. */
   onChangeRaw?: (value: DateRange | null) => void;
-  /** Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option */
+  /**
+   * Specifies the size of the input. Currently supports either `sm`, `md`, or `lg` as an option.
+   * When omitted, the size is taken from the surrounding Carbon layout context, falling back to
+   * `md` when there is none.
+   */
   size?: 'sm' | 'md' | 'lg';
   /** The value (controlled) */
   value?: [DateInputValue, DateInputValue];
@@ -57,7 +61,7 @@ export const OpenmrsDateRangePicker = /*#__PURE__*/ forwardRef<HTMLDivElement, O
       minDate: rawMinDate,
       onChange,
       onChangeRaw,
-      size = 'md',
+      size,
       value: rawValue,
       ...dateRangePickerProps
     },

--- a/packages/framework/esm-styleguide/src/datepicker/utils.test.ts
+++ b/packages/framework/esm-styleguide/src/datepicker/utils.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest';
 import { CalendarDate, CalendarDateTime, EthiopicCalendar } from '@internationalized/date';
-import { dateToInternationalizedDate, internationalizedDateToDate, removeDataAttributes } from './utils';
+import {
+  dateToInternationalizedDate,
+  getLayoutSizeClass,
+  internationalizedDateToDate,
+  removeDataAttributes,
+} from './utils';
 
 describe('dateToInternationalizedDate', () => {
   it('returns undefined for undefined input', () => {
@@ -91,6 +96,24 @@ describe('internationalizedDateToDate', () => {
     expect(result!.getFullYear()).toBe(2025);
     expect(result!.getMonth()).toBe(5);
     expect(result!.getDate()).toBe(18);
+  });
+});
+
+describe('getLayoutSizeClass', () => {
+  it.each([
+    ['sm' as const, 'cds--layout--size-sm'],
+    ['md' as const, 'cds--layout--size-md'],
+    ['lg' as const, 'cds--layout--size-lg'],
+  ])('maps size %s to the Carbon layout class %s', (size, expected) => {
+    expect(getLayoutSizeClass(size)).toBe(expected);
+  });
+
+  it('falls back to md when no size is given', () => {
+    expect(getLayoutSizeClass(undefined)).toBe('cds--layout--size-md');
+  });
+
+  it('falls back to md for an empty size', () => {
+    expect(getLayoutSizeClass('' as unknown as 'md')).toBe('cds--layout--size-md');
   });
 });
 

--- a/packages/framework/esm-styleguide/src/datepicker/utils.test.ts
+++ b/packages/framework/esm-styleguide/src/datepicker/utils.test.ts
@@ -110,12 +110,28 @@ describe('getLayoutSizeClass', () => {
 
   // No class means "inherit the surrounding Carbon layout context"; the md fallback lives in the
   // stylesheet's `layout.use()` `$default`, not here.
-  it('returns no class when no size is given', () => {
-    expect(getLayoutSizeClass(undefined)).toBeUndefined();
-  });
-
-  it('returns no class for an empty size', () => {
-    expect(getLayoutSizeClass('' as unknown as 'md')).toBeUndefined();
+  //
+  // The `size` prop is typed, but the framework is consumed from untyped JavaScript too, so these
+  // cover what a caller can actually pass at runtime, not just what the type permits. Everything
+  // outside the three supported steps has to come back `undefined` so the group falls back to the
+  // layout context rather than carrying a class that looks like a Carbon token but isn't one.
+  it.each([
+    ['undefined', undefined],
+    ['null', null],
+    ['an empty string', ''],
+    ['a step Carbon has but the pickers do not support', 'xl'],
+    ['the wrong case', 'Md'],
+    ['an unknown string', 'huge'],
+    ['a number', 40],
+    ['zero', 0],
+    ['a boolean', true],
+    ['an object', {}],
+    // A value with whitespace would otherwise emit two classes, and the later
+    // `cds--layout--size-*` wins the cascade — so a caller asking for `md` would silently render
+    // at `lg`.
+    ['a value that would inject a second class', 'md cds--layout--size-lg'],
+  ])('returns no class for %s', (_label, size) => {
+    expect(getLayoutSizeClass(size as unknown as 'md' | undefined)).toBeUndefined();
   });
 });
 

--- a/packages/framework/esm-styleguide/src/datepicker/utils.test.ts
+++ b/packages/framework/esm-styleguide/src/datepicker/utils.test.ts
@@ -108,12 +108,14 @@ describe('getLayoutSizeClass', () => {
     expect(getLayoutSizeClass(size)).toBe(expected);
   });
 
-  it('falls back to md when no size is given', () => {
-    expect(getLayoutSizeClass(undefined)).toBe('cds--layout--size-md');
+  // No class means "inherit the surrounding Carbon layout context"; the md fallback lives in the
+  // stylesheet's `layout.use()` `$default`, not here.
+  it('returns no class when no size is given', () => {
+    expect(getLayoutSizeClass(undefined)).toBeUndefined();
   });
 
-  it('falls back to md for an empty size', () => {
-    expect(getLayoutSizeClass('' as unknown as 'md')).toBe('cds--layout--size-md');
+  it('returns no class for an empty size', () => {
+    expect(getLayoutSizeClass('' as unknown as 'md')).toBeUndefined();
   });
 });
 

--- a/packages/framework/esm-styleguide/src/datepicker/utils.ts
+++ b/packages/framework/esm-styleguide/src/datepicker/utils.ts
@@ -61,15 +61,23 @@ export function internationalizedDateToDate(date: DateValue): Date | undefined {
 }
 
 /**
- * Returns the Carbon layout size class for a date picker size.
+ * Returns the Carbon layout size class for a date picker size, or `undefined` when no size was
+ * given.
  *
  * Carbon sizes its form controls through the `cds--layout--size-*` classes, which set the layout
  * size tokens (sm 32px / md 40px / lg 48px) that the control's height is read from. The date
  * pickers use the same mechanism so that they are exactly as tall as the Carbon inputs they sit
  * next to in a form row.
+ *
+ * Returning `undefined` for an absent size is deliberate, and mirrors `TextInput`, which also only
+ * emits the class when a size is passed. The class overrides the layout size for the whole subtree
+ * it is set on, so emitting it unconditionally would opt the picker out of any surrounding layout
+ * context: inside a `cds--layout--size-sm` container an unsized Carbon input is 32px, and an
+ * unsized picker would stay 40px. With no class, the size falls back to the `$default: 'md'` in
+ * `.inputGroup`'s `layout.use()`, so an unsized picker outside any layout context is still 40px.
  */
-export function getLayoutSizeClass(size: 'sm' | 'md' | 'lg' | undefined): string {
-  return `cds--layout--size-${size && size.length > 0 ? size : 'md'}`;
+export function getLayoutSizeClass(size: 'sm' | 'md' | 'lg' | undefined): string | undefined {
+  return size ? `cds--layout--size-${size}` : undefined;
 }
 
 /** Removes any data attributes from an object */

--- a/packages/framework/esm-styleguide/src/datepicker/utils.ts
+++ b/packages/framework/esm-styleguide/src/datepicker/utils.ts
@@ -60,9 +60,12 @@ export function internationalizedDateToDate(date: DateValue): Date | undefined {
   return date.toDate(getLocalTimeZone());
 }
 
+/** The layout steps the date pickers support, matching the `size` prop's type. */
+const layoutSizeSteps = new Set(['sm', 'md', 'lg']);
+
 /**
- * Returns the Carbon layout size class for a date picker size, or `undefined` when no size was
- * given.
+ * Returns the Carbon layout size class for a date picker size, or `undefined` when no usable size
+ * was given.
  *
  * Carbon sizes its form controls through the `cds--layout--size-*` classes, which set the layout
  * size tokens (sm 32px / md 40px / lg 48px) that the control's height is read from. The date
@@ -75,9 +78,17 @@ export function internationalizedDateToDate(date: DateValue): Date | undefined {
  * context: inside a `cds--layout--size-sm` container an unsized Carbon input is 32px, and an
  * unsized picker would stay 40px. With no class, the size falls back to the `$default: 'md'` in
  * `.inputGroup`'s `layout.use()`, so an unsized picker outside any layout context is still 40px.
+ *
+ * Anything outside `sm`/`md`/`lg` is treated the same as an absent size rather than interpolated
+ * into the class name. The prop is typed, but plenty of callers are untyped JavaScript, and
+ * interpolating whatever they pass puts a token that reads like a Carbon class but isn't one
+ * (`cds--layout--size-40`) into production DOM. Worse, a value containing whitespace emits *two*
+ * classes, so `size="md cds--layout--size-lg"` renders at `lg` — the opposite of what was asked
+ * for. Carbon's own `TextInput` interpolates naively; being stricter here costs nothing for
+ * in-contract callers and fails predictably for the rest.
  */
 export function getLayoutSizeClass(size: 'sm' | 'md' | 'lg' | undefined): string | undefined {
-  return size ? `cds--layout--size-${size}` : undefined;
+  return layoutSizeSteps.has(size as string) ? `cds--layout--size-${size}` : undefined;
 }
 
 /** Removes any data attributes from an object */

--- a/packages/framework/esm-styleguide/src/datepicker/utils.ts
+++ b/packages/framework/esm-styleguide/src/datepicker/utils.ts
@@ -60,6 +60,18 @@ export function internationalizedDateToDate(date: DateValue): Date | undefined {
   return date.toDate(getLocalTimeZone());
 }
 
+/**
+ * Returns the Carbon layout size class for a date picker size.
+ *
+ * Carbon sizes its form controls through the `cds--layout--size-*` classes, which set the layout
+ * size tokens (sm 32px / md 40px / lg 48px) that the control's height is read from. The date
+ * pickers use the same mechanism so that they are exactly as tall as the Carbon inputs they sit
+ * next to in a form row.
+ */
+export function getLayoutSizeClass(size: 'sm' | 'md' | 'lg' | undefined): string {
+  return `cds--layout--size-${size && size.length > 0 ? size : 'md'}`;
+}
+
 /** Removes any data attributes from an object */
 export function removeDataAttributes<T>(props: T): T {
   const prefix = /^(data-.*)$/;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [x] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [x] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes. — the mocks do not touch `size`, so there is nothing to update there. The type signatures are unchanged, but see **On the API surface** below: the *runtime default* of `size` changed, and the generated docs do need a regeneration.

## Summary

`OpenmrsDatePicker` rendered its input group at 41px where Carbon's md-size text inputs are 40px, so a date picker next to a `TextInput` or `ComboBox` in a form row put the field bottoms and underlines a pixel apart (reported from the filter row of the audit log app).

**Root cause.** The height and the 1px bottom border lived on different elements. `.inputGroup` carried `border-block-end: 1px solid` but had no height of its own; the height came from the children (`.inputWrapperMd` / `.flatButtonMd`, both `2.5rem`). With `block-size: auto`, the border is added *on top* of the 40px children, so the group measures 41px. Carbon puts the height and the border on the *same* `border-box` element — see `.cds--text-input` (`block-size: layout.size('height')` + `border-block-end: 1px solid $border-strong`) and `.cds--date-picker__input` — so the border sits *inside* the 40px.

**Fix.** The group now owns both the height and the border, and its children fill it (`block-size: 100%`). The height is read from Carbon's layout size tokens via `layout.use('size', $default: 'md', $min: 'sm', $max: 'lg')` / `layout.size('height')`, keyed off the `cds--layout--size-*` class the components set — exactly the mechanism `cds--text-input` uses (`TextInput.js` adds `` [`${prefix}--layout--size-${size}`]: size ``). Nothing is hardcoded against Carbon's sizing, so a Carbon upgrade that changes those tokens carries over automatically.

This also fixes the `sm` and `lg` variants, which were 33px and 49px against Carbon's 32px and 48px, and the same bug in `OpenmrsDateRangePicker`.

**Removed / renamed classes.** `inputWrapperSm/Md/Lg`, `inputsWrapperSm/Md/Lg` and `flatButtonSm/Md/Lg` are all gone — the group sizes its own children now. The one rule that had to survive is the calendar popover's previous/next-month buttons, which are a fixed `2.5rem` square and deliberately *don't* track the field size; that rule was renamed `flatButtonMd` → `.calendarNavButton` so the name stops implying it is the md member of a set that no longer exists. None of the removed classes had consumers outside this directory, and none of them were part of the exported sass surface.

**Size is inherited, not defaulted.** `size` no longer defaults to `'md'` in the components. Emitting `cds--layout--size-md` unconditionally would have opted the picker *out* of any surrounding Carbon layout context: inside a `cds--layout--size-sm` container an unsized `TextInput` is 32px, but an unsized picker would have stayed 40px. With no class, the size comes from the ancestor context, falling back to the `$default: 'md'` in `.inputGroup`'s `layout.use()` — so an unsized picker outside any layout context is still 40px, and inside one it now matches its neighbours. This mirrors `TextInput`, which also only emits the class when a size is passed.

Values outside `sm`/`md`/`lg` are treated as "no size" rather than interpolated into the class name. The prop is typed, but plenty of callers are untyped JavaScript, and interpolating whatever arrives produced tokens that look like Carbon classes but match nothing (`size={40}` → `cds--layout--size-40`), or — for a value containing whitespace — a *second* class that wins the cascade, so `size="md cds--layout--size-lg"` rendered at `lg`.

**Measured heights** (Chromium, `deviceScaleFactor: 1`; `getBoundingClientRect().height` of the picker's `[role="group"]` against a real Carbon `TextInput`/`ComboBox` of the same size rendered in the same document, with the styleguide's `_all.scss` loaded):

| size | Carbon TextInput | picker before | picker after |
|------|-----------------|---------------|--------------|
| sm   | 32 | **33** | 32 |
| md   | 40 | **41** | 40 |
| lg   | 48 | **49** | 48 |
| md (`OpenmrsDateRangePicker`) | 40 | **41** | 40 |

Verified three ways with the same numbers:

1. This repo's Storybook (`yarn storybook`, `Components/DatePicker` and `Components/DateRangePicker` stories, driven with Playwright), in LTR and RTL.
2. A standalone rspack page rendering the components side by side with Carbon's `TextInput` and `ComboBox`.
3. **A running OpenMRS instance.** The app shell was built from this branch (`yarn run:shell` with `OMRS_PROXY_TARGET` pointed at a local OpenMRS 8081) so the real frontend modules from the instance's own importmap render against this styleguide, then Patient Registration and Appointments were driven with Playwright. On Patient Registration the date-of-birth picker measures **41px on `main` and 40px with this branch**, against the page's `cds--text-input` fields at 40px; every element below the picker shifts up by exactly 1px between the two builds. The group's computed `--cds-layout-size-height-local` is `clamp(max(0px, 2rem), 2.5rem, min(999999999px, 3rem))` — i.e. the height really is coming from Carbon's layout token, clamped to sm..lg, and not from a hardcoded value.

**No regressions found.** In the browser, at all three sizes: the calendar opens, renders 35 day cells, a date can be picked, the popover closes and the value lands in the input, and the group height holds after a value is set. The invalid, disabled and default-value stories still render correctly (error outline, warning icon and error text intact); text and the calendar icon remain vertically centred. The popover is portaled, so it cannot inherit the group's layout class.

## Screenshots

Not attached — the change is a 1px height correction; the measurements above are the meaningful evidence. Before, in a mixed row, the date picker's underline sat 1px below the neighbouring inputs'; after, all the underlines share a baseline.

## Related Issue

https://openmrs.atlassian.net/browse/O3-5842

## Other

**On the tests.** The package runs under vitest with happy-dom, which has no layout engine and cannot report a rendered height, so there is no honest way to assert "40px" in the unit tests. Instead the `size prop` suites in `datepicker.test.tsx` and `date-range-picker.test.tsx` assert the mechanism that produces the height: the group carries `cds--layout--size-{sm,md,lg}` when a size is given, and carries **no** `cds--layout--size-*` class at all when one isn't, so that it inherits the surrounding layout context. The same suites cover the full range an untyped caller can actually pass — `null`, `''`, `'xl'`, `'Md'`, a number, an object, and a whitespace-injection string — and assert none of it reaches the DOM as a layout class. `utils.test.ts` covers `getLayoutSizeClass` directly over the same range. The height itself was verified in a real browser as described above. `yarn test` for `@openmrs/esm-styleguide` passes (289 passed, 1 skipped), as do `eslint` and `prettier --check` on the changed files.

**On the API surface.** No exported type changed and no new symbol is exported (`getLayoutSizeClass` is internal to `src/datepicker/` and is not re-exported from `datepicker/index.tsx`). Two things did change that a reviewer should see explicitly:

- The runtime default of `size` (previously always `'md'`, now inherited — see above). Callers that relied on a picker staying 40px inside a non-md layout context will now see it match that context, which is the intended behaviour.
- The TSDoc on `size` in `OpenmrsDatePickerProps` and `OpenmrsDateRangePickerProps`, which means the committed API docs are stale for this branch.

The `drift` check is therefore red on purpose and cannot be cleared from this branch: it requires the `Docs / Regenerated` check run, which only the bot posts, and the bot only runs after an approving review from a write-access reviewer. Committing regenerated docs by hand does not help — the same check hard-fails on any manual edit under `packages/framework/esm-framework/docs/`. **Please just approve; the bot will push the docs commit and `drift` will go green.** `skip-docs` would be the wrong lever here, because the docs genuinely do drift.
