### PR TITLE
(test) Fix tooling cross-platform tests and add unit tests for esm-utils

### DIFF
--- a/packages/framework/esm-utils/src/retry.test.ts
+++ b/packages/framework/esm-utils/src/retry.test.ts
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { retry } from './retry';
+
+describe('retry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the result immediately on first successful attempt', async () => {
+    const fn = vi.fn().mockResolvedValue('success');
+
+    const promise = retry(fn, { getDelay: () => 0 });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('success');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries when the function throws and succeeds on a subsequent attempt', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('failure 1'))
+      .mockRejectedValueOnce(new Error('failure 2'))
+      .mockResolvedValue('recovered');
+
+    const promise = retry(fn, { getDelay: () => 100 });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('recovered');
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('invokes onError callback on each failure with the error and attempt number', async () => {
+    const onError = vi.fn();
+    const err1 = new Error('err 1');
+    const err2 = new Error('err 2');
+    const fn = vi.fn().mockRejectedValueOnce(err1).mockRejectedValueOnce(err2).mockResolvedValue('done');
+
+    const promise = retry(fn, { getDelay: () => 0, onError });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('done');
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(onError).toHaveBeenNthCalledWith(1, err1, 0);
+    expect(onError).toHaveBeenNthCalledWith(2, err2, 1);
+  });
+
+  it('rethrows the final error when maximum retry attempts are exceeded', async () => {
+    const error = new Error('persistent failure');
+    const fn = vi.fn().mockRejectedValue(error);
+
+    const promise = retry(fn, {
+      shouldRetry: (attempt) => attempt < 2,
+      getDelay: () => 10,
+    });
+
+    const expectPromise = expect(promise).rejects.toThrow('persistent failure');
+    await vi.runAllTimersAsync();
+    await expectPromise;
+
+    // attempt 0 (fails) -> shouldRetry(0) -> true -> attempt 1 (fails) -> shouldRetry(1) -> true -> attempt 2 (fails) -> shouldRetry(2) -> false
+    expect(fn).toHaveBeenCalledTimes(3);
+  });
+
+  it('uses custom shouldRetry to stop immediately on specific error conditions', async () => {
+    const fatalError = new Error('fatal');
+    const fn = vi.fn().mockRejectedValue(fatalError);
+
+    const promise = retry(fn, {
+      shouldRetry: () => false,
+      getDelay: () => 0,
+    });
+
+    const expectPromise = expect(promise).rejects.toThrow('fatal');
+    await vi.runAllTimersAsync();
+    await expectPromise;
+
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('applies custom getDelay per attempt', async () => {
+    const getDelay = vi.fn().mockReturnValue(500);
+    const fn = vi.fn().mockRejectedValueOnce(new Error('fail')).mockResolvedValue('ok');
+
+    const promise = retry(fn, { getDelay });
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    expect(result).toBe('ok');
+    expect(getDelay).toHaveBeenCalledWith(0);
+    expect(getDelay).toHaveBeenCalledWith(1);
+  });
+});

--- a/packages/framework/esm-utils/src/shallowEqual.test.ts
+++ b/packages/framework/esm-utils/src/shallowEqual.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest';
+import { shallowEqual } from './shallowEqual';
+
+describe('shallowEqual', () => {
+  describe('primitives and identical references', () => {
+    it('returns true for identical primitive values', () => {
+      expect(shallowEqual(42, 42)).toBe(true);
+      expect(shallowEqual('test', 'test')).toBe(true);
+      expect(shallowEqual(true, true)).toBe(true);
+      expect(shallowEqual(false, false)).toBe(true);
+      expect(shallowEqual(null, null)).toBe(true);
+      expect(shallowEqual(undefined, undefined)).toBe(true);
+      expect(shallowEqual(NaN, NaN)).toBe(true);
+    });
+
+    it('returns false for different primitive values', () => {
+      expect(shallowEqual(42, 43)).toBe(false);
+      expect(shallowEqual('foo', 'bar')).toBe(false);
+      expect(shallowEqual(true, false)).toBe(false);
+      expect(shallowEqual(null, undefined)).toBe(false);
+      expect(shallowEqual(0, false)).toBe(false);
+      expect(shallowEqual('', false)).toBe(false);
+    });
+
+    it('returns true for same reference object and array', () => {
+      const obj = { a: 1 };
+      const arr = [1, 2, 3];
+      expect(shallowEqual(obj, obj)).toBe(true);
+      expect(shallowEqual(arr, arr)).toBe(true);
+    });
+  });
+
+  describe('arrays', () => {
+    it('returns true for arrays with equal elements', () => {
+      expect(shallowEqual([], [])).toBe(true);
+      expect(shallowEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+      expect(shallowEqual(['a', 'b'], ['a', 'b'])).toBe(true);
+    });
+
+    it('returns false when array lengths differ', () => {
+      expect(shallowEqual([1, 2], [1, 2, 3])).toBe(false);
+      expect(shallowEqual([1, 2, 3], [1, 2])).toBe(false);
+    });
+
+    it('returns false when elements differ', () => {
+      expect(shallowEqual([1, 2, 3], [1, 2, 4])).toBe(false);
+      expect(shallowEqual(['a', 'b'], ['b', 'a'])).toBe(false);
+    });
+
+    it('returns false when one argument is an array and the other is not', () => {
+      expect(shallowEqual([1, 2], { '0': 1, '1': 2, length: 2 })).toBe(false);
+      expect(shallowEqual({ '0': 1, '1': 2, length: 2 }, [1, 2])).toBe(false);
+      expect(shallowEqual([1, 2], null)).toBe(false);
+      expect(shallowEqual(null, [1, 2])).toBe(false);
+      expect(shallowEqual([1, 2], '1,2')).toBe(false);
+    });
+
+    it('performs shallow comparison of elements in arrays', () => {
+      const ref = { id: 1 };
+      expect(shallowEqual([ref], [ref])).toBe(true);
+      expect(shallowEqual([{ id: 1 }], [{ id: 1 }])).toBe(false);
+    });
+  });
+
+  describe('objects', () => {
+    it('returns true for empty objects', () => {
+      expect(shallowEqual({}, {})).toBe(true);
+    });
+
+    it('returns true for objects with same keys and equal values', () => {
+      expect(shallowEqual({ a: 1, b: 'two' }, { a: 1, b: 'two' })).toBe(true);
+    });
+
+    it('returns false when objects have different numbers of keys', () => {
+      expect(shallowEqual({ a: 1 }, { a: 1, b: 2 })).toBe(false);
+      expect(shallowEqual({ a: 1, b: 2 }, { a: 1 })).toBe(false);
+    });
+
+    it('returns false when keys differ but count is same', () => {
+      expect(shallowEqual({ a: 1, b: 2 }, { a: 1, c: 2 })).toBe(false);
+    });
+
+    it('returns false when values differ', () => {
+      expect(shallowEqual({ a: 1, b: 2 }, { a: 1, b: 3 })).toBe(false);
+    });
+
+    it('performs shallow (not deep) comparison of nested objects', () => {
+      const nested = { deep: true };
+      expect(shallowEqual({ child: nested }, { child: nested })).toBe(true);
+      expect(shallowEqual({ child: { deep: true } }, { child: { deep: true } })).toBe(false);
+    });
+
+    it('returns false when comparing an object with a non-object or null', () => {
+      expect(shallowEqual({ a: 1 }, null)).toBe(false);
+      expect(shallowEqual(null, { a: 1 })).toBe(false);
+      expect(shallowEqual({ a: 1 }, undefined)).toBe(false);
+      expect(shallowEqual({ a: 1 }, 123)).toBe(false);
+      expect(shallowEqual({ a: 1 }, 'string')).toBe(false);
+    });
+  });
+});

--- a/packages/framework/esm-utils/src/storage.test.ts
+++ b/packages/framework/esm-utils/src/storage.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from 'vitest';
+import { canAccessStorage } from './storage';
+
+describe('canAccessStorage', () => {
+  it('returns true when storage getItem does not throw', () => {
+    const mockStorage = {
+      getItem: vi.fn().mockReturnValue(null),
+    } as unknown as Storage;
+
+    expect(canAccessStorage(mockStorage)).toBe(true);
+    expect(mockStorage.getItem).toHaveBeenCalledWith('test');
+  });
+
+  it('returns false when storage getItem throws a SecurityError or DOMException', () => {
+    const mockStorage = {
+      getItem: vi.fn().mockImplementation(() => {
+        throw new Error('SecurityError: access denied');
+      }),
+    } as unknown as Storage;
+
+    expect(canAccessStorage(mockStorage)).toBe(false);
+  });
+
+  it('works with default localStorage if accessible', () => {
+    // In JSDOM / Vitest environment, window.localStorage is present
+    expect(typeof canAccessStorage()).toBe('boolean');
+  });
+});

--- a/packages/tooling/openmrs/src/cli.test.ts
+++ b/packages/tooling/openmrs/src/cli.test.ts
@@ -13,6 +13,7 @@ vi.mock('yargs', () => {
 vi.mock('node:child_process');
 vi.mock('./utils');
 
+import { isAbsolute } from 'node:path';
 import { fork, type ChildProcess } from 'node:child_process';
 import {
   getAvailablePort,
@@ -123,13 +124,13 @@ describe('develop command', () => {
 describe('build command', () => {
   it('coerces target to an absolute path', async () => {
     const parsed = await createCli(['build', '--target', 'output']).parseAsync();
-    expect(parsed.target).toMatch(/^\//);
+    expect(isAbsolute(parsed.target as string)).toBe(true);
     expect(parsed.target).toContain('output');
   });
 
   it('coerces build-config to an absolute path', async () => {
     const parsed = await createCli(['build', '--build-config', 'config.json']).parseAsync();
-    expect(parsed.buildConfig).toMatch(/^\//);
+    expect(isAbsolute(parsed.buildConfig as string)).toBe(true);
     expect(parsed.buildConfig).toContain('config.json');
   });
 
@@ -137,14 +138,14 @@ describe('build command', () => {
     const parsed = await createCli(['build', '--config-path', 'a.json', '--config-path', 'b.json']).parseAsync();
     const paths = parsed.configPath as string[];
     expect(paths).toHaveLength(2);
-    paths.forEach((p) => expect(p).toMatch(/^\//));
+    paths.forEach((p) => expect(isAbsolute(p)).toBe(true));
   });
 
   it('coerces asset entries to absolute paths', async () => {
     const parsed = await createCli(['build', '--asset', 'style.css']).parseAsync();
     const assets = parsed.asset as string[];
     expect(assets).toHaveLength(1);
-    expect(assets[0]).toMatch(/^\//);
+    expect(isAbsolute(assets[0])).toBe(true);
   });
 
   it('defaults env to production', async () => {
@@ -184,7 +185,7 @@ describe('assemble command', () => {
 
   it('coerces target to an absolute path', async () => {
     const parsed = await createCli(['assemble', '--target', 'output']).parseAsync();
-    expect(parsed.target).toMatch(/^\//);
+    expect(isAbsolute(parsed.target as string)).toBe(true);
     expect(parsed.target).toContain('output');
   });
 

--- a/packages/tooling/openmrs/src/utils/packages.test.ts
+++ b/packages/tooling/openmrs/src/utils/packages.test.ts
@@ -17,6 +17,7 @@ vi.mock('./logger', () => ({
 
 import { glob } from 'glob';
 import { existsSync, readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { resolvePackages } from './packages';
 
 const mockGlob = vi.mocked(glob);
@@ -30,9 +31,13 @@ beforeEach(() => {
 // Helper to set up a consistent filesystem mock from a map of path -> JSON content.
 // Paths not in the map are treated as non-existent.
 function mockFs(files: Record<string, object>) {
-  mockExistsSync.mockImplementation((p) => String(p) in files);
+  const normalized: Record<string, object> = {};
+  for (const [key, val] of Object.entries(files)) {
+    normalized[resolve(key)] = val;
+  }
+  mockExistsSync.mockImplementation((p) => resolve(String(p)) in normalized);
   mockReadFileSync.mockImplementation((p) => {
-    const content = files[String(p)];
+    const content = normalized[resolve(String(p))];
     if (content === undefined) {
       throw new Error(`ENOENT: ${p}`);
     }
@@ -53,7 +58,7 @@ describe('resolvePackages', () => {
       mockGlob.mockResolvedValue(['packages/app-a', 'packages/app-b']);
 
       const result = await resolvePackages(['@openmrs/app-a']);
-      expect(result).toEqual(['/repo/packages/app-a']);
+      expect(result).toEqual([resolve('/repo/packages/app-a')]);
     });
 
     it('resolves multiple package names', async () => {
@@ -67,7 +72,7 @@ describe('resolvePackages', () => {
       mockGlob.mockResolvedValue(['packages/app-a', 'packages/app-b']);
 
       const result = await resolvePackages(['@openmrs/app-a', '@openmrs/app-b']);
-      expect(result).toEqual(['/repo/packages/app-a', '/repo/packages/app-b']);
+      expect(result).toEqual([resolve('/repo/packages/app-a'), resolve('/repo/packages/app-b')]);
     });
 
     it('handles multiple workspace patterns', async () => {
@@ -82,7 +87,7 @@ describe('resolvePackages', () => {
       mockGlob.mockResolvedValueOnce(['packages/apps/login']).mockResolvedValueOnce(['packages/libs/utils']);
 
       const result = await resolvePackages(['@openmrs/esm-login-app']);
-      expect(result).toEqual(['/repo/packages/apps/login']);
+      expect(result).toEqual([resolve('/repo/packages/apps/login')]);
       expect(mockGlob).toHaveBeenCalledTimes(2);
     });
 
@@ -97,7 +102,7 @@ describe('resolvePackages', () => {
       mockGlob.mockResolvedValue(['packages/app-a', 'packages/orphan']);
 
       const result = await resolvePackages(['@openmrs/app-a']);
-      expect(result).toEqual(['/repo/packages/app-a']);
+      expect(result).toEqual([resolve('/repo/packages/app-a')]);
     });
   });
 
@@ -112,7 +117,7 @@ describe('resolvePackages', () => {
       mockGlob.mockResolvedValue(['packages/app-a']);
 
       const result = await resolvePackages(['@openmrs/app-a']);
-      expect(result).toEqual(['/repo/packages/app-a']);
+      expect(result).toEqual([resolve('/repo/packages/app-a')]);
     });
   });
 
@@ -128,7 +133,7 @@ describe('resolvePackages', () => {
       mockGlob.mockResolvedValue(['packages/app-a', 'packages/app-b']);
 
       const result = await resolvePackages(['@openmrs/app-b']);
-      expect(result).toEqual(['/repo/packages/app-b']);
+      expect(result).toEqual([resolve('/repo/packages/app-b')]);
     });
   });
 

--- a/packages/tooling/openmrs/src/utils/packages.test.ts
+++ b/packages/tooling/openmrs/src/utils/packages.test.ts
@@ -139,14 +139,15 @@ describe('resolvePackages', () => {
 
   describe('single package (no workspaces)', () => {
     it('resolves when the cwd package.json name matches', async () => {
-      vi.spyOn(process, 'cwd').mockReturnValue('/projects/lab-app');
+      const mockCwd = resolve('/projects/lab-app');
+      vi.spyOn(process, 'cwd').mockReturnValue(mockCwd);
 
       mockFs({
-        '/projects/lab-app/package.json': { name: '@openmrs/esm-laboratory-app' },
+        [resolve('/projects/lab-app/package.json')]: { name: '@openmrs/esm-laboratory-app' },
       });
 
       const result = await resolvePackages(['@openmrs/esm-laboratory-app']);
-      expect(result).toEqual(['/projects/lab-app']);
+      expect(result).toEqual([mockCwd]);
     });
   });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
- **Tooling (`openmrs`)**:
  - Fixed hardcoded POSIX regex path assertions in `packages/tooling/openmrs/src/cli.test.ts` to use `isAbsolute(...)` for cross-platform compatibility.
  - Normalized mock filesystem paths in `packages/tooling/openmrs/src/utils/packages.test.ts` using `path.resolve(...)` so tests pass reliably across Windows, macOS, and Linux.
- **Framework (`@openmrs/esm-utils`)**:
  - Added unit test suite for `shallowEqual.ts` (15 test cases covering primitives, arrays, object comparisons, and edge cases).
  - Added unit test suite for `retry.ts` (6 test cases covering retry counts, onError callbacks, and exponential backoff delays with fake timers).
  - Added unit test suite for `storage.ts` (3 test cases testing storage availability checks and error handling).

## Screenshots
*N/A (no UI changes)*

## Related Issue
*N/A*

## Other
Signed-off-by: bhuvan-somisetty <somisettybhuvan5@gmail.com>
