### PR TITLE
(chore) Bump @openmrs/eslint-config to ^1.0.0 and eslint to ^9.39.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "storybook": "yarn workspace @openmrs/storybook storybook"
   },
   "devDependencies": {
-    "@openmrs/eslint-config": "^0.1.0",
+    "@openmrs/eslint-config": "^1.0.0",
     "@playwright/test": "^1.55.1",
     "@swc/core": "1.15.21",
     "@testing-library/dom": "^10.4.1",
@@ -40,7 +40,7 @@
     "classnames": "^2.3.2",
     "cross-env": "^10.1.0",
     "dotenv": "^16.0.3",
-    "eslint": "^9.13.0",
+    "eslint": "^9.39.0",
     "fake-indexeddb": "^4.0.2",
     "fork-ts-checker-webpack-plugin": "^7.2.13",
     "husky": "^8.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2881,9 +2881,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openmrs/eslint-config@npm:^0.1.0":
-  version: 0.1.0
-  resolution: "@openmrs/eslint-config@npm:0.1.0"
+"@openmrs/eslint-config@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "@openmrs/eslint-config@npm:1.0.0"
   dependencies:
     "@eslint/js": "npm:^9.13.0"
     eslint-config-prettier: "npm:^9.1.0"
@@ -2895,9 +2895,9 @@ __metadata:
     globals: "npm:^15.11.0"
     typescript-eslint: "npm:^8.10.0"
   peerDependencies:
-    eslint: ">=9"
+    eslint: ^9.39.0
     typescript: ">=5"
-  checksum: 10/3719d53a812fe2c8fbee1373d7825e42777c9935d7137e37471ac50e0dbab1231e918ecefb4dc1b8d6266269f9b8a50fe9a4169b96e4eea2ed9db5a94d3c4cb2
+  checksum: 10/66c25b77c6b1d77a5b73e4074cdd17b96e7447684e71bf13509f512c8e806102e0a94fe613b33ea442e9782c8f3fb4afb2f9d5e14b5f6be6d6abb651b54d8ffe
   languageName: node
   linkType: hard
 
@@ -3007,7 +3007,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/esm-core@workspace:."
   dependencies:
-    "@openmrs/eslint-config": "npm:^0.1.0"
+    "@openmrs/eslint-config": "npm:^1.0.0"
     "@playwright/test": "npm:^1.55.1"
     "@swc/core": "npm:1.15.21"
     "@testing-library/dom": "npm:^10.4.1"
@@ -3020,7 +3020,7 @@ __metadata:
     classnames: "npm:^2.3.2"
     cross-env: "npm:^10.1.0"
     dotenv: "npm:^16.0.3"
-    eslint: "npm:^9.13.0"
+    eslint: "npm:^9.39.0"
     fake-indexeddb: "npm:^4.0.2"
     fork-ts-checker-webpack-plugin: "npm:^7.2.13"
     husky: "npm:^8.0.3"
@@ -11462,7 +11462,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint@npm:^9.13.0":
+"eslint@npm:^9.39.0":
   version: 9.39.5
   resolution: "eslint@npm:9.39.5"
   dependencies:


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary

Follow-up to #1827. The shared config graduated to [`@openmrs/eslint-config@1.0.0`](https://www.npmjs.com/package/@openmrs/eslint-config) ahead of the cross-repo rollout, and caret semantics on 0.x meant our `^0.1.0` range would never pick it up. This bumps the range to `^1.0.0` so future minor releases of the config flow in without per-repo PRs.

It also raises `eslint` from `^9.13.0` to `^9.39.0` so the declared version matches what the lockfile installs and what the config declares as its peer range, per @ibacher's feedback on #1827.

All 30 workspaces lint green against 1.0.0 with no findings changed (the 1.0.0 rule set is identical to 0.1.0).

## Screenshots

## Related Issue

## Other
