### PR TITLE
(fix) Add the growth chart app to the cross-repo E2E environment

### DIFF
--- a/e2e/support/github/run-e2e-docker-env.sh
+++ b/e2e/support/github/run-e2e-docker-env.sh
@@ -229,6 +229,7 @@ jq -n \
     "@openmrs/esm-patient-conditions-app": "next",
     "@openmrs/esm-patient-flags-app": "next",
     "@openmrs/esm-patient-forms-app": "next",
+    "@openmrs/esm-patient-growth-chart-app": "next",
     "@openmrs/esm-patient-immunizations-app": "next",
     "@openmrs/esm-patient-list-management-app": "next",
     "@openmrs/esm-patient-lists-app": "next",


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary

The cross-repo E2E job (`run-e2e-on-other-repos`) assembles its frontend from a hardcoded list of apps in `run-e2e-docker-env.sh`, all pinned to the `next` tag. openmrs-esm-patient-chart now ships a growth chart app and an E2E spec for it ([growth-chart.spec.ts](https://github.com/openmrs/openmrs-esm-patient-chart/blob/main/e2e/specs/growth-chart.spec.ts)), so the patient chart suite fails against an environment that doesn't include the app: the spec waits for the growth chart UI, which never renders. This slipped by unnoticed on main because the cross-repo job is path-filtered and only runs on PRs that touch E2E files, like [this run on #1847](https://github.com/openmrs/openmrs-esm-core/actions/runs/32186178304/job/95870614878?pr=1847).

This adds `@openmrs/esm-patient-growth-chart-app` (published under `next` as of patient-chart's monorepo adoption of the app) to the assemble list.

## Screenshots

## Related Issue

## Other

Validated locally by running the config-generation block from the script: the resulting `spa-assemble-config.json` maps `@openmrs/esm-patient-growth-chart-app` to `next`. The cross-repo E2E job runs on this PR (it touches an E2E path), which exercises the fix for real.
