### PR TITLE
(fix) Read past the first page in the docs workflow lookups

### DIFF
--- a/.github/workflows/docs-build-on-approval.yml
+++ b/.github/workflows/docs-build-on-approval.yml
@@ -58,8 +58,8 @@ jobs:
           # Only the bot's App token can post the Docs / Regenerated check run
           # (checks:write is App-scoped), so finding it on the head SHA is a
           # credible "docs are current" signal — skip the rebuild.
-          regenerated=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-            --jq '[.check_runs[] | select(.name == "Docs / Regenerated" and .conclusion == "success")] | length')
+          regenerated=$(gh api --paginate "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+            --jq '.check_runs[] | select(.name == "Docs / Regenerated" and .conclusion == "success") | .id' | wc -l)
           if [ "${regenerated}" -gt 0 ]; then
             echo "Head SHA already has a successful Docs / Regenerated check run; skipping"
             echo "proceed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docs-build-on-approval.yml
+++ b/.github/workflows/docs-build-on-approval.yml
@@ -58,8 +58,11 @@ jobs:
           # Only the bot's App token can post the Docs / Regenerated check run
           # (checks:write is App-scoped), so finding it on the head SHA is a
           # credible "docs are current" signal — skip the rebuild.
-          regenerated=$(gh api --paginate "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-            --jq '.check_runs[] | select(.name == "Docs / Regenerated" and .conclusion == "success") | .id' | wc -l)
+          # check_name filters server-side, so this is one request in practice.
+          # --method GET is required or -f would make this a POST.
+          regenerated=$(gh api --paginate --method GET "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+            -f check_name="Docs / Regenerated" \
+            --jq '.check_runs[] | select(.conclusion == "success") | .id' | wc -l)
           if [ "${regenerated}" -gt 0 ]; then
             echo "Head SHA already has a successful Docs / Regenerated check run; skipping"
             echo "proceed=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -100,7 +100,7 @@ jobs:
           # future caller that forgets to gate (or a regression in caller
           # logic) can't smuggle PR code execution through this workflow.
           approved_by_writer=false
-          for u in $(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --jq '[.[] | select(.state == "APPROVED") | .user.login] | unique | .[]'); do
+          for u in $(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --jq '.[] | select(.state == "APPROVED") | .user.login' | sort -u); do
             permission=$(gh api "repos/${REPO}/collaborators/${u}/permission" --jq '.permission' 2>/dev/null || echo "none")
             if [[ "${permission}" == "write" || "${permission}" == "admin" ]]; then
               approved_by_writer=true

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -100,7 +100,7 @@ jobs:
           # future caller that forgets to gate (or a regression in caller
           # logic) can't smuggle PR code execution through this workflow.
           approved_by_writer=false
-          for u in $(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --jq '.[] | select(.state == "APPROVED") | .user.login' | sort -u); do
+          for u in $(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | select(.state == "APPROVED") | .user.login' | sort -u); do
             permission=$(gh api "repos/${REPO}/collaborators/${u}/permission" --jq '.permission' 2>/dev/null || echo "none")
             if [[ "${permission}" == "write" || "${permission}" == "admin" ]]; then
               approved_by_writer=true

--- a/.github/workflows/docs-drift-check.yml
+++ b/.github/workflows/docs-drift-check.yml
@@ -84,8 +84,8 @@ jobs:
           # Docs / Regenerated check run (checks:write is App-scoped), so
           # finding it on the head SHA is a credible "docs are current"
           # signal — drift check passes.
-          regenerated=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-            --jq '[.check_runs[] | select(.name == "Docs / Regenerated" and .conclusion == "success")] | length')
+          regenerated=$(gh api --paginate "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+            --jq '.check_runs[] | select(.name == "Docs / Regenerated" and .conclusion == "success") | .id' | wc -l)
           if [ "${regenerated}" -gt 0 ]; then
             echo "Head SHA has Docs / Regenerated check run; check passes."
             echo "pass=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docs-drift-check.yml
+++ b/.github/workflows/docs-drift-check.yml
@@ -84,8 +84,11 @@ jobs:
           # Docs / Regenerated check run (checks:write is App-scoped), so
           # finding it on the head SHA is a credible "docs are current"
           # signal — drift check passes.
-          regenerated=$(gh api --paginate "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-            --jq '.check_runs[] | select(.name == "Docs / Regenerated" and .conclusion == "success") | .id' | wc -l)
+          # check_name filters server-side, so this is one request in practice.
+          # --method GET is required or -f would make this a POST.
+          regenerated=$(gh api --paginate --method GET "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+            -f check_name="Docs / Regenerated" \
+            --jq '.check_runs[] | select(.conclusion == "success") | .id' | wc -l)
           if [ "${regenerated}" -gt 0 ]; then
             echo "Head SHA has Docs / Regenerated check run; check passes."
             echo "pass=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/docs-rebuild-on-push.yml
+++ b/.github/workflows/docs-rebuild-on-push.yml
@@ -37,8 +37,8 @@ jobs:
           # The check run is bound to the SHA, so a new commit (= new SHA)
           # is automatically uncovered. Its presence on the current head
           # answers "are docs current?".
-          regenerated=$(gh api "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-            --jq '[.check_runs[] | select(.name == "Docs / Regenerated" and .conclusion == "success")] | length')
+          regenerated=$(gh api --paginate "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+            --jq '.check_runs[] | select(.name == "Docs / Regenerated" and .conclusion == "success") | .id' | wc -l)
           if [ "${regenerated}" -gt 0 ]; then
             echo "Head SHA already has a successful Docs / Regenerated check run; nothing to do"
             echo "rebuild=false" >> "$GITHUB_OUTPUT"
@@ -49,7 +49,7 @@ jobs:
           # write-access reviewer has approved; pre-approval, the
           # review-driven workflow handles it.
           approved_by_writer=false
-          for u in $(gh api "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --jq '[.[] | select(.state == "APPROVED") | .user.login] | unique | .[]'); do
+          for u in $(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --jq '.[] | select(.state == "APPROVED") | .user.login' | sort -u); do
             permission=$(gh api "repos/${REPO}/collaborators/${u}/permission" --jq '.permission' 2>/dev/null || echo "none")
             if [[ "${permission}" == "write" || "${permission}" == "admin" ]]; then
               approved_by_writer=true

--- a/.github/workflows/docs-rebuild-on-push.yml
+++ b/.github/workflows/docs-rebuild-on-push.yml
@@ -37,8 +37,11 @@ jobs:
           # The check run is bound to the SHA, so a new commit (= new SHA)
           # is automatically uncovered. Its presence on the current head
           # answers "are docs current?".
-          regenerated=$(gh api --paginate "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
-            --jq '.check_runs[] | select(.name == "Docs / Regenerated" and .conclusion == "success") | .id' | wc -l)
+          # check_name filters server-side, so this is one request in practice.
+          # --method GET is required or -f would make this a POST.
+          regenerated=$(gh api --paginate --method GET "repos/${REPO}/commits/${HEAD_SHA}/check-runs" \
+            -f check_name="Docs / Regenerated" \
+            --jq '.check_runs[] | select(.conclusion == "success") | .id' | wc -l)
           if [ "${regenerated}" -gt 0 ]; then
             echo "Head SHA already has a successful Docs / Regenerated check run; nothing to do"
             echo "rebuild=false" >> "$GITHUB_OUTPUT"
@@ -49,7 +52,7 @@ jobs:
           # write-access reviewer has approved; pre-approval, the
           # review-driven workflow handles it.
           approved_by_writer=false
-          for u in $(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews" --jq '.[] | select(.state == "APPROVED") | .user.login' | sort -u); do
+          for u in $(gh api --paginate "repos/${REPO}/pulls/${PR_NUMBER}/reviews?per_page=100" --jq '.[] | select(.state == "APPROVED") | .user.login' | sort -u); do
             permission=$(gh api "repos/${REPO}/collaborators/${u}/permission" --jq '.permission' 2>/dev/null || echo "none")
             if [[ "${permission}" == "write" || "${permission}" == "admin" ]]; then
               approved_by_writer=true


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary

Two lookups in the docs workflows only ever saw the first page of results.

`gh api` returns 30 items per page, so an approval past the first 30 reviews was invisible to the docs-build preflight, which aborted with "No write-access approval present". [#1819](https://github.com/openmrs/openmrs-esm-core/pull/1819) hit this: 65 reviews, with both approvals at positions 64 and 65. No retry path could go green because the approval, push, and on-demand rebuild paths all share that lookup.

The check-run lookup had the same blind spot. #1819's head SHA has exactly 30 check runs, which is exactly the page size, and a recent `main` SHA has 118, so `Docs / Regenerated` can easily fall outside page 1.

Both lookups now paginate. `gh` applies `--jq` per page, and `--slurp` cannot be combined with `--jq`, so the review loop dedupes with `sort -u` instead of jq's `unique`, and the check-run lookups count matches with `wc -l` instead of jq's `length`, which would otherwise emit one count per page. `per_page=100` keeps the review lookup to a single request.

The check-run lookups also pass `check_name`, which filters server-side, so they stay at one request whatever else the SHA has accumulated. `--method GET` is load-bearing there: without it, `-f` makes the request a POST and it 404s.

I verified both shapes against live data. The review lookup finds the approval where the old one returned nothing. The check-run lookup returns 1 on #1823's head, which has a real successful `Docs / Regenerated`, and 0 on #1819's, which has none.

## Screenshots

## Related Issue

## Other

The label lookups are still single-page. A PR with more than 30 labels is not realistic, so I left them alone. 
