### PR TITLE
(chore) Pin e2e CI installs to the lockfile

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -96,7 +96,7 @@ jobs:
           key: ${{ runner.os }}-playwright-${{ hashFiles('**/yarn.lock') }}
 
       - name: 🎭 Install Playwright Browsers
-        run: npx playwright install chromium --with-deps
+        run: yarn playwright install chromium --with-deps
 
       - name: 🖥️ Start dev server and wait for backend
         run: bash e2e/support/github/run-e2e-docker-env.sh

--- a/e2e/support/github/Dockerfile
+++ b/e2e/support/github/Dockerfile
@@ -10,7 +10,7 @@ COPY . .
 
 ARG CACHE_BUST
 
-RUN yarn install
+RUN yarn install --immutable
 RUN node packages/tooling/openmrs/dist/cli.js assemble --manifest --mode config --config spa-assemble-config.json --target /app/spa
 RUN node packages/tooling/openmrs/dist/cli.js build --target /app/spa
 

--- a/e2e/support/github/run-e2e-docker-env.sh
+++ b/e2e/support/github/run-e2e-docker-env.sh
@@ -258,7 +258,7 @@ jq -n \
 
 echo "Created dynamic spa-assemble-config.json"
 
-echo "Copying tooling, shell and framework..."
+echo "Copying tooling, shell, framework and apps..."
 mkdir -p "$working_dir/packages"
 mkdir -p "$working_dir/packages/tooling"
 
@@ -267,6 +267,9 @@ cp -r "$repository_root/.yarnrc.yml" "$working_dir/.yarnrc.yml"
 cp -r "$repository_root/packages/tooling" "$working_dir/packages"
 cp -r "$repository_root/packages/shell" "$working_dir/packages"
 cp -r "$repository_root/packages/framework" "$working_dir/packages"
+# The apps must be present for the immutable install in the Dockerfile:
+# without them, yarn would prune the missing workspaces from the lockfile.
+cp -r "$repository_root/packages/apps" "$working_dir/packages"
 cp "$repository_root/package.json" "$working_dir/package.json"
 cp "$repository_root/yarn.lock" "$working_dir/yarn.lock"
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary

SonarCloud flags two spots where our e2e setup installs dependencies without going through the lockfile:

- The e2e workflow installed Playwright browsers with `npx playwright install`, which runs whatever version npx resolves. It now runs `yarn playwright install`, which uses the `@playwright/test` version pinned in our lockfile and matches how the other-repos job already does it.
- The e2e Docker image ran a bare `yarn install`. It now runs `yarn install --immutable`, so the image is always built against exactly the locked dependency tree. For that to work, `run-e2e-docker-env.sh` also has to copy `packages/apps` into the Docker build context. Without them, yarn prunes the missing app workspaces from the lockfile and the immutable install fails with YN0028. I verified both the failure and the fix by replicating the build context locally and running the install both ways.

## Screenshots

## Related Issue

## Other

This resolves the version-pinning findings (S8543) and part of the S6505 findings on new code. The remaining S6505 "lifecycle scripts are enabled" findings on the `yarn install --immutable` steps need to be reviewed and accepted in the SonarCloud UI, since the fix Sonar suggests (disabling postinstall scripts) risks breaking installs. The quality gate on main stays red until that review pass happens.
