### PR TITLE
(fix) Import map and routes should be cached

### DIFF
--- a/.changeset/major-wings-pull.md
+++ b/.changeset/major-wings-pull.md
@@ -1,0 +1,6 @@
+---
+"@openmrs/esm-dynamic-loading": patch
+"@openmrs/esm-framework": patch
+---
+
+(fix) Import map and routes should be cached

--- a/packages/framework/esm-dynamic-loading/src/import-maps.test.ts
+++ b/packages/framework/esm-dynamic-loading/src/import-maps.test.ts
@@ -347,7 +347,7 @@ describe('import-maps', () => {
       vi.resetModules();
     });
 
-    it('fetches the import map without credentials so the preloaded response is reused', async () => {
+    it('fetches the import map with the default credentials mode so the preloaded response is reused', async () => {
       setRemoteImportMap();
       fetchMock.mockResponse(JSON.stringify({ imports: { '@openmrs/esm-remote': '/remote.js' } }));
 
@@ -356,7 +356,9 @@ describe('import-maps', () => {
 
       await getCurrentPageMap();
 
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost/importmap.json', { credentials: 'omit' });
+      // `crossorigin="anonymous"` on the preload link gives it a `same-origin` credentials mode,
+      // which is also `fetch()`'s default; passing anything else here misses the preload cache.
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost/importmap.json');
     });
 
     it('fetches the import map only once across repeated reads', async () => {
@@ -395,6 +397,25 @@ describe('import-maps', () => {
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to parse import map'), expect.anything());
 
       // The failed read was not cached, so the next call retries and succeeds
+      const retried = await getCurrentPageMap();
+      expect(retried.imports['@openmrs/esm-remote']).toBe('/remote.js');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('does not cache a map whose fetch returned an error status', async () => {
+      setRemoteImportMap();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'service unavailable' }), { status: 503 });
+      fetchMock.mockResponse(JSON.stringify({ imports: { '@openmrs/esm-remote': '/remote.js' } }));
+
+      const { setupImportMapOverrides, getCurrentPageMap } = await import('./import-maps');
+      setupImportMapOverrides();
+
+      const failed = await getCurrentPageMap();
+      expect(failed.imports).toEqual({});
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to parse import map'), expect.anything());
+
       const retried = await getCurrentPageMap();
       expect(retried.imports['@openmrs/esm-remote']).toBe('/remote.js');
       expect(fetchMock).toHaveBeenCalledTimes(2);

--- a/packages/framework/esm-dynamic-loading/src/import-maps.test.ts
+++ b/packages/framework/esm-dynamic-loading/src/import-maps.test.ts
@@ -334,6 +334,73 @@ describe('import-maps', () => {
     });
   });
 
+  describe('remote import map caching', () => {
+    function setRemoteImportMap(src = 'http://localhost/importmap.json') {
+      const script = document.createElement('script');
+      script.type = 'systemjs-importmap';
+      Object.defineProperty(script, 'src', { value: src, writable: false });
+      document.head.appendChild(script);
+    }
+
+    beforeEach(() => {
+      (window as any).spaEnv = 'production';
+      vi.resetModules();
+    });
+
+    it('fetches the import map without credentials so the preloaded response is reused', async () => {
+      setRemoteImportMap();
+      fetchMock.mockResponse(JSON.stringify({ imports: { '@openmrs/esm-remote': '/remote.js' } }));
+
+      const { setupImportMapOverrides, getCurrentPageMap } = await import('./import-maps');
+      setupImportMapOverrides();
+
+      await getCurrentPageMap();
+
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost/importmap.json', { credentials: 'omit' });
+    });
+
+    it('fetches the import map only once across repeated reads', async () => {
+      setRemoteImportMap();
+      fetchMock.mockResponse(JSON.stringify({ imports: { '@openmrs/esm-remote': '/remote.js' } }));
+
+      const { setupImportMapOverrides, getCurrentPageMap, getImportMapDefaultMap, getImportMapNextPageMap } =
+        await import('./import-maps');
+      setupImportMapOverrides();
+
+      const [first, second, third] = await Promise.all([
+        getCurrentPageMap(),
+        getImportMapDefaultMap(),
+        getImportMapNextPageMap(),
+      ]);
+      const fourth = await getCurrentPageMap();
+
+      for (const map of [first, second, third, fourth]) {
+        expect(map.imports['@openmrs/esm-remote']).toBe('/remote.js');
+      }
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a map whose fetch failed', async () => {
+      setRemoteImportMap();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      fetchMock.mockRejectOnce(new Error('network is down'));
+      fetchMock.mockResponse(JSON.stringify({ imports: { '@openmrs/esm-remote': '/remote.js' } }));
+
+      const { setupImportMapOverrides, getCurrentPageMap } = await import('./import-maps');
+      setupImportMapOverrides();
+
+      const failed = await getCurrentPageMap();
+      expect(failed.imports).toEqual({});
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to parse import map'), expect.anything());
+
+      // The failed read was not cached, so the next call retries and succeeds
+      const retried = await getCurrentPageMap();
+      expect(retried.imports['@openmrs/esm-remote']).toBe('/remote.js');
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe('error handling', () => {
     it('skips malformed inline import map script tags', async () => {
       (window as any).spaEnv = 'production';

--- a/packages/framework/esm-dynamic-loading/src/import-maps.ts
+++ b/packages/framework/esm-dynamic-loading/src/import-maps.ts
@@ -46,8 +46,10 @@ async function loadBaseMap(): Promise<{ map: ImportMap; complete: boolean }> {
     const script = scripts[i];
     try {
       if (script.src) {
-        // `credentials: 'omit'` matches the `crossorigin="anonymous"` preload
-        const response = await fetch(script.src, { credentials: 'omit' });
+        const response = await fetch(script.src);
+        if (!response.ok) {
+          throw new Error(`Request for ${script.src} returned ${response.status} ${response.statusText}`);
+        }
         maps.push(await response.json());
       } else if (script.textContent) {
         maps.push(JSON.parse(script.textContent));

--- a/packages/framework/esm-dynamic-loading/src/import-maps.ts
+++ b/packages/framework/esm-dynamic-loading/src/import-maps.ts
@@ -12,30 +12,53 @@ let devMode = false;
 // getCurrentPageMap returns the overrides as they were when the page loaded).
 let initialOverrideSnapshot: ImportMap | null = null;
 
+// Memoizes the base map so that the import map is fetched at most once per page load.
+let baseMapPromise: Promise<ImportMap> | null = null;
+
 /**
  * Reads all `<script type="systemjs-importmap">` tags from the DOM and merges
  * them into a single {@link ImportMap}. Tags with a `src` attribute are fetched;
  * inline tags have their `textContent` parsed as JSON.
+ *
+ * A read in which every tag was parsed successfully is cached and reused by all later
+ * callers. A read that lost one or more tags to an error is returned as-is but not cached, so
+ * that a transient network failure doesn't leave the page with a permanently incomplete map.
  */
 async function readBaseMap(): Promise<ImportMap> {
+  if (!baseMapPromise) {
+    baseMapPromise = loadBaseMap().then(({ map, complete }) => {
+      if (!complete) {
+        baseMapPromise = null;
+      }
+      return map;
+    });
+  }
+
+  return baseMapPromise;
+}
+
+async function loadBaseMap(): Promise<{ map: ImportMap; complete: boolean }> {
   const scripts = document.querySelectorAll<HTMLScriptElement>('script[type="systemjs-importmap"]');
   const maps: ImportMap[] = [];
+  let complete = true;
 
   for (let i = 0; i < scripts.length; i++) {
     const script = scripts[i];
     try {
       if (script.src) {
-        const response = await fetch(script.src);
+        // `credentials: 'omit'` matches the `crossorigin="anonymous"` preload
+        const response = await fetch(script.src, { credentials: 'omit' });
         maps.push(await response.json());
       } else if (script.textContent) {
         maps.push(JSON.parse(script.textContent));
       }
     } catch (e) {
+      complete = false;
       console.warn(`[import-maps] Failed to parse import map from script tag at index ${i}`, e);
     }
   }
 
-  return mergeMaps(maps);
+  return { map: mergeMaps(maps), complete };
 }
 
 function mergeMaps(maps: ImportMap[]): ImportMap {

--- a/packages/framework/esm-dynamic-loading/src/import-maps.ts
+++ b/packages/framework/esm-dynamic-loading/src/import-maps.ts
@@ -25,14 +25,12 @@ let baseMapPromise: Promise<ImportMap> | null = null;
  * that a transient network failure doesn't leave the page with a permanently incomplete map.
  */
 async function readBaseMap(): Promise<ImportMap> {
-  if (!baseMapPromise) {
-    baseMapPromise = loadBaseMap().then(({ map, complete }) => {
-      if (!complete) {
-        baseMapPromise = null;
-      }
-      return map;
-    });
-  }
+  baseMapPromise ??= loadBaseMap().then(({ map, complete }) => {
+    if (!complete) {
+      baseMapPromise = null;
+    }
+    return map;
+  });
 
   return baseMapPromise;
 }

--- a/packages/framework/esm-dynamic-loading/src/route-maps.test.ts
+++ b/packages/framework/esm-dynamic-loading/src/route-maps.test.ts
@@ -429,6 +429,25 @@ describe('route-maps', () => {
       expect(fetchMock).toHaveBeenCalledTimes(2);
     });
 
+    it('does not cache a map whose fetch returned an error status', async () => {
+      setRemoteRouteMap();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      fetchMock.mockResponseOnce(JSON.stringify({ error: 'service unavailable' }), { status: 503 });
+      fetchMock.mockResponse(JSON.stringify({ routes: { '@openmrs/esm-remote': { pages: [] } } }));
+
+      const { setupRouteMapOverrides, getCurrentRouteMap } = await import('./route-maps');
+      await setupRouteMapOverrides();
+
+      const failed = await getCurrentRouteMap();
+      expect(Object.keys(failed.routes)).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to parse routes'), expect.anything());
+
+      const retried = await getCurrentRouteMap();
+      expect(retried.routes['@openmrs/esm-remote']).toEqual({ pages: [] });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
     it('caches a map whose tags loaded but failed validation', async () => {
       setRemoteRouteMap();
       // Valid JSON that isn't an OpenmrsRoutes object is dropped without throwing. Re-fetching
@@ -463,7 +482,9 @@ describe('route-maps', () => {
 
       const map = await getCurrentRouteMap();
       expect(map.routes['@openmrs/esm-remote']).toEqual({ pages: [{ component: 'root', route: '/remote' }] });
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost/routes.json', { credentials: 'omit' });
+      // `crossorigin="anonymous"` on the preload link gives it a `same-origin` credentials mode,
+      // which is also `fetch()`'s default; passing anything else here misses the preload cache.
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost/routes.json');
     });
 
     it('merges remote and inline route maps', async () => {

--- a/packages/framework/esm-dynamic-loading/src/route-maps.test.ts
+++ b/packages/framework/esm-dynamic-loading/src/route-maps.test.ts
@@ -375,6 +375,75 @@ describe('route-maps', () => {
     });
   });
 
+  describe('remote route map caching', () => {
+    function setRemoteRouteMap(src = 'http://localhost/routes.registry.json') {
+      const script = document.createElement('script');
+      script.type = 'openmrs-routes';
+      Object.defineProperty(script, 'src', { value: src, writable: false });
+      document.head.appendChild(script);
+    }
+
+    beforeEach(() => {
+      (window as any).spaEnv = 'production';
+      vi.resetModules();
+    });
+
+    it('fetches the routes registry only once across repeated reads', async () => {
+      setRemoteRouteMap();
+      fetchMock.mockResponse(JSON.stringify({ routes: { '@openmrs/esm-remote': { pages: [] } } }));
+
+      const { setupRouteMapOverrides, getCurrentRouteMap, getRouteMapDefaultMap, getRouteMapNextPageMap } =
+        await import('./route-maps');
+      await setupRouteMapOverrides();
+
+      const [first, second, third] = await Promise.all([
+        getCurrentRouteMap(),
+        getRouteMapDefaultMap(),
+        getRouteMapNextPageMap(),
+      ]);
+      const fourth = await getCurrentRouteMap();
+
+      for (const map of [first, second, third, fourth]) {
+        expect(map.routes['@openmrs/esm-remote']).toEqual({ pages: [] });
+      }
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache a map whose fetch failed', async () => {
+      setRemoteRouteMap();
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      fetchMock.mockRejectOnce(new Error('network is down'));
+      fetchMock.mockResponse(JSON.stringify({ routes: { '@openmrs/esm-remote': { pages: [] } } }));
+
+      const { setupRouteMapOverrides, getCurrentRouteMap } = await import('./route-maps');
+      await setupRouteMapOverrides();
+
+      const failed = await getCurrentRouteMap();
+      expect(Object.keys(failed.routes)).toHaveLength(0);
+      expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Failed to parse routes'), expect.anything());
+
+      // The failed read was not cached, so the next call retries and succeeds
+      const retried = await getCurrentRouteMap();
+      expect(retried.routes['@openmrs/esm-remote']).toEqual({ pages: [] });
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('caches a map whose tags loaded but failed validation', async () => {
+      setRemoteRouteMap();
+      // Valid JSON that isn't an OpenmrsRoutes object is dropped without throwing. Re-fetching
+      // would fail identically, so this must not defeat the cache.
+      fetchMock.mockResponse(JSON.stringify({ something: 'unexpected' }));
+
+      const { setupRouteMapOverrides, getCurrentRouteMap } = await import('./route-maps');
+      await setupRouteMapOverrides();
+
+      expect(Object.keys((await getCurrentRouteMap()).routes)).toHaveLength(0);
+      expect(Object.keys((await getCurrentRouteMap()).routes)).toHaveLength(0);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('error handling', () => {
     it('reads route maps from remote script src attributes', async () => {
       (window as any).spaEnv = 'production';
@@ -394,7 +463,7 @@ describe('route-maps', () => {
 
       const map = await getCurrentRouteMap();
       expect(map.routes['@openmrs/esm-remote']).toEqual({ pages: [{ component: 'root', route: '/remote' }] });
-      expect(fetchMock).toHaveBeenCalledWith('http://localhost/routes.json');
+      expect(fetchMock).toHaveBeenCalledWith('http://localhost/routes.json', { credentials: 'omit' });
     });
 
     it('merges remote and inline route maps', async () => {

--- a/packages/framework/esm-dynamic-loading/src/route-maps.ts
+++ b/packages/framework/esm-dynamic-loading/src/route-maps.ts
@@ -47,8 +47,10 @@ async function loadBaseMap(): Promise<{ map: OpenmrsRoutes; complete: boolean }>
     try {
       let parsed: unknown;
       if (script.src) {
-        // `credentials: 'omit'` matches the `crossorigin="anonymous"` preload
-        const response = await fetch(script.src, { credentials: 'omit' });
+        const response = await fetch(script.src);
+        if (!response.ok) {
+          throw new Error(`Request for ${script.src} returned ${response.status} ${response.statusText}`);
+        }
         parsed = await response.json();
       } else if (script.textContent) {
         parsed = JSON.parse(script.textContent);

--- a/packages/framework/esm-dynamic-loading/src/route-maps.ts
+++ b/packages/framework/esm-dynamic-loading/src/route-maps.ts
@@ -25,14 +25,12 @@ let baseMapPromise: Promise<OpenmrsRoutes> | null = null;
  * dropped without invalidating the cache, since re-reading it would only fail the same way.
  */
 async function readBaseMap(): Promise<OpenmrsRoutes> {
-  if (!baseMapPromise) {
-    baseMapPromise = loadBaseMap().then(({ map, complete }) => {
-      if (!complete) {
-        baseMapPromise = null;
-      }
-      return map;
-    });
-  }
+  baseMapPromise ??= loadBaseMap().then(({ map, complete }) => {
+    if (!complete) {
+      baseMapPromise = null;
+    }
+    return map;
+  });
 
   return baseMapPromise;
 }

--- a/packages/framework/esm-dynamic-loading/src/route-maps.ts
+++ b/packages/framework/esm-dynamic-loading/src/route-maps.ts
@@ -11,21 +11,44 @@ let devMode = false;
 // getCurrentRouteMap returns the overrides as they were when the page loaded).
 let initialOverrideSnapshot: OpenmrsRoutes | null = null;
 
+// Memoizes the base map so that the routes registry is fetched at most once per page load.
+let baseMapPromise: Promise<OpenmrsRoutes> | null = null;
+
 /**
  * Reads all `<script type="openmrs-routes">` tags from the DOM and merges
  * them into a single {@link OpenmrsRoutes} object. Tags with a `src` attribute
  * are fetched; inline tags have their `textContent` parsed as JSON.
+ *
+ * A read in which no tag threw is cached and reused by all later callers. A read that lost a
+ * tag to an error is returned as-is but not cached, so that a transient network failure doesn't
+ * leave the page with a permanently incomplete map. A tag that loads but fails validation is
+ * dropped without invalidating the cache, since re-reading it would only fail the same way.
  */
 async function readBaseMap(): Promise<OpenmrsRoutes> {
+  if (!baseMapPromise) {
+    baseMapPromise = loadBaseMap().then(({ map, complete }) => {
+      if (!complete) {
+        baseMapPromise = null;
+      }
+      return map;
+    });
+  }
+
+  return baseMapPromise;
+}
+
+async function loadBaseMap(): Promise<{ map: OpenmrsRoutes; complete: boolean }> {
   const scripts = document.querySelectorAll<HTMLScriptElement>("script[type='openmrs-routes']");
   const maps: OpenmrsRoutes[] = [];
+  let complete = true;
 
   for (let i = 0; i < scripts.length; i++) {
     const script = scripts[i];
     try {
       let parsed: unknown;
       if (script.src) {
-        const response = await fetch(script.src);
+        // `credentials: 'omit'` matches the `crossorigin="anonymous"` preload
+        const response = await fetch(script.src, { credentials: 'omit' });
         parsed = await response.json();
       } else if (script.textContent) {
         parsed = JSON.parse(script.textContent);
@@ -35,11 +58,12 @@ async function readBaseMap(): Promise<OpenmrsRoutes> {
         maps.push(parsed);
       }
     } catch (e) {
+      complete = false;
       console.warn(`[route-maps] Failed to parse routes from script tag at index ${i}`, e);
     }
   }
 
-  return mergeRouteMaps(maps);
+  return { map: mergeRouteMaps(maps), complete };
 }
 
 function mergeRouteMaps(maps: OpenmrsRoutes[]): OpenmrsRoutes {

--- a/packages/framework/esm-framework/docs/interfaces/UploadedFile.md
+++ b/packages/framework/esm-framework/docs/interfaces/UploadedFile.md
@@ -56,6 +56,6 @@ Defined in: [packages/framework/esm-emr-api/src/types/attachments-types.ts:5](ht
 
 ### status?
 
-> `optional` **status**: `"uploading"` \| `"complete"`
+> `optional` **status**: `"complete"` \| `"uploading"`
 
 Defined in: [packages/framework/esm-emr-api/src/types/attachments-types.ts:7](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/types/attachments-types.ts#L7)


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->

I realized today while looking at network logs that there are circumstances where we are fetching the importmap multiple times in a single page. It turns out that that was due to the fact that `getCurrentPageMap()` was constantly re-fetching and re-parsing the import map _and_ that `getCurrentPageMap()` is called by default in `importDynamic()` when an app is loaded for the first time, so effectively, we were fetching one import map per-app, even though we don't expect the contents to change.

I had previously realized that even though we pre-fetch the import map and routes registry, these pre-fetches didn't actually take, but had never looked into why.

This PR fixes both of these things, so that under ideal circumstances (single import map or routes registry loaded successfully in pre-fetch), there is only ever _one_ request to either of these, the browser doing the pre-fetch. However, there are some allowance in the code so that if fetching an import map or routes _fails_ that result is not cached, so that the app has a chance to recover; no recovery steps are added here, but are something we may consider in the future.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

Let me know if this description is unclear; I know this is kind of deeper in the weeds than most people are.
