### PR TITLE
(BREAKING) Extension system should not re-derive in full on every write

### DIFF
--- a/.changeset/calm-slots-settle.md
+++ b/.changeset/calm-slots-settle.md
@@ -1,13 +1,22 @@
 ---
-"@openmrs/esm-config": patch
-"@openmrs/esm-extensions": major
-"@openmrs/esm-framework": major
-"@openmrs/esm-react-utils": minor
-"@openmrs/esm-routes": patch
+'@openmrs/esm-config': minor
+'@openmrs/esm-extensions': major
+'@openmrs/esm-framework': major
+'@openmrs/esm-react-utils': major
+'@openmrs/esm-routes': patch
+'@openmrs/esm-styleguide': patch
 ---
 
 (BREAKING) Rework extension and configuration derivation so writes invalidate only the affected slots instead of recomputing the complete extension graph.
 
 Extension rendering state is now tracked separately from registrations, and slot-local display conditions are evaluated for each rendering. `registerExtensionSlot` no longer accepts rendering state, and `ExtensionInfo` no longer contains live instances.
+
+`ExtensionSlotState.assignedExtensions` is renamed to `candidateExtensions` and no longer has display conditions applied to it, so it must not be used for any rendering decision. Call `getAssignedExtensions()` instead, or features like `Display conditions` will not be applied.
+
+`useStore` now returns the selected value itself rather than a copy of it, so mutating the result mutates the store.
+
+`useAssignedExtensionIds` applies display conditions, and so also takes connectivity into account.
+
+Parcels are given a 15 second bootstrap, mount and unmount timeout, after which they are marked as broken rather than left in a lifecycle that never settles.
 
 Extensions added only through `config.add` now retain their configuration order when no other ordering information is present.

--- a/packages/apps/esm-implementer-tools-app/src/configuration/configuration.component.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/configuration.component.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useState } from 'react';
-import { Button, Column, FlexGrid, Row, TextInput, Toggle } from '@carbon/react';
+import { Button, Column, FlexGrid, InlineNotification, Row, TextInput, Toggle } from '@carbon/react';
 import { useTranslation } from 'react-i18next';
 import { cloneDeep, isEmpty } from 'lodash-es';
 import type { Config } from '@openmrs/esm-framework/src/internal';
@@ -70,7 +70,7 @@ export const Configuration: React.FC = () => {
     isConfigToolbarOpen,
     toggleIsToolbarOpen,
   } = useStoreWithActions(implementerToolsStore, actions);
-  const { config } = useStore(implementerToolsConfigStore);
+  const { config, derivationError } = useStore(implementerToolsConfigStore);
   const extensionStore = useStore(getExtensionInternalStore());
   const tempConfigStore = useStore(temporaryConfigStore);
   const [filterText, setFilterText] = useState('');
@@ -183,6 +183,18 @@ export const Configuration: React.FC = () => {
           </FlexGrid>
         ) : null}
       </div>
+      {derivationError ? (
+        <InlineNotification
+          kind="error"
+          lowContrast
+          hideCloseButton
+          title={t('configDerivationFailed', 'This configuration is out of date')}
+          subtitle={`${t(
+            'configDerivationFailedSubtitle',
+            'The configuration could not be rebuilt, so what is shown below is the last version that did build.',
+          )} ${derivationError}`}
+        />
+      ) : null}
       <div className={styles.mainContent} style={{ height: mainContentHeight }}>
         {isJsonModeEnabled ? (
           <JsonEditor height={mainContentHeight} />

--- a/packages/apps/esm-implementer-tools-app/src/configuration/configuration.test.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/configuration.test.tsx
@@ -93,7 +93,8 @@ const mockImplToolsConfig = {
 
 describe('Configuration', () => {
   afterEach(() => {
-    implementerToolsConfigStore.setState({ config: {} });
+    // `setState` merges, so a test that recorded a derivation failure would leave it for the next.
+    implementerToolsConfigStore.setState({ config: {}, derivationError: undefined });
     temporaryConfigStore.setState({ config: {} });
   });
 
@@ -109,6 +110,27 @@ describe('Configuration', () => {
     screen.getByRole('switch', { name: /ui editor/i });
     screen.getByRole('button', { name: /clear local config/i });
     screen.getByRole('button', { name: /download config/i });
+  });
+
+  /*
+   * A failed derivation leaves the previous config on screen, so without this the panel presents
+   * stale — on a first failure, empty — configuration as though it were current.
+   */
+  it('warns that the configuration is stale when the last derivation failed', () => {
+    implementerToolsConfigStore.setState({ config: {}, derivationError: 'derivation blew up' });
+
+    renderConfiguration();
+
+    expect(screen.getByText(/this configuration is out of date/i)).toBeInTheDocument();
+    expect(screen.getByText(/derivation blew up/)).toBeInTheDocument();
+  });
+
+  it('does not warn when the configuration derived successfully', () => {
+    implementerToolsConfigStore.setState({ config: {} });
+
+    renderConfiguration();
+
+    expect(screen.queryByText(/this configuration is out of date/i)).not.toBeInTheDocument();
   });
 
   it('displays correct boolean value and editor', async () => {

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/extension-slots-config-tree.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/extension-slots-config-tree.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 import EditableValue from './editable-value.component';
 import isEqual from 'lodash-es/isEqual';
 import type { ExtensionSlotConfigureValueObject } from '@openmrs/esm-framework';
-import { useAssignedExtensions } from '@openmrs/esm-framework';
+import { useCandidateExtensions } from '@openmrs/esm-framework/src/internal';
 import { ExtensionConfigureTree } from './extension-configure-tree';
 import { Subtree } from './layout/subtree.component';
 import { implementerToolsStore } from '../../store';
@@ -52,7 +52,9 @@ interface ExtensionSlotConfigProps {
 function ExtensionSlotConfigTree({ config, path }: ExtensionSlotConfigProps) {
   const moduleName = path[0];
   const slotName = path[2];
-  const assignedExtensions = useAssignedExtensions(slotName);
+  // Candidates rather than assigned: the editor lists what is configured for the slot, which is not
+  // narrowed by any one rendering's display conditions.
+  const candidateExtensions = useCandidateExtensions(slotName);
   const { uiSelectedPath } = useStore(implementerToolsStore);
 
   const itemRef = useRef<HTMLLIElement>(null);
@@ -69,7 +71,7 @@ function ExtensionSlotConfigTree({ config, path }: ExtensionSlotConfigProps) {
       implementerToolsStore.setState({
         activeItemDescription: {
           path: [moduleName, slotName],
-          value: assignedExtensions.map((e) => e.id),
+          value: candidateExtensions.map((e) => e.id),
         },
       });
     }

--- a/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/extension-slot-remove.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/configuration/interactive-editor/value-editors/extension-slot-remove.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import { FilterableMultiSelect } from '@carbon/react';
-import { useAssignedExtensions } from '@openmrs/esm-framework';
+import { useCandidateExtensions } from '@openmrs/esm-framework/src/internal';
 
 export function ExtensionSlotRemove({ slotName, slotModuleName, value, setValue }) {
-  const assignedIds = useAssignedExtensions(slotName).map((e) => e.id);
+  const assignedIds = useCandidateExtensions(slotName).map((e) => e.id);
 
   return (
     <FilterableMultiSelect

--- a/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.test.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.test.tsx
@@ -10,7 +10,7 @@ const renderings = new Map(
       renderingId: 'top-nav-slot/nav-item-0',
       extensionName: 'nav-item',
       extensionModuleName: '@openmrs/esm-nav-app',
-      id: 'nav-item',
+      extensionId: 'nav-item',
       slotName: 'top-nav-slot',
       slotModuleName: '@openmrs/esm-nav-app',
     },
@@ -18,7 +18,7 @@ const renderings = new Map(
       renderingId: 'side-nav-slot/nav-item-1',
       extensionName: 'nav-item',
       extensionModuleName: '@openmrs/esm-nav-app',
-      id: 'nav-item',
+      extensionId: 'nav-item',
       slotName: 'side-nav-slot',
       slotModuleName: '@openmrs/esm-nav-app',
     },
@@ -26,7 +26,7 @@ const renderings = new Map(
       renderingId: 'patient-header-slot/patient-banner-2',
       extensionName: 'patient-banner',
       extensionModuleName: '@openmrs/esm-chart-app',
-      id: 'patient-banner',
+      extensionId: 'patient-banner',
       slotName: 'patient-header-slot',
       slotModuleName: '@openmrs/esm-chart-app',
     },
@@ -57,13 +57,43 @@ describe('getExtensionOverlayTargets', () => {
   it('surfaces real identifiers rather than structural artifacts of the store', () => {
     const targets = getExtensionOverlayTargets(renderings);
 
-    // `slotName`, `slotModuleName` and the rendering's `id` go into a DOM selector, so none of
-    // them may come from the record's own keys or an index.
+    // `slotName`, `slotModuleName` and `extensionId` go into a DOM selector, so none of them may
+    // come from the record's own keys or an index.
     expect(targets.map((target) => target.slotName)).toEqual(
       expect.not.arrayContaining(['id', 'slotName', 'slotModuleName', '0', '1', '2']),
     );
-    expect(targets.every((target) => typeof target.extensionRendering.id === 'string')).toBe(true);
+    expect(targets.every((target) => typeof target.extensionRendering.extensionId === 'string')).toBe(true);
     expect(targets.every((target) => typeof target.extensionName === 'string')).toBe(true);
+  });
+
+  it('keeps two renderings of one instance in one slot apart', () => {
+    // A list renders the same slot once per row, so these share everything but their rendering ID —
+    // which is the only thing that can key them or tell their overlays apart.
+    const sameSlot = new Map(
+      Object.entries({
+        'ward-slot/bed-card-0': {
+          renderingId: 'ward-slot/bed-card-0',
+          extensionName: 'bed-card',
+          extensionModuleName: '@openmrs/esm-ward-app',
+          extensionId: 'bed-card',
+          slotName: 'ward-slot',
+          slotModuleName: '@openmrs/esm-ward-app',
+        },
+        'ward-slot/bed-card-1': {
+          renderingId: 'ward-slot/bed-card-1',
+          extensionName: 'bed-card',
+          extensionModuleName: '@openmrs/esm-ward-app',
+          extensionId: 'bed-card',
+          slotName: 'ward-slot',
+          slotModuleName: '@openmrs/esm-ward-app',
+        },
+      }),
+    ) satisfies ExtensionRenderingsStore['renderings'];
+
+    const targets = getExtensionOverlayTargets(sameSlot);
+
+    expect(targets).toHaveLength(2);
+    expect(new Set(targets.map((target) => target.extensionRendering.renderingId)).size).toBe(2);
   });
 
   it('returns an empty list when nothing is rendered', () => {

--- a/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.test.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.test.tsx
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'vitest';
-import { type ExtensionInstancesStore } from '@openmrs/esm-framework/src/internal';
+import { type ExtensionRenderingsStore } from '@openmrs/esm-framework/src/internal';
 import { getExtensionOverlayTargets } from './ui-editor';
 
 // Each target has to carry the real slot, module and extension ID: they build the DOM selector
 // for the overlay.
-const instances = new Map(
+const renderings = new Map(
   Object.entries({
     'top-nav-slot/nav-item-0': {
-      instanceId: 'top-nav-slot/nav-item-0',
+      renderingId: 'top-nav-slot/nav-item-0',
       extensionName: 'nav-item',
       extensionModuleName: '@openmrs/esm-nav-app',
       id: 'nav-item',
@@ -15,7 +15,7 @@ const instances = new Map(
       slotModuleName: '@openmrs/esm-nav-app',
     },
     'side-nav-slot/nav-item-1': {
-      instanceId: 'side-nav-slot/nav-item-1',
+      renderingId: 'side-nav-slot/nav-item-1',
       extensionName: 'nav-item',
       extensionModuleName: '@openmrs/esm-nav-app',
       id: 'nav-item',
@@ -23,7 +23,7 @@ const instances = new Map(
       slotModuleName: '@openmrs/esm-nav-app',
     },
     'patient-header-slot/patient-banner-2': {
-      instanceId: 'patient-header-slot/patient-banner-2',
+      renderingId: 'patient-header-slot/patient-banner-2',
       extensionName: 'patient-banner',
       extensionModuleName: '@openmrs/esm-chart-app',
       id: 'patient-banner',
@@ -31,11 +31,11 @@ const instances = new Map(
       slotModuleName: '@openmrs/esm-chart-app',
     },
   }),
-) satisfies ExtensionInstancesStore['instances'];
+) satisfies ExtensionRenderingsStore['renderings'];
 
 describe('getExtensionOverlayTargets', () => {
-  it('describes every rendered instance, including two of the same extension in different slots', () => {
-    const targets = getExtensionOverlayTargets(instances);
+  it('describes every rendering, including two of the same extension in different slots', () => {
+    const targets = getExtensionOverlayTargets(renderings);
 
     expect(targets).toHaveLength(3);
     expect(targets[0]).toMatchObject({
@@ -55,14 +55,14 @@ describe('getExtensionOverlayTargets', () => {
   });
 
   it('surfaces real identifiers rather than structural artifacts of the store', () => {
-    const targets = getExtensionOverlayTargets(instances);
+    const targets = getExtensionOverlayTargets(renderings);
 
-    // `slotName`, `slotModuleName` and the instance's `id` go into a DOM selector, so none of
+    // `slotName`, `slotModuleName` and the rendering's `id` go into a DOM selector, so none of
     // them may come from the record's own keys or an index.
     expect(targets.map((target) => target.slotName)).toEqual(
       expect.not.arrayContaining(['id', 'slotName', 'slotModuleName', '0', '1', '2']),
     );
-    expect(targets.every((target) => typeof target.extensionInstance.id === 'string')).toBe(true);
+    expect(targets.every((target) => typeof target.extensionRendering.id === 'string')).toBe(true);
     expect(targets.every((target) => typeof target.extensionName === 'string')).toBe(true);
   });
 

--- a/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.test.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.test.tsx
@@ -1,25 +1,41 @@
 import { describe, expect, it } from 'vitest';
-import { type ExtensionInfo } from '@openmrs/esm-framework/src/internal';
+import { type ExtensionInstancesStore } from '@openmrs/esm-framework/src/internal';
 import { getExtensionOverlayTargets } from './ui-editor';
 
-// `extensions[name].instances` is an Array<ExtensionInstance> in the framework store. These tests
-// guard against regressing to an object-style traversal, which produced array indices as module
-// names and instance property names as slot names, so no overlay ever matched a real DOM node.
-const extensions = {
-  'nav-item': {
-    instances: [
-      { id: 'nav-item-0', slotName: 'top-nav-slot', slotModuleName: '@openmrs/esm-nav-app' },
-      { id: 'nav-item-1', slotName: 'side-nav-slot', slotModuleName: '@openmrs/esm-nav-app' },
-    ],
-  },
-  'patient-banner': {
-    instances: [{ id: 'patient-banner-0', slotName: 'patient-header-slot', slotModuleName: '@openmrs/esm-chart-app' }],
-  },
-} as unknown as Record<string, ExtensionInfo>;
+// Each target has to carry the real slot, module and extension ID: they build the DOM selector
+// for the overlay.
+const instances = new Map(
+  Object.entries({
+    'top-nav-slot/nav-item-0': {
+      instanceId: 'top-nav-slot/nav-item-0',
+      extensionName: 'nav-item',
+      extensionModuleName: '@openmrs/esm-nav-app',
+      id: 'nav-item',
+      slotName: 'top-nav-slot',
+      slotModuleName: '@openmrs/esm-nav-app',
+    },
+    'side-nav-slot/nav-item-1': {
+      instanceId: 'side-nav-slot/nav-item-1',
+      extensionName: 'nav-item',
+      extensionModuleName: '@openmrs/esm-nav-app',
+      id: 'nav-item',
+      slotName: 'side-nav-slot',
+      slotModuleName: '@openmrs/esm-nav-app',
+    },
+    'patient-header-slot/patient-banner-2': {
+      instanceId: 'patient-header-slot/patient-banner-2',
+      extensionName: 'patient-banner',
+      extensionModuleName: '@openmrs/esm-chart-app',
+      id: 'patient-banner',
+      slotName: 'patient-header-slot',
+      slotModuleName: '@openmrs/esm-chart-app',
+    },
+  }),
+) satisfies ExtensionInstancesStore['instances'];
 
 describe('getExtensionOverlayTargets', () => {
-  it('flattens the instances array into real slot, module, and id descriptors', () => {
-    const targets = getExtensionOverlayTargets(extensions);
+  it('describes every rendered instance, including two of the same extension in different slots', () => {
+    const targets = getExtensionOverlayTargets(instances);
 
     expect(targets).toHaveLength(3);
     expect(targets[0]).toMatchObject({
@@ -27,7 +43,10 @@ describe('getExtensionOverlayTargets', () => {
       slotName: 'top-nav-slot',
       slotModuleName: '@openmrs/esm-nav-app',
     });
-    expect(targets[0].extensionInstance.id).toBe('nav-item-0');
+    expect(targets[1]).toMatchObject({
+      extensionName: 'nav-item',
+      slotName: 'side-nav-slot',
+    });
     expect(targets[2]).toMatchObject({
       extensionName: 'patient-banner',
       slotName: 'patient-header-slot',
@@ -35,20 +54,20 @@ describe('getExtensionOverlayTargets', () => {
     });
   });
 
-  it('does not surface array indices or instance property names (regression guard)', () => {
-    const targets = getExtensionOverlayTargets(extensions);
+  it('surfaces real identifiers rather than structural artifacts of the store', () => {
+    const targets = getExtensionOverlayTargets(instances);
 
-    // Old object-traversal bug surfaced "0"/"1" as module names and "id"/"slotName"/"slotModuleName"
-    // as slot names, with an undefined instance id.
-    expect(targets.map((target) => target.slotModuleName)).not.toContain('0');
+    // `slotName`, `slotModuleName` and the instance's `id` go into a DOM selector, so none of
+    // them may come from the record's own keys or an index.
     expect(targets.map((target) => target.slotName)).toEqual(
-      expect.not.arrayContaining(['id', 'slotName', 'slotModuleName']),
+      expect.not.arrayContaining(['id', 'slotName', 'slotModuleName', '0', '1', '2']),
     );
     expect(targets.every((target) => typeof target.extensionInstance.id === 'string')).toBe(true);
+    expect(targets.every((target) => typeof target.extensionName === 'string')).toBe(true);
   });
 
-  it('returns an empty list when there are no extensions', () => {
+  it('returns an empty list when nothing is rendered', () => {
     expect(getExtensionOverlayTargets(undefined)).toEqual([]);
-    expect(getExtensionOverlayTargets({})).toEqual([]);
+    expect(getExtensionOverlayTargets(new Map())).toEqual([]);
   });
 });

--- a/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
@@ -38,7 +38,7 @@ export interface ExtensionOverlayTarget {
 
 /**
  * Turns the rendering store's records into overlay targets, each naming a slot and extension to look
- * for in the DOM. A rendering is registered before its bundle loads, so the node may not exist yet.
+ * for in the DOM. Not every rendering has a matching node.
  */
 export function getExtensionOverlayTargets(
   renderings: ExtensionRenderingsStore['renderings'] | undefined,
@@ -95,16 +95,14 @@ export default function UiEditor() {
       .filter((x): x is NonNullable<typeof x> => Boolean(x));
   }, [slots]);
 
-  const extensionElements = useMemo(
-    () =>
-      getExtensionOverlayTargets(renderingsState.renderings).map((target) => ({
-        ...target,
-        element: document.querySelector(
-          `*[data-extension-slot-name="${target.slotName}"][data-extension-slot-module-name="${target.slotModuleName}"] *[data-extension-id="${target.extensionRendering.id}"]`,
-        ) as HTMLElement | null,
-      })),
-    [renderingsState],
-  );
+  const extensionElements = useMemo(() => {
+    return getExtensionOverlayTargets(renderingsState.renderings).map((target) => ({
+      ...target,
+      element: document.querySelector(
+        `*[data-extension-rendering-id="${CSS.escape(target.extensionRendering.renderingId)}"]`,
+      ) as HTMLElement | null,
+    }));
+  }, [renderingsState]);
 
   return (
     <>
@@ -129,7 +127,7 @@ export default function UiEditor() {
             <ExtensionOverlay
               domElement={element}
               extensionName={extensionName}
-              key={`${slotName}-${extensionRendering.id}`}
+              key={extensionRendering.renderingId}
               slotModuleName={slotModuleName}
               slotName={slotName}
             />

--- a/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
@@ -5,7 +5,9 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@carbon/react';
 import {
   CloseIcon,
-  type ExtensionInfo,
+  type ExtensionInstance,
+  type ExtensionInstancesStore,
+  getExtensionInstancesStore,
   getExtensionInternalStore,
   useStore,
   useStoreWithActions,
@@ -31,31 +33,30 @@ export interface ExtensionOverlayTarget {
   extensionName: string;
   slotModuleName: string;
   slotName: string;
-  extensionInstance: ExtensionInfo['instances'][number];
+  extensionInstance: ExtensionInstance;
 }
 
 /**
- * Flattens `extensions[name].instances` into a flat list of overlay targets. `instances` is an
- * `Array<ExtensionInstance>`, so it must be iterated directly. Treating it as a nested object (via
- * `Object.entries`) yields array indices as the module name and instance property names as the slot
- * name, so the generated selectors never match a real extension DOM node.
+ * Turns the instance store's records into overlay targets. Only currently-rendered extensions
+ * have an instance, so each target names a slot and extension the DOM is expected to contain.
  */
 export function getExtensionOverlayTargets(
-  extensions: Record<string, ExtensionInfo> | undefined,
+  instances: ExtensionInstancesStore['instances'] | undefined,
 ): Array<ExtensionOverlayTarget> {
-  return Object.entries(extensions ?? {}).flatMap(([extensionName, extensionInfo]) =>
-    (extensionInfo.instances ?? []).map((extensionInstance) => ({
-      extensionName,
-      slotModuleName: extensionInstance.slotModuleName,
-      slotName: extensionInstance.slotName,
-      extensionInstance,
-    })),
-  );
+  return Array.from(instances?.values() ?? [], (extensionInstance) => ({
+    extensionName: extensionInstance.extensionName,
+    slotModuleName: extensionInstance.slotModuleName,
+    slotName: extensionInstance.slotName,
+    extensionInstance,
+  }));
 }
 
 export default function UiEditor() {
   const { t } = useTranslation();
   const { slots, extensions } = useStore(getExtensionInternalStore());
+  // Depended on as a whole below: the instance map is mutated in place, so only the state
+  // object around it changes identity when an extension mounts or unmounts.
+  const instancesState = useStore(getExtensionInstancesStore());
   const { isOpen: areImplementerToolsOpen } = useStore(implementerToolsStore);
 
   const getExtensionCount = (slotName: string, moduleName: string) => {
@@ -96,13 +97,13 @@ export default function UiEditor() {
 
   const extensionElements = useMemo(
     () =>
-      getExtensionOverlayTargets(extensions).map((target) => ({
+      getExtensionOverlayTargets(instancesState.instances).map((target) => ({
         ...target,
         element: document.querySelector(
           `*[data-extension-slot-name="${target.slotName}"][data-extension-slot-module-name="${target.slotModuleName}"] *[data-extension-id="${target.extensionInstance.id}"]`,
         ) as HTMLElement | null,
       })),
-    [extensions],
+    [instancesState],
   );
 
   return (

--- a/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
+++ b/packages/apps/esm-implementer-tools-app/src/ui-editor/ui-editor.tsx
@@ -5,9 +5,9 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@carbon/react';
 import {
   CloseIcon,
-  type ExtensionInstance,
-  type ExtensionInstancesStore,
-  getExtensionInstancesStore,
+  type ExtensionRendering,
+  type ExtensionRenderingsStore,
+  getExtensionRenderingsStore,
   getExtensionInternalStore,
   useStore,
   useStoreWithActions,
@@ -33,30 +33,30 @@ export interface ExtensionOverlayTarget {
   extensionName: string;
   slotModuleName: string;
   slotName: string;
-  extensionInstance: ExtensionInstance;
+  extensionRendering: ExtensionRendering;
 }
 
 /**
- * Turns the instance store's records into overlay targets. Only currently-rendered extensions
- * have an instance, so each target names a slot and extension the DOM is expected to contain.
+ * Turns the rendering store's records into overlay targets, each naming a slot and extension to look
+ * for in the DOM. A rendering is registered before its bundle loads, so the node may not exist yet.
  */
 export function getExtensionOverlayTargets(
-  instances: ExtensionInstancesStore['instances'] | undefined,
+  renderings: ExtensionRenderingsStore['renderings'] | undefined,
 ): Array<ExtensionOverlayTarget> {
-  return Array.from(instances?.values() ?? [], (extensionInstance) => ({
-    extensionName: extensionInstance.extensionName,
-    slotModuleName: extensionInstance.slotModuleName,
-    slotName: extensionInstance.slotName,
-    extensionInstance,
+  return Array.from(renderings?.values() ?? [], (extensionRendering) => ({
+    extensionName: extensionRendering.extensionName,
+    slotModuleName: extensionRendering.slotModuleName,
+    slotName: extensionRendering.slotName,
+    extensionRendering,
   }));
 }
 
 export default function UiEditor() {
   const { t } = useTranslation();
   const { slots, extensions } = useStore(getExtensionInternalStore());
-  // Depended on as a whole below: the instance map is mutated in place, so only the state
+  // Depended on as a whole below: the rendering map is mutated in place, so only the state
   // object around it changes identity when an extension mounts or unmounts.
-  const instancesState = useStore(getExtensionInstancesStore());
+  const renderingsState = useStore(getExtensionRenderingsStore());
   const { isOpen: areImplementerToolsOpen } = useStore(implementerToolsStore);
 
   const getExtensionCount = (slotName: string, moduleName: string) => {
@@ -97,13 +97,13 @@ export default function UiEditor() {
 
   const extensionElements = useMemo(
     () =>
-      getExtensionOverlayTargets(instancesState.instances).map((target) => ({
+      getExtensionOverlayTargets(renderingsState.renderings).map((target) => ({
         ...target,
         element: document.querySelector(
-          `*[data-extension-slot-name="${target.slotName}"][data-extension-slot-module-name="${target.slotModuleName}"] *[data-extension-id="${target.extensionInstance.id}"]`,
+          `*[data-extension-slot-name="${target.slotName}"][data-extension-slot-module-name="${target.slotModuleName}"] *[data-extension-id="${target.extensionRendering.id}"]`,
         ) as HTMLElement | null,
       })),
-    [instancesState],
+    [renderingsState],
   );
 
   return (
@@ -124,12 +124,12 @@ export default function UiEditor() {
           ),
       )}
       {extensionElements.map(
-        ({ extensionName, slotModuleName, slotName, extensionInstance, element }) =>
+        ({ extensionName, slotModuleName, slotName, extensionRendering, element }) =>
           element && (
             <ExtensionOverlay
               domElement={element}
               extensionName={extensionName}
-              key={`${slotName}-${extensionInstance.id}`}
+              key={`${slotName}-${extensionRendering.id}`}
               slotModuleName={slotModuleName}
               slotName={slotName}
             />

--- a/packages/apps/esm-implementer-tools-app/translations/en.json
+++ b/packages/apps/esm-implementer-tools-app/translations/en.json
@@ -6,6 +6,8 @@
   "checkImplementerToolsMessage": "Check the Backend Modules tab in the Implementer Tools for more details",
   "clearConfig": "Clear local config",
   "close": "Close",
+  "configDerivationFailed": "This configuration is out of date",
+  "configDerivationFailedSubtitle": "The configuration could not be rebuilt, so what is shown below is the last version that did build.",
   "configuration": "Configuration",
   "description": "Description",
   "downloadConfig": "Download config",

--- a/packages/framework/esm-config/src/module-config/config-derivation-failure.test.ts
+++ b/packages/framework/esm-config/src/module-config/config-derivation-failure.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import { configInternalStore, implementerToolsConfigStore, temporaryConfigStore } from './state';
+import { defineConfigSchema, provide, registerModuleLoad, resetConfigSystem } from './module-config';
+import { Type } from '../types';
+
+/**
+ * The derivation runs from subscribers to the config system's input stores, so a failure that
+ * escapes reaches whichever call happened to write one — an app's `provide()`, an extension
+ * mounting, an implementer editing a value in the tools panel — rather than the configuration that
+ * caused it.
+ *
+ * A function is one value `setDefaults` cannot clone; the point is any throw in the derivation,
+ * not this particular input.
+ */
+describe('a configuration that cannot be derived', () => {
+  let consoleError: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    temporaryConfigStore.setState({ config: {} });
+    configInternalStore.setState({ providedConfigs: [], schemas: {}, moduleLoaded: {} });
+    implementerToolsConfigStore.setState({ config: {}, derivationError: undefined });
+    resetConfigSystem();
+    defineConfigSchema('esm-probe', { thing: { _type: Type.Object, _default: {} } });
+    registerModuleLoad('esm-probe');
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('does not throw out of the call that provided it', () => {
+    expect(() => provide({ 'esm-probe': { thing: { fn: () => {} } } })).not.toThrow();
+    expect(consoleError).toHaveBeenCalledWith('Failed to recompute the configuration', expect.anything());
+  });
+
+  it('does not throw out of an implementer editing a value', () => {
+    expect(() => temporaryConfigStore.setState({ config: { 'esm-probe': { thing: { fn: () => {} } } } })).not.toThrow();
+  });
+
+  it('is recorded so the implementer tools can report the values they show are out of date', () => {
+    provide({ 'esm-probe': { thing: { fn: () => {} } } });
+
+    expect(implementerToolsConfigStore.getState().derivationError).toEqual(
+      expect.stringMatching(/could not be cloned/),
+    );
+  });
+
+  it('leaves the configuration derived before it in place', () => {
+    provide({ 'esm-probe': { thing: { good: 'value' } } });
+
+    const before = implementerToolsConfigStore.getState().config;
+
+    provide({ 'esm-probe': { thing: { fn: () => {} } } });
+
+    expect(implementerToolsConfigStore.getState().config).toEqual(before);
+  });
+});

--- a/packages/framework/esm-config/src/module-config/implementer-tools-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/implementer-tools-config.test.ts
@@ -9,6 +9,18 @@ import { defineConfigSchema, provide, registerModuleLoad, resetConfigSystem } fr
 import { Type } from '../types';
 
 /**
+ * The derived tree is `{ [module]: { ...keys, _value, _source } }` all the way down, which the
+ * store types only as `Config`. Reading it in a test needs the shape spelled out.
+ */
+interface ConfigNode {
+  _value?: unknown;
+  _source?: string;
+  [key: string]: any;
+}
+
+type ImplementerToolsTree = Record<string, ConfigNode>;
+
+/**
  * The implementer tools config is derived lazily — only while something is subscribed to it — so
  * these cover the two ways it can be read, and the transition back to lazy when the last
  * subscriber goes away.
@@ -27,7 +39,7 @@ describe('implementer tools config', () => {
   it('derives on demand when nothing is subscribed', () => {
     provide({ 'esm-flintstone': { label: 'provided-label' } });
 
-    const config = implementerToolsConfigStore.getState().config as never;
+    const config = implementerToolsConfigStore.getState().config as ImplementerToolsTree;
 
     expect(config['esm-flintstone'].label._value).toBe('provided-label');
     expect(config['esm-flintstone'].label._source).toBe('provided');
@@ -38,10 +50,14 @@ describe('implementer tools config', () => {
     const unsubscribe = implementerToolsConfigStore.subscribe((state) => seen.push(state.config));
 
     provide({ 'esm-flintstone': { label: 'first' } });
-    expect((implementerToolsConfigStore.getState().config as never)['esm-flintstone'].label._value).toBe('first');
+    expect((implementerToolsConfigStore.getState().config as ImplementerToolsTree)['esm-flintstone'].label._value).toBe(
+      'first',
+    );
 
     temporaryConfigStore.setState({ config: { 'esm-flintstone': { label: 'second' } } });
-    expect((implementerToolsConfigStore.getState().config as never)['esm-flintstone'].label._value).toBe('second');
+    expect((implementerToolsConfigStore.getState().config as ImplementerToolsTree)['esm-flintstone'].label._value).toBe(
+      'second',
+    );
 
     expect(seen.length).toBeGreaterThanOrEqual(2);
     unsubscribe();
@@ -55,7 +71,7 @@ describe('implementer tools config', () => {
     // Back to deriving lazily; a read still has to see changes made while nothing was watching.
     temporaryConfigStore.setState({ config: { 'esm-flintstone': { label: 'after-unsubscribe' } } });
 
-    expect((implementerToolsConfigStore.getState().config as never)['esm-flintstone'].label._value).toBe(
+    expect((implementerToolsConfigStore.getState().config as ImplementerToolsTree)['esm-flintstone'].label._value).toBe(
       'after-unsubscribe',
     );
   });
@@ -63,7 +79,7 @@ describe('implementer tools config', () => {
   it('includes a module that is configured but never declared a schema', () => {
     provide({ 'esm-no-schema': { someSetting: 'configured' } });
 
-    const config = implementerToolsConfigStore.getState().config as never;
+    const config = implementerToolsConfigStore.getState().config as ImplementerToolsTree;
 
     // Merging happens per module, so a module present only in a provided config still has to
     // reach the output.
@@ -83,7 +99,7 @@ describe('implementer tools config', () => {
     provide({ 'esm-rubble': { nested: { overridden: 'from-provided' } } });
     temporaryConfigStore.setState({ config: { 'esm-rubble': { nested: { overridden: 'from-temporary' } } } });
 
-    const config = implementerToolsConfigStore.getState().config as never;
+    const config = implementerToolsConfigStore.getState().config as ImplementerToolsTree;
 
     expect(config['esm-rubble'].nested.overridden._value).toBe('from-temporary');
     expect(config['esm-rubble'].nested.overridden._source).toBe('temporary config');
@@ -141,6 +157,29 @@ describe('implementer tools config', () => {
     expect(derived).toBe(true);
   });
 
+  /*
+   * A failed derivation leaves the last config that built successfully in place — on a first
+   * failure, nothing at all — so the panel has no way to tell it is looking at stale data unless
+   * the failure is recorded alongside it.
+   */
+  it('records a failed derivation in the store, and clears it once one succeeds', () => {
+    let shouldThrow = true;
+    setImplementerToolsConfigRecomputer(() => {
+      if (shouldThrow) {
+        throw new Error('derivation blew up');
+      }
+    });
+
+    provide({ 'esm-flintstone': { label: 'x' } });
+
+    expect(implementerToolsConfigStore.getState().derivationError).toBe('derivation blew up');
+
+    shouldThrow = false;
+    provide({ 'esm-flintstone': { label: 'y' } });
+
+    expect(implementerToolsConfigStore.getState().derivationError).toBeUndefined();
+  });
+
   it('tolerates unsubscribing twice', () => {
     const unsubscribe = implementerToolsConfigStore.subscribe(() => {});
     unsubscribe();
@@ -148,7 +187,7 @@ describe('implementer tools config', () => {
 
     // A subscriber count driven below zero would leave `getState` permanently unable to derive.
     temporaryConfigStore.setState({ config: { 'esm-flintstone': { label: 'after-double' } } });
-    expect((implementerToolsConfigStore.getState().config as never)['esm-flintstone'].label._value).toBe(
+    expect((implementerToolsConfigStore.getState().config as ImplementerToolsTree)['esm-flintstone'].label._value).toBe(
       'after-double',
     );
   });
@@ -168,8 +207,8 @@ describe('implementer tools config', () => {
   });
 
   it('does not overwrite a config written directly to the store', () => {
-    implementerToolsConfigStore.setState({ config: { manual: true } as never });
+    implementerToolsConfigStore.setState({ config: { 'esm-manual': { written: true } } });
 
-    expect(implementerToolsConfigStore.getState().config).toEqual({ manual: true });
+    expect(implementerToolsConfigStore.getState().config).toEqual({ 'esm-manual': { written: true } });
   });
 });

--- a/packages/framework/esm-config/src/module-config/implementer-tools-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/implementer-tools-config.test.ts
@@ -1,0 +1,175 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  configInternalStore,
+  implementerToolsConfigStore,
+  setImplementerToolsConfigRecomputer,
+  temporaryConfigStore,
+} from './state';
+import { defineConfigSchema, provide, registerModuleLoad, resetConfigSystem } from './module-config';
+import { Type } from '../types';
+
+/**
+ * The implementer tools config is derived lazily — only while something is subscribed to it — so
+ * these cover the two ways it can be read, and the transition back to lazy when the last
+ * subscriber goes away.
+ */
+describe('implementer tools config', () => {
+  beforeEach(() => {
+    temporaryConfigStore.setState({ config: {} });
+    configInternalStore.setState({ providedConfigs: [], schemas: {}, moduleLoaded: {} });
+    resetConfigSystem();
+    defineConfigSchema('esm-flintstone', {
+      label: { _type: Type.String, _default: 'default-label', _description: 'x' },
+    });
+    registerModuleLoad('esm-flintstone');
+  });
+
+  it('derives on demand when nothing is subscribed', () => {
+    provide({ 'esm-flintstone': { label: 'provided-label' } });
+
+    const config = implementerToolsConfigStore.getState().config as never;
+
+    expect(config['esm-flintstone'].label._value).toBe('provided-label');
+    expect(config['esm-flintstone'].label._source).toBe('provided');
+  });
+
+  it('keeps a subscriber up to date as the config changes', () => {
+    const seen: Array<unknown> = [];
+    const unsubscribe = implementerToolsConfigStore.subscribe((state) => seen.push(state.config));
+
+    provide({ 'esm-flintstone': { label: 'first' } });
+    expect((implementerToolsConfigStore.getState().config as never)['esm-flintstone'].label._value).toBe('first');
+
+    temporaryConfigStore.setState({ config: { 'esm-flintstone': { label: 'second' } } });
+    expect((implementerToolsConfigStore.getState().config as never)['esm-flintstone'].label._value).toBe('second');
+
+    expect(seen.length).toBeGreaterThanOrEqual(2);
+    unsubscribe();
+  });
+
+  it('still reports the current config after the last subscriber goes away', () => {
+    const unsubscribe = implementerToolsConfigStore.subscribe(() => {});
+    provide({ 'esm-flintstone': { label: 'while-subscribed' } });
+    unsubscribe();
+
+    // Back to deriving lazily; a read still has to see changes made while nothing was watching.
+    temporaryConfigStore.setState({ config: { 'esm-flintstone': { label: 'after-unsubscribe' } } });
+
+    expect((implementerToolsConfigStore.getState().config as never)['esm-flintstone'].label._value).toBe(
+      'after-unsubscribe',
+    );
+  });
+
+  it('includes a module that is configured but never declared a schema', () => {
+    provide({ 'esm-no-schema': { someSetting: 'configured' } });
+
+    const config = implementerToolsConfigStore.getState().config as never;
+
+    // Merging happens per module, so a module present only in a provided config still has to
+    // reach the output.
+    expect(config['esm-no-schema'].someSetting._value).toBe('configured');
+    expect(config['esm-flintstone'].label._value).toBe('default-label');
+  });
+
+  it('layers sources for one module, with later sources winning', () => {
+    defineConfigSchema('esm-rubble', {
+      nested: {
+        kept: { _type: Type.String, _default: 'from-schema', _description: 'x' },
+        overridden: { _type: Type.String, _default: 'from-schema', _description: 'x' },
+      },
+    });
+    registerModuleLoad('esm-rubble');
+
+    provide({ 'esm-rubble': { nested: { overridden: 'from-provided' } } });
+    temporaryConfigStore.setState({ config: { 'esm-rubble': { nested: { overridden: 'from-temporary' } } } });
+
+    const config = implementerToolsConfigStore.getState().config as never;
+
+    expect(config['esm-rubble'].nested.overridden._value).toBe('from-temporary');
+    expect(config['esm-rubble'].nested.overridden._source).toBe('temporary config');
+    // Sibling keys the later sources don't mention keep their schema default.
+    expect(config['esm-rubble'].nested.kept._value).toBe('from-schema');
+    expect(config['esm-rubble'].nested.kept._source).toBe('default');
+  });
+
+  it('stops deriving once the last subscriber goes away, and starts again on demand', () => {
+    // Counting derivations is the only way to observe the laziness itself; asserting on the value
+    // alone passes whether or not the derivation was skipped.
+    let derivations = 0;
+    const realRecomputer = () => {
+      derivations++;
+      configInternalStore.setState(configInternalStore.getState());
+    };
+    setImplementerToolsConfigRecomputer(realRecomputer);
+
+    const unsubscribe = implementerToolsConfigStore.subscribe(() => {});
+    derivations = 0;
+
+    provide({ 'esm-flintstone': { label: 'while-subscribed' } });
+    expect(derivations).toBe(1);
+
+    unsubscribe();
+    provide({ 'esm-flintstone': { label: 'after-unsubscribe' } });
+    expect(derivations).toBe(1);
+
+    // ...but a read still pays for one.
+    implementerToolsConfigStore.getState();
+    expect(derivations).toBe(2);
+  });
+
+  it('survives a derivation that throws, and retries on the next read', () => {
+    let shouldThrow = true;
+    setImplementerToolsConfigRecomputer(() => {
+      if (shouldThrow) {
+        throw new Error('derivation blew up');
+      }
+    });
+
+    // A failing derivation must not escape into a store listener, a render, or `subscribe`.
+    expect(() => provide({ 'esm-flintstone': { label: 'x' } })).not.toThrow();
+    expect(() => implementerToolsConfigStore.getState()).not.toThrow();
+
+    const unsubscribe = implementerToolsConfigStore.subscribe(() => {});
+    shouldThrow = false;
+    unsubscribe();
+
+    let derived = false;
+    setImplementerToolsConfigRecomputer(() => {
+      derived = true;
+    });
+    implementerToolsConfigStore.getState();
+    expect(derived).toBe(true);
+  });
+
+  it('tolerates unsubscribing twice', () => {
+    const unsubscribe = implementerToolsConfigStore.subscribe(() => {});
+    unsubscribe();
+    unsubscribe();
+
+    // A subscriber count driven below zero would leave `getState` permanently unable to derive.
+    temporaryConfigStore.setState({ config: { 'esm-flintstone': { label: 'after-double' } } });
+    expect((implementerToolsConfigStore.getState().config as never)['esm-flintstone'].label._value).toBe(
+      'after-double',
+    );
+  });
+
+  it('stays eager while a second subscriber remains', () => {
+    const first = implementerToolsConfigStore.subscribe(() => {});
+    const second = implementerToolsConfigStore.subscribe(() => {});
+    first();
+
+    let notified = 0;
+    const third = implementerToolsConfigStore.subscribe(() => notified++);
+    provide({ 'esm-flintstone': { label: 'two-watchers' } });
+    expect(notified).toBeGreaterThan(0);
+
+    second();
+    third();
+  });
+
+  it('does not overwrite a config written directly to the store', () => {
+    implementerToolsConfigStore.setState({ config: { manual: true } as never });
+
+    expect(implementerToolsConfigStore.getState().config).toEqual({ manual: true });
+  });
+});

--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -9,6 +9,7 @@ import type { ConfigExtensionStore, ConfigInternalStore, ImplementerToolsConfigS
 import {
   configExtensionStore,
   configInternalStore,
+  getConfigStore,
   getExtensionConfig,
   implementerToolsConfigStore,
   temporaryConfigStore,
@@ -1260,6 +1261,49 @@ describe('extension config', () => {
 
   afterEach(resetAll);
 
+  it('does not re-derive the configs of extensions that were already mounted', () => {
+    let derivations = 0;
+    Config.defineExtensionConfigSchema('countedExt', {
+      bar: {
+        _default: 'barry',
+        _validators: [
+          validator(() => {
+            derivations++;
+            return true;
+          }, 'never fails'),
+        ],
+      },
+    });
+    // Validators are skipped for a value that is still its default, so the counter only moves
+    // when the config is genuinely rebuilt.
+    Config.provide({ countedExt: { bar: 'qux' } });
+
+    const mount = (extensionIds: Array<string>) =>
+      configExtensionStore.setState({
+        mountedExtensions: extensionIds.map((extensionId) => ({
+          slotModuleName: 'slot-mod',
+          extensionModuleName: 'ext-mod',
+          slotName: 'countedSlot',
+          extensionId,
+        })),
+      });
+
+    mount(['countedExt#0']);
+    expect(derivations).toBe(1);
+
+    // Mounting a second extension must not rebuild the first one's config: a list that mounts
+    // extensions one at a time would otherwise cost O(mounted²) derivations to fill.
+    mount(['countedExt#0', 'countedExt#1']);
+    expect(derivations).toBe(2);
+
+    mount(['countedExt#0', 'countedExt#1', 'countedExt#2']);
+    expect(derivations).toBe(3);
+
+    // Unmounting is likewise not a reason to rebuild what is left.
+    mount(['countedExt#0']);
+    expect(derivations).toBe(3);
+  });
+
   it('returns the module config', async () => {
     const moduleLevelConfig = { 'ext-mod': { bar: 'qux' } };
     updateConfigExtensionStore();
@@ -1432,6 +1476,80 @@ describe('translation overrides', () => {
     const config = Config.getConfig('corge-module');
     expect(config).resolves.toStrictEqual({ corges: true });
     expect(console.error).not.toHaveBeenCalled();
+  });
+});
+
+describe('promise-based config accessors', () => {
+  beforeAll(resetAll);
+  beforeEach(() => {
+    console.error = vi.fn();
+  });
+  afterEach(resetAll);
+
+  /**
+   * Counts subscriptions that are currently live on a module's config store, so a leak shows up
+   * as a non-zero count. This patches the store the mock registry holds rather than the object
+   * `getConfigStore` hands back, because the mock instruments a fresh wrapper on every call.
+   */
+  function countSubscriptions(moduleName: string) {
+    getConfigStore(moduleName);
+    const store = mockStores[`config-module-${moduleName}`].value;
+    const realSubscribe = store.subscribe.bind(store);
+    const counter = { live: 0 };
+
+    store.subscribe = ((listener: Parameters<typeof store.subscribe>[0]) => {
+      counter.live++;
+      const unsubscribe = realSubscribe(listener);
+
+      return () => {
+        counter.live--;
+        unsubscribe();
+      };
+    }) as typeof store.subscribe;
+
+    return counter;
+  }
+
+  it('getConfig does not subscribe at all when the config has already loaded', async () => {
+    Config.defineConfigSchema('leak-module', { foo: { _default: 'qux' } });
+    Config.registerModuleLoad('leak-module');
+    await Config.getConfig('leak-module');
+
+    const subscriptions = countSubscriptions('leak-module');
+
+    // openmrs-fetch calls this on every HTTP request, so a subscription per call is unbounded.
+    for (let i = 0; i < 25; i++) {
+      await Config.getConfig('leak-module');
+    }
+
+    expect(subscriptions.live).toBe(0);
+  });
+
+  it('getConfig releases its subscription once the config loads', async () => {
+    const subscriptions = countSubscriptions('slow-module');
+    const config = Config.getConfig('slow-module');
+
+    expect(subscriptions.live).toBe(1);
+
+    Config.defineConfigSchema('slow-module', { foo: { _default: 'qux' } });
+    Config.registerModuleLoad('slow-module');
+
+    await expect(config).resolves.toStrictEqual({ foo: 'qux' });
+    expect(subscriptions.live).toBe(0);
+  });
+
+  it('getTranslationOverrides does not leave subscriptions behind', async () => {
+    Config.defineConfigSchema('overrides-module', { foo: { _default: 'qux' } });
+    Config.registerModuleLoad('overrides-module');
+    await Config.getTranslationOverrides('overrides-module');
+
+    const subscriptions = countSubscriptions('overrides-module');
+
+    for (let i = 0; i < 25; i++) {
+      await Config.getTranslationOverrides('overrides-module');
+    }
+
+    expect(subscriptions.live).toBe(0);
   });
 });
 

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -535,7 +535,9 @@ function computeExtensionConfig(
 ) {
   const extensionName = getExtensionNameFromId(extensionId);
   const extensionConfigSchema = configState.schemas[extensionName];
-  const cacheKey = [slotName, extensionId, slotModuleName, extensionModuleName].join(' ');
+  // `|` rather than a space, which slot names and extension IDs are allowed to contain: joining on
+  // one lets ('a b', 'c') and ('a', 'b c') collide and share a config.
+  const cacheKey = [slotName, extensionId, slotModuleName, extensionModuleName].join('|');
   const cached = extensionConfigCache.get(cacheKey);
 
   if (
@@ -572,9 +574,8 @@ function computeExtensionConfig(
 }
 
 /**
- * The annotated config tree is keyed by module, and a config only ever mentions a few modules, so
- * merging per module means editing one module's configuration rebuilds only that module and every
- * other subtree keeps its identity — which also makes the deep comparison downstream cheap. Adding
+ * Merging per module means editing one module's configuration rebuilds only that module, and the
+ * other subtrees keep their identity — which also makes the deep comparison downstream cheap. Adding
  * a config source is the exception: it lengthens the source list, invalidating every entry.
  */
 interface ImplementerToolsModuleCacheEntry {

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -4,7 +4,13 @@ import type { Config, ConfigObject, ConfigSchema, ExtensionSlotConfig } from '..
 import { Type } from '../types';
 import { isArray, isBoolean, isUuid, isNumber, isObject, isString } from '../validators/type-validators';
 import { validator } from '../validators/validator';
-import { type ConfigExtensionStore, type ConfigInternalStore, type ConfigStore } from './state';
+import {
+  type ConfigExtensionStore,
+  type ConfigInternalStore,
+  type ConfigStore,
+  type ExtensionSlotsConfigStore,
+  type ExtensionsConfigStore,
+} from './state';
 import {
   configExtensionStore,
   configInternalStore,
@@ -13,6 +19,8 @@ import {
   getExtensionSlotsConfigStore,
   getExtensionsConfigStore,
   implementerToolsConfigStore,
+  invalidateImplementerToolsConfig,
+  setImplementerToolsConfigRecomputer,
   temporaryConfigStore,
 } from './state';
 import { type TemporaryConfigStore } from '..';
@@ -63,12 +71,19 @@ function recomputeAllConfigs() {
   const extensionState = configExtensionStore.getState();
 
   computeModuleConfig(configState, tempConfigState);
-  computeImplementerToolsConfig(configState, tempConfigState);
   computeExtensionSlotConfigs(configState, tempConfigState);
   computeExtensionConfigs(configState, extensionState, tempConfigState);
+  // Last, because a failure here must not skip the outputs above. Only kept current while the
+  // implementer tools are watching it; otherwise derived on read.
+  invalidateImplementerToolsConfig();
 }
 
 function setupConfigSubscriptions() {
+  // Registered here rather than at module load so that `resetConfigSystem` restores it.
+  setImplementerToolsConfigRecomputer(() =>
+    computeImplementerToolsConfig(configInternalStore.getState(), temporaryConfigStore.getState()),
+  );
+
   // Initial computation
   recomputeAllConfigs();
 
@@ -82,6 +97,21 @@ function setupConfigSubscriptions() {
 // Set up subscriptions at module load time
 setupConfigSubscriptions();
 
+/**
+ * A module's config is a pure function of its schema, whether it has loaded, and the provided and
+ * temporary configs. Every module is recomputed whenever any input store changes, so without this
+ * cache loading N modules costs N² full derivations.
+ */
+interface ModuleConfigCacheEntry {
+  schema: ConfigSchema;
+  moduleLoaded: boolean;
+  providedConfigs: ConfigInternalStore['providedConfigs'];
+  temporaryConfig: Config;
+  state: ConfigStore;
+}
+
+const moduleConfigCache = new Map<string, ModuleConfigCacheEntry>();
+
 function computeModuleConfig(state: ConfigInternalStore, tempState: TemporaryConfigStore) {
   for (let moduleName of Object.keys(state.schemas)) {
     // At this point the schema could be either just the implicit schema or the actually
@@ -91,38 +121,79 @@ function computeModuleConfig(state: ConfigInternalStore, tempState: TemporaryCon
     // available, which as of this writing blocks the schema definition from occurring
     // for modules loaded based on their extensions.
     const moduleStore = getConfigStore(moduleName);
-    let newState;
-    if (state.moduleLoaded[moduleName]) {
-      const config = getConfigForModule(moduleName, state, tempState);
-      newState = {
-        translationOverridesLoaded: true,
-        loaded: true,
-        config,
-      };
+    const schema = state.schemas[moduleName];
+    const moduleLoaded = Boolean(state.moduleLoaded[moduleName]);
+    const cached = moduleConfigCache.get(moduleName);
+
+    let newState: ConfigStore;
+
+    if (
+      cached &&
+      cached.schema === schema &&
+      cached.moduleLoaded === moduleLoaded &&
+      cached.providedConfigs === state.providedConfigs &&
+      cached.temporaryConfig === tempState.config
+    ) {
+      newState = cached.state;
     } else {
-      const config = getConfigForModuleImplicitSchema(moduleName, state, tempState);
+      const config = moduleLoaded
+        ? getConfigForModule(moduleName, state, tempState)
+        : getConfigForModuleImplicitSchema(moduleName, state, tempState);
+
       newState = {
         translationOverridesLoaded: true,
-        loaded: false,
+        loaded: moduleLoaded,
         config,
       };
+
+      moduleConfigCache.set(moduleName, {
+        schema,
+        moduleLoaded,
+        providedConfigs: state.providedConfigs,
+        temporaryConfig: tempState.config,
+        state: newState,
+      });
     }
 
-    moduleStore.setState(newState);
+    // Writing unconditionally would hand every `useConfig` consumer in the application a new
+    // object — and a re-render — whenever any module or extension anywhere is loaded.
+    const oldState = moduleStore.getState();
+
+    if (
+      oldState.loaded !== newState.loaded ||
+      oldState.translationOverridesLoaded !== newState.translationOverridesLoaded ||
+      !isEqual(oldState.config, newState.config)
+    ) {
+      moduleStore.setState(newState);
+    }
   }
 }
 
 function computeExtensionSlotConfigs(state: ConfigInternalStore, tempState: TemporaryConfigStore) {
   const slotConfigs = getExtensionSlotConfigs(state, tempState);
-  const newSlotStoreEntries = Object.fromEntries(
-    Object.entries(slotConfigs).map(([slotName, config]) => [slotName, { loaded: true, config }]),
-  );
   const slotStore = getExtensionSlotsConfigStore();
-  const oldState = slotStore.getState();
-  const newState = { slots: { ...oldState.slots, ...newSlotStoreEntries } };
+  const oldSlots = slotStore.getState().slots;
+  const slots: ExtensionSlotsConfigStore['slots'] = {};
+  let changed = false;
 
-  if (!isEqual(oldState.slots, newState.slots)) {
-    slotStore.setState(newState);
+  for (const [slotName, config] of Object.entries(slotConfigs)) {
+    const previous = oldSlots[slotName];
+
+    // Entries keep their identity when the configuration behind them hasn't changed, so that
+    // changing one slot's configuration doesn't invalidate every other configured slot.
+    if (previous?.loaded && isEqual(previous.config, config)) {
+      slots[slotName] = previous;
+    } else {
+      slots[slotName] = { loaded: true, config };
+      changed = true;
+    }
+  }
+
+  // Built from scratch rather than merged over the previous state: a slot whose configuration
+  // has been removed — clearing the temporary config, say — has to lose its entry, or the old
+  // configuration stays in force until the page is reloaded.
+  if (changed || Object.keys(oldSlots).length !== Object.keys(slots).length) {
+    slotStore.setState({ slots });
   }
 }
 
@@ -142,7 +213,12 @@ function computeExtensionConfigs(
   extensionState: ConfigExtensionStore,
   tempConfigState: TemporaryConfigStore,
 ) {
-  const configs = {};
+  const extensionsConfigStore = getExtensionsConfigStore();
+  const oldConfigs = extensionsConfigStore.getState().configs;
+  const configs: ExtensionsConfigStore['configs'] = {};
+  let changed = false;
+  let entryCount = 0;
+
   // We assume that the module schema has already been defined, since the extension
   // it contains is mounted.
   for (let extension of extensionState.mountedExtensions) {
@@ -155,18 +231,33 @@ function computeExtensionConfigs(
       tempConfigState,
     );
 
+    const previous = oldConfigs[extension.slotName]?.[extension.extensionId];
+    // Entries keep their identity when the configuration behind them hasn't changed, so that
+    // mounting one extension doesn't hand every other mounted extension a new config object.
+    const entry = previous?.loaded && isEqual(previous.config, config) ? previous : { config, loaded: true };
+
+    if (entry !== previous) {
+      changed = true;
+    }
+
     if (!configs[extension.slotName]) {
       configs[extension.slotName] = {};
     }
-    configs[extension.slotName][extension.extensionId] = { config, loaded: true };
-  }
-  const extensionsConfigStore = getExtensionsConfigStore();
-  const oldState = extensionsConfigStore.getState();
-  const newState = { configs };
 
-  // Use deep equality to only update if configs actually changed
-  if (!isEqual(oldState.configs, newState.configs)) {
-    extensionsConfigStore.setState(newState);
+    configs[extension.slotName][extension.extensionId] = entry as ConfigStore;
+    entryCount++;
+  }
+
+  if (!changed) {
+    // Nothing was added or altered, but an extension may have unmounted, which only shows up as a
+    // missing entry.
+    changed =
+      Object.keys(oldConfigs).length !== Object.keys(configs).length ||
+      Object.values(oldConfigs).reduce((total, slot) => total + Object.keys(slot).length, 0) !== entryCount;
+  }
+
+  if (changed) {
+    extensionsConfigStore.setState({ configs });
   }
 }
 
@@ -297,6 +388,37 @@ export function provide(config: Config, sourceName = 'provided') {
 }
 
 /**
+ * Resolves with `select(state)` as soon as the store's state satisfies `ready`, leaving no
+ * subscription behind: nothing subscribes at all when the store is already ready. That matters
+ * because `getConfig` runs on every HTTP request, and a subscription that outlives its promise
+ * both retains its closure forever and slows down every later write to that store.
+ */
+function whenStoreReady<S, T>(
+  store: { getState(): S; subscribe(listener: (state: S) => void): () => void },
+  ready: (state: S) => boolean,
+  select: (state: S) => T,
+): Promise<T> {
+  return new Promise<T>((resolve) => {
+    let unsubscribe: (() => void) | undefined;
+    let resolved = false;
+
+    function update(state: S) {
+      if (!resolved && ready(state)) {
+        resolved = true;
+        resolve(select(state));
+        unsubscribe?.();
+      }
+    }
+
+    update(store.getState());
+
+    if (!resolved) {
+      unsubscribe = store.subscribe(update);
+    }
+  });
+}
+
+/**
  * A promise-based way to access the config as soon as it is fully loaded.
  * If it is already loaded, resolves the config in its present state.
  *
@@ -306,21 +428,11 @@ export function provide(config: Config, sourceName = 'provided') {
  * @param moduleName The name of the module for which to look up the config
  */
 export function getConfig<T = Record<string, any>>(moduleName: string): Promise<T> {
-  return new Promise<T>((resolve) => {
-    const store = getConfigStore(moduleName);
-    function update(state: ConfigStore) {
-      if (state.loaded && state.config) {
-        const config = lodashOmit(state.config, ['Display conditions', 'Translation overrides']);
-        resolve(config as T);
-
-        if (unsubscribe) {
-          unsubscribe();
-        }
-      }
-    }
-    update(store.getState());
-    const unsubscribe = store.subscribe(update);
-  });
+  return whenStoreReady(
+    getConfigStore(moduleName),
+    (state: ConfigStore) => Boolean(state.loaded && state.config),
+    (state: ConfigStore) => lodashOmit(state.config!, ['Display conditions', 'Translation overrides']) as T,
+  );
 }
 
 /**
@@ -342,40 +454,20 @@ export function getTranslationOverrides(
   extensionId?: string,
 ): Promise<Array<Record<string, Record<string, string>>>> {
   const promises = [
-    new Promise<Record<string, Record<string, string>>>((resolve) => {
-      const configStore = getConfigStore(moduleName);
-      function update(state: ReturnType<(typeof configStore)['getState']>) {
-        if (state.translationOverridesLoaded && state.config) {
-          const translationOverrides = state.config['Translation overrides'] ?? {};
-          resolve(translationOverrides);
-
-          if (unsubscribe) {
-            unsubscribe();
-          }
-        }
-      }
-      update(configStore.getState());
-      const unsubscribe = configStore.subscribe(update);
-    }),
+    whenStoreReady(
+      getConfigStore(moduleName),
+      (state) => Boolean(state.translationOverridesLoaded && state.config),
+      (state) => (state.config!['Translation overrides'] ?? {}) as Record<string, Record<string, string>>,
+    ),
   ];
 
   if (slotName && extensionId) {
     promises.push(
-      new Promise<Record<string, Record<string, string>>>((resolve) => {
-        const configStore = getExtensionConfig(slotName, extensionId);
-        function update(state: ReturnType<(typeof configStore)['getState']>) {
-          if (state.loaded && state.config) {
-            const translationOverrides = state.config['Translation overrides'] ?? {};
-            resolve(translationOverrides);
-
-            if (unsubscribe) {
-              unsubscribe();
-            }
-          }
-        }
-        update(configStore.getState());
-        const unsubscribe = configStore.subscribe(update);
-      }),
+      whenStoreReady(
+        getExtensionConfig(slotName, extensionId),
+        (state) => Boolean(state.loaded && state.config),
+        (state) => (state.config!['Translation overrides'] ?? {}) as Record<string, Record<string, string>>,
+      ),
     );
   }
 
@@ -417,6 +509,22 @@ export function processConfig(schema: ConfigSchema, providedConfig: ConfigObject
  * @param slotName The name of the extension slot where the extension is mounted
  * @param extensionId The ID of the extension in its slot
  */
+/**
+ * An extension's config depends only on the two schemas that can define it and on the config
+ * sources, so mounting one extension leaves every other mounted extension's config untouched.
+ * Without this, every mount and unmount re-derives — merge, clone, validate — a config for every
+ * extension currently on screen.
+ */
+interface ExtensionConfigCacheEntry {
+  extensionSchema: ConfigSchema | undefined;
+  extensionModuleSchema: ConfigSchema | undefined;
+  providedConfigs: ConfigInternalStore['providedConfigs'];
+  temporaryConfig: Config;
+  config: ConfigObject;
+}
+
+const extensionConfigCache = new Map<string, ExtensionConfigCacheEntry>();
+
 function computeExtensionConfig(
   slotModuleName: string,
   extensionModuleName: string,
@@ -427,6 +535,19 @@ function computeExtensionConfig(
 ) {
   const extensionName = getExtensionNameFromId(extensionId);
   const extensionConfigSchema = configState.schemas[extensionName];
+  const cacheKey = [slotName, extensionId, slotModuleName, extensionModuleName].join(' ');
+  const cached = extensionConfigCache.get(cacheKey);
+
+  if (
+    cached &&
+    cached.extensionSchema === extensionConfigSchema &&
+    cached.extensionModuleSchema === configState.schemas[extensionModuleName] &&
+    cached.providedConfigs === configState.providedConfigs &&
+    cached.temporaryConfig === tempConfigState.config
+  ) {
+    return cached.config;
+  }
+
   const nameOfSchemaSource = extensionConfigSchema ? extensionName : extensionModuleName;
   const providedConfigs = getProvidedConfigs(configState, tempConfigState);
   const slotModuleConfig = mergeConfigsFor(slotModuleName, providedConfigs);
@@ -438,21 +559,113 @@ function computeExtensionConfig(
   const config = setDefaults(schema, combinedConfig);
   runAllValidatorsInConfigTree(schema, config, nameOfSchemaSource);
   delete config.extensionSlots;
+
+  extensionConfigCache.set(cacheKey, {
+    extensionSchema: extensionConfigSchema,
+    extensionModuleSchema: configState.schemas[extensionModuleName],
+    providedConfigs: configState.providedConfigs,
+    temporaryConfig: tempConfigState.config,
+    config,
+  });
+
   return config;
 }
+
+/**
+ * The annotated config tree is keyed by module, and a config only ever mentions a few modules, so
+ * merging per module means editing one module's configuration rebuilds only that module and every
+ * other subtree keeps its identity — which also makes the deep comparison downstream cheap. Adding
+ * a config source is the exception: it lengthens the source list, invalidating every entry.
+ */
+interface ImplementerToolsModuleCacheEntry {
+  annotatedSchema: Config | undefined;
+  configSlices: Array<Config | undefined>;
+  /** Part of the key: the tree records which source each value came from. */
+  sources: Array<string>;
+  result: Config;
+}
+
+const implementerToolsModuleCache = new Map<string, ImplementerToolsModuleCacheEntry>();
 
 function getImplementerToolsConfig(
   configState: ConfigInternalStore,
   tempConfigState: TemporaryConfigStore,
 ): Record<string, Config> {
-  let result = getSchemaWithValuesAndSources(cloneDeep(configState.schemas));
+  const annotatedSchemas = getAllSchemasWithValuesAndSources(configState.schemas);
   const configsAndSources = [
     ...configState.providedConfigs.map((c) => [c.config, c.source]),
     [tempConfigState.config, 'temporary config'],
   ] as Array<[Config, string]>;
-  for (let [config, source] of configsAndSources) {
-    result = mergeConfigs([result, createValuesAndSourcesTree(config, source)]);
+
+  // A module can be configured without having declared a schema, so the module list is the union
+  // of both rather than just the schemas.
+  const moduleNames = new Set(Object.keys(annotatedSchemas));
+  for (const [config] of configsAndSources) {
+    for (const moduleName of Object.keys(config)) {
+      moduleNames.add(moduleName);
+    }
   }
+
+  const result: Record<string, Config> = {};
+
+  for (const moduleName of moduleNames) {
+    const annotatedSchema = annotatedSchemas[moduleName];
+    const configSlices = configsAndSources.map(([config]) => config[moduleName]);
+    const sources = configsAndSources.map(([, source]) => source);
+    const cached = implementerToolsModuleCache.get(moduleName);
+
+    if (
+      cached &&
+      cached.annotatedSchema === annotatedSchema &&
+      cached.configSlices.length === configSlices.length &&
+      cached.configSlices.every((slice, i) => slice === configSlices[i]) &&
+      cached.sources.every((source, i) => source === sources[i])
+    ) {
+      result[moduleName] = cached.result;
+      continue;
+    }
+
+    let merged: Config = annotatedSchema ?? {};
+
+    configsAndSources.forEach(([, source], i) => {
+      const slice = configSlices[i];
+
+      if (slice !== undefined) {
+        merged = mergeDeepReplace(merged, createValuesAndSourcesTree(slice, source));
+      }
+    });
+
+    implementerToolsModuleCache.set(moduleName, { annotatedSchema, configSlices, sources, result: merged });
+    result[moduleName] = merged;
+  }
+
+  return result;
+}
+
+/**
+ * Caching per module is what stops the walk being quadratic: defining one module's schema
+ * recomputes every module.
+ *
+ * A module with no configuration of its own is published straight from this cache, so nothing may
+ * mutate a tree it reads out of the implementer tools config — it is the cache entry.
+ */
+const schemaValuesAndSourcesCache = new Map<string, { schema: ConfigSchema; annotated: Config }>();
+
+function getAllSchemasWithValuesAndSources(schemas: Record<string, ConfigSchema>): Record<string, Config> {
+  const result: Record<string, Config> = {};
+
+  for (const [moduleName, schema] of Object.entries(schemas)) {
+    const cached = schemaValuesAndSourcesCache.get(moduleName);
+
+    if (cached && cached.schema === schema) {
+      result[moduleName] = cached.annotated;
+    } else {
+      const annotated = getSchemaWithValuesAndSources(cloneDeep(schema));
+      schemaValuesAndSourcesCache.set(moduleName, { schema, annotated });
+      result[moduleName] = annotated;
+    }
+  }
+
   return result;
 }
 
@@ -917,6 +1130,12 @@ export function clearConfigErrors(keyPath?: string) {
 export function resetConfigSystem() {
   configSubscriptions.forEach((unsubscribe) => unsubscribe());
   configSubscriptions.length = 0;
+  // Cached configs are keyed on input identity, so a test that reuses the same schema or config
+  // objects across cases would otherwise be served the previous case's result.
+  moduleConfigCache.clear();
+  extensionConfigCache.clear();
+  schemaValuesAndSourcesCache.clear();
+  implementerToolsModuleCache.clear();
   setupConfigSubscriptions();
 }
 

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -18,8 +18,10 @@ import {
   getExtensionConfig,
   getExtensionSlotsConfigStore,
   getExtensionsConfigStore,
+  clearConfigDerivationError,
   implementerToolsConfigStore,
   invalidateImplementerToolsConfig,
+  recordConfigDerivationError,
   setImplementerToolsConfigRecomputer,
   temporaryConfigStore,
 } from './state';
@@ -89,9 +91,21 @@ function setupConfigSubscriptions() {
 
   // Subscribe to all input stores with a single handler
   // This ensures we only recompute once even if multiple stores change simultaneously
-  configSubscriptions.push(configInternalStore.subscribe(recomputeAllConfigs));
-  configSubscriptions.push(temporaryConfigStore.subscribe(recomputeAllConfigs));
-  configSubscriptions.push(configExtensionStore.subscribe(recomputeAllConfigs));
+  configSubscriptions.push(configInternalStore.subscribe(recomputeAllConfigsSafely));
+  configSubscriptions.push(temporaryConfigStore.subscribe(recomputeAllConfigsSafely));
+  configSubscriptions.push(configExtensionStore.subscribe(recomputeAllConfigsSafely));
+}
+
+/** Ensure that we do not throw during a store subscription */
+function recomputeAllConfigsSafely() {
+  clearConfigDerivationError();
+
+  try {
+    recomputeAllConfigs();
+  } catch (e) {
+    recordConfigDerivationError(e);
+    console.error('Failed to recompute the configuration', e);
+  }
 }
 
 // Set up subscriptions at module load time
@@ -246,6 +260,21 @@ function computeExtensionConfigs(
 
     configs[extension.slotName][extension.extensionId] = entry as ConfigStore;
     entryCount++;
+  }
+
+  // Slots keep their identity too when none of their entries changed. Subscribers compare these
+  // per-slot objects to work out which slots to re-derive, so handing out a fresh one for every
+  // slot on every write would mark every slot with a mounted extension dirty.
+  for (const [slotName, slotConfigs] of Object.entries(configs)) {
+    const previousSlot = oldConfigs[slotName];
+
+    if (
+      previousSlot &&
+      Object.keys(previousSlot).length === Object.keys(slotConfigs).length &&
+      Object.entries(slotConfigs).every(([extensionId, entry]) => previousSlot[extensionId] === entry)
+    ) {
+      configs[slotName] = previousSlot;
+    }
   }
 
   if (!changed) {
@@ -497,19 +526,6 @@ export function processConfig(schema: ConfigSchema, providedConfig: ConfigObject
  */
 
 /**
- * Returns the configuration for an extension. This configuration is specific
- * to the slot in which it is mounted, and its ID within that slot.
- *
- * The schema for that configuration is the extension schema. If no extension
- * schema has been provided, the schema used is the schema of the module in
- * which the extension is defined.
- *
- * @param slotModuleName The name of the module which defines the extension slot
- * @param extensionModuleName The name of the module which defines the extension (and therefore the config schema)
- * @param slotName The name of the extension slot where the extension is mounted
- * @param extensionId The ID of the extension in its slot
- */
-/**
  * An extension's config depends only on the two schemas that can define it and on the config
  * sources, so mounting one extension leaves every other mounted extension's config untouched.
  * Without this, every mount and unmount re-derives — merge, clone, validate — a config for every
@@ -525,6 +541,19 @@ interface ExtensionConfigCacheEntry {
 
 const extensionConfigCache = new Map<string, ExtensionConfigCacheEntry>();
 
+/**
+ * Returns the configuration for an extension. This configuration is specific
+ * to the slot in which it is mounted, and its ID within that slot.
+ *
+ * The schema for that configuration is the extension schema. If no extension
+ * schema has been provided, the schema used is the schema of the module in
+ * which the extension is defined.
+ *
+ * @param slotModuleName The name of the module which defines the extension slot
+ * @param extensionModuleName The name of the module which defines the extension (and therefore the config schema)
+ * @param slotName The name of the extension slot where the extension is mounted
+ * @param extensionId The ID of the extension in its slot
+ */
 function computeExtensionConfig(
   slotModuleName: string,
   extensionModuleName: string,
@@ -535,9 +564,8 @@ function computeExtensionConfig(
 ) {
   const extensionName = getExtensionNameFromId(extensionId);
   const extensionConfigSchema = configState.schemas[extensionName];
-  // `|` rather than a space, which slot names and extension IDs are allowed to contain: joining on
-  // one lets ('a b', 'c') and ('a', 'b c') collide and share a config.
-  const cacheKey = [slotName, extensionId, slotModuleName, extensionModuleName].join('|');
+  // JSON string of these elements should be unique-per-extension
+  const cacheKey = JSON.stringify([slotName, extensionId, slotModuleName, extensionModuleName]);
   const cached = extensionConfigCache.get(cacheKey);
 
   if (

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -91,9 +91,11 @@ function setupConfigSubscriptions() {
 
   // Subscribe to all input stores with a single handler
   // This ensures we only recompute once even if multiple stores change simultaneously
-  configSubscriptions.push(configInternalStore.subscribe(recomputeAllConfigsSafely));
-  configSubscriptions.push(temporaryConfigStore.subscribe(recomputeAllConfigsSafely));
-  configSubscriptions.push(configExtensionStore.subscribe(recomputeAllConfigsSafely));
+  configSubscriptions.push(
+    configInternalStore.subscribe(recomputeAllConfigsSafely),
+    temporaryConfigStore.subscribe(recomputeAllConfigsSafely),
+    configExtensionStore.subscribe(recomputeAllConfigsSafely),
+  );
 }
 
 /** Ensure that we do not throw during a store subscription */

--- a/packages/framework/esm-config/src/module-config/state.ts
+++ b/packages/framework/esm-config/src/module-config/state.ts
@@ -269,11 +269,9 @@ const baseImplementerToolsConfigStore = createGlobalStore<ImplementerToolsConfig
 });
 
 /**
- * Deriving this config means cloning, walking and deep-comparing every module's schema, which
- * makes it by a wide margin the most expensive thing the config system computes — and nothing but
- * the implementer tools panel ever reads it. So it is only kept current while something is
- * subscribed. Once the panel closes and the last subscriber goes away, config changes just mark it
- * stale and the work stops again.
+ * Deriving this config walks every module's schema, making it the most expensive thing the config
+ * system computes — and nothing but the implementer tools panel reads it. So it is only kept current
+ * while something is subscribed; otherwise config changes just mark it stale.
  */
 let implementerToolsSubscribers = 0;
 let implementerToolsConfigStale = true;
@@ -301,8 +299,8 @@ export function invalidateImplementerToolsConfig() {
 }
 
 function recomputeImplementerToolsConfigIfStale() {
-  // The guard is load-bearing rather than defensive: deriving writes to this store, and when
-  // nothing is subscribed that write re-enters through `getState`.
+  // `isRecomputing` is load-bearing rather than defensive: the derivation opens by reading this
+  // store, and with nothing subscribed that read comes straight back here.
   if (!implementerToolsConfigStale || !recomputeImplementerToolsConfig || isRecomputing) {
     return;
   }

--- a/packages/framework/esm-config/src/module-config/state.ts
+++ b/packages/framework/esm-config/src/module-config/state.ts
@@ -264,7 +264,98 @@ export interface ImplementerToolsConfigStore {
   config: Config;
 }
 
-/** @internal */
-export const implementerToolsConfigStore = createGlobalStore<ImplementerToolsConfigStore>('config-implementer-tools', {
+const baseImplementerToolsConfigStore = createGlobalStore<ImplementerToolsConfigStore>('config-implementer-tools', {
   config: {},
 });
+
+/**
+ * Deriving this config means cloning, walking and deep-comparing every module's schema, which
+ * makes it by a wide margin the most expensive thing the config system computes — and nothing but
+ * the implementer tools panel ever reads it. So it is only kept current while something is
+ * subscribed. Once the panel closes and the last subscriber goes away, config changes just mark it
+ * stale and the work stops again.
+ */
+let implementerToolsSubscribers = 0;
+let implementerToolsConfigStale = true;
+let isRecomputing = false;
+let recomputeImplementerToolsConfig: (() => void) | undefined;
+
+/**
+ * Registers how to derive the implementer tools config; the store decides whether to.
+ * @internal
+ */
+export function setImplementerToolsConfigRecomputer(recompute: () => void) {
+  recomputeImplementerToolsConfig = recompute;
+}
+
+/**
+ * Marks the implementer tools config stale, deriving it again only if something is watching.
+ * @internal
+ */
+export function invalidateImplementerToolsConfig() {
+  implementerToolsConfigStale = true;
+
+  if (implementerToolsSubscribers > 0) {
+    recomputeImplementerToolsConfigIfStale();
+  }
+}
+
+function recomputeImplementerToolsConfigIfStale() {
+  // The guard is load-bearing rather than defensive: deriving writes to this store, and when
+  // nothing is subscribed that write re-enters through `getState`.
+  if (!implementerToolsConfigStale || !recomputeImplementerToolsConfig || isRecomputing) {
+    return;
+  }
+
+  isRecomputing = true;
+  // Cleared before the work, so that a config change made while it runs marks this stale again
+  // instead of being wiped when the pass finishes.
+  implementerToolsConfigStale = false;
+
+  try {
+    recomputeImplementerToolsConfig();
+  } catch (e) {
+    // Never allowed to escape: this runs from a store listener, from `getState` during a render
+    // and from `subscribe`, and a throw through any of those wedges far more than a developer
+    // tool. Left stale so the next config change tries again.
+    implementerToolsConfigStale = true;
+    console.error('Failed to derive the implementer tools config', e);
+  } finally {
+    isRecomputing = false;
+  }
+}
+
+/** @internal */
+export const implementerToolsConfigStore: StoreApi<ImplementerToolsConfigStore> = {
+  ...baseImplementerToolsConfigStore,
+  getState() {
+    // While something is subscribed the store is already current, so a read costs nothing. This
+    // branch is what serves the panel's very first render, before it has subscribed.
+    if (implementerToolsSubscribers === 0) {
+      recomputeImplementerToolsConfigIfStale();
+    }
+
+    return baseImplementerToolsConfigStore.getState();
+  },
+  setState(...args: Parameters<StoreApi<ImplementerToolsConfigStore>['setState']>) {
+    // An explicit write is the current value by definition, so don't overwrite it on the next read.
+    implementerToolsConfigStale = false;
+    return baseImplementerToolsConfigStore.setState(...args);
+  },
+  subscribe(listener) {
+    implementerToolsSubscribers++;
+    recomputeImplementerToolsConfigIfStale();
+
+    const unsubscribe = baseImplementerToolsConfigStore.subscribe(listener);
+    let hasUnsubscribed = false;
+
+    return () => {
+      if (!hasUnsubscribed) {
+        hasUnsubscribed = true;
+        implementerToolsSubscribers--;
+      }
+
+      unsubscribe();
+    };
+  },
+};

--- a/packages/framework/esm-config/src/module-config/state.ts
+++ b/packages/framework/esm-config/src/module-config/state.ts
@@ -1,6 +1,7 @@
-import { createGlobalStore, getGlobalStore } from '@openmrs/esm-state';
+import { createGlobalStore, getGlobalStore, registerGlobalStore } from '@openmrs/esm-state';
 import { shallowEqual } from '@openmrs/esm-utils';
 import { type StoreApi } from 'zustand';
+import { createStore } from 'zustand/vanilla';
 import type { Config, ConfigObject, ConfigSchema, ExtensionSlotConfig, ProvidedConfig } from '../types';
 
 /**
@@ -177,11 +178,23 @@ export function getExtensionsConfigStore() {
   });
 }
 
-/** @internal */
+/**
+ * The read-only part of a store's API.
+ * @internal
+ */
+export type ReadableStore<T> = Pick<StoreApi<T>, 'getInitialState' | 'getState' | 'subscribe'>;
+
+/**
+ * A read-only view of one extension instance's config within a slot. Read-only because these
+ * configs are derived from the config system's inputs, so a write here would be overwritten by the
+ * next recomputation; provide a config or set a temporary one instead.
+ *
+ * @internal
+ */
 export function getExtensionConfig(
   slotName: string,
   extensionId: string,
-): StoreApi<Omit<ConfigStore, 'translationOverridesLoaded'>> {
+): ReadableStore<Omit<ConfigStore, 'translationOverridesLoaded'>> {
   if (
     typeof slotName !== 'string' ||
     typeof extensionId !== 'string' ||
@@ -205,25 +218,6 @@ export function getExtensionConfig(
     getState() {
       return selector(extensionConfigStore.getState()) ?? { loaded: false, config: null };
     },
-    setState(
-      partial: ConfigStore | Partial<ConfigStore> | ((state: ConfigStore) => ConfigStore | Partial<ConfigStore>),
-      replace: boolean = false,
-    ) {
-      extensionConfigStore.setState((state) => {
-        if (!state.configs[slotName]) {
-          state.configs[slotName] = {};
-        }
-
-        const newState = typeof partial === 'function' ? partial(state.configs.slotName[extensionId]) : partial;
-        if (replace) {
-          state.configs[slotName][extensionId] = Object.assign({}, newState) as ConfigStore;
-        } else {
-          state.configs[slotName][extensionId] = Object.assign({}, state.configs[slotName][extensionId], newState);
-        }
-
-        return state;
-      });
-    },
     subscribe(listener) {
       return extensionConfigStore.subscribe((state, prevState) => {
         const newState = selector(state);
@@ -233,9 +227,6 @@ export function getExtensionConfig(
           listener(newState, oldState);
         }
       });
-    },
-    destroy() {
-      /* this is a no-op */
     },
   };
 }
@@ -262,11 +253,18 @@ export function getExtensionConfigFromExtensionSlotStore(
  */
 export interface ImplementerToolsConfigStore {
   config: Config;
+  /**
+   * Set when the last attempt to derive `config` threw, in which case `config` is whatever was
+   * last derived successfully — on a first failure, nothing at all. Cleared by a later success.
+   */
+  derivationError?: string;
 }
 
-const baseImplementerToolsConfigStore = createGlobalStore<ImplementerToolsConfigStore>('config-implementer-tools', {
+// Deliberately not registered: the wrapper below is what gets published under
+// `config-implementer-tools`, so that a lookup can't hand out the store that skips the derivation.
+const baseImplementerToolsConfigStore = createStore<ImplementerToolsConfigStore>()(() => ({
   config: {},
-});
+}));
 
 /**
  * Deriving this config walks every module's schema, making it the most expensive thing the config
@@ -299,8 +297,6 @@ export function invalidateImplementerToolsConfig() {
 }
 
 function recomputeImplementerToolsConfigIfStale() {
-  // `isRecomputing` is load-bearing rather than defensive: the derivation opens by reading this
-  // store, and with nothing subscribed that read comes straight back here.
   if (!implementerToolsConfigStale || !recomputeImplementerToolsConfig || isRecomputing) {
     return;
   }
@@ -313,18 +309,38 @@ function recomputeImplementerToolsConfigIfStale() {
   try {
     recomputeImplementerToolsConfig();
   } catch (e) {
-    // Never allowed to escape: this runs from a store listener, from `getState` during a render
-    // and from `subscribe`, and a throw through any of those wedges far more than a developer
-    // tool. Left stale so the next config change tries again.
     implementerToolsConfigStale = true;
+    recordConfigDerivationError(e);
     console.error('Failed to derive the implementer tools config', e);
   } finally {
     isRecomputing = false;
   }
 }
 
-/** @internal */
-export const implementerToolsConfigStore: StoreApi<ImplementerToolsConfigStore> = {
+/**
+ * Records that configuration could not be rebuilt so that the user can be informed
+ *
+ * @internal
+ */
+export function recordConfigDerivationError(error: unknown) {
+  baseImplementerToolsConfigStore.setState({
+    derivationError: error instanceof Error ? error.message : String(error),
+  });
+}
+
+/**
+ * Cleared at the start of a derivation pass rather than the end of a successful one, so that a
+ * failure recorded partway through the pass is not wiped by the pass completing.
+ *
+ * @internal
+ */
+export function clearConfigDerivationError() {
+  if (baseImplementerToolsConfigStore.getState().derivationError) {
+    baseImplementerToolsConfigStore.setState({ derivationError: undefined });
+  }
+}
+
+const lazyImplementerToolsConfigStore: StoreApi<ImplementerToolsConfigStore> = {
   ...baseImplementerToolsConfigStore,
   getState() {
     // While something is subscribed the store is already current, so a read costs nothing. This
@@ -357,3 +373,14 @@ export const implementerToolsConfigStore: StoreApi<ImplementerToolsConfigStore> 
     };
   },
 };
+
+/**
+ * Published rather than the store it wraps, so that a lookup by name can't hand out the one that
+ * skips the derivation and always reads empty.
+ *
+ * @internal
+ */
+export const implementerToolsConfigStore = registerGlobalStore(
+  'config-implementer-tools',
+  lazyImplementerToolsConfigStore,
+);

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -1,3 +1,9 @@
+/*
+ * `render-result-naming-convention` reads any `render`-prefixed name as a testing-library render
+ * result. Nothing here renders anything — these are store tests, and "rendering" is the extension
+ * system's word for one live copy of an extension instance.
+ */
+/* eslint-disable testing-library/render-result-naming-convention */
 import { describe, expect, it, vi } from 'vitest';
 import { createGlobalStore } from '@openmrs/esm-state';
 import type { Session } from '@openmrs/esm-api';
@@ -11,16 +17,15 @@ import {
   getExtensionRegistrationFrom,
   registerExtension,
   registerExtensionSlot,
-  updateExtensionSlotState,
 } from './extensions';
 import type { ExtensionInfo, ExtensionInternalStore, ExtensionRegistration } from './store';
 import {
   batchExtensionUpdates,
-  getExtensionInstancesStore,
+  getExtensionRenderingsStore,
   getExtensionInternalStore,
   getExtensionStore,
-  registerExtensionInstance,
-  unregisterExtensionInstance,
+  registerExtensionRendering,
+  unregisterExtensionRendering,
   updateInternalExtensionStore,
 } from './store';
 import { configExtensionStore } from '@openmrs/esm-config';
@@ -188,7 +193,7 @@ describe('attach', () => {
     const store = getExtensionInternalStore();
     const state = store.getState();
 
-    // Both instances should be in the attachedIds array
+    // Both attachments should be in the attachedIds array
     const count = state.slots[slotName].attachedIds.filter((id) => id === extensionId).length;
     expect(count).toBe(2);
   });
@@ -363,18 +368,6 @@ describe('registerExtensionSlot', () => {
     expect(state.slots[slotName].moduleName).toBe(moduleName);
   });
 
-  it('should register a slot with custom state', () => {
-    const slotName = getUniqueName('slot-with-state');
-    const customState = { foo: 'bar', count: 42 };
-
-    registerExtensionSlot('test-module', slotName, customState);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].state).toEqual(customState);
-  });
-
   it('should preserve attachedIds when registering an existing slot', () => {
     const slotName = getUniqueName('preserve-attached');
     const extensionId = 'test-extension';
@@ -386,56 +379,6 @@ describe('registerExtensionSlot', () => {
     const state = store.getState();
 
     expect(state.slots[slotName].attachedIds).toContain(extensionId);
-  });
-});
-
-describe('updateExtensionSlotState', () => {
-  it('should update the full state when partial is false', () => {
-    const slotName = getUniqueName('test-slot-state');
-
-    registerExtensionSlot('test-module', slotName, { initial: 'state' });
-
-    const newState = { updated: 'state', count: 1 };
-    updateExtensionSlotState(slotName, newState, false);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].state).toEqual(newState);
-    expect(state.slots[slotName].state).not.toHaveProperty('initial');
-  });
-
-  it('should merge state when partial is true', () => {
-    const slotName = getUniqueName('test-slot-partial');
-
-    registerExtensionSlot('test-module', slotName, { foo: 'bar', count: 1 });
-
-    const partialState = { count: 2, newProp: 'value' };
-    updateExtensionSlotState(slotName, partialState, true);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].state).toEqual({
-      foo: 'bar',
-      count: 2,
-      newProp: 'value',
-    });
-  });
-
-  it('should default partial to false when not specified', () => {
-    const slotName = getUniqueName('test-slot-default');
-
-    registerExtensionSlot('test-module', slotName, { foo: 'bar' });
-
-    const newState = { new: 'state' };
-    updateExtensionSlotState(slotName, newState);
-
-    const store = getExtensionInternalStore();
-    const state = store.getState();
-
-    expect(state.slots[slotName].state).toEqual(newState);
-    expect(state.slots[slotName].state).not.toHaveProperty('foo');
   });
 });
 
@@ -485,6 +428,70 @@ describe('getAssignedExtensions', () => {
     const result = getAssignedExtensions(slotName);
 
     expect(result[0].meta).toEqual(meta);
+  });
+
+  it('applies display conditions even when no state is given', () => {
+    const slotName = getUniqueName('no-state-slot');
+    const hidden = getUniqueName('always-hidden');
+    const shown = getUniqueName('always-shown');
+
+    registerExtension(createMockExtension(hidden, { displayExpression: 'false' }));
+    registerExtension(createMockExtension(shown));
+    attach(slotName, hidden);
+    attach(slotName, shown);
+
+    // A caller that skips the filter builds UI around extensions the slot will then refuse to
+    // render — an empty tab, in the case this came from.
+    expect(getAssignedExtensions(slotName).map((e) => e.id)).toEqual([shown]);
+  });
+});
+
+describe('output store recomputation', () => {
+  it('picks up a slot dirtied by a subscriber while the store is being published', () => {
+    const extensionStore = getExtensionStore();
+    const outerSlot = getUniqueName('publishing-slot');
+    const nestedSlot = getUniqueName('nested-slot');
+    const extensionName = getUniqueName('nested-extension');
+
+    registerExtension(createMockExtension(extensionName));
+
+    // Attaches once, from inside the notification for the outer slot's own write. Without a drain
+    // the nested write is swallowed by the re-entrancy guard and `nestedSlot` never appears.
+    let attached = false;
+    const unsubscribe = extensionStore.subscribe(() => {
+      if (!attached) {
+        attached = true;
+        attach(nestedSlot, extensionName);
+      }
+    });
+
+    attach(outerSlot, extensionName);
+    unsubscribe();
+
+    expect(attached).toBe(true);
+    expect(extensionStore.getState().slots[nestedSlot]?.assignedExtensions.map((e) => e.id)).toEqual([extensionName]);
+  });
+
+  it('gives up rather than spinning when a subscriber dirties on every write', () => {
+    const extensionStore = getExtensionStore();
+    const slotName = getUniqueName('runaway-slot');
+    const extensionName = getUniqueName('runaway-extension');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    registerExtension(createMockExtension(extensionName));
+
+    let writes = 0;
+    const unsubscribe = extensionStore.subscribe(() => {
+      writes++;
+      attach(getUniqueName('runaway-nested'), extensionName);
+    });
+
+    attach(slotName, extensionName);
+    unsubscribe();
+
+    expect(writes).toBeLessThanOrEqual(20);
+    expect(consoleError).toHaveBeenCalledWith(expect.stringMatching(/stopped recomputing after 20 passes/));
+    consoleError.mockRestore();
   });
 });
 
@@ -562,14 +569,14 @@ describe('batchExtensionUpdates', () => {
 });
 
 describe('the bridge to the config system', () => {
-  function mountInstances(slotName: string, extensionName: string, count: number, firstId = 0) {
-    const instanceIds: Array<string> = [];
+  function mountRenderings(slotName: string, extensionName: string, count: number, firstId = 0) {
+    const renderingIds: Array<string> = [];
 
     for (let i = firstId; i < firstId + count; i++) {
-      const instanceId = `${slotName}/${extensionName}-${i}`;
-      instanceIds.push(instanceId);
-      registerExtensionInstance({
-        instanceId,
+      const renderingId = `${slotName}/${extensionName}-${i}`;
+      renderingIds.push(renderingId);
+      registerExtensionRendering({
+        renderingId,
         extensionName,
         extensionModuleName: `${extensionName}-module`,
         id: extensionName,
@@ -578,7 +585,7 @@ describe('the bridge to the config system', () => {
       });
     }
 
-    return instanceIds;
+    return renderingIds;
   }
 
   it('should record one entry per slot and extension however many copies are rendered', () => {
@@ -587,7 +594,7 @@ describe('the bridge to the config system', () => {
     let writes = 0;
     const unsubscribe = configExtensionStore.subscribe(() => writes++);
 
-    mountInstances(slotName, extensionName, 50);
+    mountRenderings(slotName, extensionName, 50);
     unsubscribe();
 
     expect(configExtensionStore.getState().mountedExtensions.filter((r) => r.slotName === slotName)).toEqual([
@@ -598,54 +605,54 @@ describe('the bridge to the config system', () => {
         extensionId: extensionName,
       },
     ]);
-    // A list renders the same slot once per row, and every one of those mounts rewrites this store
-    // and re-derives a config for everything else on screen. Only the first copy is a real change.
+    // A list renders the same slot once per row; each of those mounts would otherwise rewrite this
+    // store and re-derive a config for everything else on screen. Only the first copy is a change.
     expect(writes).toBe(1);
   });
 
   it('should keep the entry until the last copy of an extension is gone', () => {
     const slotName = getUniqueName('drain-slot');
     const extensionName = getUniqueName('drain-extension');
-    const instanceIds = mountInstances(slotName, extensionName, 10);
+    const renderingIds = mountRenderings(slotName, extensionName, 10);
 
     let writes = 0;
     const unsubscribe = configExtensionStore.subscribe(() => writes++);
 
-    for (const instanceId of instanceIds.slice(0, -1)) {
-      unregisterExtensionInstance(instanceId);
+    for (const renderingId of renderingIds.slice(0, -1)) {
+      unregisterExtensionRendering(renderingId);
     }
 
     expect(configExtensionStore.getState().mountedExtensions.filter((r) => r.slotName === slotName)).toHaveLength(1);
     expect(writes).toBe(0);
 
-    unregisterExtensionInstance(instanceIds[instanceIds.length - 1]);
+    unregisterExtensionRendering(renderingIds[renderingIds.length - 1]);
     unsubscribe();
 
     expect(configExtensionStore.getState().mountedExtensions.filter((r) => r.slotName === slotName)).toHaveLength(0);
     expect(writes).toBe(1);
   });
 
-  it('should notify on every mount even though the instance map keeps its identity', () => {
+  it('should notify on every mount even though the rendering map keeps its identity', () => {
     const slotName = getUniqueName('identity-slot');
     const extensionName = getUniqueName('identity-extension');
-    const instancesStore = getExtensionInstancesStore();
+    const renderingsStore = getExtensionRenderingsStore();
     const seen: Array<ReadonlyMap<string, unknown>> = [];
     let notifications = 0;
 
-    const unsubscribe = instancesStore.subscribe((state) => {
+    const unsubscribe = renderingsStore.subscribe((state) => {
       notifications++;
-      seen.push(state.instances);
+      seen.push(state.renderings);
     });
 
-    const before = instancesStore.getState().instances.size;
-    const instanceIds = mountInstances(slotName, extensionName, 3);
-    unregisterExtensionInstance(instanceIds[0]);
+    const before = renderingsStore.getState().renderings.size;
+    const renderingIds = mountRenderings(slotName, extensionName, 3);
+    unregisterExtensionRendering(renderingIds[0]);
     unsubscribe();
 
     // The map is mutated in place, so consumers have to key off the state object around it.
     expect(notifications).toBe(4);
     expect(new Set(seen).size).toBe(1);
-    expect(instancesStore.getState().instances.size).toBe(before + 2);
+    expect(renderingsStore.getState().renderings.size).toBe(before + 2);
   });
 
   it('should record separate entries for the same extension in different slots', () => {
@@ -653,7 +660,7 @@ describe('the bridge to the config system', () => {
     const slotNames = [getUniqueName('slot-a'), getUniqueName('slot-b')];
 
     for (const slotName of slotNames) {
-      mountInstances(slotName, extensionName, 3);
+      mountRenderings(slotName, extensionName, 3);
     }
 
     const records = configExtensionStore

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -1,12 +1,12 @@
 /*
- * `render-result-naming-convention` reads any `render`-prefixed name as a testing-library render
- * result. Nothing here renders anything — these are store tests, and "rendering" is the extension
- * system's word for one live copy of an extension instance.
+ * `render-result-naming-convention` flags any callee name containing `render`, which
+ * `getExtensionRenderingsStore` does. Nothing here renders anything — these are store tests, and
+ * "rendering" is the extension system's word for one live copy of an extension instance.
  */
 /* eslint-disable testing-library/render-result-naming-convention */
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { createGlobalStore } from '@openmrs/esm-state';
-import type { Session } from '@openmrs/esm-api';
+import { sessionStore, userHasAccess, type Session } from '@openmrs/esm-api';
 import {
   attach,
   detach,
@@ -17,8 +17,9 @@ import {
   getExtensionRegistrationFrom,
   registerExtension,
   registerExtensionSlot,
+  reset,
 } from './extensions';
-import type { ExtensionInfo, ExtensionInternalStore, ExtensionRegistration } from './store';
+import type { ExtensionInternalStore, ExtensionRegistration } from './store';
 import {
   batchExtensionUpdates,
   getExtensionRenderingsStore,
@@ -28,7 +29,7 @@ import {
   unregisterExtensionRendering,
   updateInternalExtensionStore,
 } from './store';
-import { configExtensionStore } from '@openmrs/esm-config';
+import { configExtensionStore, getExtensionSlotsConfigStore } from '@openmrs/esm-config';
 
 // Minimal mocking - only what we need for fine-grained control
 vi.mock('@openmrs/esm-api', () => ({
@@ -62,7 +63,7 @@ function getUniqueName(prefix: string = 'test'): string {
 }
 
 // Helper to create a mock extension registration
-function createMockExtension(name: string, overrides: Partial<ExtensionRegistration> = {}): ExtensionInfo {
+function createMockExtension(name: string, overrides: Partial<ExtensionRegistration> = {}): ExtensionRegistration {
   return {
     name,
     load: vi.fn(async () => ({ bootstrap: vi.fn(), mount: vi.fn(), unmount: vi.fn() })),
@@ -71,6 +72,13 @@ function createMockExtension(name: string, overrides: Partial<ExtensionRegistrat
     ...overrides,
   };
 }
+
+// Every store the extension system writes is module-global, and so is its invalidation state, so
+// a test that leaves slots attached or slots dirty changes what the next one measures.
+beforeEach(() => {
+  reset();
+  getExtensionSlotsConfigStore().setState({ slots: {} });
+});
 
 describe('getExtensionNameFromId', () => {
   it('should extract the extension name from a simple ID', () => {
@@ -224,8 +232,6 @@ describe('attach', () => {
       moduleName: undefined,
       name: slotName,
       attachedIds: [extensionId],
-      config: null,
-      state: undefined,
     });
   });
 });
@@ -469,7 +475,7 @@ describe('output store recomputation', () => {
     unsubscribe();
 
     expect(attached).toBe(true);
-    expect(extensionStore.getState().slots[nestedSlot]?.assignedExtensions.map((e) => e.id)).toEqual([extensionName]);
+    expect(extensionStore.getState().slots[nestedSlot]?.candidateExtensions.map((e) => e.id)).toEqual([extensionName]);
   });
 
   it('gives up rather than spinning when a subscriber dirties on every write', () => {
@@ -489,9 +495,97 @@ describe('output store recomputation', () => {
     attach(slotName, extensionName);
     unsubscribe();
 
-    expect(writes).toBeLessThanOrEqual(20);
+    expect(writes).toBe(20);
     expect(consoleError).toHaveBeenCalledWith(expect.stringMatching(/stopped recomputing after 20 passes/));
     consoleError.mockRestore();
+
+    // Giving up leaves the guard down and the outstanding slots dirty rather than wedging the
+    // system: once whatever was dirtying them stops, the next write settles them.
+    const recoveredSlot = getUniqueName('recovered-slot');
+    attach(recoveredSlot, extensionName);
+
+    expect(extensionStore.getState().slots[recoveredSlot]?.candidateExtensions.map((e) => e.id)).toEqual([
+      extensionName,
+    ]);
+  });
+
+  it('leaves a slot it failed to derive dirty, so a later write retries it', () => {
+    const extensionStore = getExtensionStore();
+    const failingSlot = getUniqueName('failing-slot');
+    const laterSlot = getUniqueName('later-slot');
+    const guarded = getUniqueName('guarded-extension');
+    const plain = getUniqueName('plain-extension');
+
+    sessionStore.setState({ loaded: true, session: { user: { uuid: 'test-user' } } as Session });
+    registerExtension(createMockExtension(guarded, { privileges: 'Fold Back Privilege' }));
+    registerExtension(createMockExtension(plain));
+
+    // Throws while the slot's extensions are being narrowed, which is before the output store is
+    // written — so this slot is left with no entry at all rather than a partial one.
+    let failNext = true;
+    vi.mocked(userHasAccess).mockImplementation((privileges) => {
+      if (privileges === 'Fold Back Privilege' && failNext) {
+        failNext = false;
+        throw new Error('privilege lookup failed');
+      }
+
+      return true;
+    });
+
+    // Logged rather than thrown: the derivation runs from a store subscriber, so letting it escape
+    // would surface here, from `attach`, and abort the subscribers behind it.
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    expect(() => attach(failingSlot, guarded)).not.toThrow();
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringMatching(/recomputation failed/),
+      expect.objectContaining({ message: 'privilege lookup failed' }),
+    );
+    consoleError.mockRestore();
+    expect(extensionStore.getState().slots[failingSlot]).toBeUndefined();
+
+    // A write to an unrelated slot: the folded-back slot is recomputed alongside it.
+    attach(laterSlot, plain);
+
+    expect(extensionStore.getState().slots[failingSlot]?.candidateExtensions.map((e) => e.id)).toEqual([guarded]);
+
+    vi.mocked(userHasAccess).mockImplementation(() => true);
+    sessionStore.setState({ loaded: false, session: null });
+  });
+
+  /*
+   * The session loads asynchronously, after the shell has already rendered its slots, so this is
+   * the ordinary path rather than an edge case. Privileges are applied while the slot is derived
+   * and never re-applied on read, so without this invalidation a gated extension stays missing
+   * until some unrelated input happens to dirty its slot.
+   */
+  it('re-derives a slot when the session changes', () => {
+    const extensionStore = getExtensionStore();
+    const slotName = getUniqueName('session-slot');
+    const guarded = getUniqueName('guarded-extension');
+    const plain = getUniqueName('plain-extension');
+
+    sessionStore.setState({ loaded: false, session: null });
+    vi.mocked(userHasAccess).mockImplementation((_privileges, user) => Boolean(user));
+
+    registerExtension(createMockExtension(guarded, { privileges: 'Session Privilege' }));
+    registerExtension(createMockExtension(plain));
+    attach(slotName, guarded);
+    attach(slotName, plain);
+
+    // Gated out while there is nobody to check the privilege against.
+    expect(extensionStore.getState().slots[slotName]?.candidateExtensions.map((e) => e.id)).toEqual([plain]);
+
+    sessionStore.setState({ loaded: true, session: { user: { uuid: 'test-user' } } as Session });
+
+    expect(extensionStore.getState().slots[slotName]?.candidateExtensions.map((e) => e.id)).toEqual([guarded, plain]);
+
+    sessionStore.setState({ loaded: true, session: null });
+
+    expect(extensionStore.getState().slots[slotName]?.candidateExtensions.map((e) => e.id)).toEqual([plain]);
+
+    vi.mocked(userHasAccess).mockImplementation(() => true);
+    sessionStore.setState({ loaded: false, session: null });
   });
 });
 
@@ -537,7 +631,58 @@ describe('batchExtensionUpdates', () => {
     unsubscribe();
 
     expect(writes).toBe(1);
-    expect(extensionStore.getState().slots[slotName].assignedExtensions).toHaveLength(1);
+    expect(extensionStore.getState().slots[slotName].candidateExtensions).toHaveLength(1);
+  });
+
+  /*
+   * The flush runs each queued recomputation in turn, so one that throws must not take the ones
+   * behind it with it — the config bridge and the output store are queued independently and a
+   * failure in either would otherwise leave the other's work silently dropped.
+   */
+  it('should run the remaining recomputations when one of them throws during the flush', () => {
+    const slotName = getUniqueName('isolation-slot');
+    const extensionName = getUniqueName('isolation-extension');
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    registerExtension(createMockExtension(extensionName, { privileges: 'Isolation Privilege' }));
+    sessionStore.setState({ loaded: true, session: { user: { uuid: 'test-user' } } as Session });
+
+    let failNext = true;
+    vi.mocked(userHasAccess).mockImplementation((privileges) => {
+      if (privileges === 'Isolation Privilege' && failNext) {
+        failNext = false;
+        throw new Error('privilege lookup failed');
+      }
+
+      return true;
+    });
+
+    // Both are queued: attaching dirties the slot, and registering a rendering marks the config
+    // records changed. The first throws; the second still has to run.
+    batchExtensionUpdates(() => {
+      attach(slotName, extensionName);
+      registerExtensionRendering({
+        renderingId: `${slotName}/${extensionName}-0`,
+        extensionName,
+        extensionModuleName: `${extensionName}-module`,
+        extensionId: extensionName,
+        slotName,
+        slotModuleName: 'isolation-module',
+      });
+    });
+
+    expect(consoleError).toHaveBeenCalledWith(
+      expect.stringMatching(/recomputation failed/),
+      expect.objectContaining({ message: 'privilege lookup failed' }),
+    );
+    expect(
+      configExtensionStore.getState().mountedExtensions.filter((record) => record.slotName === slotName),
+    ).toHaveLength(1);
+
+    unregisterExtensionRendering(`${slotName}/${extensionName}-0`);
+    vi.mocked(userHasAccess).mockImplementation(() => true);
+    sessionStore.setState({ loaded: false, session: null });
+    consoleError.mockRestore();
   });
 
   it('should only flush at the end of the outermost batch when batches nest', () => {
@@ -579,7 +724,7 @@ describe('the bridge to the config system', () => {
         renderingId,
         extensionName,
         extensionModuleName: `${extensionName}-module`,
-        id: extensionName,
+        extensionId: extensionName,
         slotName,
         slotModuleName: 'test-module',
       });
@@ -655,6 +800,58 @@ describe('the bridge to the config system', () => {
     expect(renderingsStore.getState().renderings.size).toBe(before + 2);
   });
 
+  it('should keep entries apart when a slot name and extension ID could run together', () => {
+    const suffix = getUniqueName('collide');
+    // Joining these on a space would give both pairs the key `a b ${suffix} test-module ...`, and
+    // the second would be folded into the first's record instead of getting one of its own.
+    const pairs = [
+      { slotName: `a b`, extensionId: `${suffix}` },
+      { slotName: `a`, extensionId: `b ${suffix}` },
+    ];
+
+    for (const { slotName, extensionId } of pairs) {
+      registerExtensionRendering({
+        renderingId: `${slotName}/${extensionId}`,
+        extensionName: extensionId,
+        extensionModuleName: 'collide-module',
+        extensionId,
+        slotName,
+        slotModuleName: 'test-module',
+      });
+    }
+
+    const records = configExtensionStore
+      .getState()
+      .mountedExtensions.filter((record) => record.extensionModuleName === 'collide-module');
+
+    expect(records).toHaveLength(2);
+    expect(records.map((record) => [record.slotName, record.extensionId]).sort()).toEqual(
+      pairs.map(({ slotName, extensionId }) => [slotName, extensionId]).sort(),
+    );
+  });
+
+  it('should ignore a rendering registered twice and a rendering released twice', () => {
+    const slotName = getUniqueName('idempotent-slot');
+    const extensionName = getUniqueName('idempotent-extension');
+    const [renderingId] = mountRenderings(slotName, extensionName, 1);
+
+    let writes = 0;
+    const unsubscribe = configExtensionStore.subscribe(() => writes++);
+
+    // A duplicate registration must not raise the count, or the record outlives its one rendering.
+    mountRenderings(slotName, extensionName, 1);
+    unregisterExtensionRendering(renderingId);
+
+    expect(configExtensionStore.getState().mountedExtensions.filter((r) => r.slotName === slotName)).toHaveLength(0);
+
+    // Releasing an unknown rendering is a no-op rather than a negative count.
+    unregisterExtensionRendering(renderingId);
+    unsubscribe();
+
+    expect(configExtensionStore.getState().mountedExtensions.filter((r) => r.slotName === slotName)).toHaveLength(0);
+    expect(writes).toBe(1);
+  });
+
   it('should record separate entries for the same extension in different slots', () => {
     const extensionName = getUniqueName('shared-extension');
     const slotNames = [getUniqueName('slot-a'), getUniqueName('slot-b')];
@@ -682,12 +879,13 @@ describe('extension ordering', () => {
     attach(slotName, first);
     attach(slotName, second);
     registerExtensionSlot('test-module', slotName);
-    updateInternalExtensionStore((state) => ({
-      ...state,
-      slots: { ...state.slots, [slotName]: { ...state.slots[slotName], config: { order: [second] } } },
+    getExtensionSlotsConfigStore().setState((state) => ({
+      slots: { ...state.slots, [slotName]: { loaded: true, config: { order: [second] } } },
     }));
 
-    expect(getAssignedExtensions(slotName).map((e) => e.id)).toEqual([first, second]);
+    // `second` has no order of its own, but the slot's configured order names it, which outranks
+    // the registered order `first` carries.
+    expect(getAssignedExtensions(slotName).map((e) => e.id)).toEqual([second, first]);
   });
 
   it('should place a registered order ahead of attachment order', () => {

--- a/packages/framework/esm-extensions/src/extensions.test.ts
+++ b/packages/framework/esm-extensions/src/extensions.test.ts
@@ -14,7 +14,16 @@ import {
   updateExtensionSlotState,
 } from './extensions';
 import type { ExtensionInfo, ExtensionInternalStore, ExtensionRegistration } from './store';
-import { getExtensionInternalStore } from './store';
+import {
+  batchExtensionUpdates,
+  getExtensionInstancesStore,
+  getExtensionInternalStore,
+  getExtensionStore,
+  registerExtensionInstance,
+  unregisterExtensionInstance,
+  updateInternalExtensionStore,
+} from './store';
+import { configExtensionStore } from '@openmrs/esm-config';
 
 // Minimal mocking - only what we need for fine-grained control
 vi.mock('@openmrs/esm-api', () => ({
@@ -54,7 +63,6 @@ function createMockExtension(name: string, overrides: Partial<ExtensionRegistrat
     load: vi.fn(async () => ({ bootstrap: vi.fn(), mount: vi.fn(), unmount: vi.fn() })),
     moduleName: `${name}-module`,
     meta: {},
-    instances: [],
     ...overrides,
   };
 }
@@ -477,5 +485,240 @@ describe('getAssignedExtensions', () => {
     const result = getAssignedExtensions(slotName);
 
     expect(result[0].meta).toEqual(meta);
+  });
+});
+
+describe('batchExtensionUpdates', () => {
+  it('should recompute the output store once for a batch of registrations', () => {
+    const extensionStore = getExtensionStore();
+    let writes = 0;
+    const unsubscribe = extensionStore.subscribe(() => writes++);
+    const slotNames = [0, 1, 2].map((i) => getUniqueName(`batch-slot-${i}`));
+
+    batchExtensionUpdates(() => {
+      for (let i = 0; i < 15; i++) {
+        const extensionName = getUniqueName('batched-extension');
+        registerExtension(createMockExtension(extensionName));
+        attach(slotNames[i % slotNames.length], extensionName);
+      }
+
+      expect(writes).toBe(0);
+    });
+    unsubscribe();
+
+    expect(writes).toBe(1);
+
+    for (const slotName of slotNames) {
+      expect(getAssignedExtensions(slotName)).toHaveLength(5);
+    }
+  });
+
+  it('should flush pending recomputation when the batched work throws', () => {
+    const extensionStore = getExtensionStore();
+    const slotName = getUniqueName('throwing-slot');
+    const extensionName = getUniqueName('throwing-extension');
+    let writes = 0;
+    const unsubscribe = extensionStore.subscribe(() => writes++);
+
+    expect(() =>
+      batchExtensionUpdates(() => {
+        registerExtension(createMockExtension(extensionName));
+        attach(slotName, extensionName);
+        throw new Error('boom');
+      }),
+    ).toThrow('boom');
+    unsubscribe();
+
+    expect(writes).toBe(1);
+    expect(extensionStore.getState().slots[slotName].assignedExtensions).toHaveLength(1);
+  });
+
+  it('should only flush at the end of the outermost batch when batches nest', () => {
+    const extensionStore = getExtensionStore();
+    const outerSlot = getUniqueName('outer-slot');
+    const innerSlot = getUniqueName('inner-slot');
+    let writes = 0;
+    const unsubscribe = extensionStore.subscribe(() => writes++);
+
+    batchExtensionUpdates(() => {
+      const outerExtension = getUniqueName('outer-extension');
+      registerExtension(createMockExtension(outerExtension));
+      attach(outerSlot, outerExtension);
+
+      batchExtensionUpdates(() => {
+        const innerExtension = getUniqueName('inner-extension');
+        registerExtension(createMockExtension(innerExtension));
+        attach(innerSlot, innerExtension);
+      });
+
+      expect(writes).toBe(0);
+    });
+    unsubscribe();
+
+    expect(writes).toBe(1);
+    expect(getAssignedExtensions(outerSlot)).toHaveLength(1);
+    expect(getAssignedExtensions(innerSlot)).toHaveLength(1);
+  });
+});
+
+describe('the bridge to the config system', () => {
+  function mountInstances(slotName: string, extensionName: string, count: number, firstId = 0) {
+    const instanceIds: Array<string> = [];
+
+    for (let i = firstId; i < firstId + count; i++) {
+      const instanceId = `${slotName}/${extensionName}-${i}`;
+      instanceIds.push(instanceId);
+      registerExtensionInstance({
+        instanceId,
+        extensionName,
+        extensionModuleName: `${extensionName}-module`,
+        id: extensionName,
+        slotName,
+        slotModuleName: 'test-module',
+      });
+    }
+
+    return instanceIds;
+  }
+
+  it('should record one entry per slot and extension however many copies are rendered', () => {
+    const slotName = getUniqueName('dedupe-slot');
+    const extensionName = getUniqueName('dedupe-extension');
+    let writes = 0;
+    const unsubscribe = configExtensionStore.subscribe(() => writes++);
+
+    mountInstances(slotName, extensionName, 50);
+    unsubscribe();
+
+    expect(configExtensionStore.getState().mountedExtensions.filter((r) => r.slotName === slotName)).toEqual([
+      {
+        slotModuleName: 'test-module',
+        extensionModuleName: `${extensionName}-module`,
+        slotName,
+        extensionId: extensionName,
+      },
+    ]);
+    // A list renders the same slot once per row, and every one of those mounts rewrites this store
+    // and re-derives a config for everything else on screen. Only the first copy is a real change.
+    expect(writes).toBe(1);
+  });
+
+  it('should keep the entry until the last copy of an extension is gone', () => {
+    const slotName = getUniqueName('drain-slot');
+    const extensionName = getUniqueName('drain-extension');
+    const instanceIds = mountInstances(slotName, extensionName, 10);
+
+    let writes = 0;
+    const unsubscribe = configExtensionStore.subscribe(() => writes++);
+
+    for (const instanceId of instanceIds.slice(0, -1)) {
+      unregisterExtensionInstance(instanceId);
+    }
+
+    expect(configExtensionStore.getState().mountedExtensions.filter((r) => r.slotName === slotName)).toHaveLength(1);
+    expect(writes).toBe(0);
+
+    unregisterExtensionInstance(instanceIds[instanceIds.length - 1]);
+    unsubscribe();
+
+    expect(configExtensionStore.getState().mountedExtensions.filter((r) => r.slotName === slotName)).toHaveLength(0);
+    expect(writes).toBe(1);
+  });
+
+  it('should notify on every mount even though the instance map keeps its identity', () => {
+    const slotName = getUniqueName('identity-slot');
+    const extensionName = getUniqueName('identity-extension');
+    const instancesStore = getExtensionInstancesStore();
+    const seen: Array<ReadonlyMap<string, unknown>> = [];
+    let notifications = 0;
+
+    const unsubscribe = instancesStore.subscribe((state) => {
+      notifications++;
+      seen.push(state.instances);
+    });
+
+    const before = instancesStore.getState().instances.size;
+    const instanceIds = mountInstances(slotName, extensionName, 3);
+    unregisterExtensionInstance(instanceIds[0]);
+    unsubscribe();
+
+    // The map is mutated in place, so consumers have to key off the state object around it.
+    expect(notifications).toBe(4);
+    expect(new Set(seen).size).toBe(1);
+    expect(instancesStore.getState().instances.size).toBe(before + 2);
+  });
+
+  it('should record separate entries for the same extension in different slots', () => {
+    const extensionName = getUniqueName('shared-extension');
+    const slotNames = [getUniqueName('slot-a'), getUniqueName('slot-b')];
+
+    for (const slotName of slotNames) {
+      mountInstances(slotName, extensionName, 3);
+    }
+
+    const records = configExtensionStore
+      .getState()
+      .mountedExtensions.filter((r) => slotNames.includes(r.slotName))
+      .map((r) => r.slotName);
+
+    expect(records.sort()).toEqual([...slotNames].sort());
+  });
+});
+
+describe('extension ordering', () => {
+  it('should place a configured order ahead of a registered one', () => {
+    const slotName = getUniqueName('order-configured');
+    const [first, second] = [getUniqueName('cfg-a'), getUniqueName('cfg-b')];
+
+    registerExtension(createMockExtension(first, { order: 0 }));
+    registerExtension(createMockExtension(second));
+    attach(slotName, first);
+    attach(slotName, second);
+    registerExtensionSlot('test-module', slotName);
+    updateInternalExtensionStore((state) => ({
+      ...state,
+      slots: { ...state.slots, [slotName]: { ...state.slots[slotName], config: { order: [second] } } },
+    }));
+
+    expect(getAssignedExtensions(slotName).map((e) => e.id)).toEqual([first, second]);
+  });
+
+  it('should place a registered order ahead of attachment order', () => {
+    const slotName = getUniqueName('order-registered');
+    const [unordered, ordered] = [getUniqueName('ord-none'), getUniqueName('ord-five')];
+
+    registerExtension(createMockExtension(unordered));
+    registerExtension(createMockExtension(ordered, { order: 5 }));
+    // Attached first, but has no order of its own, so it still sorts last.
+    attach(slotName, unordered);
+    attach(slotName, ordered);
+
+    expect(getAssignedExtensions(slotName).map((e) => e.id)).toEqual([ordered, unordered]);
+  });
+
+  it('should keep attachment order for extensions registered with the same order', () => {
+    const slotName = getUniqueName('order-tied');
+    const names = [getUniqueName('tie-a'), getUniqueName('tie-b'), getUniqueName('tie-c')];
+
+    for (const name of names) {
+      registerExtension(createMockExtension(name, { order: 3 }));
+      attach(slotName, name);
+    }
+
+    // The comparator returns 0 for these, so the result depends on the sort being stable.
+    expect(getAssignedExtensions(slotName).map((e) => e.id)).toEqual(names);
+  });
+
+  it('should order extensions with no ordering information after every other kind', () => {
+    const slotName = getUniqueName('order-bands');
+    const registered = getUniqueName('band-registered');
+    const attached = getUniqueName('band-attached');
+
+    registerExtension(createMockExtension(registered, { order: 1 }));
+    registerExtension(createMockExtension(attached));
+    attach(slotName, registered);
+    attach(slotName, attached);
+
+    expect(getAssignedExtensions(slotName).map((e) => e.id)).toEqual([registered, attached]);
   });
 });

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -20,10 +20,10 @@ import {
   getExtensionSlotsConfigStore,
   getExtensionsConfigStore,
 } from '@openmrs/esm-config';
-import { evaluateAsBoolean } from '@openmrs/esm-expression-evaluator';
+import { evaluateAsBoolean, type VariablesMap } from '@openmrs/esm-expression-evaluator';
 import { type FeatureFlagsStore, featureFlagsStore } from '@openmrs/esm-feature-flags';
 import { subscribeConnectivityChanged } from '@openmrs/esm-globals';
-import { isOnline as isOnlineFn } from '@openmrs/esm-utils';
+import { isOnline as isOnlineFn, shallowEqual } from '@openmrs/esm-utils';
 import { isEqual, merge } from 'lodash-es';
 import { checkStatusFor } from './helpers';
 import {
@@ -33,8 +33,10 @@ import {
   type ExtensionSlotCustomState,
   type ExtensionSlotInfo,
   type ExtensionSlotState,
+  getExtensionInstancesStore,
   getExtensionInternalStore,
   getExtensionStore,
+  scheduleRecomputation,
   updateInternalExtensionStore,
 } from './store';
 
@@ -43,98 +45,170 @@ const extensionStore = getExtensionStore();
 const slotsConfigStore = getExtensionSlotsConfigStore();
 const extensionsConfigStore = getExtensionsConfigStore();
 
-// Keep the output store updated
+/**
+ * Slots whose derived state may have changed since the output store was last updated. `null`
+ * stands for "every slot", and is used when an input changes that isn't scoped to one slot —
+ * the session, a feature flag, connectivity, or a new extension registration.
+ */
+let dirtySlots: Set<string> | null = new Set();
+let isRecomputingOutputStore = false;
+
+function markSlotsDirty(slots: Set<string> | null) {
+  if (slots === null) {
+    dirtySlots = null;
+  } else if (dirtySlots !== null) {
+    for (const slotName of slots) {
+      dirtySlots.add(slotName);
+    }
+  }
+
+  scheduleRecomputation(recomputeExtensionOutputStore);
+}
+
+function recomputeExtensionOutputStore() {
+  // Writing the output store notifies its subscribers synchronously, and a subscriber that dirties
+  // a slot would otherwise re-enter here and recurse without bound. What it dirties is picked up
+  // by the next recomputation.
+  if (isRecomputingOutputStore) {
+    return;
+  }
+
+  const slots = dirtySlots;
+
+  if (slots !== null && slots.size === 0) {
+    return;
+  }
+
+  isRecomputingOutputStore = true;
+  // Taken before the work so that anything dirtied while it runs accumulates for next time rather
+  // than being discarded when this pass finishes.
+  dirtySlots = new Set();
+
+  try {
+    updateExtensionOutputStore(
+      extensionInternalStore.getState(),
+      slotsConfigStore.getState(),
+      extensionsConfigStore.getState(),
+      featureFlagsStore.getState(),
+      sessionStore.getState(),
+      slots,
+    );
+  } catch (e) {
+    // Fold the work back in, so a failure leaves these slots marked for the next recomputation
+    // instead of stranding them stale.
+    dirtySlots = slots === null || dirtySlots === null ? null : new Set([...slots, ...dirtySlots]);
+    throw e;
+  } finally {
+    isRecomputingOutputStore = false;
+  }
+}
+
+/**
+ * Re-derives the output store from the extension system's inputs.
+ *
+ * Two things keep this cheap. `dirtySlotNames` limits which slots are recomputed at all; passing
+ * `null` recomputes every slot. And slots whose derived value hasn't changed keep their existing
+ * object, so that components subscribed to one slot don't re-render because a different slot
+ * changed.
+ */
 function updateExtensionOutputStore(
   internalState: ExtensionInternalStore,
   extensionSlotConfigs: ExtensionSlotsConfigStore,
-  extensionsConfigStore: ExtensionsConfigStore,
-  featureFlagStore: FeatureFlagsStore,
-  sessionStore: SessionStore,
+  extensionsConfigState: ExtensionsConfigStore,
+  featureFlagState: FeatureFlagsStore,
+  sessionState: SessionStore,
+  dirtySlotNames: Set<string> | null = null,
 ) {
+  const previousSlots = extensionStore.getState().slots;
   const slots: Record<string, ExtensionSlotState> = {};
+  let changed = false;
 
   const isOnline = isOnlineFn();
-  const enabledFeatureFlags = Object.entries(featureFlagStore.flags)
+  const enabledFeatureFlags = Object.entries(featureFlagState.flags)
     .filter(([, { enabled }]) => enabled)
     .map(([name]) => name);
 
   for (let [slotName, slot] of Object.entries(internalState.slots)) {
+    const previous = previousSlots[slotName];
+
+    if (previous && dirtySlotNames && !dirtySlotNames.has(slotName)) {
+      slots[slotName] = previous;
+      continue;
+    }
+
     const { config } = getExtensionSlotConfigFromStore(extensionSlotConfigs, slot.name);
     const assignedExtensions = getAssignedExtensionsFromSlotData(
       slotName,
       internalState,
       config,
-      extensionsConfigStore,
+      extensionsConfigState,
       enabledFeatureFlags,
       isOnline,
-      sessionStore.session,
+      sessionState.session,
     );
-    slots[slotName] = { moduleName: slot.moduleName, assignedExtensions };
+
+    if (
+      previous &&
+      previous.moduleName === slot.moduleName &&
+      isEqual(previous.assignedExtensions, assignedExtensions)
+    ) {
+      slots[slotName] = previous;
+    } else {
+      slots[slotName] = { moduleName: slot.moduleName, assignedExtensions };
+      changed = true;
+    }
   }
 
-  if (!isEqual(extensionStore.getState().slots, slots)) {
+  if (changed || Object.keys(previousSlots).length !== Object.keys(slots).length) {
     extensionStore.setState({ slots });
   }
 }
 
-extensionInternalStore.subscribe((internalStore) => {
-  updateExtensionOutputStore(
-    internalStore,
-    slotsConfigStore.getState(),
-    extensionsConfigStore.getState(),
-    featureFlagsStore.getState(),
-    sessionStore.getState(),
-  );
+/**
+ * Returns the keys whose values differ between two records, including keys present in only one.
+ */
+function changedKeys(next: Record<string, unknown>, previous: Record<string, unknown>): Set<string> {
+  const changed = new Set<string>();
+
+  for (const key of Object.keys(next)) {
+    if (next[key] !== previous[key]) {
+      changed.add(key);
+    }
+  }
+
+  for (const key of Object.keys(previous)) {
+    if (!(key in next)) {
+      changed.add(key);
+    }
+  }
+
+  return changed;
+}
+
+extensionInternalStore.subscribe((state, previousState) => {
+  // A new or changed registration can affect any slot the extension might be assigned to. Every
+  // other kind of change here — attaching, registering a slot, slot state — is scoped to the
+  // slots whose entries actually changed.
+  markSlotsDirty(state.extensions !== previousState.extensions ? null : changedKeys(state.slots, previousState.slots));
 });
 
-slotsConfigStore.subscribe((slotConfigs) => {
-  updateExtensionOutputStore(
-    extensionInternalStore.getState(),
-    slotConfigs,
-    extensionsConfigStore.getState(),
-    featureFlagsStore.getState(),
-    sessionStore.getState(),
-  );
+// Slot configs are per-slot, so a config change invalidates only the slots it names.
+slotsConfigStore.subscribe((state, previousState) => {
+  markSlotsDirty(changedKeys(state.slots, previousState.slots));
 });
 
-extensionsConfigStore.subscribe((extensionConfigs) => {
-  updateExtensionOutputStore(
-    extensionInternalStore.getState(),
-    slotsConfigStore.getState(),
-    extensionConfigs,
-    featureFlagsStore.getState(),
-    sessionStore.getState(),
-  );
+// Extension configs are keyed by slot too, but rebuilt wholesale on every config recomputation,
+// so in practice any change here dirties every slot that has a mounted extension.
+extensionsConfigStore.subscribe((state, previousState) => {
+  markSlotsDirty(changedKeys(state.configs, previousState.configs));
 });
 
-featureFlagsStore.subscribe((featureFlagStore) => {
-  updateExtensionOutputStore(
-    extensionInternalStore.getState(),
-    slotsConfigStore.getState(),
-    extensionsConfigStore.getState(),
-    featureFlagStore,
-    sessionStore.getState(),
-  );
-});
+featureFlagsStore.subscribe(() => markSlotsDirty(null));
 
-sessionStore.subscribe((session) => {
-  updateExtensionOutputStore(
-    extensionInternalStore.getState(),
-    slotsConfigStore.getState(),
-    extensionsConfigStore.getState(),
-    featureFlagsStore.getState(),
-    session,
-  );
-});
+sessionStore.subscribe(() => markSlotsDirty(null));
 
 function updateOutputStoreToCurrent() {
-  updateExtensionOutputStore(
-    extensionInternalStore.getState(),
-    slotsConfigStore.getState(),
-    extensionsConfigStore.getState(),
-    featureFlagsStore.getState(),
-    sessionStore.getState(),
-  );
+  markSlotsDirty(null);
 }
 
 updateOutputStoreToCurrent();
@@ -192,13 +266,13 @@ export function getExtensionRegistration(extensionId: string): ExtensionRegistra
  * @internal
  */
 export const registerExtension: (extensionRegistration: ExtensionRegistration) => void = (extensionRegistration) =>
-  extensionInternalStore.setState((state) => {
-    state.extensions[extensionRegistration.name] = {
-      ...extensionRegistration,
-      instances: [],
-    };
-    return state;
-  });
+  updateInternalExtensionStore((state) => ({
+    ...state,
+    extensions: {
+      ...state.extensions,
+      [extensionRegistration.name]: { ...extensionRegistration },
+    },
+  }));
 
 /**
  * Attach an extension to an extension slot.
@@ -310,6 +384,10 @@ export function detachAll(extensionSlotName: string) {
  * Get an order index for the extension. This will
  * come from either its configured order, its registered order
  * parameter, or the order in which it happened to be attached.
+ *
+ * The four bands below are what makes the comparison a total order: every extension lands in
+ * exactly one, and extensions with no ordering information of any kind share the last band rather
+ * than getting a sentinel that can't be compared against itself.
  */
 function getOrder(
   extensionId: string,
@@ -330,7 +408,9 @@ function getOrder(
       // after all others
       return 2000 + assignedIndex;
     } else {
-      return -1;
+      // Added by configuration with no order of any kind — after everything else, and among
+      // themselves in the order the configuration lists them.
+      return 3000;
     }
   }
 }
@@ -348,14 +428,14 @@ function getAssignedExtensionsFromSlotData(
   const assignedIds = calculateAssignedIds(config, attachedIds);
   const extensions: Array<AssignedExtension> = [];
 
-  // Create context once for all extensions in this slot
-  const slotState = internalState.slots[slotName]?.state;
-  const expressionContext = slotState && typeof slotState === 'object' ? { session, ...slotState } : { session };
-
   for (let id of assignedIds) {
     const { config: rawExtensionConfig } = getExtensionConfigFromStore(extensionConfigStoreState, slotName, id);
     const rawExtensionSlotExtensionConfig = getExtensionConfigFromExtensionSlotStore(config, slotName, id);
-    const extensionConfig = merge(rawExtensionConfig, rawExtensionSlotExtensionConfig);
+    // `merge` mutates its first argument, and `rawExtensionConfig` belongs to the config store,
+    // so never merge into it.
+    const extensionConfig = rawExtensionSlotExtensionConfig
+      ? merge({}, rawExtensionConfig, rawExtensionSlotExtensionConfig)
+      : rawExtensionConfig;
 
     const name = getExtensionNameFromId(id);
     const extension = internalState.extensions[name];
@@ -372,27 +452,6 @@ function getAssignedExtensionsFromSlotData(
         }
 
         if (!userHasAccess(requiredPrivileges, session.user)) {
-          continue;
-        }
-      }
-
-      const displayConditionExpression =
-        extensionConfig?.['Display conditions']?.expression || extension.displayExpression;
-
-      if (
-        displayConditionExpression !== undefined &&
-        typeof displayConditionExpression === 'string' &&
-        displayConditionExpression.trim().length > 0
-      ) {
-        try {
-          if (!evaluateAsBoolean(displayConditionExpression, expressionContext)) {
-            continue;
-          }
-        } catch (e) {
-          console.error(
-            `Error while evaluating expression '${displayConditionExpression}' for extension ${name} in slot ${slotName}`,
-            e,
-          );
           continue;
         }
       }
@@ -414,6 +473,7 @@ function getAssignedExtensionsFromSlotData(
         meta: extension.meta,
         online: extensionConfig?.['Display conditions']?.online ?? extension.online ?? true,
         offline: extensionConfig?.['Display conditions']?.offline ?? extension.offline ?? false,
+        displayConditionExpression: extensionConfig?.['Display conditions']?.expression || extension.displayExpression,
       });
     }
   }
@@ -422,12 +482,64 @@ function getAssignedExtensionsFromSlotData(
 }
 
 /**
- * Gets the list of extensions assigned to a given slot
+ * Narrows `extensions` to those whose display condition holds for one particular rendering of a
+ * slot, evaluating each condition against `state`.
+ *
+ * The same slot can be rendered many times at once with different state — a list renders one per
+ * row — so a display condition cannot be resolved when the slot's extensions are derived. It has
+ * to be resolved against the state of the rendering being displayed, which is what this takes.
+ *
+ * An extension whose condition throws is left out, on the grounds that a condition that cannot be
+ * evaluated has not been met.
+ *
+ * @param extensions The extensions assigned to the slot, from `getAssignedExtensions` or the store
+ * @param state The state of this rendering of the slot
+ * @param session The current session, which conditions may refer to as `session`
+ * @returns Those of `extensions` that should be displayed, in the same order. Always a new array.
+ */
+export function filterExtensionsByDisplayConditions(
+  extensions: Array<AssignedExtension>,
+  state?: ExtensionSlotCustomState,
+  session: Session | null = null,
+): Array<AssignedExtension> {
+  // Built once for the whole slot rather than per extension: the context is the same for all of
+  // them, and most slots have no conditions at all.
+  let expressionContext: VariablesMap | undefined;
+
+  return extensions.filter((extension) => {
+    const expression = extension.displayConditionExpression;
+
+    if (typeof expression !== 'string' || expression.trim().length === 0) {
+      return true;
+    }
+
+    expressionContext ??= state && typeof state === 'object' ? { session, ...state } : { session };
+
+    try {
+      return Boolean(evaluateAsBoolean(expression, expressionContext));
+    } catch (e) {
+      console.error(
+        `Error while evaluating expression '${expression}' for extension ${extension.name} in slot ${extension.id}`,
+        e,
+      );
+      return false;
+    }
+  });
+}
+
+/**
+ * Gets the list of extensions assigned to a given slot.
+ *
+ * Pass `state` whenever the extensions are being displayed. A slot can be rendered in several
+ * places at once with different state, so display conditions are evaluated against the state of the
+ * rendering rather than against the slot, and are only applied when `state` is given. Omitting it
+ * returns every assigned extension, including those a display condition might hide.
  *
  * @param slotName The slot to load the assigned extensions for
+ * @param state The state of the rendering of the slot the extensions will be displayed in
  * @returns An array of extensions assigned to the named slot
  */
-export function getAssignedExtensions(slotName: string): Array<AssignedExtension> {
+export function getAssignedExtensions(slotName: string, state?: ExtensionSlotCustomState): Array<AssignedExtension> {
   const internalState = extensionInternalStore.getState();
   const { config: slotConfig } = getExtensionSlotConfig(slotName);
   const extensionStoreState = extensionsConfigStore.getState();
@@ -438,7 +550,7 @@ export function getAssignedExtensions(slotName: string): Array<AssignedExtension
     .filter(([, { enabled }]) => enabled)
     .map(([name]) => name);
 
-  return getAssignedExtensionsFromSlotData(
+  const assigned = getAssignedExtensionsFromSlotData(
     slotName,
     internalState,
     slotConfig,
@@ -447,6 +559,8 @@ export function getAssignedExtensions(slotName: string): Array<AssignedExtension
     isOnline,
     sessionState.session,
   );
+
+  return state === undefined ? assigned : filterExtensionsByDisplayConditions(assigned, state, sessionState.session);
 }
 
 function calculateAssignedIds(config: ExtensionSlotConfig, attachedIds: Array<string>) {
@@ -461,13 +575,10 @@ function calculateAssignedIds(config: ExtensionSlotConfig, attachedIds: Array<st
       const ai = getOrder(idA, idOrder, extensions[getExtensionNameFromId(idA)]?.order, attachedIds);
       const bi = getOrder(idB, idOrder, extensions[getExtensionNameFromId(idB)]?.order, attachedIds);
 
-      if (bi === -1) {
-        return -1;
-      } else if (ai === -1) {
-        return 1;
-      } else {
-        return ai - bi;
-      }
+      // Ties keep their input order — `Array.prototype.sort` is stable, and the input is
+      // `[...attachedIds, ...addedIds]`, so two extensions the ordering rules can't separate
+      // come out in the order the code and the configuration declared them.
+      return ai - bi;
     });
 }
 
@@ -525,21 +636,45 @@ export const registerExtensionSlot: (moduleName: string, slotName: string, state
   });
 
 /**
- * Used by extension slots to update the copy of the state for the extension slot
+ * Used by extension slots to update the copy of the state for the extension slot.
+ *
+ * Callers generally pass a fresh object every render, so this compares the new state against
+ * the stored one and does nothing if they match. Without that, every render of every extension
+ * slot would invalidate the extension graph.
+ *
+ * Does nothing if the slot has not been registered.
  *
  * @param slotName The name of the slot with state to update
  * @param state A copy of the new state
  * @param partial Whether this should be applied as a partial
  */
 export function updateExtensionSlotState(slotName: string, state: ExtensionSlotCustomState, partial: boolean = false) {
-  extensionInternalStore.setState((currentState) => {
-    const newState = partial ? merge(currentState.slots[slotName].state, state) : state;
+  updateInternalExtensionStore((currentState) => {
+    const slot = currentState.slots[slotName];
+
+    if (!slot) {
+      console.warn(
+        `Attempted to update the state of extension slot '${slotName}', which has not been registered. ` +
+          `The update was ignored. Extension slots must be registered — normally by rendering ` +
+          `<ExtensionSlot> — before their state can be set.`,
+      );
+      return currentState;
+    }
+
+    // Merged into a fresh object: `merge` mutates its first argument, and mutating the stored
+    // state in place would make the comparison below always find them equal.
+    const newState = partial ? merge({}, slot.state, state) : state;
+
+    if (shallowEqual(slot.state, newState)) {
+      return currentState;
+    }
+
     return {
       ...currentState,
       slots: {
         ...currentState.slots,
         [slotName]: {
-          ...currentState.slots[slotName],
+          ...slot,
           state: newState,
         },
       },
@@ -551,10 +686,11 @@ export function updateExtensionSlotState(slotName: string, state: ExtensionSlotC
  * @internal
  * Just for testing.
  */
-export const reset: () => void = () =>
-  extensionStore.setState(() => {
-    return {
-      slots: {},
-      extensions: {},
-    };
-  });
+export const reset: () => void = () => {
+  // Invalidation is carried in module state, so it has to be reset too or it bleeds into the
+  // next test as either a stale dirty set or a missing one.
+  dirtySlots = null;
+  updateInternalExtensionStore(() => ({ slots: {}, extensions: {} }));
+  getExtensionInstancesStore().setState({ instances: new Map() });
+  extensionStore.setState({ slots: {} });
+};

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -23,7 +23,7 @@ import {
 import { evaluateAsBoolean, type VariablesMap } from '@openmrs/esm-expression-evaluator';
 import { type FeatureFlagsStore, featureFlagsStore } from '@openmrs/esm-feature-flags';
 import { subscribeConnectivityChanged } from '@openmrs/esm-globals';
-import { isOnline as isOnlineFn, shallowEqual } from '@openmrs/esm-utils';
+import { isOnline as isOnlineFn } from '@openmrs/esm-utils';
 import { isEqual, merge } from 'lodash-es';
 import { checkStatusFor } from './helpers';
 import {
@@ -33,7 +33,7 @@ import {
   type ExtensionSlotCustomState,
   type ExtensionSlotInfo,
   type ExtensionSlotState,
-  getExtensionInstancesStore,
+  getExtensionRenderingsStore,
   getExtensionInternalStore,
   getExtensionStore,
   scheduleRecomputation,
@@ -65,39 +65,59 @@ function markSlotsDirty(slots: Set<string> | null) {
   scheduleRecomputation(recomputeExtensionOutputStore);
 }
 
+/**
+ * A subscriber that dirties a slot every time the output store is published would loop here for
+ * ever, so the drain gives up after this many passes and leaves the rest for the next write. Any
+ * real cascade settles in two or three.
+ */
+const maxRecomputationPasses = 20;
+
 function recomputeExtensionOutputStore() {
-  // Writing the output store notifies its subscribers synchronously, and a subscriber that dirties
-  // a slot would otherwise re-enter here and recurse without bound. What it dirties is picked up
-  // by the next recomputation.
+  // Publishing notifies subscribers synchronously, so one that dirties a slot re-enters here. The
+  // loop below picks that work up; recursing instead would nest without bound.
   if (isRecomputingOutputStore) {
     return;
   }
 
-  const slots = dirtySlots;
-
-  if (slots !== null && slots.size === 0) {
-    return;
-  }
-
   isRecomputingOutputStore = true;
-  // Taken before the work so that anything dirtied while it runs accumulates for next time rather
-  // than being discarded when this pass finishes.
-  dirtySlots = new Set();
 
   try {
-    updateExtensionOutputStore(
-      extensionInternalStore.getState(),
-      slotsConfigStore.getState(),
-      extensionsConfigStore.getState(),
-      featureFlagsStore.getState(),
-      sessionStore.getState(),
-      slots,
-    );
-  } catch (e) {
-    // Fold the work back in, so a failure leaves these slots marked for the next recomputation
-    // instead of stranding them stale.
-    dirtySlots = slots === null || dirtySlots === null ? null : new Set([...slots, ...dirtySlots]);
-    throw e;
+    for (let pass = 1; ; pass++) {
+      const slots = dirtySlots;
+
+      if (slots !== null && slots.size === 0) {
+        return;
+      }
+
+      // Taken before the work so that anything dirtied while it runs accumulates for the next pass
+      // rather than being discarded when this one finishes.
+      dirtySlots = new Set();
+
+      try {
+        updateExtensionOutputStore(
+          extensionInternalStore.getState(),
+          slotsConfigStore.getState(),
+          extensionsConfigStore.getState(),
+          featureFlagsStore.getState(),
+          sessionStore.getState(),
+          slots,
+        );
+      } catch (e) {
+        // Fold the work back in, so a failure leaves these slots marked for the next recomputation
+        // instead of stranding them stale.
+        dirtySlots = slots === null || dirtySlots === null ? null : new Set([...slots, ...dirtySlots]);
+        throw e;
+      }
+
+      if (pass >= maxRecomputationPasses) {
+        console.error(
+          `The extension system stopped recomputing after ${maxRecomputationPasses} passes because ` +
+            `something keeps invalidating slots in response to the extension store being written. ` +
+            `Some slots are left stale until the next write.`,
+        );
+        return;
+      }
+    }
   } finally {
     isRecomputingOutputStore = false;
   }
@@ -187,8 +207,8 @@ function changedKeys(next: Record<string, unknown>, previous: Record<string, unk
 
 extensionInternalStore.subscribe((state, previousState) => {
   // A new or changed registration can affect any slot the extension might be assigned to. Every
-  // other kind of change here — attaching, registering a slot, slot state — is scoped to the
-  // slots whose entries actually changed.
+  // other kind of change here — attaching, registering a slot — is scoped to the slots whose
+  // entries actually changed.
   markSlotsDirty(state.extensions !== previousState.extensions ? null : changedKeys(state.slots, previousState.slots));
 });
 
@@ -214,17 +234,12 @@ function updateOutputStoreToCurrent() {
 updateOutputStoreToCurrent();
 subscribeConnectivityChanged(updateOutputStoreToCurrent);
 
-function createNewExtensionSlotInfo(
-  slotName: string,
-  moduleName?: string,
-  state?: ExtensionSlotCustomState,
-): ExtensionSlotInfo {
+function createNewExtensionSlotInfo(slotName: string, moduleName?: string): ExtensionSlotInfo {
   return {
     moduleName,
     name: slotName,
     attachedIds: [],
     config: null,
-    state,
   };
 }
 
@@ -385,9 +400,9 @@ export function detachAll(extensionSlotName: string) {
  * come from either its configured order, its registered order
  * parameter, or the order in which it happened to be attached.
  *
- * The four bands below are what makes the comparison a total order: every extension lands in
- * exactly one, and extensions with no ordering information of any kind share the last band rather
- * than getting a sentinel that can't be compared against itself.
+ * The four bands below keep the comparison a total order: every extension lands in exactly one, and
+ * those with no ordering information share the last band rather than taking a sentinel that can't be
+ * compared against itself.
  */
 function getOrder(
   extensionId: string,
@@ -495,12 +510,14 @@ function getAssignedExtensionsFromSlotData(
  * @param extensions The extensions assigned to the slot, from `getAssignedExtensions` or the store
  * @param state The state of this rendering of the slot
  * @param session The current session, which conditions may refer to as `session`
+ * @param slotName The slot these were assigned to, used only to identify them if a condition throws
  * @returns Those of `extensions` that should be displayed, in the same order. Always a new array.
  */
 export function filterExtensionsByDisplayConditions(
   extensions: Array<AssignedExtension>,
   state?: ExtensionSlotCustomState,
   session: Session | null = null,
+  slotName?: string,
 ): Array<AssignedExtension> {
   // Built once for the whole slot rather than per extension: the context is the same for all of
   // them, and most slots have no conditions at all.
@@ -519,7 +536,7 @@ export function filterExtensionsByDisplayConditions(
       return Boolean(evaluateAsBoolean(expression, expressionContext));
     } catch (e) {
       console.error(
-        `Error while evaluating expression '${expression}' for extension ${extension.name} in slot ${extension.id}`,
+        `Error while evaluating expression '${expression}' for ${extension.id}` + (slotName ? ` in ${slotName}` : ''),
         e,
       );
       return false;
@@ -530,10 +547,11 @@ export function filterExtensionsByDisplayConditions(
 /**
  * Gets the list of extensions assigned to a given slot.
  *
- * Pass `state` whenever the extensions are being displayed. A slot can be rendered in several
- * places at once with different state, so display conditions are evaluated against the state of the
- * rendering rather than against the slot, and are only applied when `state` is given. Omitting it
- * returns every assigned extension, including those a display condition might hide.
+ * Display conditions are always applied, so the result is what would actually be displayed. Pass
+ * `state` whenever you know it: a slot can be rendered in several places at once with different
+ * state, so conditions are resolved against the state of the rendering rather than against the slot.
+ * Omitting it resolves them against the session alone, which will hide any extension whose condition
+ * depends on state — the same answer `<ExtensionSlot>` would reach with no state of its own.
  *
  * @param slotName The slot to load the assigned extensions for
  * @param state The state of the rendering of the slot the extensions will be displayed in
@@ -560,7 +578,7 @@ export function getAssignedExtensions(slotName: string, state?: ExtensionSlotCus
     sessionState.session,
   );
 
-  return state === undefined ? assigned : filterExtensionsByDisplayConditions(assigned, state, sessionState.session);
+  return filterExtensionsByDisplayConditions(assigned, state, sessionState.session, slotName);
 }
 
 function calculateAssignedIds(config: ExtensionSlotConfig, attachedIds: Array<string>) {
@@ -587,14 +605,9 @@ function calculateAssignedIds(config: ExtensionSlotConfig, attachedIds: Array<st
  *
  * @param moduleName The name of the module that contains the extension slot
  * @param slotName The extension slot name that is actually used
- * @param state Optional custom state for the slot, which will be stored in the extension store.
  * @internal
  */
-export const registerExtensionSlot: (moduleName: string, slotName: string, state?: ExtensionSlotCustomState) => void = (
-  moduleName,
-  slotName,
-  state,
-) =>
+export const registerExtensionSlot: (moduleName: string, slotName: string) => void = (moduleName, slotName) =>
   extensionInternalStore.setState((currentState) => {
     const existingModuleName = currentState.slots[slotName]?.moduleName;
     if (existingModuleName && existingModuleName != moduleName) {
@@ -617,13 +630,12 @@ export const registerExtensionSlot: (moduleName: string, slotName: string, state
           [slotName]: {
             ...currentState.slots[slotName],
             moduleName,
-            state,
           },
         },
       };
     }
 
-    const slot = createNewExtensionSlotInfo(slotName, moduleName, state);
+    const slot = createNewExtensionSlotInfo(slotName, moduleName);
     return {
       ...currentState,
       slots: {
@@ -634,53 +646,6 @@ export const registerExtensionSlot: (moduleName: string, slotName: string, state
       },
     };
   });
-
-/**
- * Used by extension slots to update the copy of the state for the extension slot.
- *
- * Callers generally pass a fresh object every render, so this compares the new state against
- * the stored one and does nothing if they match. Without that, every render of every extension
- * slot would invalidate the extension graph.
- *
- * Does nothing if the slot has not been registered.
- *
- * @param slotName The name of the slot with state to update
- * @param state A copy of the new state
- * @param partial Whether this should be applied as a partial
- */
-export function updateExtensionSlotState(slotName: string, state: ExtensionSlotCustomState, partial: boolean = false) {
-  updateInternalExtensionStore((currentState) => {
-    const slot = currentState.slots[slotName];
-
-    if (!slot) {
-      console.warn(
-        `Attempted to update the state of extension slot '${slotName}', which has not been registered. ` +
-          `The update was ignored. Extension slots must be registered — normally by rendering ` +
-          `<ExtensionSlot> — before their state can be set.`,
-      );
-      return currentState;
-    }
-
-    // Merged into a fresh object: `merge` mutates its first argument, and mutating the stored
-    // state in place would make the comparison below always find them equal.
-    const newState = partial ? merge({}, slot.state, state) : state;
-
-    if (shallowEqual(slot.state, newState)) {
-      return currentState;
-    }
-
-    return {
-      ...currentState,
-      slots: {
-        ...currentState.slots,
-        [slotName]: {
-          ...slot,
-          state: newState,
-        },
-      },
-    };
-  });
-}
 
 /**
  * @internal
@@ -691,6 +656,6 @@ export const reset: () => void = () => {
   // next test as either a stale dirty set or a missing one.
   dirtySlots = null;
   updateInternalExtensionStore(() => ({ slots: {}, extensions: {} }));
-  getExtensionInstancesStore().setState({ instances: new Map() });
+  getExtensionRenderingsStore().setState({ renderings: new Map() });
   extensionStore.setState({ slots: {} });
 };

--- a/packages/framework/esm-extensions/src/extensions.ts
+++ b/packages/framework/esm-extensions/src/extensions.ts
@@ -5,7 +5,7 @@
  * - attached (set via code in form of: attach, detach, ...)
  * - configured (set via configuration in form of: added, removed, ...)
  * - assigned (computed from attached and configured)
- * - connected (computed from assigned using connectivity and online / offline)
+ * - displayed (computed from assigned)
  */
 
 import { type Session, type SessionStore, sessionStore, userHasAccess } from '@openmrs/esm-api';
@@ -15,7 +15,6 @@ import {
   type ExtensionsConfigStore,
   getExtensionConfigFromExtensionSlotStore,
   getExtensionConfigFromStore,
-  getExtensionSlotConfig,
   getExtensionSlotConfigFromStore,
   getExtensionSlotsConfigStore,
   getExtensionsConfigStore,
@@ -157,7 +156,7 @@ function updateExtensionOutputStore(
     }
 
     const { config } = getExtensionSlotConfigFromStore(extensionSlotConfigs, slot.name);
-    const assignedExtensions = getAssignedExtensionsFromSlotData(
+    const candidateExtensions = getAssignedExtensionsFromSlotData(
       slotName,
       internalState,
       config,
@@ -170,11 +169,11 @@ function updateExtensionOutputStore(
     if (
       previous &&
       previous.moduleName === slot.moduleName &&
-      isEqual(previous.assignedExtensions, assignedExtensions)
+      isEqual(previous.candidateExtensions, candidateExtensions)
     ) {
       slots[slotName] = previous;
     } else {
-      slots[slotName] = { moduleName: slot.moduleName, assignedExtensions };
+      slots[slotName] = { moduleName: slot.moduleName, candidateExtensions };
       changed = true;
     }
   }
@@ -217,8 +216,8 @@ slotsConfigStore.subscribe((state, previousState) => {
   markSlotsDirty(changedKeys(state.slots, previousState.slots));
 });
 
-// Extension configs are keyed by slot too, but rebuilt wholesale on every config recomputation,
-// so in practice any change here dirties every slot that has a mounted extension.
+// Extension configs are keyed by slot too, and the config system hands back the same per-slot
+// object when nothing under it changed, so only the slots whose configs actually moved are dirtied.
 extensionsConfigStore.subscribe((state, previousState) => {
   markSlotsDirty(changedKeys(state.configs, previousState.configs));
 });
@@ -239,7 +238,6 @@ function createNewExtensionSlotInfo(slotName: string, moduleName?: string): Exte
     moduleName,
     name: slotName,
     attachedIds: [],
-    config: null,
   };
 }
 
@@ -500,20 +498,16 @@ function getAssignedExtensionsFromSlotData(
  * Narrows `extensions` to those whose display condition holds for one particular rendering of a
  * slot, evaluating each condition against `state`.
  *
- * The same slot can be rendered many times at once with different state — a list renders one per
- * row — so a display condition cannot be resolved when the slot's extensions are derived. It has
- * to be resolved against the state of the rendering being displayed, which is what this takes.
- *
- * An extension whose condition throws is left out, on the grounds that a condition that cannot be
+ * An extension whose display condition throws is left out, on the grounds that a condition that cannot be
  * evaluated has not been met.
  *
- * @param extensions The extensions assigned to the slot, from `getAssignedExtensions` or the store
+ * @param extensions The extensions assigned to the slot, as the extension store holds them
  * @param state The state of this rendering of the slot
  * @param session The current session, which conditions may refer to as `session`
  * @param slotName The slot these were assigned to, used only to identify them if a condition throws
  * @returns Those of `extensions` that should be displayed, in the same order. Always a new array.
  */
-export function filterExtensionsByDisplayConditions(
+function filterExtensionsByDisplayConditions(
   extensions: Array<AssignedExtension>,
   state?: ExtensionSlotCustomState,
   session: Session | null = null,
@@ -545,40 +539,39 @@ export function filterExtensionsByDisplayConditions(
 }
 
 /**
- * Gets the list of extensions assigned to a given slot.
+ * Gets the extensions a given rendering of a slot should display, in order. This is the supported
+ * way to ask what belongs in a slot; reading the extension store directly skips display conditions.
  *
- * Display conditions are always applied, so the result is what would actually be displayed. Pass
- * `state` whenever you know it: a slot can be rendered in several places at once with different
- * state, so conditions are resolved against the state of the rendering rather than against the slot.
- * Omitting it resolves them against the session alone, which will hide any extension whose condition
- * depends on state — the same answer `<ExtensionSlot>` would reach with no state of its own.
+ * Display conditions are evaluated against `state`, so pass whatever the slot is being rendered
+ * for. The same slot can be rendered many times with different state — once per row of a table,
+ * say — and each rendering can resolve to a different set of extensions. Omitting `state` hides
+ * every extension whose condition refers to it, since the condition cannot be evaluated.
  *
- * @param slotName The slot to load the assigned extensions for
+ * @param slotName The slot to load the extensions for
  * @param state The state of the rendering of the slot the extensions will be displayed in
- * @returns An array of extensions assigned to the named slot
+ * @returns Those extensions assigned to the slot whose display conditions hold
  */
 export function getAssignedExtensions(slotName: string, state?: ExtensionSlotCustomState): Array<AssignedExtension> {
-  const internalState = extensionInternalStore.getState();
-  const { config: slotConfig } = getExtensionSlotConfig(slotName);
-  const extensionStoreState = extensionsConfigStore.getState();
-  const featureFlagState = featureFlagsStore.getState();
-  const sessionState = sessionStore.getState();
-  const isOnline = isOnlineFn();
-  const enabledFeatureFlags = Object.entries(featureFlagState.flags)
-    .filter(([, { enabled }]) => enabled)
-    .map(([name]) => name);
-
-  const assigned = getAssignedExtensionsFromSlotData(
+  return filterExtensionsByDisplayConditions(
+    getCandidateExtensions(slotName),
+    state,
+    sessionStore.getState().session,
     slotName,
-    internalState,
-    slotConfig,
-    extensionStoreState,
-    enabledFeatureFlags,
-    isOnline,
-    sessionState.session,
   );
+}
 
-  return filterExtensionsByDisplayConditions(assigned, state, sessionState.session, slotName);
+/**
+ * Gets everything assigned to a slot without evaluating any display condition, which
+ * {@link getAssignedExtensions} cannot do without knowing the state of a particular rendering.
+ *
+ * This exists for tools that present a slot's configuration rather than render it — the UI editor
+ * has to list an extension in order to let an implementer reorder or remove it, even where no
+ * rendering would display it. Anything deciding what to render wants `getAssignedExtensions()`.
+ *
+ * @internal
+ */
+export function getCandidateExtensions(slotName: string): Array<AssignedExtension> {
+  return extensionStore.getState().slots[slotName]?.candidateExtensions ?? [];
 }
 
 function calculateAssignedIds(config: ExtensionSlotConfig, attachedIds: Array<string>) {

--- a/packages/framework/esm-extensions/src/public.ts
+++ b/packages/framework/esm-extensions/src/public.ts
@@ -12,7 +12,7 @@ export { type LeftNavStore, setLeftNav, unsetLeftNav, type SetLeftNavParams } fr
 export { type CancelLoading, renderExtension } from './render';
 export {
   type ExtensionMeta,
-  type ExtensionInstance,
+  type ExtensionRendering,
   type ExtensionRegistration,
   type ExtensionStore,
   type AssignedExtension,

--- a/packages/framework/esm-extensions/src/public.ts
+++ b/packages/framework/esm-extensions/src/public.ts
@@ -5,20 +5,18 @@ export {
   detach,
   detachAll,
   getAssignedExtensions,
-  filterExtensionsByDisplayConditions,
   registerExtensionSlot,
 } from './extensions';
 export { type LeftNavStore, setLeftNav, unsetLeftNav, type SetLeftNavParams } from './left-nav';
 export { type CancelLoading, renderExtension } from './render';
 export {
   type ExtensionMeta,
-  type ExtensionRendering,
   type ExtensionRegistration,
   type ExtensionStore,
   type AssignedExtension,
   type ConnectedExtension,
+  type ExtensionSlotCustomState,
   type ExtensionSlotState,
-  batchExtensionUpdates,
   getExtensionStore,
 } from './store';
 export { type WorkspaceRegistration } from './workspaces';

--- a/packages/framework/esm-extensions/src/public.ts
+++ b/packages/framework/esm-extensions/src/public.ts
@@ -5,17 +5,20 @@ export {
   detach,
   detachAll,
   getAssignedExtensions,
+  filterExtensionsByDisplayConditions,
   registerExtensionSlot,
 } from './extensions';
 export { type LeftNavStore, setLeftNav, unsetLeftNav, type SetLeftNavParams } from './left-nav';
 export { type CancelLoading, renderExtension } from './render';
 export {
   type ExtensionMeta,
+  type ExtensionInstance,
   type ExtensionRegistration,
   type ExtensionStore,
   type AssignedExtension,
   type ConnectedExtension,
   type ExtensionSlotState,
+  batchExtensionUpdates,
   getExtensionStore,
 } from './store';
 export { type WorkspaceRegistration } from './workspaces';

--- a/packages/framework/esm-extensions/src/render.test.ts
+++ b/packages/framework/esm-extensions/src/render.test.ts
@@ -30,6 +30,16 @@ const lifecycles = {
 };
 
 /**
+ * Every parcel the framework mounts is given these, so that a lifecycle which never settles fails
+ * rather than leaving a parcel that can never be unmounted.
+ */
+const lifecycleTimeouts = {
+  bootstrap: { millis: 15_000, dieOnTimeout: true },
+  mount: { millis: 15_000, dieOnTimeout: true },
+  unmount: { millis: 15_000, dieOnTimeout: true },
+};
+
+/**
  * A stand-in for the external parcel representation single-spa returns. single-spa only provides
  * `update()` for a config that has an update lifecycle, so `hasUpdate` allows omitting it.
  */
@@ -106,7 +116,7 @@ describe('renderExtension', () => {
       renderingId: 'test-slot/test-extension#instance-0',
       extensionName: 'test-extension#instance',
       extensionModuleName: 'test-module',
-      id: 'test-extension#instance',
+      extensionId: 'test-extension#instance',
       slotName: 'test-slot',
       slotModuleName: 'slot-module',
     });
@@ -139,6 +149,29 @@ describe('renderExtension', () => {
     await Promise.resolve();
 
     expect(unregisterExtensionRendering).toHaveBeenCalledWith('test-slot/test-extension#instance-0');
+  });
+
+  /*
+   * Attaching a handler to `mountPromise` stops single-spa's rejection reaching the global one, so
+   * this handler is the only thing left to record a failed mount.
+   */
+  it('logs a failure to mount', async () => {
+    const { hostMountParcel, mountTestExtension } = await loadRenderModule();
+    const mountError = new Error('extension mount failed');
+
+    hostMountParcel.mockImplementationOnce(
+      () => ({ ...fakeParcel(), mountPromise: Promise.reject(mountError) }) as unknown as Parcel,
+    );
+
+    const parcel = await mountTestExtension();
+
+    await expect(parcel!.mountPromise).rejects.toBe(mountError);
+    await Promise.resolve();
+
+    expect(console.error).toHaveBeenCalledWith(
+      "Extension 'test-extension#instance' in slot 'test-slot' failed to mount",
+      mountError,
+    );
   });
 
   it('contains cleanup failures after the hosted parcel fails to mount', async () => {
@@ -229,10 +262,29 @@ describe('renderParcel', () => {
 
     const parcel = await renderParcel(lifecycles, { domElement, someProp: 'value' });
 
-    expect(hostMountParcel).toHaveBeenCalledWith(lifecycles, { domElement, someProp: 'value' });
+    expect(hostMountParcel).toHaveBeenCalledWith(
+      { ...lifecycles, timeouts: lifecycleTimeouts },
+      { domElement, someProp: 'value' },
+    );
     expect(parcel).toBe(hostMountParcel.mock.results[0].value);
     expect(mountRootParcel).toHaveBeenCalledTimes(1);
     expect(mountRootParcel).toHaveBeenCalledWith(expect.objectContaining({ name: hostParcelName }), expect.anything());
+  });
+
+  it('bounds the lifecycles of both the object and the lazily-loaded config forms', async () => {
+    const { hostMountParcel, renderParcel } = await loadRenderModule();
+    const domElement = document.createElement('div');
+
+    await renderParcel(lifecycles, { domElement });
+    await renderParcel(() => Promise.resolve(lifecycles), { domElement });
+
+    // Without these, a lifecycle that never settles leaves a parcel single-spa can never unmount,
+    // so nothing the caller tracks against it is ever released.
+    const [objectForm] = hostMountParcel.mock.calls[0] as [{ timeouts: unknown }];
+    const [functionForm] = hostMountParcel.mock.calls[1] as [() => Promise<{ timeouts: unknown }>];
+
+    expect(objectForm.timeouts).toEqual(lifecycleTimeouts);
+    expect((await functionForm()).timeouts).toEqual(lifecycleTimeouts);
   });
 });
 
@@ -249,7 +301,7 @@ describe('createParcelMounter', () => {
 
     await parcel.mountPromise;
 
-    expect(hostMountParcel).toHaveBeenCalledWith(lifecycles, { domElement });
+    expect(hostMountParcel).toHaveBeenCalledWith({ ...lifecycles, timeouts: lifecycleTimeouts }, { domElement });
     expect(parcel.getStatus()).toBe('MOUNTED');
   });
 

--- a/packages/framework/esm-extensions/src/render.ts
+++ b/packages/framework/esm-extensions/src/render.ts
@@ -186,7 +186,7 @@ export async function renderExtension(
 
       // Marks the node for the UI editor, which needs to pair a rendering with the element it went
       // into and cannot tell two renderings of one extension apart by any other attribute.
-      domElement.setAttribute('data-extension-rendering-id', renderingId);
+      domElement.dataset.extensionRenderingId = renderingId;
 
       const forget = () => unregisterExtensionRendering(renderingId);
       const forgetSafely = (cleanupErrorMessage: string) => {

--- a/packages/framework/esm-extensions/src/render.ts
+++ b/packages/framework/esm-extensions/src/render.ts
@@ -1,8 +1,8 @@
 /** @module @category Extension */
-import { mountRootParcel, type Parcel, type ParcelConfig } from 'single-spa';
+import { type LifeCycles, mountRootParcel, type Parcel, type ParcelConfig } from 'single-spa';
 import { getExtensionNameFromId, getExtensionRegistration } from './extensions';
 import { checkStatus } from './helpers';
-import { updateInternalExtensionStore } from './store';
+import { registerExtensionInstance, unregisterExtensionInstance } from './store';
 
 export interface CancelLoading {
   (): void;
@@ -35,44 +35,77 @@ export async function renderExtension(
     const { meta, moduleName, online, offline, load } = extensionRegistration;
 
     if (checkStatus(online, offline)) {
-      updateInternalExtensionStore((state) => {
-        const instance = {
-          domElement,
-          id: extensionId,
-          slotName: extensionSlotName,
-          slotModuleName: extensionSlotModuleName,
-        };
-        return {
-          ...state,
-          extensions: {
-            ...state.extensions,
-            [extensionName]: {
-              ...state.extensions[extensionName],
-              instances: [...state.extensions[extensionName].instances, instance],
-            },
-          },
-        };
+      const id = parcelCount++;
+      const instanceId = `${extensionSlotName}/${extensionId}-${id}`;
+
+      // Registered before loading so that the config system can start resolving this extension's
+      // config while its bundle is still in flight.
+      registerExtensionInstance({
+        instanceId,
+        extensionName,
+        extensionModuleName: moduleName,
+        id: extensionId,
+        slotName: extensionSlotName,
+        slotModuleName: extensionSlotModuleName,
       });
 
-      const lifecycle = await load();
-      const id = parcelCount++;
-      parcel = mountRootParcel(
-        renderFunction({
-          ...lifecycle,
-          name: `${extensionSlotName}/${extensionName}-${id}`,
-        }),
-        {
-          ...additionalProps,
-          _meta: meta,
-          _extensionContext: {
-            extensionId,
-            extensionSlotName,
-            extensionSlotModuleName,
-            extensionModuleName: moduleName,
+      let lifecycle: LifeCycles;
+
+      try {
+        lifecycle = await load();
+      } catch (e) {
+        // Releasing the record runs the config recomputation cascade, which can itself throw;
+        // letting that escape would replace the load failure that actually matters.
+        try {
+          unregisterExtensionInstance(instanceId);
+        } catch (cleanupError) {
+          console.error(`Recomputing configuration after '${extensionId}' failed to load also failed`, cleanupError);
+        }
+
+        throw e;
+      }
+
+      const forget = () => unregisterExtensionInstance(instanceId);
+
+      try {
+        parcel = mountRootParcel(
+          renderFunction({
+            ...lifecycle,
+            name: `${extensionSlotName}/${extensionName}-${id}`,
+          }),
+          {
+            ...additionalProps,
+            _meta: meta,
+            _extensionContext: {
+              extensionId,
+              extensionSlotName,
+              extensionSlotModuleName,
+              extensionModuleName: moduleName,
+            },
+            domElement,
           },
-          domElement,
-        },
-      );
+        );
+      } catch (e) {
+        try {
+          forget();
+        } catch (cleanupError) {
+          console.error(`Recomputing configuration after '${extensionId}' failed to mount also failed`, cleanupError);
+        }
+
+        throw e;
+      }
+
+      // A parcel that fails to bootstrap or mount never settles `unmountPromise`, so the mount
+      // rejection has to release the record too. single-spa hard-fails parcels, so its own error
+      // handlers never see either failure and the rejected promise is the only channel left.
+      parcel.mountPromise.then(undefined, (err) => {
+        console.error(`Extension '${extensionId}' in slot '${extensionSlotName}' failed to mount`, err);
+        forget();
+      });
+      parcel.unmountPromise.then(forget, (err) => {
+        console.error(`Extension '${extensionId}' in slot '${extensionSlotName}' failed to unmount`, err);
+        forget();
+      });
     }
   } else {
     console.warn(`Tried to render ${extensionId} into ${extensionSlotName} but no DOM element was available.`);

--- a/packages/framework/esm-extensions/src/render.ts
+++ b/packages/framework/esm-extensions/src/render.ts
@@ -22,6 +22,33 @@ let parcelCount = 0;
 let parcelMounter: Promise<MountParcel> | null = null;
 
 /**
+ * Mark parcels as dead if they do not succeed within 15s. Note that loading and unloading is
+ * skipped as that has an unpredictable timing. Failing here allows us to clean-up correctly
+ * if the parcel doesn't fully mount.
+ */
+const lifecycleTimeouts = {
+  bootstrap: { millis: 15_000, dieOnTimeout: true },
+  mount: { millis: 15_000, dieOnTimeout: true },
+  unmount: { millis: 15_000, dieOnTimeout: true },
+};
+
+/**
+ * Applies {@link lifecycleTimeouts} to a parcel config, resolving the function form first so that a
+ * lazily loaded config gets them too.
+ *
+ * The cast is needed because single-spa reads `timeouts` off a parcel config but doesn't declare it
+ * on `ParcelConfigObject`.
+ */
+function withLifecycleTimeouts(parcelConfig: ParcelConfig): ParcelConfig {
+  // Spread after ours, so a parcel that declares its own timeouts keeps them.
+  if (typeof parcelConfig === 'function') {
+    return (() => parcelConfig().then((resolved) => ({ timeouts: lifecycleTimeouts, ...resolved }))) as ParcelConfig;
+  }
+
+  return { timeouts: lifecycleTimeouts, ...parcelConfig } as ParcelConfig;
+}
+
+/**
  * Resolves the function used to mount extensions, which is the `mountParcel()` of a long-lived
  * parcel of our own rather than single-spa's `mountRootParcel()`.
  *
@@ -78,7 +105,7 @@ export async function renderParcel<T = CustomProps>(
   customProps: ParcelProps & T,
 ): Promise<ReturnType<MountParcel>> {
   const mountParcel = await getParcelMounter();
-  return mountParcel(parcelConfig, customProps);
+  return mountParcel(withLifecycleTimeouts(parcelConfig), customProps);
 }
 
 /**
@@ -157,16 +184,9 @@ export async function renderExtension(
       const id = parcelCount++;
       const renderingId = `${extensionSlotName}/${extensionId}-${id}`;
 
-      // Registered before loading so that the config system can start resolving this extension's
-      // config while its bundle is still in flight.
-      registerExtensionRendering({
-        renderingId,
-        extensionName,
-        extensionModuleName: moduleName,
-        id: extensionId,
-        slotName: extensionSlotName,
-        slotModuleName: extensionSlotModuleName,
-      });
+      // Marks the node for the UI editor, which needs to pair a rendering with the element it went
+      // into and cannot tell two renderings of one extension apart by any other attribute.
+      domElement.setAttribute('data-extension-rendering-id', renderingId);
 
       const forget = () => unregisterExtensionRendering(renderingId);
       const forgetSafely = (cleanupErrorMessage: string) => {
@@ -176,6 +196,25 @@ export async function renderExtension(
           console.error(cleanupErrorMessage, cleanupError);
         }
       };
+
+      // Registered before loading so that the config system can start resolving this extension's
+      // config while its bundle is still in flight. Registering drives the config derivation
+      // synchronously, so a failure there has to release the record before it propagates — nothing
+      // else has a handle on it yet.
+      try {
+        registerExtensionRendering({
+          renderingId,
+          extensionName,
+          extensionModuleName: moduleName,
+          extensionId,
+          slotName: extensionSlotName,
+          slotModuleName: extensionSlotModuleName,
+        });
+      } catch (e) {
+        forgetSafely(`Recomputing configuration after registering '${extensionId}' failed also failed`);
+
+        throw e;
+      }
 
       let lifecycle: LifeCycles;
 

--- a/packages/framework/esm-extensions/src/render.ts
+++ b/packages/framework/esm-extensions/src/render.ts
@@ -2,7 +2,7 @@
 import { type LifeCycles, mountRootParcel, type Parcel, type ParcelConfig } from 'single-spa';
 import { getExtensionNameFromId, getExtensionRegistration } from './extensions';
 import { checkStatus } from './helpers';
-import { registerExtensionInstance, unregisterExtensionInstance } from './store';
+import { registerExtensionRendering, unregisterExtensionRendering } from './store';
 
 export interface CancelLoading {
   (): void;
@@ -36,12 +36,12 @@ export async function renderExtension(
 
     if (checkStatus(online, offline)) {
       const id = parcelCount++;
-      const instanceId = `${extensionSlotName}/${extensionId}-${id}`;
+      const renderingId = `${extensionSlotName}/${extensionId}-${id}`;
 
       // Registered before loading so that the config system can start resolving this extension's
       // config while its bundle is still in flight.
-      registerExtensionInstance({
-        instanceId,
+      registerExtensionRendering({
+        renderingId,
         extensionName,
         extensionModuleName: moduleName,
         id: extensionId,
@@ -57,7 +57,7 @@ export async function renderExtension(
         // Releasing the record runs the config recomputation cascade, which can itself throw;
         // letting that escape would replace the load failure that actually matters.
         try {
-          unregisterExtensionInstance(instanceId);
+          unregisterExtensionRendering(renderingId);
         } catch (cleanupError) {
           console.error(`Recomputing configuration after '${extensionId}' failed to load also failed`, cleanupError);
         }
@@ -65,7 +65,7 @@ export async function renderExtension(
         throw e;
       }
 
-      const forget = () => unregisterExtensionInstance(instanceId);
+      const forget = () => unregisterExtensionRendering(renderingId);
 
       try {
         parcel = mountRootParcel(

--- a/packages/framework/esm-extensions/src/store.ts
+++ b/packages/framework/esm-extensions/src/store.ts
@@ -1,6 +1,5 @@
 /** @module @category Extension */
-import { isEqual } from 'lodash-es';
-import type { ConfigExtensionStoreElement, ConfigObject, ExtensionSlotConfig } from '@openmrs/esm-config';
+import type { ConfigExtensionStoreElement, ConfigObject } from '@openmrs/esm-config';
 import { configExtensionStore } from '@openmrs/esm-config';
 import { createGlobalStore, getGlobalStore } from '@openmrs/esm-state';
 import { type LifeCycles } from 'single-spa';
@@ -37,7 +36,7 @@ export type ExtensionInfo = ExtensionRegistration;
  *  - an *extension instance* is a configurable use of one within a slot, identified by its
  *    **ID** — the name plus an optional `#`-suffix (`obs#weight`) — which is what an implementer
  *    writes under a slot's `configure` key, and what a config is derived for;
- *  - a *rendering*, this type, is one live copy of an instance on screen.
+ *  - a *rendering*, this type, is one live copy of an instance being rendered.
  *
  * One instance has any number of renderings at a time: a list renders the same slot once per row,
  * so each row holds its own rendering of every instance assigned to that slot.
@@ -50,7 +49,7 @@ export interface ExtensionRendering {
   /** The module which registered the extension. */
   readonly extensionModuleName: string;
   /** The ID of the extension instance being rendered: the name plus an optional `#`-suffix. */
-  readonly id: string;
+  readonly extensionId: string;
   readonly slotName: string;
   readonly slotModuleName: string;
 }
@@ -62,19 +61,23 @@ export interface ExtensionInternalStore {
   extensions: Record<string, ExtensionRegistration>;
 }
 
+/** @internal */
 export interface ExtensionRenderingsStore {
   /**
    * Every rendering that has started and not yet been released, indexed by rendering ID.
    *
-   * Mutated in place as extensions mount and unmount, because an application renders thousands at
-   * once and copying them all per mount is quadratic over a page's lifetime. So its identity never
-   * changes: subscribe to the state object around it, never to this map, and read it during render
-   * rather than holding a reference across a change.
+   * Mutated in place as extensions mount and unmount, retaining identity across mounts
+   * and unmounts.
    */
   renderings: ReadonlyMap<string, ExtensionRendering>;
 }
 
-export type ExtensionSlotCustomState = Record<string | symbol | number, unknown> | undefined | null;
+/**
+ * The state one rendering of a slot is displaying, which its extensions' display conditions are
+ * evaluated against. Each key becomes a variable of that name in the expression, so only string
+ * keys are reachable from a condition.
+ */
+export type ExtensionSlotCustomState = Record<string, unknown> | undefined;
 
 export interface ExtensionSlotInfo {
   /**
@@ -91,8 +94,6 @@ export interface ExtensionSlotInfo {
    * `assignedIds` is the set defining those.
    */
   attachedIds: Array<string>;
-  /** The configuration provided for this slot. `null` if not yet loaded. */
-  config: Omit<ExtensionSlotConfig, 'configuration'> | null;
 }
 
 export interface ExtensionStore {
@@ -101,7 +102,11 @@ export interface ExtensionStore {
 
 export interface ExtensionSlotState {
   moduleName?: string;
-  assignedExtensions: Array<AssignedExtension>;
+  /**
+   * Candidates only. Call `getAssignedExtensions()` for the extensions a given rendering of
+   * this slot should actually display.
+   */
+  candidateExtensions: Array<AssignedExtension>;
 }
 
 export interface AssignedExtension {
@@ -114,12 +119,7 @@ export interface AssignedExtension {
   readonly online?: boolean | object;
   readonly offline?: boolean | object;
   readonly featureFlag?: string;
-  /**
-   * The condition under which this extension should be displayed, if it has one. Unresolved: a
-   * slot can be rendered several times at once with different state, so the condition can only be
-   * evaluated against the state of a particular rendering. Pass these extensions through
-   * `filterExtensionsByDisplayConditions` with that state before displaying them.
-   */
+  /** The condition under which this extension should be displayed. */
   readonly displayConditionExpression?: string;
 }
 
@@ -168,8 +168,7 @@ export const getExtensionRenderingsStore = () =>
 
 /** @internal */
 export function updateInternalExtensionStore(updater: (state: ExtensionInternalStore) => ExtensionInternalStore) {
-  // The guard below is what makes a no-op updater free: an updater that returns the state it was
-  // given never reaches `setState`, so no subscriber runs.
+  // Skips the write entirely when the updater returns the state it was given.
   const state = extensionInternalStore.getState();
   const newState = updater(state);
 
@@ -190,11 +189,7 @@ function currentRenderings() {
   const state = extensionRenderingsStore.getState();
 
   if (!ownedRenderings || state !== publishedRenderings) {
-    // Tolerates a plain object as well as a map: this store is reset by test harnesses, and a
-    // throw here would escape from inside a `setState` call.
-    ownedRenderings = new Map(
-      state.renderings instanceof Map ? state.renderings : Object.entries(state.renderings ?? {}),
-    );
+    ownedRenderings = new Map(state.renderings);
     publishedRenderings = state;
     rebuildConfigExtensionRecords(ownedRenderings);
   }
@@ -216,7 +211,7 @@ export function registerExtensionRendering(rendering: ExtensionRendering) {
   }
 
   renderings.set(rendering.renderingId, rendering);
-  configExtensionRecordsChanged = countRenderingRecord(rendering, 1) || configExtensionRecordsChanged;
+  countRenderingRecord(rendering, 1);
   publishRenderings(renderings);
 }
 
@@ -230,7 +225,7 @@ export function unregisterExtensionRendering(renderingId: string) {
   }
 
   renderings.delete(renderingId);
-  configExtensionRecordsChanged = countRenderingRecord(rendering, -1) || configExtensionRecordsChanged;
+  countRenderingRecord(rendering, -1);
   publishRenderings(renderings);
 }
 
@@ -254,6 +249,7 @@ const pendingRecomputations = new Set<() => void>();
  *
  * Calls nest, and only the outermost one flushes. `fn` must be synchronous: the batch ends when
  * `fn` returns, so anything written after an `await` is not batched.
+ * @internal
  */
 export function batchExtensionUpdates<T>(fn: () => T): T {
   batchDepth++;
@@ -270,13 +266,21 @@ export function batchExtensionUpdates<T>(fn: () => T): T {
       for (const recompute of pending) {
         // Isolated so one failure doesn't drop the recomputations queued behind it, and so an
         // exception here can't escape the `finally` and replace one thrown by `fn` itself.
-        try {
-          recompute();
-        } catch (e) {
-          console.error(`The extension system's '${recompute.name}' recomputation failed`, e);
-        }
+        runRecomputation(recompute);
       }
     }
+  }
+}
+
+/**
+ * Simple wrapper to ensure recomputations do not throw during store state updates, as this
+ * can block other consumers.
+ */
+function runRecomputation(recompute: () => void) {
+  try {
+    recompute();
+  } catch (e) {
+    console.error(`The extension system's '${recompute.name}' recomputation failed`, e);
   }
 }
 
@@ -289,7 +293,7 @@ export function scheduleRecomputation(recompute: () => void) {
   if (batchDepth > 0) {
     pendingRecomputations.add(recompute);
   } else {
-    recompute();
+    runRecomputation(recompute);
   }
 }
 
@@ -308,16 +312,22 @@ let configExtensionRecordsChanged = false;
 updateConfigExtensionStoreToCurrent();
 extensionRenderingsStore.subscribe(() => scheduleRecomputation(updateConfigExtensionStoreToCurrent));
 
-/** @returns whether the set of records changed, rather than just the count behind one of them. */
+/**
+ * Adjusts the count behind one record, marking the records changed only when the *set* of them
+ * changes rather than merely the count behind one.
+ */
 function countRenderingRecord(rendering: ExtensionRendering, delta: 1 | -1) {
-  // `|` rather than a space, which slot names and extension IDs are allowed to contain: joining on
-  // one lets ('a b', 'c') and ('a', 'b c') collide, and the loser gets no config record at all.
-  const key = [rendering.slotName, rendering.id, rendering.slotModuleName, rendering.extensionModuleName].join('|');
+  const key = JSON.stringify([
+    rendering.slotName,
+    rendering.extensionId,
+    rendering.slotModuleName,
+    rendering.extensionModuleName,
+  ]);
   const counted = configExtensionRecordCounts.get(key);
 
   if (!counted) {
     if (delta < 0) {
-      return false;
+      return;
     }
 
     configExtensionRecordCounts.set(key, {
@@ -326,21 +336,20 @@ function countRenderingRecord(rendering: ExtensionRendering, delta: 1 | -1) {
         slotModuleName: rendering.slotModuleName,
         extensionModuleName: rendering.extensionModuleName,
         slotName: rendering.slotName,
-        extensionId: rendering.id,
+        extensionId: rendering.extensionId,
       },
     });
 
-    return true;
+    configExtensionRecordsChanged = true;
+    return;
   }
 
   counted.count += delta;
 
   if (counted.count < 1) {
     configExtensionRecordCounts.delete(key);
-    return true;
+    configExtensionRecordsChanged = true;
   }
-
-  return false;
 }
 
 function rebuildConfigExtensionRecords(renderings: ReadonlyMap<string, ExtensionRendering>) {
@@ -368,18 +377,41 @@ function updateConfigExtensionStoreToCurrent() {
   // recomputation every time a rendering is remounted in a different position.
   configExtensionRecords.sort(compareConfigExtensionRecords);
 
-  if (!isEqual(configExtensionStore.getState().mountedExtensions, configExtensionRecords)) {
+  if (!sameConfigExtensionRecords(configExtensionStore.getState().mountedExtensions, configExtensionRecords)) {
     configExtensionStore.setState({
       mountedExtensions: configExtensionRecords,
     });
   }
 }
 
+/**
+ * Deep-equality predicate for arrays of `ConfigExtensionStoreElement`, defined in terms of
+ * {@link compareConfigExtensionRecords} so that ordering and equality cannot drift apart.
+ */
+function sameConfigExtensionRecords(
+  a: Array<ConfigExtensionStoreElement>,
+  b: Array<ConfigExtensionStoreElement>,
+): boolean {
+  return a.length === b.length && a.every((record, i) => compareConfigExtensionRecords(record, b[i]) === 0);
+}
+
+/**
+ * Orders records by their four identifying strings. No collation is used as these are internal
+ * identifiers.
+ */
 function compareConfigExtensionRecords(a: ConfigExtensionStoreElement, b: ConfigExtensionStoreElement) {
   return (
-    a.slotName.localeCompare(b.slotName, 'en') ||
-    a.extensionId.localeCompare(b.extensionId, 'en') ||
-    a.slotModuleName.localeCompare(b.slotModuleName, 'en') ||
-    a.extensionModuleName.localeCompare(b.extensionModuleName, 'en')
+    compareStrings(a.slotName, b.slotName) ||
+    compareStrings(a.extensionId, b.extensionId) ||
+    compareStrings(a.slotModuleName, b.slotModuleName) ||
+    compareStrings(a.extensionModuleName, b.extensionModuleName)
   );
+}
+
+function compareStrings(a: string, b: string) {
+  if (a === b) {
+    return 0;
+  }
+
+  return a < b ? -1 : 1;
 }

--- a/packages/framework/esm-extensions/src/store.ts
+++ b/packages/framework/esm-extensions/src/store.ts
@@ -23,24 +23,33 @@ export interface ExtensionRegistration {
 }
 
 /**
- * @deprecated Use `ExtensionRegistration`, which this aliases. Rendered instances are not
- *   reachable from a registration; they are tracked separately.
+ * @deprecated Use `ExtensionRegistration`, which this aliases. Renderings are not reachable from
+ *   a registration; they are tracked separately.
  */
 export type ExtensionInfo = ExtensionRegistration;
 
 /**
- * A single rendering of an extension into a slot. One registered extension can have any number
- * of these at a time — the same extension may be mounted into several slots, or into several
- * simultaneously-rendered copies of the same slot.
+ * A single rendering of an extension into a slot.
+ *
+ * Three things are easily confused, and the extension system distinguishes them:
+ *
+ *  - an *extension* is what a module registers, identified by its **name** (`obs`);
+ *  - an *extension instance* is a configurable use of one within a slot, identified by its
+ *    **ID** — the name plus an optional `#`-suffix (`obs#weight`) — which is what an implementer
+ *    writes under a slot's `configure` key, and what a config is derived for;
+ *  - a *rendering*, this type, is one live copy of an instance on screen.
+ *
+ * One instance has any number of renderings at a time: a list renders the same slot once per row,
+ * so each row holds its own rendering of every instance assigned to that slot.
  */
-export interface ExtensionInstance {
+export interface ExtensionRendering {
   /** Uniquely identifies this rendering. Never reused. */
-  readonly instanceId: string;
+  readonly renderingId: string;
   /** The name of the extension being rendered. */
   readonly extensionName: string;
   /** The module which registered the extension. */
   readonly extensionModuleName: string;
-  /** The extension ID, which is the extension name plus an optional `#`-suffix. */
+  /** The ID of the extension instance being rendered: the name plus an optional `#`-suffix. */
   readonly id: string;
   readonly slotName: string;
   readonly slotModuleName: string;
@@ -53,16 +62,16 @@ export interface ExtensionInternalStore {
   extensions: Record<string, ExtensionRegistration>;
 }
 
-export interface ExtensionInstancesStore {
+export interface ExtensionRenderingsStore {
   /**
-   * Currently-rendered extension instances, indexed by instance ID.
+   * Every rendering that has started and not yet been released, indexed by rendering ID.
    *
-   * The map is mutated in place as extensions mount and unmount — an application routinely renders
-   * thousands of instances at once, and copying them all on every mount is quadratic over a page's
-   * lifetime. Read it during render, as a store consumer does; a reference held across a change
-   * reflects the new contents rather than the state it was read from.
+   * Mutated in place as extensions mount and unmount, because an application renders thousands at
+   * once and copying them all per mount is quadratic over a page's lifetime. So its identity never
+   * changes: subscribe to the state object around it, never to this map, and read it during render
+   * rather than holding a reference across a change.
    */
-  instances: ReadonlyMap<string, ExtensionInstance>;
+  renderings: ReadonlyMap<string, ExtensionRendering>;
 }
 
 export type ExtensionSlotCustomState = Record<string | symbol | number, unknown> | undefined | null;
@@ -84,7 +93,6 @@ export interface ExtensionSlotInfo {
   attachedIds: Array<string>;
   /** The configuration provided for this slot. `null` if not yet loaded. */
   config: Omit<ExtensionSlotConfig, 'configuration'> | null;
-  state?: ExtensionSlotCustomState;
 }
 
 export interface ExtensionStore {
@@ -94,7 +102,6 @@ export interface ExtensionStore {
 export interface ExtensionSlotState {
   moduleName?: string;
   assignedExtensions: Array<AssignedExtension>;
-  state?: ExtensionSlotCustomState;
 }
 
 export interface AssignedExtension {
@@ -131,8 +138,8 @@ const extensionInternalStore = createGlobalStore<ExtensionInternalStore>('extens
   extensions: {},
 });
 
-const extensionInstancesStore = createGlobalStore<ExtensionInstancesStore>('extensionInstances', {
-  instances: new Map(),
+const extensionRenderingsStore = createGlobalStore<ExtensionRenderingsStore>('extensionRenderings', {
+  renderings: new Map(),
 });
 
 /**
@@ -148,15 +155,15 @@ export const getExtensionInternalStore = () =>
   });
 
 /**
- * This gets the store of currently-rendered extension instances. Instances are added by
+ * This gets the store of extension renderings currently on screen. Renderings are added by
  * `renderExtension` and removed once their parcel is gone — whether it unmounted, failed to load,
  * or failed to mount. It is subject to change radically and without warning. It should not be
  * used outside esm-core.
  * @internal
  */
-export const getExtensionInstancesStore = () =>
-  getGlobalStore<ExtensionInstancesStore>('extensionInstances', {
-    instances: new Map(),
+export const getExtensionRenderingsStore = () =>
+  getGlobalStore<ExtensionRenderingsStore>('extensionRenderings', {
+    renderings: new Map(),
   });
 
 /** @internal */
@@ -172,57 +179,59 @@ export function updateInternalExtensionStore(updater: (state: ExtensionInternalS
 }
 
 /**
- * The instance map this module owns and mutates, and the state object it last published. Comparing
- * the store's current state against that is how a write from anywhere else — a test reset, say — is
- * detected, so the map and the record counts below can be rebuilt from it.
+ * The rendering map this module owns and mutates, and the state object it last published. A current
+ * state that isn't the published one means someone else wrote the store, and the map and the record
+ * counts below have to be rebuilt from it.
  */
-let ownedInstances: Map<string, ExtensionInstance> | null = null;
-let publishedInstances: ExtensionInstancesStore | null = null;
+let ownedRenderings: Map<string, ExtensionRendering> | null = null;
+let publishedRenderings: ExtensionRenderingsStore | null = null;
 
-function currentInstances() {
-  const state = extensionInstancesStore.getState();
+function currentRenderings() {
+  const state = extensionRenderingsStore.getState();
 
-  if (!ownedInstances || state !== publishedInstances) {
+  if (!ownedRenderings || state !== publishedRenderings) {
     // Tolerates a plain object as well as a map: this store is reset by test harnesses, and a
     // throw here would escape from inside a `setState` call.
-    ownedInstances = new Map(state.instances instanceof Map ? state.instances : Object.entries(state.instances ?? {}));
-    publishedInstances = state;
-    rebuildConfigExtensionRecords(ownedInstances);
+    ownedRenderings = new Map(
+      state.renderings instanceof Map ? state.renderings : Object.entries(state.renderings ?? {}),
+    );
+    publishedRenderings = state;
+    rebuildConfigExtensionRecords(ownedRenderings);
   }
 
-  return ownedInstances;
+  return ownedRenderings;
 }
 
-function publishInstances(instances: Map<string, ExtensionInstance>) {
-  publishedInstances = { instances };
-  extensionInstancesStore.setState(publishedInstances, true);
-}
-
-/** @internal */
-export function registerExtensionInstance(instance: ExtensionInstance) {
-  const instances = currentInstances();
-
-  if (instances.has(instance.instanceId)) {
-    return;
-  }
-
-  instances.set(instance.instanceId, instance);
-  configExtensionRecordsChanged = countInstanceRecord(instance, 1) || configExtensionRecordsChanged;
-  publishInstances(instances);
+function publishRenderings(renderings: Map<string, ExtensionRendering>) {
+  publishedRenderings = { renderings };
+  extensionRenderingsStore.setState(publishedRenderings, true);
 }
 
 /** @internal */
-export function unregisterExtensionInstance(instanceId: string) {
-  const instances = currentInstances();
-  const instance = instances.get(instanceId);
+export function registerExtensionRendering(rendering: ExtensionRendering) {
+  const renderings = currentRenderings();
 
-  if (!instance) {
+  if (renderings.has(rendering.renderingId)) {
     return;
   }
 
-  instances.delete(instanceId);
-  configExtensionRecordsChanged = countInstanceRecord(instance, -1) || configExtensionRecordsChanged;
-  publishInstances(instances);
+  renderings.set(rendering.renderingId, rendering);
+  configExtensionRecordsChanged = countRenderingRecord(rendering, 1) || configExtensionRecordsChanged;
+  publishRenderings(renderings);
+}
+
+/** @internal */
+export function unregisterExtensionRendering(renderingId: string) {
+  const renderings = currentRenderings();
+  const rendering = renderings.get(renderingId);
+
+  if (!rendering) {
+    return;
+  }
+
+  renderings.delete(renderingId);
+  configExtensionRecordsChanged = countRenderingRecord(rendering, -1) || configExtensionRecordsChanged;
+  publishRenderings(renderings);
 }
 
 /**
@@ -285,31 +294,25 @@ export function scheduleRecomputation(recompute: () => void) {
 }
 
 /**
- * esm-config maintains its own store of the extension information it needs
- * to generate extension configs. We keep it updated based on which extension
- * instances are currently rendered.
- */
-
-/**
- * The config system derives one config per slot and extension, so any number of rendered instances
- * of the same extension in the same slot collapse into a single record. These counts track how many
- * instances stand behind each record.
+ * esm-config keeps its own store of what it needs to derive extension configs. It derives one config
+ * per extension instance in a slot, so renderings of the same instance collapse into a single record;
+ * these count how many stand behind each.
  *
- * They are maintained as instances come and go rather than rebuilt from the instances store, because
- * an application routinely has thousands of instances rendered at once: rebuilding would make every
- * mount and unmount cost a walk over all of them, where this way rendering another copy of a slot
- * already on screen costs nothing.
+ * Counted as renderings come and go rather than rebuilt from the store: an application has thousands
+ * on screen at once, so rebuilding would make every mount cost a walk over all of them.
  */
 const configExtensionRecordCounts = new Map<string, { count: number; record: ConfigExtensionStoreElement }>();
 
 let configExtensionRecordsChanged = false;
 
 updateConfigExtensionStoreToCurrent();
-extensionInstancesStore.subscribe(() => scheduleRecomputation(updateConfigExtensionStoreToCurrent));
+extensionRenderingsStore.subscribe(() => scheduleRecomputation(updateConfigExtensionStoreToCurrent));
 
 /** @returns whether the set of records changed, rather than just the count behind one of them. */
-function countInstanceRecord(instance: ExtensionInstance, delta: 1 | -1) {
-  const key = [instance.slotName, instance.id, instance.slotModuleName, instance.extensionModuleName].join(' ');
+function countRenderingRecord(rendering: ExtensionRendering, delta: 1 | -1) {
+  // `|` rather than a space, which slot names and extension IDs are allowed to contain: joining on
+  // one lets ('a b', 'c') and ('a', 'b c') collide, and the loser gets no config record at all.
+  const key = [rendering.slotName, rendering.id, rendering.slotModuleName, rendering.extensionModuleName].join('|');
   const counted = configExtensionRecordCounts.get(key);
 
   if (!counted) {
@@ -320,10 +323,10 @@ function countInstanceRecord(instance: ExtensionInstance, delta: 1 | -1) {
     configExtensionRecordCounts.set(key, {
       count: 1,
       record: {
-        slotModuleName: instance.slotModuleName,
-        extensionModuleName: instance.extensionModuleName,
-        slotName: instance.slotName,
-        extensionId: instance.id,
+        slotModuleName: rendering.slotModuleName,
+        extensionModuleName: rendering.extensionModuleName,
+        slotName: rendering.slotName,
+        extensionId: rendering.id,
       },
     });
 
@@ -340,11 +343,11 @@ function countInstanceRecord(instance: ExtensionInstance, delta: 1 | -1) {
   return false;
 }
 
-function rebuildConfigExtensionRecords(instances: ReadonlyMap<string, ExtensionInstance>) {
+function rebuildConfigExtensionRecords(renderings: ReadonlyMap<string, ExtensionRendering>) {
   configExtensionRecordCounts.clear();
 
-  for (const instance of instances.values()) {
-    countInstanceRecord(instance, 1);
+  for (const rendering of renderings.values()) {
+    countRenderingRecord(rendering, 1);
   }
 
   configExtensionRecordsChanged = true;
@@ -352,7 +355,7 @@ function rebuildConfigExtensionRecords(instances: ReadonlyMap<string, ExtensionI
 
 function updateConfigExtensionStoreToCurrent() {
   // Catches a write that bypassed the helpers above, which has to rebuild the counts.
-  currentInstances();
+  currentRenderings();
 
   if (!configExtensionRecordsChanged) {
     return;
@@ -362,7 +365,7 @@ function updateConfigExtensionStoreToCurrent() {
 
   const configExtensionRecords = Array.from(configExtensionRecordCounts.values(), ({ record }) => record);
   // Compared as an array, so an unstable order would look like a change and trigger a full config
-  // recomputation every time an instance is remounted in a different position.
+  // recomputation every time a rendering is remounted in a different position.
   configExtensionRecords.sort(compareConfigExtensionRecords);
 
   if (!isEqual(configExtensionStore.getState().mountedExtensions, configExtensionRecords)) {

--- a/packages/framework/esm-extensions/src/store.ts
+++ b/packages/framework/esm-extensions/src/store.ts
@@ -22,24 +22,47 @@ export interface ExtensionRegistration {
   readonly displayExpression?: string;
 }
 
-export interface ExtensionInfo extends ExtensionRegistration {
-  /**
-   * The instances where the extension has been rendered using `renderExtension`.
-   */
-  instances: Array<ExtensionInstance>;
-}
+/**
+ * @deprecated Use `ExtensionRegistration`, which this aliases. Rendered instances are not
+ *   reachable from a registration; they are tracked separately.
+ */
+export type ExtensionInfo = ExtensionRegistration;
 
+/**
+ * A single rendering of an extension into a slot. One registered extension can have any number
+ * of these at a time — the same extension may be mounted into several slots, or into several
+ * simultaneously-rendered copies of the same slot.
+ */
 export interface ExtensionInstance {
-  id: string;
-  slotName: string;
-  slotModuleName: string;
+  /** Uniquely identifies this rendering. Never reused. */
+  readonly instanceId: string;
+  /** The name of the extension being rendered. */
+  readonly extensionName: string;
+  /** The module which registered the extension. */
+  readonly extensionModuleName: string;
+  /** The extension ID, which is the extension name plus an optional `#`-suffix. */
+  readonly id: string;
+  readonly slotName: string;
+  readonly slotModuleName: string;
 }
 
 export interface ExtensionInternalStore {
   /** Slots indexed by name */
   slots: Record<string, ExtensionSlotInfo>;
-  /** Extensions indexed by name */
-  extensions: Record<string, ExtensionInfo>;
+  /** Extension registrations indexed by name */
+  extensions: Record<string, ExtensionRegistration>;
+}
+
+export interface ExtensionInstancesStore {
+  /**
+   * Currently-rendered extension instances, indexed by instance ID.
+   *
+   * The map is mutated in place as extensions mount and unmount — an application routinely renders
+   * thousands of instances at once, and copying them all on every mount is quadratic over a page's
+   * lifetime. Read it during render, as a store consumer does; a reference held across a change
+   * reflects the new contents rather than the state it was read from.
+   */
+  instances: ReadonlyMap<string, ExtensionInstance>;
 }
 
 export type ExtensionSlotCustomState = Record<string | symbol | number, unknown> | undefined | null;
@@ -84,6 +107,13 @@ export interface AssignedExtension {
   readonly online?: boolean | object;
   readonly offline?: boolean | object;
   readonly featureFlag?: string;
+  /**
+   * The condition under which this extension should be displayed, if it has one. Unresolved: a
+   * slot can be rendered several times at once with different state, so the condition can only be
+   * evaluated against the state of a particular rendering. Pass these extensions through
+   * `filterExtensionsByDisplayConditions` with that state before displaying them.
+   */
+  readonly displayConditionExpression?: string;
 }
 
 /** @deprecated replaced with AssignedExtension */
@@ -101,6 +131,10 @@ const extensionInternalStore = createGlobalStore<ExtensionInternalStore>('extens
   extensions: {},
 });
 
+const extensionInstancesStore = createGlobalStore<ExtensionInstancesStore>('extensionInstances', {
+  instances: new Map(),
+});
+
 /**
  * This gets the extension system's internal store. It is subject
  * to change radically and without warning. It should not be used
@@ -113,15 +147,82 @@ export const getExtensionInternalStore = () =>
     extensions: {},
   });
 
+/**
+ * This gets the store of currently-rendered extension instances. Instances are added by
+ * `renderExtension` and removed once their parcel is gone — whether it unmounted, failed to load,
+ * or failed to mount. It is subject to change radically and without warning. It should not be
+ * used outside esm-core.
+ * @internal
+ */
+export const getExtensionInstancesStore = () =>
+  getGlobalStore<ExtensionInstancesStore>('extensionInstances', {
+    instances: new Map(),
+  });
+
 /** @internal */
 export function updateInternalExtensionStore(updater: (state: ExtensionInternalStore) => ExtensionInternalStore) {
-  // This is a function that updates the internal extension store.
+  // The guard below is what makes a no-op updater free: an updater that returns the state it was
+  // given never reaches `setState`, so no subscriber runs.
   const state = extensionInternalStore.getState();
   const newState = updater(state);
 
   if (newState !== state) {
     extensionInternalStore.setState(newState);
   }
+}
+
+/**
+ * The instance map this module owns and mutates, and the state object it last published. Comparing
+ * the store's current state against that is how a write from anywhere else — a test reset, say — is
+ * detected, so the map and the record counts below can be rebuilt from it.
+ */
+let ownedInstances: Map<string, ExtensionInstance> | null = null;
+let publishedInstances: ExtensionInstancesStore | null = null;
+
+function currentInstances() {
+  const state = extensionInstancesStore.getState();
+
+  if (!ownedInstances || state !== publishedInstances) {
+    // Tolerates a plain object as well as a map: this store is reset by test harnesses, and a
+    // throw here would escape from inside a `setState` call.
+    ownedInstances = new Map(state.instances instanceof Map ? state.instances : Object.entries(state.instances ?? {}));
+    publishedInstances = state;
+    rebuildConfigExtensionRecords(ownedInstances);
+  }
+
+  return ownedInstances;
+}
+
+function publishInstances(instances: Map<string, ExtensionInstance>) {
+  publishedInstances = { instances };
+  extensionInstancesStore.setState(publishedInstances, true);
+}
+
+/** @internal */
+export function registerExtensionInstance(instance: ExtensionInstance) {
+  const instances = currentInstances();
+
+  if (instances.has(instance.instanceId)) {
+    return;
+  }
+
+  instances.set(instance.instanceId, instance);
+  configExtensionRecordsChanged = countInstanceRecord(instance, 1) || configExtensionRecordsChanged;
+  publishInstances(instances);
+}
+
+/** @internal */
+export function unregisterExtensionInstance(instanceId: string) {
+  const instances = currentInstances();
+  const instance = instances.get(instanceId);
+
+  if (!instance) {
+    return;
+  }
+
+  instances.delete(instanceId);
+  configExtensionRecordsChanged = countInstanceRecord(instance, -1) || configExtensionRecordsChanged;
+  publishInstances(instances);
 }
 
 /**
@@ -133,32 +234,149 @@ export const getExtensionStore = () =>
     slots: {},
   });
 
+let batchDepth = 0;
+const pendingRecomputations = new Set<() => void>();
+
 /**
- * esm-config maintains its own store of the extension information it needs
- * to generate extension configs. We keep it updated based on what's in
- * `extensionStore`.
+ * Recomputing the extension system's derived state is eager: each write to one of its input
+ * stores immediately re-derives the output store and the config bridge. `batchExtensionUpdates`
+ * defers that work until `fn` returns, so a burst of related writes — registering all of an
+ * app's extensions, say — costs one recomputation rather than one per write.
+ *
+ * Calls nest, and only the outermost one flushes. `fn` must be synchronous: the batch ends when
+ * `fn` returns, so anything written after an `await` is not batched.
  */
+export function batchExtensionUpdates<T>(fn: () => T): T {
+  batchDepth++;
 
-updateConfigExtensionStore(extensionInternalStore.getState());
-extensionInternalStore.subscribe(updateConfigExtensionStore);
+  try {
+    return fn();
+  } finally {
+    batchDepth--;
 
-function updateConfigExtensionStore(extensionState: ExtensionInternalStore) {
-  const configExtensionRecords: Array<ConfigExtensionStoreElement> = [];
+    if (batchDepth === 0 && pendingRecomputations.size > 0) {
+      const pending = Array.from(pendingRecomputations);
+      pendingRecomputations.clear();
 
-  for (let extensionInfo of Object.values(extensionState.extensions)) {
-    for (let instance of extensionInfo.instances) {
-      configExtensionRecords.push({
-        slotModuleName: instance.slotModuleName,
-        extensionModuleName: extensionInfo.moduleName,
-        slotName: instance.slotName,
-        extensionId: instance.id,
-      });
+      for (const recompute of pending) {
+        // Isolated so one failure doesn't drop the recomputations queued behind it, and so an
+        // exception here can't escape the `finally` and replace one thrown by `fn` itself.
+        try {
+          recompute();
+        } catch (e) {
+          console.error(`The extension system's '${recompute.name}' recomputation failed`, e);
+        }
+      }
     }
   }
+}
+
+/**
+ * Runs `recompute` now, or defers it to the end of the enclosing `batchExtensionUpdates` call.
+ * Deferred callbacks are de-duplicated, so a batch ends in one pass per derived target.
+ * @internal
+ */
+export function scheduleRecomputation(recompute: () => void) {
+  if (batchDepth > 0) {
+    pendingRecomputations.add(recompute);
+  } else {
+    recompute();
+  }
+}
+
+/**
+ * esm-config maintains its own store of the extension information it needs
+ * to generate extension configs. We keep it updated based on which extension
+ * instances are currently rendered.
+ */
+
+/**
+ * The config system derives one config per slot and extension, so any number of rendered instances
+ * of the same extension in the same slot collapse into a single record. These counts track how many
+ * instances stand behind each record.
+ *
+ * They are maintained as instances come and go rather than rebuilt from the instances store, because
+ * an application routinely has thousands of instances rendered at once: rebuilding would make every
+ * mount and unmount cost a walk over all of them, where this way rendering another copy of a slot
+ * already on screen costs nothing.
+ */
+const configExtensionRecordCounts = new Map<string, { count: number; record: ConfigExtensionStoreElement }>();
+
+let configExtensionRecordsChanged = false;
+
+updateConfigExtensionStoreToCurrent();
+extensionInstancesStore.subscribe(() => scheduleRecomputation(updateConfigExtensionStoreToCurrent));
+
+/** @returns whether the set of records changed, rather than just the count behind one of them. */
+function countInstanceRecord(instance: ExtensionInstance, delta: 1 | -1) {
+  const key = [instance.slotName, instance.id, instance.slotModuleName, instance.extensionModuleName].join(' ');
+  const counted = configExtensionRecordCounts.get(key);
+
+  if (!counted) {
+    if (delta < 0) {
+      return false;
+    }
+
+    configExtensionRecordCounts.set(key, {
+      count: 1,
+      record: {
+        slotModuleName: instance.slotModuleName,
+        extensionModuleName: instance.extensionModuleName,
+        slotName: instance.slotName,
+        extensionId: instance.id,
+      },
+    });
+
+    return true;
+  }
+
+  counted.count += delta;
+
+  if (counted.count < 1) {
+    configExtensionRecordCounts.delete(key);
+    return true;
+  }
+
+  return false;
+}
+
+function rebuildConfigExtensionRecords(instances: ReadonlyMap<string, ExtensionInstance>) {
+  configExtensionRecordCounts.clear();
+
+  for (const instance of instances.values()) {
+    countInstanceRecord(instance, 1);
+  }
+
+  configExtensionRecordsChanged = true;
+}
+
+function updateConfigExtensionStoreToCurrent() {
+  // Catches a write that bypassed the helpers above, which has to rebuild the counts.
+  currentInstances();
+
+  if (!configExtensionRecordsChanged) {
+    return;
+  }
+
+  configExtensionRecordsChanged = false;
+
+  const configExtensionRecords = Array.from(configExtensionRecordCounts.values(), ({ record }) => record);
+  // Compared as an array, so an unstable order would look like a change and trigger a full config
+  // recomputation every time an instance is remounted in a different position.
+  configExtensionRecords.sort(compareConfigExtensionRecords);
 
   if (!isEqual(configExtensionStore.getState().mountedExtensions, configExtensionRecords)) {
     configExtensionStore.setState({
       mountedExtensions: configExtensionRecords,
     });
   }
+}
+
+function compareConfigExtensionRecords(a: ConfigExtensionStoreElement, b: ConfigExtensionStoreElement) {
+  return (
+    a.slotName.localeCompare(b.slotName, 'en') ||
+    a.extensionId.localeCompare(b.extensionId, 'en') ||
+    a.slotModuleName.localeCompare(b.slotModuleName, 'en') ||
+    a.extensionModuleName.localeCompare(b.extensionModuleName, 'en')
+  );
 }

--- a/packages/framework/esm-framework/docs/functions/attach.md
+++ b/packages/framework/esm-framework/docs/functions/attach.md
@@ -4,7 +4,7 @@
 
 > **attach**(`slotName`, `extensionId`): `void`
 
-Defined in: [packages/framework/esm-extensions/src/extensions.ts:222](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L222)
+Defined in: [packages/framework/esm-extensions/src/extensions.ts:309](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L309)
 
 Attach an extension to an extension slot.
 

--- a/packages/framework/esm-framework/docs/functions/createUseStore.md
+++ b/packages/framework/esm-framework/docs/functions/createUseStore.md
@@ -4,7 +4,7 @@
 
 > **createUseStore**\<`T`\>(`store`): \{(): `T`; \<`A`\>(`actions`): `T` & [`BoundActions`](../type-aliases/BoundActions.md)\<`T`, `A`\>; \<`A`\>(`actions?`): `T` & [`BoundActions`](../type-aliases/BoundActions.md)\<`T`, `A`\>; \}
 
-Defined in: [packages/framework/esm-react-utils/src/useStore.ts:104](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useStore.ts#L104)
+Defined in: [packages/framework/esm-react-utils/src/useStore.ts:111](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useStore.ts#L111)
 
 Whenever possible, use `useStore(yourStore)` instead. This function is for creating a
 custom hook for a specific store.

--- a/packages/framework/esm-framework/docs/functions/defineConfigSchema.md
+++ b/packages/framework/esm-framework/docs/functions/defineConfigSchema.md
@@ -4,7 +4,7 @@
 
 > **defineConfigSchema**(`moduleName`, `schema`): `void`
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:190](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L190)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:312](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L312)
 
 This defines a configuration schema for a module. The schema tells the
 configuration system how the module can be configured. It specifies

--- a/packages/framework/esm-framework/docs/functions/defineExtensionConfigSchema.md
+++ b/packages/framework/esm-framework/docs/functions/defineExtensionConfigSchema.md
@@ -4,7 +4,7 @@
 
 > **defineExtensionConfigSchema**(`extensionName`, `schema`): `void`
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:266](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L266)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:388](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L388)
 
 This defines a configuration schema for an extension. When a schema is defined
 for an extension, that extension will receive the configuration corresponding

--- a/packages/framework/esm-framework/docs/functions/detach.md
+++ b/packages/framework/esm-framework/docs/functions/detach.md
@@ -4,7 +4,7 @@
 
 > **detach**(`extensionSlotName`, `extensionId`): `void`
 
-Defined in: [packages/framework/esm-extensions/src/extensions.ts:260](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L260)
+Defined in: [packages/framework/esm-extensions/src/extensions.ts:347](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L347)
 
 Detaches an extension from an extension slot.
 

--- a/packages/framework/esm-framework/docs/functions/detachAll.md
+++ b/packages/framework/esm-framework/docs/functions/detachAll.md
@@ -4,7 +4,7 @@
 
 > **detachAll**(`extensionSlotName`): `void`
 
-Defined in: [packages/framework/esm-extensions/src/extensions.ts:288](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L288)
+Defined in: [packages/framework/esm-extensions/src/extensions.ts:375](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L375)
 
 Detaches all extensions from an extension slot.
 

--- a/packages/framework/esm-framework/docs/functions/getAssignedExtensions.md
+++ b/packages/framework/esm-framework/docs/functions/getAssignedExtensions.md
@@ -2,11 +2,17 @@
 
 # Function: getAssignedExtensions()
 
-> **getAssignedExtensions**(`slotName`): [`AssignedExtension`](../interfaces/AssignedExtension.md)[]
+> **getAssignedExtensions**(`slotName`, `state?`): [`AssignedExtension`](../interfaces/AssignedExtension.md)[]
 
-Defined in: [packages/framework/esm-extensions/src/extensions.ts:430](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L430)
+Defined in: [packages/framework/esm-extensions/src/extensions.ts:554](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L554)
 
-Gets the list of extensions assigned to a given slot
+Gets the extensions a given rendering of a slot should display, in order. This is the supported
+way to ask what belongs in a slot; reading the extension store directly skips display conditions.
+
+Display conditions are evaluated against `state`, so pass whatever the slot is being rendered
+for. The same slot can be rendered many times with different state — once per row of a table,
+say — and each rendering can resolve to a different set of extensions. Omitting `state` hides
+every extension whose condition refers to it, since the condition cannot be evaluated.
 
 ## Parameters
 
@@ -14,10 +20,16 @@ Gets the list of extensions assigned to a given slot
 
 `string`
 
-The slot to load the assigned extensions for
+The slot to load the extensions for
+
+### state?
+
+[`ExtensionSlotCustomState`](../type-aliases/ExtensionSlotCustomState.md)
+
+The state of the rendering of the slot the extensions will be displayed in
 
 ## Returns
 
 [`AssignedExtension`](../interfaces/AssignedExtension.md)[]
 
-An array of extensions assigned to the named slot
+Those extensions assigned to the slot whose display conditions hold

--- a/packages/framework/esm-framework/docs/functions/getConfig.md
+++ b/packages/framework/esm-framework/docs/functions/getConfig.md
@@ -4,7 +4,7 @@
 
 > **getConfig**\<`T`\>(`moduleName`): `Promise`\<`T`\>
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:308](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L308)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:461](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L461)
 
 A promise-based way to access the config as soon as it is fully loaded.
 If it is already loaded, resolves the config in its present state.

--- a/packages/framework/esm-framework/docs/functions/getExtensionNameFromId.md
+++ b/packages/framework/esm-framework/docs/functions/getExtensionNameFromId.md
@@ -4,7 +4,7 @@
 
 > **getExtensionNameFromId**(`extensionId`): `string`
 
-Defined in: [packages/framework/esm-extensions/src/extensions.ts:170](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L170)
+Defined in: [packages/framework/esm-extensions/src/extensions.ts:257](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/extensions.ts#L257)
 
 Given an extension ID, which is a string uniquely identifying
 an instance of an extension within an extension slot, this

--- a/packages/framework/esm-framework/docs/functions/getExtensionStore.md
+++ b/packages/framework/esm-framework/docs/functions/getExtensionStore.md
@@ -4,7 +4,7 @@
 
 > **getExtensionStore**(): `StoreApi`\<[`ExtensionStore`](../interfaces/ExtensionStore.md)\>
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:131](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L131)
+Defined in: [packages/framework/esm-extensions/src/store.ts:236](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L236)
 
 This returns a store that modules can use to get information about the
 state of the extension system.

--- a/packages/framework/esm-framework/docs/functions/provide.md
+++ b/packages/framework/esm-framework/docs/functions/provide.md
@@ -4,7 +4,7 @@
 
 > **provide**(`config`, `sourceName`): `void`
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:292](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L292)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:414](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L414)
 
 Provides configuration values programmatically. This is an alternative to
 providing configuration through the config-file. Configuration provided this

--- a/packages/framework/esm-framework/docs/functions/renderExtension.md
+++ b/packages/framework/esm-framework/docs/functions/renderExtension.md
@@ -4,7 +4,7 @@
 
 > **renderExtension**(`domElement`, `extensionSlotName`, `extensionSlotModuleName`, `extensionId`, `renderFunction`, `additionalProps`): `Promise`\<`null` \| `Parcel`\>
 
-Defined in: [packages/framework/esm-extensions/src/render.ts:136](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L136)
+Defined in: [packages/framework/esm-extensions/src/render.ts:164](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L164)
 
 Mounts into a DOM node (representing an extension slot)
 a lazy-loaded component from *any* frontend module

--- a/packages/framework/esm-framework/docs/functions/showModal.md
+++ b/packages/framework/esm-framework/docs/functions/showModal.md
@@ -4,7 +4,7 @@
 
 > **showModal**(`modalName`, `props`, `onClose`): () => `void`
 
-Defined in: [packages/framework/esm-styleguide/src/modals/index.tsx:200](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/modals/index.tsx#L200)
+Defined in: [packages/framework/esm-styleguide/src/modals/index.tsx:293](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-styleguide/src/modals/index.tsx#L293)
 
 Shows a modal dialog.
 

--- a/packages/framework/esm-framework/docs/functions/useAssignedExtensionIds.md
+++ b/packages/framework/esm-framework/docs/functions/useAssignedExtensionIds.md
@@ -4,10 +4,9 @@
 
 > **useAssignedExtensionIds**(`slotName`): `string`[]
 
-Defined in: [packages/framework/esm-react-utils/src/useAssignedExtensionIds.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useAssignedExtensionIds.ts#L13)
+Defined in: [packages/framework/esm-react-utils/src/useAssignedExtensionIds.ts:12](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useAssignedExtensionIds.ts#L12)
 
 Gets the assigned extension ids for a given extension slot name.
-Does not consider if offline or online.
 
 ## Parameters
 

--- a/packages/framework/esm-framework/docs/functions/useAssignedExtensions.md
+++ b/packages/framework/esm-framework/docs/functions/useAssignedExtensions.md
@@ -2,11 +2,20 @@
 
 # Function: useAssignedExtensions()
 
-> **useAssignedExtensions**(`slotName`): [`AssignedExtension`](../interfaces/AssignedExtension.md)[]
+> **useAssignedExtensions**(`slotName`, `state?`): [`AssignedExtension`](../interfaces/AssignedExtension.md)[]
 
-Defined in: [packages/framework/esm-react-utils/src/useAssignedExtensions.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useAssignedExtensions.ts#L8)
+Defined in: [packages/framework/esm-react-utils/src/useAssignedExtensions.ts:26](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useAssignedExtensions.ts#L26)
 
 Gets the assigned extensions for a given extension slot name.
+
+The reactive form of `getAssignedExtensions`, and it answers the same thing: display conditions
+are always applied, so the result is what should actually be displayed. Pass `state` whenever you
+know it: the same slot can be rendered in several places at once with different state, so
+conditions are resolved against the state of this rendering. Omitting it resolves them against
+the session alone, hiding any extension whose condition depends on state.
+
+The returned array is a copy, so sorting or filtering it in place can't corrupt the extension
+store. Its reference is stable for as long as the slot's extensions, the state and the session are.
 
 ## Parameters
 
@@ -15,6 +24,12 @@ Gets the assigned extensions for a given extension slot name.
 `string`
 
 The name of the slot to get the assigned extensions for.
+
+### state?
+
+[`ExtensionSlotCustomState`](../type-aliases/ExtensionSlotCustomState.md)
+
+The state of this rendering of the slot.
 
 ## Returns
 

--- a/packages/framework/esm-framework/docs/functions/useExtensionSlotStore.md
+++ b/packages/framework/esm-framework/docs/functions/useExtensionSlotStore.md
@@ -4,7 +4,7 @@
 
 > **useExtensionSlotStore**(`slot`): [`ExtensionSlotState`](../interfaces/ExtensionSlotState.md)
 
-Defined in: [packages/framework/esm-react-utils/src/useExtensionSlotStore.ts:5](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useExtensionSlotStore.ts#L5)
+Defined in: [packages/framework/esm-react-utils/src/useExtensionSlotStore.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useExtensionSlotStore.ts#L22)
 
 ## Parameters
 

--- a/packages/framework/esm-framework/docs/functions/useStore.md
+++ b/packages/framework/esm-framework/docs/functions/useStore.md
@@ -6,7 +6,7 @@
 
 > **useStore**\<`T`\>(`store`): `T`
 
-Defined in: [packages/framework/esm-react-utils/src/useStore.ts:52](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useStore.ts#L52)
+Defined in: [packages/framework/esm-react-utils/src/useStore.ts:56](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useStore.ts#L56)
 
 ### Type Parameters
 
@@ -28,7 +28,7 @@ Defined in: [packages/framework/esm-react-utils/src/useStore.ts:52](https://gith
 
 > **useStore**\<`T`, `U`\>(`store`, `select`): `U`
 
-Defined in: [packages/framework/esm-react-utils/src/useStore.ts:53](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useStore.ts#L53)
+Defined in: [packages/framework/esm-react-utils/src/useStore.ts:57](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useStore.ts#L57)
 
 ### Type Parameters
 
@@ -58,7 +58,7 @@ Defined in: [packages/framework/esm-react-utils/src/useStore.ts:53](https://gith
 
 > **useStore**\<`T`, `U`, `A`\>(`store`, `select`, `actions`): `T` & [`BoundActions`](../type-aliases/BoundActions.md)\<`T`, `A`\>
 
-Defined in: [packages/framework/esm-react-utils/src/useStore.ts:54](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useStore.ts#L54)
+Defined in: [packages/framework/esm-react-utils/src/useStore.ts:58](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useStore.ts#L58)
 
 ### Type Parameters
 
@@ -96,7 +96,7 @@ Defined in: [packages/framework/esm-react-utils/src/useStore.ts:54](https://gith
 
 > **useStore**\<`T`, `U`, `A`\>(`store`, `select`, `actions`): `U` & [`BoundActions`](../type-aliases/BoundActions.md)\<`T`, `A`\>
 
-Defined in: [packages/framework/esm-react-utils/src/useStore.ts:59](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useStore.ts#L59)
+Defined in: [packages/framework/esm-react-utils/src/useStore.ts:63](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useStore.ts#L63)
 
 ### Type Parameters
 

--- a/packages/framework/esm-framework/docs/functions/useStoreWithActions.md
+++ b/packages/framework/esm-framework/docs/functions/useStoreWithActions.md
@@ -4,7 +4,7 @@
 
 > **useStoreWithActions**\<`T`, `A`\>(`store`, `actions`): `T` & [`BoundActions`](../type-aliases/BoundActions.md)\<`T`, `A`\>
 
-Defined in: [packages/framework/esm-react-utils/src/useStore.ts:96](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useStore.ts#L96)
+Defined in: [packages/framework/esm-react-utils/src/useStore.ts:103](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useStore.ts#L103)
 
 ## Type Parameters
 

--- a/packages/framework/esm-framework/docs/interfaces/AssignedExtension.md
+++ b/packages/framework/esm-framework/docs/interfaces/AssignedExtension.md
@@ -2,7 +2,7 @@
 
 # Interface: AssignedExtension
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:77](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L77)
+Defined in: [packages/framework/esm-extensions/src/store.ts:112](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L112)
 
 ## Properties
 
@@ -10,9 +10,19 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:77](https://github.c
 
 > `readonly` **config**: `null` \| `Readonly`\<[`ConfigObject`](ConfigObject.md)\>
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:83](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L83)
+Defined in: [packages/framework/esm-extensions/src/store.ts:118](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L118)
 
 The extension's config. Note that this will be `null` until the slot is mounted.
+
+***
+
+### displayConditionExpression?
+
+> `readonly` `optional` **displayConditionExpression**: `string`
+
+Defined in: [packages/framework/esm-extensions/src/store.ts:123](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L123)
+
+The condition under which this extension should be displayed.
 
 ***
 
@@ -20,7 +30,7 @@ The extension's config. Note that this will be `null` until the slot is mounted.
 
 > `readonly` `optional` **featureFlag**: `string`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:86](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L86)
+Defined in: [packages/framework/esm-extensions/src/store.ts:121](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L121)
 
 ***
 
@@ -28,7 +38,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:86](https://github.c
 
 > `readonly` **id**: `string`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:78](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L78)
+Defined in: [packages/framework/esm-extensions/src/store.ts:113](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L113)
 
 ***
 
@@ -36,7 +46,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:78](https://github.c
 
 > `readonly` **meta**: `Readonly`\<[`ExtensionMeta`](ExtensionMeta.md)\>
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:81](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L81)
+Defined in: [packages/framework/esm-extensions/src/store.ts:116](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L116)
 
 ***
 
@@ -44,7 +54,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:81](https://github.c
 
 > `readonly` **moduleName**: `string`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:80](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L80)
+Defined in: [packages/framework/esm-extensions/src/store.ts:115](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L115)
 
 ***
 
@@ -52,7 +62,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:80](https://github.c
 
 > `readonly` **name**: `string`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:79](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L79)
+Defined in: [packages/framework/esm-extensions/src/store.ts:114](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L114)
 
 ***
 
@@ -60,7 +70,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:79](https://github.c
 
 > `readonly` `optional` **offline**: `boolean` \| `object`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:85](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L85)
+Defined in: [packages/framework/esm-extensions/src/store.ts:120](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L120)
 
 ***
 
@@ -68,4 +78,4 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:85](https://github.c
 
 > `readonly` `optional` **online**: `boolean` \| `object`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:84](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L84)
+Defined in: [packages/framework/esm-extensions/src/store.ts:119](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L119)

--- a/packages/framework/esm-framework/docs/interfaces/CancelLoading.md
+++ b/packages/framework/esm-framework/docs/interfaces/CancelLoading.md
@@ -2,11 +2,11 @@
 
 # Interface: CancelLoading()
 
-Defined in: [packages/framework/esm-extensions/src/render.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L14)
+Defined in: [packages/framework/esm-extensions/src/render.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L15)
 
 > **CancelLoading**(): `void`
 
-Defined in: [packages/framework/esm-extensions/src/render.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L15)
+Defined in: [packages/framework/esm-extensions/src/render.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L16)
 
 ## Returns
 

--- a/packages/framework/esm-framework/docs/interfaces/ConnectedExtension.md
+++ b/packages/framework/esm-framework/docs/interfaces/ConnectedExtension.md
@@ -2,7 +2,7 @@
 
 # Interface: ~~ConnectedExtension~~
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:90](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L90)
+Defined in: [packages/framework/esm-extensions/src/store.ts:127](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L127)
 
 ## Deprecated
 
@@ -14,7 +14,7 @@ replaced with AssignedExtension
 
 > `readonly` **config**: `null` \| `Readonly`\<[`ConfigObject`](ConfigObject.md)\>
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:96](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L96)
+Defined in: [packages/framework/esm-extensions/src/store.ts:133](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L133)
 
 The extension's config. Note that this will be `null` until the slot is mounted.
 
@@ -24,7 +24,7 @@ The extension's config. Note that this will be `null` until the slot is mounted.
 
 > `readonly` **id**: `string`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:91](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L91)
+Defined in: [packages/framework/esm-extensions/src/store.ts:128](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L128)
 
 ***
 
@@ -32,7 +32,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:91](https://github.c
 
 > `readonly` **meta**: `Readonly`\<[`ExtensionMeta`](ExtensionMeta.md)\>
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:94](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L94)
+Defined in: [packages/framework/esm-extensions/src/store.ts:131](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L131)
 
 ***
 
@@ -40,7 +40,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:94](https://github.c
 
 > `readonly` **moduleName**: `string`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:93](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L93)
+Defined in: [packages/framework/esm-extensions/src/store.ts:130](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L130)
 
 ***
 
@@ -48,4 +48,4 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:93](https://github.c
 
 > `readonly` **name**: `string`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:92](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L92)
+Defined in: [packages/framework/esm-extensions/src/store.ts:129](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L129)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionMeta.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionMeta.md
@@ -2,7 +2,7 @@
 
 # Interface: ExtensionMeta
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L8)
+Defined in: [packages/framework/esm-extensions/src/store.ts:7](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L7)
 
 ## Indexable
 

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionRegistration.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionRegistration.md
@@ -2,7 +2,7 @@
 
 # Interface: ExtensionRegistration
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:12](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L12)
+Defined in: [packages/framework/esm-extensions/src/store.ts:11](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L11)
 
 ## Properties
 
@@ -10,7 +10,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:12](https://github.c
 
 > `readonly` `optional` **displayExpression**: `string`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:22](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L22)
+Defined in: [packages/framework/esm-extensions/src/store.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L21)
 
 ***
 
@@ -18,7 +18,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:22](https://github.c
 
 > `readonly` `optional` **featureFlag**: `string`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:21](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L21)
+Defined in: [packages/framework/esm-extensions/src/store.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L20)
 
 ***
 
@@ -26,7 +26,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:21](https://github.c
 
 > `readonly` **meta**: `Readonly`\<[`ExtensionMeta`](ExtensionMeta.md)\>
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L16)
+Defined in: [packages/framework/esm-extensions/src/store.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L15)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:16](https://github.c
 
 > `readonly` **moduleName**: `string`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L15)
+Defined in: [packages/framework/esm-extensions/src/store.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L14)
 
 ***
 
@@ -42,7 +42,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:15](https://github.c
 
 > `readonly` **name**: `string`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L13)
+Defined in: [packages/framework/esm-extensions/src/store.ts:12](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L12)
 
 ***
 
@@ -50,7 +50,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:13](https://github.c
 
 > `readonly` `optional` **offline**: `boolean`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L19)
+Defined in: [packages/framework/esm-extensions/src/store.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L18)
 
 ***
 
@@ -58,7 +58,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:19](https://github.c
 
 > `readonly` `optional` **online**: `boolean`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L18)
+Defined in: [packages/framework/esm-extensions/src/store.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L17)
 
 ***
 
@@ -66,7 +66,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:18](https://github.c
 
 > `readonly` `optional` **order**: `number`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:17](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L17)
+Defined in: [packages/framework/esm-extensions/src/store.ts:16](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L16)
 
 ***
 
@@ -74,7 +74,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:17](https://github.c
 
 > `readonly` `optional` **privileges**: `string` \| `string`[]
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:20](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L20)
+Defined in: [packages/framework/esm-extensions/src/store.ts:19](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L19)
 
 ## Methods
 
@@ -82,7 +82,7 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:20](https://github.c
 
 > **load**(): `Promise`\<`LifeCycles`\>
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L14)
+Defined in: [packages/framework/esm-extensions/src/store.ts:13](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L13)
 
 #### Returns
 

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionSlotState.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionSlotState.md
@@ -2,15 +2,18 @@
 
 # Interface: ExtensionSlotState
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:71](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L71)
+Defined in: [packages/framework/esm-extensions/src/store.ts:103](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L103)
 
 ## Properties
 
-### assignedExtensions
+### candidateExtensions
 
-> **assignedExtensions**: [`AssignedExtension`](AssignedExtension.md)[]
+> **candidateExtensions**: [`AssignedExtension`](AssignedExtension.md)[]
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:73](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L73)
+Defined in: [packages/framework/esm-extensions/src/store.ts:109](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L109)
+
+Candidates only. Call `getAssignedExtensions()` for the extensions a given rendering of
+this slot should actually display.
 
 ***
 
@@ -18,12 +21,4 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:73](https://github.c
 
 > `optional` **moduleName**: `string`
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:72](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L72)
-
-***
-
-### state?
-
-> `optional` **state**: `ExtensionSlotCustomState`
-
-Defined in: [packages/framework/esm-extensions/src/store.ts:74](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L74)
+Defined in: [packages/framework/esm-extensions/src/store.ts:104](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L104)

--- a/packages/framework/esm-framework/docs/interfaces/ExtensionStore.md
+++ b/packages/framework/esm-framework/docs/interfaces/ExtensionStore.md
@@ -2,7 +2,7 @@
 
 # Interface: ExtensionStore
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:67](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L67)
+Defined in: [packages/framework/esm-extensions/src/store.ts:99](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L99)
 
 ## Properties
 
@@ -10,4 +10,4 @@ Defined in: [packages/framework/esm-extensions/src/store.ts:67](https://github.c
 
 > **slots**: `Record`\<`string`, [`ExtensionSlotState`](ExtensionSlotState.md)\>
 
-Defined in: [packages/framework/esm-extensions/src/store.ts:68](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L68)
+Defined in: [packages/framework/esm-extensions/src/store.ts:100](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L100)

--- a/packages/framework/esm-framework/docs/type-aliases/ExtensionSlotCustomState.md
+++ b/packages/framework/esm-framework/docs/type-aliases/ExtensionSlotCustomState.md
@@ -1,0 +1,11 @@
+[O3 Framework](../API.md) / ExtensionSlotCustomState
+
+# Type Alias: ExtensionSlotCustomState
+
+> **ExtensionSlotCustomState** = `Record`\<`string`, `unknown`\> \| `undefined`
+
+Defined in: [packages/framework/esm-extensions/src/store.ts:80](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/store.ts#L80)
+
+The state one rendering of a slot is displaying, which its extensions' display conditions are
+evaluated against. Each key becomes a variable of that name in the expression, so only string
+keys are reachable from a condition.

--- a/packages/framework/esm-framework/src/integration-tests/extension-config-expressions.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-config-expressions.test.tsx
@@ -7,7 +7,7 @@ import { type Person } from '@openmrs/esm-api';
 import { mockSessionStore } from '@openmrs/esm-api/mock';
 import {
   attach,
-  getExtensionInstancesStore,
+  getExtensionRenderingsStore,
   registerExtension,
   updateInternalExtensionStore,
 } from '../../../esm-extensions/src';
@@ -46,9 +46,10 @@ vi.mock('@openmrs/esm-api', async () => {
  */
 describe('Expression evaluation in extension display conditions', () => {
   beforeEach(() => {
-    // An instance outliving its module's schema makes the config system derive a config for an
+    // A rendering outliving its module's schema makes the config system derive a config for an
     // extension this test never registered.
-    getExtensionInstancesStore().setState({ instances: new Map() });
+    // eslint-disable-next-line testing-library/no-render-in-lifecycle -- not a render; the rule matches any callee name containing "render"
+    getExtensionRenderingsStore().setState({ renderings: new Map() });
     temporaryConfigStore.setState({ config: {} });
     configInternalStore.setState({ providedConfigs: [], schemas: {}, moduleLoaded: {} });
     mockSessionStore.setState({});
@@ -233,7 +234,7 @@ describe('Expression evaluation in extension display conditions', () => {
     });
   }, 10000);
 
-  it('evaluates a display condition against each slot instance own state', async () => {
+  it('evaluates a display condition against each rendering of a slot', async () => {
     registerExtension({
       name: 'Always',
       moduleName: 'esm-bedrock',
@@ -259,7 +260,7 @@ describe('Expression evaluation in extension display conditions', () => {
     attach('rows-slot', 'Flagged');
 
     // A virtualized list renders the same slot once per row, each with its own patient. The slot
-    // is not "a place on the screen" here, so the condition has to be evaluated per instance.
+    // is not "a place on the screen" here, so the condition has to be evaluated per rendering.
     const Rows = openmrsComponentDecorator({
       moduleName: 'esm-bedrock',
       featureName: 'Bedrock',

--- a/packages/framework/esm-framework/src/integration-tests/extension-config-expressions.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-config-expressions.test.tsx
@@ -2,10 +2,15 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor, within } from '@testing-library/react';
 import { type Person } from '@openmrs/esm-api';
 import { mockSessionStore } from '@openmrs/esm-api/mock';
-import { attach, registerExtension, updateInternalExtensionStore } from '../../../esm-extensions/src';
+import {
+  attach,
+  getExtensionInstancesStore,
+  registerExtension,
+  updateInternalExtensionStore,
+} from '../../../esm-extensions/src';
 import { ExtensionSlot, getSyncLifecycle, openmrsComponentDecorator, useConfig } from '../../../esm-react-utils/src';
 import {
   configInternalStore,
@@ -41,6 +46,9 @@ vi.mock('@openmrs/esm-api', async () => {
  */
 describe('Expression evaluation in extension display conditions', () => {
   beforeEach(() => {
+    // An instance outliving its module's schema makes the config system derive a config for an
+    // extension this test never registered.
+    getExtensionInstancesStore().setState({ instances: new Map() });
     temporaryConfigStore.setState({ config: {} });
     configInternalStore.setState({ providedConfigs: [], schemas: {}, moduleLoaded: {} });
     mockSessionStore.setState({});
@@ -223,6 +231,59 @@ describe('Expression evaluation in extension display conditions', () => {
       const slot = screen.getByTestId('slot');
       expect(slot.firstChild).toBeNull();
     });
+  }, 10000);
+
+  it('evaluates a display condition against each slot instance own state', async () => {
+    registerExtension({
+      name: 'Always',
+      moduleName: 'esm-bedrock',
+      load: getSyncLifecycle(() => <div>Always</div>, {
+        moduleName: 'esm-bedrock',
+        featureName: 'Bedrock',
+        disableTranslations: true,
+      }),
+      meta: {},
+    });
+    registerExtension({
+      name: 'Flagged',
+      moduleName: 'esm-bedrock',
+      load: getSyncLifecycle(() => <div>Flagged</div>, {
+        moduleName: 'esm-bedrock',
+        featureName: 'Bedrock',
+        disableTranslations: true,
+      }),
+      meta: {},
+      displayExpression: 'patient.flagged',
+    });
+    attach('rows-slot', 'Always');
+    attach('rows-slot', 'Flagged');
+
+    // A virtualized list renders the same slot once per row, each with its own patient. The slot
+    // is not "a place on the screen" here, so the condition has to be evaluated per instance.
+    const Rows = openmrsComponentDecorator({
+      moduleName: 'esm-bedrock',
+      featureName: 'Bedrock',
+      disableTranslations: true,
+    })(() => (
+      <div>
+        <div data-testid="row-flagged">
+          <ExtensionSlot name="rows-slot" state={{ patient: { flagged: true } }} />
+        </div>
+        <div data-testid="row-plain">
+          <ExtensionSlot name="rows-slot" state={{ patient: { flagged: false } }} />
+        </div>
+      </div>
+    ));
+
+    await act(async () => {
+      render(<Rows />);
+    });
+
+    await waitFor(() => expect(within(screen.getByTestId('row-flagged')).getByText('Always')).toBeInTheDocument());
+
+    expect(within(screen.getByTestId('row-flagged')).getByText('Flagged')).toBeInTheDocument();
+    expect(within(screen.getByTestId('row-plain')).getByText('Always')).toBeInTheDocument();
+    expect(within(screen.getByTestId('row-plain')).queryByText('Flagged')).not.toBeInTheDocument();
   }, 10000);
 });
 

--- a/packages/framework/esm-framework/src/integration-tests/extension-config-propagation.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-config-propagation.test.tsx
@@ -6,7 +6,7 @@ import { act, cleanup, render, screen } from '@testing-library/react';
 import { mockSessionStore } from '@openmrs/esm-api/mock';
 import {
   attach,
-  getExtensionInstancesStore,
+  getExtensionRenderingsStore,
   registerExtension,
   updateInternalExtensionStore,
 } from '../../../esm-extensions/src';
@@ -49,7 +49,8 @@ function reg(name: string) {
  */
 describe('runtime slot config changes', () => {
   beforeEach(() => {
-    getExtensionInstancesStore().setState({ instances: new Map() });
+    // eslint-disable-next-line testing-library/no-render-in-lifecycle -- not a render; the rule matches any callee name containing "render"
+    getExtensionRenderingsStore().setState({ renderings: new Map() });
     temporaryConfigStore.setState({ config: {} });
     configInternalStore.setState({ providedConfigs: [], schemas: {}, moduleLoaded: {} });
     mockSessionStore.setState({});

--- a/packages/framework/esm-framework/src/integration-tests/extension-config-propagation.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-config-propagation.test.tsx
@@ -1,0 +1,202 @@
+/* eslint-disable testing-library/no-unnecessary-act, testing-library/no-manual-cleanup */
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { mockSessionStore } from '@openmrs/esm-api/mock';
+import {
+  attach,
+  getExtensionInstancesStore,
+  registerExtension,
+  updateInternalExtensionStore,
+} from '../../../esm-extensions/src';
+import { ExtensionSlot, getSyncLifecycle, openmrsComponentDecorator } from '../../../esm-react-utils/src';
+import {
+  configExtensionStore,
+  configInternalStore,
+  defineConfigSchema,
+  getExtensionSlotsConfigStore,
+  getExtensionsConfigStore,
+  provide,
+  registerModuleLoad,
+  resetConfigSystem,
+  temporaryConfigStore,
+} from '../../../esm-config/src';
+
+vi.mock('@openmrs/esm-api', async () => {
+  const original = await import('@openmrs/esm-api');
+  return { ...original, sessionStore: mockSessionStore, refetchCurrentUser: vi.fn() };
+});
+
+const moduleName = 'esm-flintstone';
+
+function reg(name: string) {
+  registerExtension({
+    name,
+    moduleName,
+    load: getSyncLifecycle(() => <div>{name}</div>, { moduleName, featureName: name }),
+    meta: {},
+    online: true,
+    offline: true,
+  });
+}
+
+/**
+ * Slots are recomputed only when an input that affects them changes, so a slot's configuration
+ * changing has to invalidate that slot. These cover the case the pre-existing config tests don't:
+ * the configuration changing *after* the slot has already rendered, which is what an implementer
+ * does from the implementer tools.
+ */
+describe('runtime slot config changes', () => {
+  beforeEach(() => {
+    getExtensionInstancesStore().setState({ instances: new Map() });
+    temporaryConfigStore.setState({ config: {} });
+    configInternalStore.setState({ providedConfigs: [], schemas: {}, moduleLoaded: {} });
+    mockSessionStore.setState({});
+    getExtensionSlotsConfigStore().setState({ slots: {} });
+    getExtensionsConfigStore().setState({ configs: {} });
+    configExtensionStore.setState({ mountedExtensions: [] });
+    updateInternalExtensionStore(() => ({ slots: {}, extensions: {} }));
+    resetConfigSystem();
+    defineConfigSchema(moduleName, {});
+    registerModuleLoad(moduleName);
+    cleanup();
+  });
+
+  async function renderSlot() {
+    const App = openmrsComponentDecorator({ moduleName, featureName: 'f', disableTranslations: true })(() => (
+      <ExtensionSlot data-testid="slot" name="cfg-slot" />
+    ));
+    await act(async () => {
+      render(<App />);
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+  }
+
+  function rendered() {
+    return Array.from(screen.getByTestId('slot').childNodes).map((n) => (n as HTMLElement).textContent);
+  }
+
+  it('ADD: config adding an extension after the slot is mounted shows it', async () => {
+    reg('Fred');
+    reg('Barney');
+    attach('cfg-slot', 'Fred');
+    await renderSlot();
+    expect(rendered()).toEqual(['Fred']);
+
+    await act(async () => {
+      provide({ [moduleName]: { extensionSlots: { 'cfg-slot': { add: ['Barney'] } } } });
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(rendered()).toEqual(['Fred', 'Barney']);
+  });
+
+  it('REMOVE: config removing an extension after the slot is mounted hides it', async () => {
+    reg('Fred');
+    reg('Wilma');
+    attach('cfg-slot', 'Fred');
+    attach('cfg-slot', 'Wilma');
+    await renderSlot();
+    expect(rendered()).toEqual(['Fred', 'Wilma']);
+
+    await act(async () => {
+      provide({ [moduleName]: { extensionSlots: { 'cfg-slot': { remove: ['Fred'] } } } });
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(rendered()).toEqual(['Wilma']);
+  });
+
+  it('ORDER: config reordering after the slot is mounted reorders the DOM', async () => {
+    reg('Fred');
+    reg('Wilma');
+    attach('cfg-slot', 'Fred');
+    attach('cfg-slot', 'Wilma');
+    await renderSlot();
+    expect(rendered()).toEqual(['Fred', 'Wilma']);
+
+    await act(async () => {
+      provide({ [moduleName]: { extensionSlots: { 'cfg-slot': { order: ['Wilma', 'Fred'] } } } });
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(rendered()).toEqual(['Wilma', 'Fred']);
+  });
+
+  it('TEMPORARY CONFIG: implementer-tools style change propagates', async () => {
+    reg('Fred');
+    reg('Barney');
+    attach('cfg-slot', 'Fred');
+    await renderSlot();
+    expect(rendered()).toEqual(['Fred']);
+
+    await act(async () => {
+      temporaryConfigStore.setState({
+        config: { [moduleName]: { extensionSlots: { 'cfg-slot': { add: ['Barney'] } } } },
+      });
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(rendered()).toEqual(['Fred', 'Barney']);
+  });
+
+  it('CLEARED: clearing the temporary config reverts the slot to its unconfigured state', async () => {
+    reg('Fred');
+    reg('Barney');
+    attach('cfg-slot', 'Fred');
+    await renderSlot();
+
+    await act(async () => {
+      temporaryConfigStore.setState({
+        config: { [moduleName]: { extensionSlots: { 'cfg-slot': { add: ['Barney'] } } } },
+      });
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(rendered()).toEqual(['Fred', 'Barney']);
+
+    // What the implementer tools' "clear temporary config" does. The slot loses its config
+    // entry entirely, which has to take effect without a page reload.
+    await act(async () => {
+      temporaryConfigStore.setState({ config: {} });
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(rendered()).toEqual(['Fred']);
+  });
+
+  it('REPEATED: a second config change after the first still propagates', async () => {
+    reg('Fred');
+    reg('Barney');
+    reg('Betty');
+    attach('cfg-slot', 'Fred');
+    await renderSlot();
+
+    await act(async () => {
+      provide({ [moduleName]: { extensionSlots: { 'cfg-slot': { add: ['Barney'] } } } });
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    expect(rendered()).toEqual(['Fred', 'Barney']);
+
+    await act(async () => {
+      provide({ [moduleName]: { extensionSlots: { 'cfg-slot': { add: ['Barney', 'Betty'] } } } });
+    });
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 20));
+    });
+    // Two config-`add`ed extensions with no explicit order come out in the order the
+    // configuration lists them.
+    expect(rendered()).toEqual(['Fred', 'Barney', 'Betty']);
+  });
+});

--- a/packages/framework/esm-framework/src/integration-tests/extension-config-propagation.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-config-propagation.test.tsx
@@ -2,7 +2,7 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { act, cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import { mockSessionStore } from '@openmrs/esm-api/mock';
 import {
   attach,
@@ -80,20 +80,23 @@ describe('runtime slot config changes', () => {
     return Array.from(screen.getByTestId('slot').childNodes).map((n) => (n as HTMLElement).textContent);
   }
 
+  // Polls rather than sleeping: the cascade from a config write to the DOM runs across several
+  // store updates and a parcel mount, which is not a fixed amount of wall-clock time.
+  async function expectRendered(expected: Array<string | null>) {
+    await waitFor(() => expect(rendered()).toEqual(expected));
+  }
+
   it('ADD: config adding an extension after the slot is mounted shows it', async () => {
     reg('Fred');
     reg('Barney');
     attach('cfg-slot', 'Fred');
     await renderSlot();
-    expect(rendered()).toEqual(['Fred']);
+    await expectRendered(['Fred']);
 
     await act(async () => {
       provide({ [moduleName]: { extensionSlots: { 'cfg-slot': { add: ['Barney'] } } } });
     });
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 20));
-    });
-    expect(rendered()).toEqual(['Fred', 'Barney']);
+    await expectRendered(['Fred', 'Barney']);
   });
 
   it('REMOVE: config removing an extension after the slot is mounted hides it', async () => {
@@ -102,15 +105,12 @@ describe('runtime slot config changes', () => {
     attach('cfg-slot', 'Fred');
     attach('cfg-slot', 'Wilma');
     await renderSlot();
-    expect(rendered()).toEqual(['Fred', 'Wilma']);
+    await expectRendered(['Fred', 'Wilma']);
 
     await act(async () => {
       provide({ [moduleName]: { extensionSlots: { 'cfg-slot': { remove: ['Fred'] } } } });
     });
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 20));
-    });
-    expect(rendered()).toEqual(['Wilma']);
+    await expectRendered(['Wilma']);
   });
 
   it('ORDER: config reordering after the slot is mounted reorders the DOM', async () => {
@@ -119,15 +119,12 @@ describe('runtime slot config changes', () => {
     attach('cfg-slot', 'Fred');
     attach('cfg-slot', 'Wilma');
     await renderSlot();
-    expect(rendered()).toEqual(['Fred', 'Wilma']);
+    await expectRendered(['Fred', 'Wilma']);
 
     await act(async () => {
       provide({ [moduleName]: { extensionSlots: { 'cfg-slot': { order: ['Wilma', 'Fred'] } } } });
     });
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 20));
-    });
-    expect(rendered()).toEqual(['Wilma', 'Fred']);
+    await expectRendered(['Wilma', 'Fred']);
   });
 
   it('TEMPORARY CONFIG: implementer-tools style change propagates', async () => {
@@ -135,17 +132,14 @@ describe('runtime slot config changes', () => {
     reg('Barney');
     attach('cfg-slot', 'Fred');
     await renderSlot();
-    expect(rendered()).toEqual(['Fred']);
+    await expectRendered(['Fred']);
 
     await act(async () => {
       temporaryConfigStore.setState({
         config: { [moduleName]: { extensionSlots: { 'cfg-slot': { add: ['Barney'] } } } },
       });
     });
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 20));
-    });
-    expect(rendered()).toEqual(['Fred', 'Barney']);
+    await expectRendered(['Fred', 'Barney']);
   });
 
   it('CLEARED: clearing the temporary config reverts the slot to its unconfigured state', async () => {
@@ -159,20 +153,14 @@ describe('runtime slot config changes', () => {
         config: { [moduleName]: { extensionSlots: { 'cfg-slot': { add: ['Barney'] } } } },
       });
     });
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 20));
-    });
-    expect(rendered()).toEqual(['Fred', 'Barney']);
+    await expectRendered(['Fred', 'Barney']);
 
     // What the implementer tools' "clear temporary config" does. The slot loses its config
     // entry entirely, which has to take effect without a page reload.
     await act(async () => {
       temporaryConfigStore.setState({ config: {} });
     });
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 20));
-    });
-    expect(rendered()).toEqual(['Fred']);
+    await expectRendered(['Fred']);
   });
 
   it('REPEATED: a second config change after the first still propagates', async () => {
@@ -185,19 +173,13 @@ describe('runtime slot config changes', () => {
     await act(async () => {
       provide({ [moduleName]: { extensionSlots: { 'cfg-slot': { add: ['Barney'] } } } });
     });
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 20));
-    });
-    expect(rendered()).toEqual(['Fred', 'Barney']);
+    await expectRendered(['Fred', 'Barney']);
 
     await act(async () => {
       provide({ [moduleName]: { extensionSlots: { 'cfg-slot': { add: ['Barney', 'Betty'] } } } });
     });
-    await act(async () => {
-      await new Promise((r) => setTimeout(r, 20));
-    });
     // Two config-`add`ed extensions with no explicit order come out in the order the
     // configuration lists them.
-    expect(rendered()).toEqual(['Fred', 'Barney', 'Betty']);
+    await expectRendered(['Fred', 'Barney', 'Betty']);
   });
 });

--- a/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
@@ -5,7 +5,12 @@ import '@testing-library/jest-dom/vitest';
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import { type Person } from '@openmrs/esm-api';
 import { mockSessionStore } from '@openmrs/esm-api/mock';
-import { attach, registerExtension, updateInternalExtensionStore } from '../../../esm-extensions/src';
+import {
+  attach,
+  getExtensionInstancesStore,
+  registerExtension,
+  updateInternalExtensionStore,
+} from '../../../esm-extensions/src';
 import {
   ExtensionSlot,
   getSyncLifecycle,
@@ -36,6 +41,9 @@ vi.mock('@openmrs/esm-api', async () => {
 
 describe('Interaction between configuration and extension systems', () => {
   beforeEach(() => {
+    // An instance outliving its module's schema makes the config system derive a config for an
+    // extension this test never registered.
+    getExtensionInstancesStore().setState({ instances: new Map() });
     temporaryConfigStore.setState({ config: {} });
     configInternalStore.setState({ providedConfigs: [], schemas: {}, moduleLoaded: {} });
     mockSessionStore.setState({});

--- a/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
@@ -7,7 +7,7 @@ import { type Person } from '@openmrs/esm-api';
 import { mockSessionStore } from '@openmrs/esm-api/mock';
 import {
   attach,
-  getExtensionInstancesStore,
+  getExtensionRenderingsStore,
   registerExtension,
   updateInternalExtensionStore,
 } from '../../../esm-extensions/src';
@@ -41,9 +41,10 @@ vi.mock('@openmrs/esm-api', async () => {
 
 describe('Interaction between configuration and extension systems', () => {
   beforeEach(() => {
-    // An instance outliving its module's schema makes the config system derive a config for an
+    // A rendering outliving its module's schema makes the config system derive a config for an
     // extension this test never registered.
-    getExtensionInstancesStore().setState({ instances: new Map() });
+    // eslint-disable-next-line testing-library/no-render-in-lifecycle -- not a render; the rule matches any callee name containing "render"
+    getExtensionRenderingsStore().setState({ renderings: new Map() });
     temporaryConfigStore.setState({ config: {} });
     configInternalStore.setState({ providedConfigs: [], schemas: {}, moduleLoaded: {} });
     mockSessionStore.setState({});
@@ -192,6 +193,52 @@ describe('Interaction between configuration and extension systems', () => {
     await waitFor(() => {
       expect(slot.firstChild).toHaveTextContent(/Dino/);
       expect(slot.lastChild).toHaveTextContent(/Baby Puss/);
+    });
+  });
+
+  it('Should give each extension instance its own config in every rendering of the slot', async () => {
+    registerSimpleExtension('obs', 'esm-widgets', true);
+    defineConfigSchema('esm-widgets', {
+      concept: { _type: Type.String, _default: '(none)' },
+    });
+    registerModuleLoad('esm-widgets');
+
+    attach('Vitals slot', 'obs#weight');
+    attach('Vitals slot', 'obs#height');
+    provide({
+      'esm-chart': {
+        extensionSlots: {
+          'Vitals slot': {
+            configure: {
+              'obs#weight': { concept: 'Weight (kg)' },
+              'obs#height': { concept: 'Height (cm)' },
+            },
+          },
+        },
+      },
+    });
+
+    const App = openmrsComponentDecorator({
+      moduleName: 'esm-chart',
+      featureName: 'The chart',
+      disableTranslations: true,
+    })(() => (
+      <>
+        <ExtensionSlot data-testid="row-1" name="Vitals slot" />
+        <ExtensionSlot data-testid="row-2" name="Vitals slot" />
+      </>
+    ));
+
+    act(() => {
+      render(<App />);
+    });
+
+    await waitFor(() => {
+      for (const testId of ['row-1', 'row-2']) {
+        const slot = screen.getByTestId(testId);
+        expect(slot.firstChild).toHaveTextContent(/Weight \(kg\)/);
+        expect(slot.lastChild).toHaveTextContent(/Height \(cm\)/);
+      }
     });
   });
 

--- a/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-config.test.tsx
@@ -327,7 +327,7 @@ describe('Interaction between configuration and extension systems', () => {
       return (
         <div>
           <ExtensionSlot data-testid="slot" name="A slot" />
-          {store.slots['A slot'].assignedExtensions.map((e) => (
+          {store.slots['A slot'].candidateExtensions.map((e) => (
             <div key={e.name}>{JSON.stringify(e.config)}</div>
           ))}
         </div>

--- a/packages/framework/esm-framework/src/integration-tests/extension-recomputation.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-recomputation.test.tsx
@@ -1,0 +1,582 @@
+/* eslint-disable testing-library/no-unnecessary-act, testing-library/no-manual-cleanup */
+// Rendering is wrapped in `act` because the extension system settles across several store
+// updates, and the store resets in `beforeEach` require the previous render to be torn down first.
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import '@testing-library/jest-dom/vitest';
+import { act, cleanup, render, screen } from '@testing-library/react';
+import { mockSessionStore } from '@openmrs/esm-api/mock';
+import {
+  attach,
+  type ExtensionRegistration,
+  getAssignedExtensions,
+  getExtensionInstancesStore,
+  getExtensionInternalStore,
+  getExtensionStore,
+  registerExtension,
+  renderExtension,
+  updateInternalExtensionStore,
+} from '../../../esm-extensions/src';
+import {
+  ExtensionSlot,
+  getSyncLifecycle,
+  openmrsComponentDecorator,
+  useAssignedExtensions,
+} from '../../../esm-react-utils/src';
+import {
+  configExtensionStore,
+  configInternalStore,
+  defineConfigSchema,
+  defineExtensionConfigSchema,
+  getConfigStore,
+  getExtensionSlotsConfigStore,
+  getExtensionsConfigStore,
+  provide,
+  registerModuleLoad,
+  resetConfigSystem,
+  temporaryConfigStore,
+} from '../../../esm-config/src';
+
+vi.mock('@openmrs/esm-api', async () => {
+  const original = await import('@openmrs/esm-api');
+  return { ...original, sessionStore: mockSessionStore, refetchCurrentUser: vi.fn() };
+});
+
+const moduleName = 'esm-flintstone';
+
+function registerSimpleExtension(name: string, extensionModuleName = moduleName) {
+  const registration: ExtensionRegistration = {
+    name,
+    moduleName: extensionModuleName,
+    load: getSyncLifecycle(() => <div>{name}</div>, { moduleName: extensionModuleName, featureName: name }),
+    meta: {},
+    online: true,
+    offline: true,
+  };
+  registerExtension(registration);
+}
+
+function decorate(Component: React.ComponentType) {
+  return openmrsComponentDecorator({ moduleName, featureName: 'The Flintstones', disableTranslations: true })(
+    Component,
+  );
+}
+
+describe('Extension system recomputation', () => {
+  beforeEach(() => {
+    getExtensionInstancesStore().setState({ instances: new Map() });
+    temporaryConfigStore.setState({ config: {} });
+    configInternalStore.setState({ providedConfigs: [], schemas: {}, moduleLoaded: {} });
+    mockSessionStore.setState({});
+    getExtensionSlotsConfigStore().setState({ slots: {} });
+    getExtensionsConfigStore().setState({ configs: {} });
+    getExtensionStore().setState({ slots: {} });
+    configExtensionStore.setState({ mountedExtensions: [] });
+    updateInternalExtensionStore(() => ({ slots: {}, extensions: {} }));
+    resetConfigSystem();
+    defineConfigSchema(moduleName, {});
+    registerModuleLoad(moduleName);
+    cleanup();
+  });
+
+  it('notifies subscribers when an extension is registered', () => {
+    const internalStore = getExtensionInternalStore();
+    let notifications = 0;
+    const unsubscribe = internalStore.subscribe(() => notifications++);
+
+    registerSimpleExtension('Fred');
+    registerSimpleExtension('Wilma');
+    unsubscribe();
+
+    // zustand skips notification when an updater returns the same object, so a registration has
+    // to produce a new state or nothing downstream learns about it.
+    expect(notifications).toBe(2);
+    expect(Object.keys(internalStore.getState().extensions)).toEqual(['Fred', 'Wilma']);
+  });
+
+  it('does not write to the extension store when a slot re-renders with an equal state object', async () => {
+    registerSimpleExtension('Fred');
+    attach('state-slot', 'Fred');
+
+    const internalStore = getExtensionInternalStore();
+    let setCount: (n: number) => void = () => {};
+
+    function Host() {
+      const [count, setCountState] = React.useState(0);
+      setCount = setCountState;
+      // A fresh object literal every render — overwhelmingly the most common call pattern.
+      return <ExtensionSlot name="state-slot" state={{ patientUuid: 'abc-123' }} data-count={count} />;
+    }
+
+    const App = decorate(Host);
+
+    await act(async () => {
+      render(<App />);
+    });
+
+    let writes = 0;
+    const unsubscribe = internalStore.subscribe(() => writes++);
+
+    await act(async () => {
+      setCount(1);
+    });
+    await act(async () => {
+      setCount(2);
+    });
+    unsubscribe();
+
+    expect(writes).toBe(0);
+    expect(internalStore.getState().slots['state-slot']).toBeDefined();
+  });
+
+  it('settles when two slots share a name and disagree about state', async () => {
+    registerSimpleExtension('Fred');
+    attach('shared-name-slot', 'Fred');
+
+    const internalStore = getExtensionInternalStore();
+    let bump: (n: number) => void = () => {};
+
+    function Host() {
+      const [count, setCount] = React.useState(0);
+      bump = setCount;
+      return (
+        <div data-count={count}>
+          <ExtensionSlot name="shared-name-slot" state={{ patientUuid: 'abc' }} />
+          <ExtensionSlot name="shared-name-slot" />
+        </div>
+      );
+    }
+
+    await act(async () => {
+      render(React.createElement(decorate(Host)));
+    });
+
+    let writes = 0;
+    const unsubscribe = internalStore.subscribe(() => writes++);
+
+    await act(async () => {
+      bump(1);
+    });
+    await act(async () => {
+      bump(2);
+    });
+    unsubscribe();
+
+    // Each slot writes only when its own state changes, so they stop overwriting each other
+    // rather than trading the slot's state back and forth on every render.
+    expect(writes).toBe(0);
+  });
+
+  it('keeps slot state out of the store while still letting it reach the extensions', async () => {
+    registerExtension({
+      name: 'OnlyWhenFlagged',
+      moduleName,
+      load: getSyncLifecycle(() => <div>OnlyWhenFlagged</div>, { moduleName, featureName: 'flagged' }),
+      meta: {},
+      online: true,
+      offline: true,
+      displayExpression: 'flagged',
+    });
+    attach('changing-state-slot', 'OnlyWhenFlagged');
+
+    const internalStore = getExtensionInternalStore();
+    let setFlagged: (flagged: boolean) => void = () => {};
+
+    function Host() {
+      const [flagged, setFlaggedState] = React.useState(false);
+      setFlagged = setFlaggedState;
+      return <ExtensionSlot name="changing-state-slot" state={{ flagged }} />;
+    }
+
+    await act(async () => {
+      render(React.createElement(decorate(Host)));
+    });
+
+    expect(screen.queryByText('OnlyWhenFlagged')).not.toBeInTheDocument();
+
+    let writes = 0;
+    const unsubscribe = internalStore.subscribe(() => writes++);
+
+    await act(async () => {
+      setFlagged(true);
+    });
+    unsubscribe();
+
+    // The state belongs to this rendering of the slot, not to the slot, so changing it re-resolves
+    // the display condition without touching the store every other rendering shares.
+    expect(await screen.findByText('OnlyWhenFlagged')).toBeInTheDocument();
+    expect(writes).toBe(0);
+    expect(internalStore.getState().slots['changing-state-slot'].state).toBeUndefined();
+  });
+
+  it('does not re-render a slot consumer when an unrelated slot changes', async () => {
+    registerSimpleExtension('Fred');
+    attach('watched-slot', 'Fred');
+
+    let watcherPasses = 0;
+
+    function Watcher() {
+      watcherPasses++;
+      const extensions = useAssignedExtensions('watched-slot');
+      return <span>{extensions.length}</span>;
+    }
+
+    await act(async () => {
+      render(React.createElement(decorate(Watcher)));
+    });
+
+    const countAfterMount = watcherPasses;
+
+    await act(async () => {
+      registerSimpleExtension('Barney');
+      attach('unrelated-slot', 'Barney');
+    });
+
+    expect(watcherPasses).toBe(countAfterMount);
+
+    // The watched slot itself changing must still propagate.
+    await act(async () => {
+      registerSimpleExtension('Wilma');
+      attach('watched-slot', 'Wilma');
+    });
+
+    expect(watcherPasses).toBeGreaterThan(countAfterMount);
+  });
+
+  it('preserves the identity of slots whose assigned extensions did not change', async () => {
+    registerSimpleExtension('Fred');
+    attach('stable-slot', 'Fred');
+
+    await act(async () => {
+      render(React.createElement(decorate(() => <ExtensionSlot name="stable-slot" />)));
+    });
+
+    const extensionStore = getExtensionStore();
+    const before = extensionStore.getState().slots['stable-slot'];
+
+    await act(async () => {
+      registerSimpleExtension('Barney');
+      attach('another-slot', 'Barney');
+    });
+
+    expect(extensionStore.getState().slots['stable-slot']).toBe(before);
+  });
+
+  it('releases an extension instance when it unmounts', async () => {
+    registerSimpleExtension('Fred');
+    attach('mounting-slot', 'Fred');
+
+    const instancesStore = getExtensionInstancesStore();
+    const App = decorate(() => <ExtensionSlot name="mounting-slot" />);
+
+    for (let i = 0; i < 3; i++) {
+      const { unmount } = render(<App />);
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      expect(instancesStore.getState().instances.size).toBe(1);
+
+      unmount();
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      });
+
+      // An instance record must not outlive its parcel.
+      expect(instancesStore.getState().instances.size).toBe(0);
+      expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
+    }
+  });
+
+  it('renders an extension whose parcel resolves after the StrictMode remount', async () => {
+    registerSimpleExtension('Fred');
+    attach('strict-slot', 'Fred');
+
+    const App = decorate(() => <ExtensionSlot data-testid="strict-slot" name="strict-slot" />);
+
+    await act(async () => {
+      render(<App />);
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    // StrictMode mounts, tears down and mounts again before the parcel resolves. Teardown state
+    // has to be per-mount, or the live component's parcel is unmounted as soon as it arrives.
+    expect(screen.getByTestId('strict-slot')).toHaveTextContent('Fred');
+    expect(getExtensionInstancesStore().getState().instances.size).toBe(1);
+  });
+
+  it('releases an extension instance when the slot unmounts before the bundle loads', async () => {
+    let releaseLoad: () => void = () => {};
+    const loadGate = new Promise<void>((resolve) => {
+      releaseLoad = resolve;
+    });
+
+    registerExtension({
+      name: 'Slow',
+      moduleName,
+      meta: {},
+      online: true,
+      offline: true,
+      load: async () => {
+        await loadGate;
+        return { bootstrap: async () => {}, mount: async () => {}, unmount: async () => {} };
+      },
+    });
+    attach('slow-slot', 'Slow');
+
+    const instancesStore = getExtensionInstancesStore();
+    const App = decorate(() => <ExtensionSlot name="slow-slot" />);
+    const { unmount } = render(<App />);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    });
+
+    unmount();
+    await act(async () => {
+      releaseLoad();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    // Navigating away while a lazy bundle is still downloading is routine; the record has to be
+    // released even though the component never saw a parcel.
+    expect(instancesStore.getState().instances.size).toBe(0);
+    expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
+  });
+
+  it('releases an extension instance when the extension bundle fails to load', async () => {
+    registerExtension({
+      name: 'Unloadable',
+      moduleName,
+      meta: {},
+      online: true,
+      offline: true,
+      load: () => Promise.reject(new Error('chunk load failed')),
+    });
+    attach('unloadable-slot', 'Unloadable');
+
+    const instancesStore = getExtensionInstancesStore();
+
+    // Driven directly rather than through <ExtensionSlot>: `renderExtension` rethrows and
+    // `Extension` has no rejection handler, so a failed load reaches the app's global handler.
+    await expect(
+      renderExtension(document.createElement('div'), 'unloadable-slot', moduleName, 'Unloadable'),
+    ).rejects.toThrow('chunk load failed');
+
+    // The record is registered before the load starts, so the failure has to release it.
+    expect(instancesStore.getState().instances.size).toBe(0);
+    expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
+  });
+
+  it('releases an extension instance when the slot unmounts while the parcel is bootstrapping', async () => {
+    let releaseBootstrap: () => void = () => {};
+    const bootstrapGate = new Promise<void>((resolve) => {
+      releaseBootstrap = resolve;
+    });
+
+    registerExtension({
+      name: 'SlowBootstrap',
+      moduleName,
+      meta: {},
+      online: true,
+      offline: true,
+      load: async () => ({
+        bootstrap: async () => {
+          await bootstrapGate;
+        },
+        mount: async () => {},
+        unmount: async () => {},
+      }),
+    });
+    attach('bootstrapping-slot', 'SlowBootstrap');
+
+    const instancesStore = getExtensionInstancesStore();
+    const App = decorate(() => <ExtensionSlot name="bootstrapping-slot" />);
+    const { unmount } = render(<App />);
+
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    // The parcel exists but hasn't reached MOUNTED, so teardown has to wait for the mount to
+    // settle rather than assuming a status it can unmount from.
+    unmount();
+    await act(async () => {
+      releaseBootstrap();
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    expect(instancesStore.getState().instances.size).toBe(0);
+    expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
+  });
+
+  it('releases an extension instance when the extension fails to mount', async () => {
+    registerExtension({
+      name: 'Broken',
+      moduleName,
+      meta: {},
+      online: true,
+      offline: true,
+      load: async () => ({
+        bootstrap: async () => {},
+        mount: async () => {
+          throw new Error('mount failed');
+        },
+        unmount: async () => {},
+      }),
+    });
+    attach('broken-slot', 'Broken');
+
+    const instancesStore = getExtensionInstancesStore();
+    const App = decorate(() => <ExtensionSlot name="broken-slot" />);
+
+    await act(async () => {
+      render(<App />);
+    });
+    await act(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 20));
+    });
+
+    // A parcel that never mounts never settles `unmountPromise`, so the mount rejection is the
+    // only thing that can release the record.
+    expect(instancesStore.getState().instances.size).toBe(0);
+    expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
+  });
+
+  it('does not rewrite a module config store when nothing about the config changed', () => {
+    const moduleStore = getConfigStore(moduleName);
+    let writes = 0;
+    const unsubscribe = moduleStore.subscribe(() => writes++);
+
+    // Poking an input store recomputes every module's config, so an unchanged config must not
+    // reach the store.
+
+    for (let i = 0; i < 10; i++) {
+      configExtensionStore.setState({ mountedExtensions: [...configExtensionStore.getState().mountedExtensions] });
+    }
+    unsubscribe();
+
+    expect(writes).toBe(0);
+  });
+
+  it('does not mutate the config objects it reads while deriving assigned extensions', () => {
+    registerSimpleExtension('widget');
+    attach('merge-slot', 'widget');
+
+    // Deriving only merges when the slot configures the extension, so without this the merge
+    // branch is never taken and the assertions below hold vacuously.
+    provide({
+      [moduleName]: {
+        extensionSlots: { 'merge-slot': { configure: { widget: { fromSlotConfig: true } } } },
+      },
+    });
+
+    const storedConfig = { untouched: true };
+    getExtensionsConfigStore().setState({
+      configs: { 'merge-slot': { widget: { loaded: true, config: storedConfig as never } } },
+    });
+
+    // The slot's `configure` block still reaches the extension...
+    expect(getAssignedExtensions('merge-slot')[0]?.config).toEqual({
+      untouched: true,
+      fromSlotConfig: true,
+    });
+
+    // ...but as a fresh object. The config store owns `storedConfig`, and deriving must not
+    // write the slot's overrides into it.
+    expect(storedConfig).toEqual({ untouched: true });
+    expect(getExtensionsConfigStore().getState().configs['merge-slot']?.['widget']?.config).toEqual({
+      untouched: true,
+    });
+  });
+
+  it("does not remount other rows' extensions when a row with different state arrives", async () => {
+    registerSimpleExtension('always');
+    registerExtension({
+      name: 'conditional',
+      moduleName,
+      load: getSyncLifecycle(() => <div>conditional</div>, { moduleName, featureName: 'conditional' }),
+      meta: {},
+      online: true,
+      offline: true,
+      displayExpression: 'patient.flagged',
+    });
+    attach('rows-slot', 'always');
+    attach('rows-slot', 'conditional');
+
+    let setRows: (n: number) => void = () => {};
+
+    function List() {
+      const [rows, setRowsState] = React.useState(1);
+      setRows = setRowsState;
+      return (
+        <div>
+          {Array.from({ length: rows }, (_, i) => (
+            <ExtensionSlot key={i} name="rows-slot" state={{ patient: { flagged: i % 2 === 0 } }} />
+          ))}
+        </div>
+      );
+    }
+
+    await act(async () => {
+      render(React.createElement(decorate(List)));
+    });
+
+    const everMounted = new Set<string>();
+    const unsubscribe = getExtensionInstancesStore().subscribe((state) => {
+      for (const instanceId of state.instances.keys()) {
+        everMounted.add(instanceId);
+      }
+    });
+
+    // Rows scroll in one at a time, alternating whether their patient satisfies the condition.
+    for (let rows = 2; rows <= 12; rows++) {
+      await act(async () => {
+        setRows(rows);
+      });
+    }
+    unsubscribe();
+
+    const live = getExtensionInstancesStore().getState().instances.size;
+
+    // Resolving the condition per rendering rather than per slot is what makes this hold: when it
+    // was resolved once for the whole slot, each arriving row flipped the answer for every row
+    // already on screen, mounting and unmounting their parcels again each time.
+    expect(everMounted.size).toBe(live);
+    expect(live).toBe(12 + 6);
+  });
+
+  it('derives an extension config once however many rows render the same slot', async () => {
+    defineExtensionConfigSchema('widget', { greeting: { _default: 'yabba' } });
+    provide({ widget: { greeting: 'dabba' } });
+    registerSimpleExtension('widget');
+    attach('row-slot', 'widget');
+
+    const rows = 25;
+    const App = decorate(() => (
+      <div>
+        {Array.from({ length: rows }, (_, i) => (
+          <ExtensionSlot key={i} name="row-slot" />
+        ))}
+      </div>
+    ));
+
+    let extensionConfigWrites = 0;
+    const unsubscribe = getExtensionsConfigStore().subscribe(() => extensionConfigWrites++);
+
+    await act(async () => {
+      render(<App />);
+    });
+    unsubscribe();
+
+    expect(await screen.findAllByText('widget')).toHaveLength(rows);
+    // A list renders the same slot once per row, but the config system derives one config per
+    // slot and extension, so the work must not grow with the number of rows on screen.
+    expect(getExtensionsConfigStore().getState().configs['row-slot']).toEqual({
+      widget: { loaded: true, config: expect.objectContaining({ greeting: 'dabba' }) },
+    });
+    expect(extensionConfigWrites).toBe(1);
+  });
+});

--- a/packages/framework/esm-framework/src/integration-tests/extension-recomputation.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-recomputation.test.tsx
@@ -1,6 +1,11 @@
-/* eslint-disable testing-library/no-unnecessary-act, testing-library/no-manual-cleanup */
-// Rendering is wrapped in `act` because the extension system settles across several store
-// updates, and the store resets in `beforeEach` require the previous render to be torn down first.
+/*
+ * Rendering is wrapped in `act` because the extension system settles across several store updates,
+ * and the store resets in `beforeEach` require the previous render to be torn down first.
+ *
+ * `render-result-naming-convention` misreads this file's vocabulary: a `rendering` is one live copy
+ * of an extension, not a testing-library render result.
+ */
+/* eslint-disable testing-library/no-unnecessary-act, testing-library/no-manual-cleanup, testing-library/render-result-naming-convention */
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
@@ -10,7 +15,7 @@ import {
   attach,
   type ExtensionRegistration,
   getAssignedExtensions,
-  getExtensionInstancesStore,
+  getExtensionRenderingsStore,
   getExtensionInternalStore,
   getExtensionStore,
   registerExtension,
@@ -64,7 +69,8 @@ function decorate(Component: React.ComponentType) {
 
 describe('Extension system recomputation', () => {
   beforeEach(() => {
-    getExtensionInstancesStore().setState({ instances: new Map() });
+    // eslint-disable-next-line testing-library/no-render-in-lifecycle -- not a render; the rule matches any callee name containing "render"
+    getExtensionRenderingsStore().setState({ renderings: new Map() });
     temporaryConfigStore.setState({ config: {} });
     configInternalStore.setState({ providedConfigs: [], schemas: {}, moduleLoaded: {} });
     mockSessionStore.setState({});
@@ -206,7 +212,6 @@ describe('Extension system recomputation', () => {
     // the display condition without touching the store every other rendering shares.
     expect(await screen.findByText('OnlyWhenFlagged')).toBeInTheDocument();
     expect(writes).toBe(0);
-    expect(internalStore.getState().slots['changing-state-slot'].state).toBeUndefined();
   });
 
   it('does not re-render a slot consumer when an unrelated slot changes', async () => {
@@ -262,11 +267,11 @@ describe('Extension system recomputation', () => {
     expect(extensionStore.getState().slots['stable-slot']).toBe(before);
   });
 
-  it('releases an extension instance when it unmounts', async () => {
+  it('releases an extension rendering when it unmounts', async () => {
     registerSimpleExtension('Fred');
     attach('mounting-slot', 'Fred');
 
-    const instancesStore = getExtensionInstancesStore();
+    const renderingsStore = getExtensionRenderingsStore();
     const App = decorate(() => <ExtensionSlot name="mounting-slot" />);
 
     for (let i = 0; i < 3; i++) {
@@ -275,15 +280,15 @@ describe('Extension system recomputation', () => {
         await new Promise((resolve) => setTimeout(resolve, 10));
       });
 
-      expect(instancesStore.getState().instances.size).toBe(1);
+      expect(renderingsStore.getState().renderings.size).toBe(1);
 
       unmount();
       await act(async () => {
         await new Promise((resolve) => setTimeout(resolve, 10));
       });
 
-      // An instance record must not outlive its parcel.
-      expect(instancesStore.getState().instances.size).toBe(0);
+      // A rendering record must not outlive its parcel.
+      expect(renderingsStore.getState().renderings.size).toBe(0);
       expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
     }
   });
@@ -304,10 +309,10 @@ describe('Extension system recomputation', () => {
     // StrictMode mounts, tears down and mounts again before the parcel resolves. Teardown state
     // has to be per-mount, or the live component's parcel is unmounted as soon as it arrives.
     expect(screen.getByTestId('strict-slot')).toHaveTextContent('Fred');
-    expect(getExtensionInstancesStore().getState().instances.size).toBe(1);
+    expect(getExtensionRenderingsStore().getState().renderings.size).toBe(1);
   });
 
-  it('releases an extension instance when the slot unmounts before the bundle loads', async () => {
+  it('releases an extension rendering when the slot unmounts before the bundle loads', async () => {
     let releaseLoad: () => void = () => {};
     const loadGate = new Promise<void>((resolve) => {
       releaseLoad = resolve;
@@ -326,7 +331,7 @@ describe('Extension system recomputation', () => {
     });
     attach('slow-slot', 'Slow');
 
-    const instancesStore = getExtensionInstancesStore();
+    const renderingsStore = getExtensionRenderingsStore();
     const App = decorate(() => <ExtensionSlot name="slow-slot" />);
     const { unmount } = render(<App />);
 
@@ -342,11 +347,11 @@ describe('Extension system recomputation', () => {
 
     // Navigating away while a lazy bundle is still downloading is routine; the record has to be
     // released even though the component never saw a parcel.
-    expect(instancesStore.getState().instances.size).toBe(0);
+    expect(renderingsStore.getState().renderings.size).toBe(0);
     expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
   });
 
-  it('releases an extension instance when the extension bundle fails to load', async () => {
+  it('releases an extension rendering when the extension bundle fails to load', async () => {
     registerExtension({
       name: 'Unloadable',
       moduleName,
@@ -357,7 +362,7 @@ describe('Extension system recomputation', () => {
     });
     attach('unloadable-slot', 'Unloadable');
 
-    const instancesStore = getExtensionInstancesStore();
+    const renderingsStore = getExtensionRenderingsStore();
 
     // Driven directly rather than through <ExtensionSlot>: `renderExtension` rethrows and
     // `Extension` has no rejection handler, so a failed load reaches the app's global handler.
@@ -366,11 +371,11 @@ describe('Extension system recomputation', () => {
     ).rejects.toThrow('chunk load failed');
 
     // The record is registered before the load starts, so the failure has to release it.
-    expect(instancesStore.getState().instances.size).toBe(0);
+    expect(renderingsStore.getState().renderings.size).toBe(0);
     expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
   });
 
-  it('releases an extension instance when the slot unmounts while the parcel is bootstrapping', async () => {
+  it('releases an extension rendering when the slot unmounts while the parcel is bootstrapping', async () => {
     let releaseBootstrap: () => void = () => {};
     const bootstrapGate = new Promise<void>((resolve) => {
       releaseBootstrap = resolve;
@@ -392,7 +397,7 @@ describe('Extension system recomputation', () => {
     });
     attach('bootstrapping-slot', 'SlowBootstrap');
 
-    const instancesStore = getExtensionInstancesStore();
+    const renderingsStore = getExtensionRenderingsStore();
     const App = decorate(() => <ExtensionSlot name="bootstrapping-slot" />);
     const { unmount } = render(<App />);
 
@@ -408,11 +413,11 @@ describe('Extension system recomputation', () => {
       await new Promise((resolve) => setTimeout(resolve, 20));
     });
 
-    expect(instancesStore.getState().instances.size).toBe(0);
+    expect(renderingsStore.getState().renderings.size).toBe(0);
     expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
   });
 
-  it('releases an extension instance when the extension fails to mount', async () => {
+  it('releases an extension rendering when the extension fails to mount', async () => {
     registerExtension({
       name: 'Broken',
       moduleName,
@@ -429,7 +434,7 @@ describe('Extension system recomputation', () => {
     });
     attach('broken-slot', 'Broken');
 
-    const instancesStore = getExtensionInstancesStore();
+    const renderingsStore = getExtensionRenderingsStore();
     const App = decorate(() => <ExtensionSlot name="broken-slot" />);
 
     await act(async () => {
@@ -441,7 +446,7 @@ describe('Extension system recomputation', () => {
 
     // A parcel that never mounts never settles `unmountPromise`, so the mount rejection is the
     // only thing that can release the record.
-    expect(instancesStore.getState().instances.size).toBe(0);
+    expect(renderingsStore.getState().renderings.size).toBe(0);
     expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
   });
 
@@ -525,9 +530,9 @@ describe('Extension system recomputation', () => {
     });
 
     const everMounted = new Set<string>();
-    const unsubscribe = getExtensionInstancesStore().subscribe((state) => {
-      for (const instanceId of state.instances.keys()) {
-        everMounted.add(instanceId);
+    const unsubscribe = getExtensionRenderingsStore().subscribe((state) => {
+      for (const renderingId of state.renderings.keys()) {
+        everMounted.add(renderingId);
       }
     });
 
@@ -539,7 +544,7 @@ describe('Extension system recomputation', () => {
     }
     unsubscribe();
 
-    const live = getExtensionInstancesStore().getState().instances.size;
+    const live = getExtensionRenderingsStore().getState().renderings.size;
 
     // Resolving the condition per rendering rather than per slot is what makes this hold: when it
     // was resolved once for the whole slot, each arriving row flipped the answer for every row

--- a/packages/framework/esm-framework/src/integration-tests/extension-recomputation.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-recomputation.test.tsx
@@ -340,6 +340,72 @@ describe('Extension system recomputation', () => {
     expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
   });
 
+  it('applies a state change that arrived while the extension bundle was still loading', async () => {
+    let releaseLoad: () => void = () => {};
+    const loadGate = new Promise<void>((resolve) => {
+      releaseLoad = resolve;
+    });
+    const labelsSeen: Array<string> = [];
+    let container: HTMLElement | null = null;
+
+    registerExtension({
+      name: 'Gated',
+      moduleName,
+      meta: {},
+      online: true,
+      offline: true,
+      load: async () => {
+        await loadGate;
+        return {
+          bootstrap: async () => {},
+          // `domElement` is captured here rather than read from the update props, which carry only
+          // what the update was called with.
+          mount: async (props) => {
+            container = props.domElement as HTMLElement;
+            container.textContent = props.label as string;
+            labelsSeen.push(props.label as string);
+          },
+          update: async (props) => {
+            labelsSeen.push(props.label as string);
+
+            if (container) {
+              container.textContent = props.label as string;
+            }
+          },
+          unmount: async () => {
+            container = null;
+          },
+        };
+      },
+    });
+    attach('gated-slot', 'Gated');
+
+    let setLabel: (label: string) => void = () => {};
+
+    function Host() {
+      const [label, setLabelState] = React.useState('before');
+      setLabel = setLabelState;
+      return <ExtensionSlot name="gated-slot" state={{ label }} />;
+    }
+
+    await act(async () => {
+      render(React.createElement(decorate(Host)));
+    });
+
+    // The row's state moves on while the bundle is still in flight, so there is no parcel for the
+    // update to reach and no later render to retry it.
+    await act(async () => {
+      setLabel('after');
+    });
+    await act(async () => {
+      releaseLoad();
+    });
+
+    // Mounting with the state captured when the node was attached is fine; being left there is not.
+    expect(await screen.findByText('after')).toBeInTheDocument();
+    expect(labelsSeen).toEqual(['before', 'after']);
+  });
+
   it('releases an extension rendering when the extension bundle fails to load', async () => {
     registerExtension({
       name: 'Unloadable',

--- a/packages/framework/esm-framework/src/integration-tests/extension-recomputation.test.tsx
+++ b/packages/framework/esm-framework/src/integration-tests/extension-recomputation.test.tsx
@@ -9,7 +9,7 @@
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
-import { act, cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
 import { mockSessionStore } from '@openmrs/esm-api/mock';
 import {
   attach,
@@ -29,6 +29,7 @@ import {
   useAssignedExtensions,
 } from '../../../esm-react-utils/src';
 import {
+  type ConfigObject,
   configExtensionStore,
   configInternalStore,
   defineConfigSchema,
@@ -276,19 +277,12 @@ describe('Extension system recomputation', () => {
 
     for (let i = 0; i < 3; i++) {
       const { unmount } = render(<App />);
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
-
-      expect(renderingsStore.getState().renderings.size).toBe(1);
+      await waitFor(() => expect(renderingsStore.getState().renderings.size).toBe(1));
 
       unmount();
-      await act(async () => {
-        await new Promise((resolve) => setTimeout(resolve, 10));
-      });
 
       // A rendering record must not outlive its parcel.
-      expect(renderingsStore.getState().renderings.size).toBe(0);
+      await waitFor(() => expect(renderingsStore.getState().renderings.size).toBe(0));
       expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
     }
   });
@@ -302,13 +296,10 @@ describe('Extension system recomputation', () => {
     await act(async () => {
       render(<App />);
     });
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    });
 
     // StrictMode mounts, tears down and mounts again before the parcel resolves. Teardown state
     // has to be per-mount, or the live component's parcel is unmounted as soon as it arrives.
-    expect(screen.getByTestId('strict-slot')).toHaveTextContent('Fred');
+    await waitFor(() => expect(screen.getByTestId('strict-slot')).toHaveTextContent('Fred'));
     expect(getExtensionRenderingsStore().getState().renderings.size).toBe(1);
   });
 
@@ -335,19 +326,17 @@ describe('Extension system recomputation', () => {
     const App = decorate(() => <ExtensionSlot name="slow-slot" />);
     const { unmount } = render(<App />);
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    });
+    // Registered before the load starts, so this settles while the bundle is still gated.
+    await waitFor(() => expect(renderingsStore.getState().renderings.size).toBe(1));
 
     unmount();
     await act(async () => {
       releaseLoad();
-      await new Promise((resolve) => setTimeout(resolve, 20));
     });
 
     // Navigating away while a lazy bundle is still downloading is routine; the record has to be
     // released even though the component never saw a parcel.
-    expect(renderingsStore.getState().renderings.size).toBe(0);
+    await waitFor(() => expect(renderingsStore.getState().renderings.size).toBe(0));
     expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
   });
 
@@ -401,19 +390,16 @@ describe('Extension system recomputation', () => {
     const App = decorate(() => <ExtensionSlot name="bootstrapping-slot" />);
     const { unmount } = render(<App />);
 
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    });
+    await waitFor(() => expect(renderingsStore.getState().renderings.size).toBe(1));
 
     // The parcel exists but hasn't reached MOUNTED, so teardown has to wait for the mount to
     // settle rather than assuming a status it can unmount from.
     unmount();
     await act(async () => {
       releaseBootstrap();
-      await new Promise((resolve) => setTimeout(resolve, 20));
     });
 
-    expect(renderingsStore.getState().renderings.size).toBe(0);
+    await waitFor(() => expect(renderingsStore.getState().renderings.size).toBe(0));
     expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
   });
 
@@ -435,19 +421,28 @@ describe('Extension system recomputation', () => {
     attach('broken-slot', 'Broken');
 
     const renderingsStore = getExtensionRenderingsStore();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const App = decorate(() => <ExtensionSlot name="broken-slot" />);
 
     await act(async () => {
       render(<App />);
     });
-    await act(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 20));
-    });
+
+    // The record is registered and released within the same render, so there is no moment to
+    // observe it held. Waiting on the failure itself is what makes the assertion below meaningful
+    // rather than a reading of the empty state this started in.
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith(
+        expect.stringContaining("Extension 'Broken' in slot 'broken-slot' failed to mount"),
+        expect.anything(),
+      ),
+    );
 
     // A parcel that never mounts never settles `unmountPromise`, so the mount rejection is the
     // only thing that can release the record.
     expect(renderingsStore.getState().renderings.size).toBe(0);
     expect(configExtensionStore.getState().mountedExtensions).toEqual([]);
+    consoleError.mockRestore();
   });
 
   it('does not rewrite a module config store when nothing about the config changed', () => {
@@ -480,7 +475,11 @@ describe('Extension system recomputation', () => {
 
     const storedConfig = { untouched: true };
     getExtensionsConfigStore().setState({
-      configs: { 'merge-slot': { widget: { loaded: true, config: storedConfig as never } } },
+      configs: {
+        'merge-slot': {
+          widget: { loaded: true, translationOverridesLoaded: true, config: storedConfig as ConfigObject },
+        },
+      },
     });
 
     // The slot's `configure` block still reaches the extension...

--- a/packages/framework/esm-framework/vitest.config.ts
+++ b/packages/framework/esm-framework/vitest.config.ts
@@ -1,6 +1,28 @@
+import { readdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
 
+const frameworkRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+
+/*
+ * These tests exercise the framework end to end, so every package involved has to be the *same*
+ * copy the components under test import. Without this, a test importing `../../../esm-extensions/src`
+ * renders components that resolve `@openmrs/esm-extensions` through the workspace symlink to
+ * `dist/` — two module instances, each with its own recomputation state, caches and subscriptions,
+ * so a regression in `src` is masked by the previously built `dist`.
+ *
+ * Bare specifiers only: subpaths like `@openmrs/esm-api/mock` keep their own resolution.
+ */
+const frameworkSourceAliases = readdirSync(frameworkRoot, { withFileTypes: true })
+  .filter((entry) => entry.isDirectory() && entry.name.startsWith('esm-'))
+  .map((entry) => ({
+    find: new RegExp(`^@openmrs/${entry.name}$`),
+    replacement: resolve(frameworkRoot, entry.name, 'src/index.ts'),
+  }));
+
 export default defineConfig({
+  resolve: { alias: frameworkSourceAliases },
   test: {
     environment: 'happy-dom',
     mockReset: true,

--- a/packages/framework/esm-react-utils/src/Extension.tsx
+++ b/packages/framework/esm-react-utils/src/Extension.tsx
@@ -22,6 +22,7 @@ export const Extension: React.FC<ExtensionProps> = ({ state, children, ...divPro
   const parcel = useRef<Parcel | null>(null);
   const updatePromise = useRef<Promise<void>>(Promise.resolve());
   const isUnmounted = useRef(false);
+  const isRendering = useRef(false);
 
   // Takes the parcel to tear down rather than reading `parcel.current`, which can be reassigned
   // between scheduling this and running it.
@@ -53,12 +54,20 @@ export const Extension: React.FC<ExtensionProps> = ({ state, children, ...divPro
   }, []);
 
   const ref = useCallback((node: HTMLDivElement | null) => {
-    // React detaches a ref by calling it with null. That is not a request to render anything, and
-    // rendering into it warns and then resolves to null — clearing a parcel that may still be
-    // coming up, which leaves it mounted into a detached node for the life of the page.
-    if (!node || parcel.current || !extension?.extensionSlotName || !extension.extensionSlotModuleName) {
+    // React detaches a ref by calling it with null. If we render something in response to this,
+    // React ignores it and we're left tracking a parcel with no visible DOM, so skip conditions
+    // we can't handle.
+    if (
+      !node ||
+      parcel.current ||
+      isRendering.current ||
+      !extension?.extensionSlotName ||
+      !extension.extensionSlotModuleName
+    ) {
       return;
     }
+
+    isRendering.current = true;
 
     renderExtension(
       node,
@@ -67,16 +76,23 @@ export const Extension: React.FC<ExtensionProps> = ({ state, children, ...divPro
       extension.extensionId,
       undefined,
       state,
-    ).then((newParcel: Parcel | null) => {
-      parcel.current = newParcel;
+    ).then(
+      (newParcel: Parcel | null) => {
+        isRendering.current = false;
+        parcel.current = newParcel;
 
-      // Loading an extension's bundle can outlast the component that asked for it: the cleanup
-      // effect has already run and saw no parcel, so teardown has to happen here instead, or the
-      // parcel mounts into a detached node and its rendering record outlives the page.
-      if (isUnmounted.current) {
-        unmountParcel(newParcel);
-      }
-    });
+        // Loading an extension's bundle can outlast the component that asked for it: the cleanup
+        // effect has already run and saw no parcel, so teardown has to happen here instead, or the
+        // parcel mounts into a detached node and its rendering record outlives the page.
+        if (isUnmounted.current) {
+          unmountParcel(newParcel);
+        }
+      },
+      // Cleared so a later reattach can try again; `renderExtension` reports its own failures.
+      () => {
+        isRendering.current = false;
+      },
+    );
   }, []);
 
   useEffect(() => {
@@ -91,23 +107,28 @@ export const Extension: React.FC<ExtensionProps> = ({ state, children, ...divPro
   }, []);
 
   useEffect(() => {
-    if (parcel.current && parcel.current.update && parcel.current.getStatus() !== 'UNMOUNTING') {
-      Promise.all([parcel.current.mountPromise, updatePromise.current]).then(() => {
-        if (parcel?.current?.getStatus() === 'MOUNTED' && parcel.current.update) {
-          updatePromise.current = parcel.current.update({ ...state }).catch((err) => {
-            // if we were trying to update but the component was unmounted
-            // while this was happening, ignore the error
-            if (
-              !(err instanceof Error) ||
-              !err.message.includes('minified message #32') ||
-              parcel.current?.getStatus() === 'MOUNTED'
-            ) {
-              throw err;
-            }
-          });
+    const target = parcel.current;
+
+    if (!target?.update || target.getStatus() === 'UNMOUNTING') {
+      return;
+    }
+
+    // Every later update chains onto this promise, so it has to settle even when an update fails.
+    updatePromise.current = Promise.all([target.mountPromise, updatePromise.current])
+      .then(() => {
+        if (parcel.current?.getStatus() === 'MOUNTED' && parcel.current.update) {
+          return parcel.current.update({ ...state });
+        }
+      })
+      .catch((err) => {
+        // A parcel torn down while its update was in flight rejects, and that race is expected.
+        // We use the status to distinguish reject reasons as the message isn't reliable
+        const status = parcel.current?.getStatus();
+
+        if (status !== 'UNMOUNTING' && status !== 'NOT_MOUNTED' && status !== 'UNLOADING') {
+          console.error(`The extension '${extension?.extensionId}' failed to update`, err);
         }
       });
-    }
   }, [state]);
 
   // The extension is rendered into the `<div>`. The `<div>` has relative

--- a/packages/framework/esm-react-utils/src/Extension.tsx
+++ b/packages/framework/esm-react-utils/src/Extension.tsx
@@ -72,7 +72,7 @@ export const Extension: React.FC<ExtensionProps> = ({ state, children, ...divPro
 
       // Loading an extension's bundle can outlast the component that asked for it: the cleanup
       // effect has already run and saw no parcel, so teardown has to happen here instead, or the
-      // parcel mounts into a detached node and its instance record outlives the page.
+      // parcel mounts into a detached node and its rendering record outlives the page.
       if (isUnmounted.current) {
         unmountParcel(newParcel);
       }

--- a/packages/framework/esm-react-utils/src/Extension.tsx
+++ b/packages/framework/esm-react-utils/src/Extension.tsx
@@ -23,6 +23,7 @@ export const Extension: React.FC<ExtensionProps> = ({ state, children, ...divPro
   const updatePromise = useRef<Promise<void>>(Promise.resolve());
   const isUnmounted = useRef(false);
   const isRendering = useRef(false);
+  const latestState = useRef(state);
 
   // Takes the parcel to tear down rather than reading `parcel.current`, which can be reassigned
   // between scheduling this and running it.
@@ -51,6 +52,29 @@ export const Extension: React.FC<ExtensionProps> = ({ state, children, ...divPro
         // `mountPromise` has settled or will, and `unmountWhenMounted` re-checks the status.
         target.mountPromise.then(unmountWhenMounted, () => {});
     }
+  }, []);
+
+  const applyUpdate = useCallback((target: Parcel, nextState: ExtensionProps['state']) => {
+    if (!target.update || target.getStatus() === 'UNMOUNTING') {
+      return;
+    }
+
+    // Every later update chains onto this promise, so it has to settle even when an update fails.
+    updatePromise.current = Promise.all([target.mountPromise, updatePromise.current])
+      .then(() => {
+        if (parcel.current?.getStatus() === 'MOUNTED' && parcel.current.update) {
+          return parcel.current.update({ ...nextState });
+        }
+      })
+      .catch((err) => {
+        // A parcel torn down while its update was in flight rejects, and that race is expected.
+        // We use the status to distinguish reject reasons as the message isn't reliable
+        const status = parcel.current?.getStatus();
+
+        if (status !== 'UNMOUNTING' && status !== 'NOT_MOUNTED' && status !== 'UNLOADING') {
+          console.error(`The extension '${extension?.extensionId}' failed to update`, err);
+        }
+      });
   }, []);
 
   const ref = useCallback((node: HTMLDivElement | null) => {
@@ -86,6 +110,12 @@ export const Extension: React.FC<ExtensionProps> = ({ state, children, ...divPro
         // parcel mounts into a detached node and its rendering record outlives the page.
         if (isUnmounted.current) {
           unmountParcel(newParcel);
+          return;
+        }
+
+        // Ensure we update the state of the parcel to the latest version we've received
+        if (newParcel && latestState.current !== state) {
+          applyUpdate(newParcel, latestState.current);
         }
       },
       // Cleared so a later reattach can try again; `renderExtension` reports its own failures.
@@ -107,28 +137,13 @@ export const Extension: React.FC<ExtensionProps> = ({ state, children, ...divPro
   }, []);
 
   useEffect(() => {
-    const target = parcel.current;
+    // Recorded before the parcel is checked, so that a state that arrives before there is a parcel
+    // to receive it is still the one applied once there is.
+    latestState.current = state;
 
-    if (!target?.update || target.getStatus() === 'UNMOUNTING') {
-      return;
+    if (parcel.current) {
+      applyUpdate(parcel.current, state);
     }
-
-    // Every later update chains onto this promise, so it has to settle even when an update fails.
-    updatePromise.current = Promise.all([target.mountPromise, updatePromise.current])
-      .then(() => {
-        if (parcel.current?.getStatus() === 'MOUNTED' && parcel.current.update) {
-          return parcel.current.update({ ...state });
-        }
-      })
-      .catch((err) => {
-        // A parcel torn down while its update was in flight rejects, and that race is expected.
-        // We use the status to distinguish reject reasons as the message isn't reliable
-        const status = parcel.current?.getStatus();
-
-        if (status !== 'UNMOUNTING' && status !== 'NOT_MOUNTED' && status !== 'UNLOADING') {
-          console.error(`The extension '${extension?.extensionId}' failed to update`, err);
-        }
-      });
   }, [state]);
 
   // The extension is rendered into the `<div>`. The `<div>` has relative

--- a/packages/framework/esm-react-utils/src/Extension.tsx
+++ b/packages/framework/esm-react-utils/src/Extension.tsx
@@ -21,52 +21,72 @@ export const Extension: React.FC<ExtensionProps> = ({ state, children, ...divPro
   const { extension } = useContext(ComponentContext);
   const parcel = useRef<Parcel | null>(null);
   const updatePromise = useRef<Promise<void>>(Promise.resolve());
+  const isUnmounted = useRef(false);
 
-  const ref = useCallback((node: HTMLDivElement) => {
-    if (
-      extension?.extensionSlotName &&
-      extension.extensionSlotModuleName &&
-      extension.extensionSlotModuleName &&
-      !parcel.current
-    ) {
-      renderExtension(
-        node,
-        extension.extensionSlotName,
-        extension.extensionSlotModuleName,
-        extension.extensionId,
-        undefined,
-        state,
-      ).then((newParcel: Parcel) => {
-        parcel.current = newParcel;
-      });
+  // Takes the parcel to tear down rather than reading `parcel.current`, which can be reassigned
+  // between scheduling this and running it.
+  const unmountParcel = useCallback((target: Parcel | null) => {
+    if (!target) {
+      return;
+    }
+
+    const unmountWhenMounted = () => {
+      if (target.getStatus() === 'MOUNTED') {
+        target.unmount();
+      }
+    };
+
+    switch (target.getStatus()) {
+      case 'MOUNTED':
+        target.unmount();
+        break;
+      case 'UPDATING':
+        // The rejection is reported by whoever owns `updatePromise`; here it only matters that a
+        // failed update still runs the teardown, or the parcel is left broken and mounted.
+        updatePromise.current?.then(unmountWhenMounted, unmountWhenMounted);
+        break;
+      default:
+        // Any other status: the parcel either hasn't finished coming up or is already gone.
+        // `mountPromise` has settled or will, and `unmountWhenMounted` re-checks the status.
+        target.mountPromise.then(unmountWhenMounted, () => {});
     }
   }, []);
 
-  useEffect(() => {
-    return () => {
-      if (parcel && parcel.current) {
-        const status = parcel.current.getStatus();
-        switch (status) {
-          case 'MOUNTING':
-            parcel.current.mountPromise.then(() => {
-              if (parcel.current?.getStatus() === 'MOUNTED') {
-                parcel.current.unmount();
-              }
-            });
-            break;
-          case 'MOUNTED':
-            parcel.current.unmount();
-            break;
-          case 'UPDATING':
-            if (updatePromise.current) {
-              updatePromise.current.then(() => {
-                if (parcel.current?.getStatus() === 'MOUNTED') {
-                  parcel.current.unmount();
-                }
-              });
-            }
-        }
+  const ref = useCallback((node: HTMLDivElement | null) => {
+    // React detaches a ref by calling it with null. That is not a request to render anything, and
+    // rendering into it warns and then resolves to null — clearing a parcel that may still be
+    // coming up, which leaves it mounted into a detached node for the life of the page.
+    if (!node || parcel.current || !extension?.extensionSlotName || !extension.extensionSlotModuleName) {
+      return;
+    }
+
+    renderExtension(
+      node,
+      extension.extensionSlotName,
+      extension.extensionSlotModuleName,
+      extension.extensionId,
+      undefined,
+      state,
+    ).then((newParcel: Parcel | null) => {
+      parcel.current = newParcel;
+
+      // Loading an extension's bundle can outlast the component that asked for it: the cleanup
+      // effect has already run and saw no parcel, so teardown has to happen here instead, or the
+      // parcel mounts into a detached node and its instance record outlives the page.
+      if (isUnmounted.current) {
+        unmountParcel(newParcel);
       }
+    });
+  }, []);
+
+  useEffect(() => {
+    // Reset on every run, not just the first: StrictMode mounts, tears down and mounts again, so
+    // a flag only ever set by the cleanup would still read "unmounted" for the live component.
+    isUnmounted.current = false;
+
+    return () => {
+      isUnmounted.current = true;
+      unmountParcel(parcel.current);
     };
   }, []);
 

--- a/packages/framework/esm-react-utils/src/extensions.test.tsx
+++ b/packages/framework/esm-react-utils/src/extensions.test.tsx
@@ -58,6 +58,69 @@ describe('ExtensionSlot, Extension, and useExtensionSlotMeta', () => {
     expect(screen.getByText(/English/)).toHaveTextContent('English?');
   });
 
+  it('Extension reports a failed update instead of rejecting silently', async () => {
+    const user = userEvent.setup();
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const delivered: Array<number> = [];
+    let failNextUpdate = true;
+
+    registerExtension({
+      name: 'Flaky',
+      moduleName: 'esm-flaky-app',
+      meta: {},
+      load: async () => ({
+        bootstrap: async () => {},
+        mount: async (props: any) => {
+          props.domElement.textContent = 'flaky extension';
+        },
+        unmount: async (props: any) => {
+          props.domElement.textContent = '';
+        },
+        update: async (props: any) => {
+          if (failNextUpdate) {
+            failNextUpdate = false;
+            throw new Error('update blew up');
+          }
+
+          delivered.push(props.value);
+        },
+      }),
+    });
+    attach('FlakyBox', 'Flaky');
+
+    const App = openmrsComponentDecorator({
+      moduleName: 'esm-flaky-app',
+      featureName: 'Flaky',
+      disableTranslations: true,
+    })(() => {
+      const [value, next] = useReducer((value: number) => value + 1, 1);
+
+      return (
+        <div>
+          <ExtensionSlot name="FlakyBox" state={{ value }} />
+          <button onClick={next}>Next</button>
+        </div>
+      );
+    });
+
+    render(<App />);
+    expect(await screen.findByText('flaky extension')).toBeInTheDocument();
+
+    // The first of these fails, which makes single-spa hard-fail the parcel, so no later update
+    // reaches the extension. What must not happen is the failure going unreported and the promise
+    // chain being left rejected, which used to produce an unhandled rejection per later change.
+    await user.click(screen.getByText('Next'));
+    await user.click(screen.getByText('Next'));
+    await user.click(screen.getByText('Next'));
+
+    await waitFor(() =>
+      expect(consoleError).toHaveBeenCalledWith("The extension 'Flaky' failed to update", expect.any(Error)),
+    );
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    expect(delivered).toEqual([]);
+    consoleError.mockRestore();
+  });
+
   it('Extension receives state changes (using <Extension>)', async () => {
     const user = userEvent.setup();
 

--- a/packages/framework/esm-react-utils/src/extensions.test.tsx
+++ b/packages/framework/esm-react-utils/src/extensions.test.tsx
@@ -7,7 +7,7 @@ import { act, render, screen, waitFor, within } from '@testing-library/react';
 import { registerFeatureFlag, setFeatureFlag } from '@openmrs/esm-feature-flags';
 import {
   attach,
-  getExtensionInstancesStore,
+  getExtensionRenderingsStore,
   getExtensionNameFromId,
   registerExtension,
   updateInternalExtensionStore,
@@ -285,10 +285,10 @@ describe('ExtensionSlot, Extension, and useExtensionSlotMeta', () => {
 describe('Extension teardown', () => {
   beforeEach(() => {
     updateInternalExtensionStore(() => ({ slots: {}, extensions: {} }));
-    getExtensionInstancesStore().setState({ instances: new Map() });
+    getExtensionRenderingsStore().setState({ renderings: new Map() });
   });
 
-  it('releases the instance when the slot unmounts while the bundle is still loading', async () => {
+  it('releases the rendering when the slot unmounts while the bundle is still loading', async () => {
     const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
     let releaseLoad = () => {};
     const loadGate = new Promise<void>((resolve) => (releaseLoad = resolve));
@@ -317,12 +317,12 @@ describe('Extension teardown', () => {
 
     const { unmount } = render(<App />);
     await act(async () => {});
-    expect(getExtensionInstancesStore().getState().instances.size).toBe(1);
+    expect(getExtensionRenderingsStore().getState().renderings.size).toBe(1);
 
     unmount();
     releaseLoad();
 
-    await waitFor(() => expect(getExtensionInstancesStore().getState().instances.size).toBe(0));
+    await waitFor(() => expect(getExtensionRenderingsStore().getState().renderings.size).toBe(0));
     // React detaches the ref by calling it with `null`; taking that for a render request starts a
     // second render that resolves to null and clears the parcel still coming up.
     expect(consoleWarn).not.toHaveBeenCalledWith(expect.stringContaining('no DOM element was available'));

--- a/packages/framework/esm-react-utils/src/extensions.test.tsx
+++ b/packages/framework/esm-react-utils/src/extensions.test.tsx
@@ -7,6 +7,7 @@ import { act, render, screen, waitFor, within } from '@testing-library/react';
 import { registerFeatureFlag, setFeatureFlag } from '@openmrs/esm-feature-flags';
 import {
   attach,
+  getExtensionInstancesStore,
   getExtensionNameFromId,
   registerExtension,
   updateInternalExtensionStore,
@@ -278,6 +279,54 @@ describe('ExtensionSlot, Extension, and useExtensionSlotMeta', () => {
     render(<App />);
 
     expect(await screen.findByText('Spanish hola')).toBeInTheDocument();
+  });
+});
+
+describe('Extension teardown', () => {
+  beforeEach(() => {
+    updateInternalExtensionStore(() => ({ slots: {}, extensions: {} }));
+    getExtensionInstancesStore().setState({ instances: new Map() });
+  });
+
+  it('releases the instance when the slot unmounts while the bundle is still loading', async () => {
+    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    let releaseLoad = () => {};
+    const loadGate = new Promise<void>((resolve) => (releaseLoad = resolve));
+    const lifecycle = getSyncLifecycle(() => <div>Fred</div>, {
+      moduleName: 'esm-flintstone',
+      featureName: 'Flintstone',
+      disableTranslations: true,
+    });
+
+    registerExtension({
+      name: 'Fred',
+      moduleName: 'esm-flintstone',
+      load: async () => {
+        await loadGate;
+        return lifecycle();
+      },
+      meta: {},
+    });
+    attach('Box', 'Fred');
+
+    const App = openmrsComponentDecorator({
+      moduleName: 'esm-flintstone',
+      featureName: 'Flintstone',
+      disableTranslations: true,
+    })(() => <ExtensionSlot name="Box" />);
+
+    const { unmount } = render(<App />);
+    await act(async () => {});
+    expect(getExtensionInstancesStore().getState().instances.size).toBe(1);
+
+    unmount();
+    releaseLoad();
+
+    await waitFor(() => expect(getExtensionInstancesStore().getState().instances.size).toBe(0));
+    // React detaches the ref by calling it with `null`; taking that for a render request starts a
+    // second render that resolves to null and clears the parcel still coming up.
+    expect(consoleWarn).not.toHaveBeenCalledWith(expect.stringContaining('no DOM element was available'));
+    consoleWarn.mockRestore();
   });
 });
 

--- a/packages/framework/esm-react-utils/src/index.ts
+++ b/packages/framework/esm-react-utils/src/index.ts
@@ -10,6 +10,7 @@ export * from './useAbortController';
 export * from './useAppContext';
 export * from './useAssignedExtensionIds';
 export * from './useAssignedExtensions';
+export * from './useCandidateExtensions';
 export * from './useShallowStableValue';
 export * from './useAttachments';
 export * from './useBodyScrollLock';

--- a/packages/framework/esm-react-utils/src/index.ts
+++ b/packages/framework/esm-react-utils/src/index.ts
@@ -10,6 +10,7 @@ export * from './useAbortController';
 export * from './useAppContext';
 export * from './useAssignedExtensionIds';
 export * from './useAssignedExtensions';
+export * from './useShallowStableValue';
 export * from './useAttachments';
 export * from './useBodyScrollLock';
 export * from './useConfig';

--- a/packages/framework/esm-react-utils/src/useAssignedExtensionIds.ts
+++ b/packages/framework/esm-react-utils/src/useAssignedExtensionIds.ts
@@ -1,26 +1,16 @@
 /** @module @category Extension */
-import { useEffect, useState } from 'react';
-import { getExtensionStore } from '@openmrs/esm-extensions';
-import { isEqual } from 'lodash-es';
+import { useMemo } from 'react';
+import { useAssignedExtensions } from './useAssignedExtensions';
 
 /**
  * Gets the assigned extension ids for a given extension slot name.
- * Does not consider if offline or online.
+ *
  * @param slotName The name of the slot to get the assigned IDs for.
  *
  * @deprecated Use `useAssignedExtensions`
  */
 export function useAssignedExtensionIds(slotName: string) {
-  const [ids, setIds] = useState<Array<string>>([]);
+  const assignedExtensions = useAssignedExtensions(slotName);
 
-  useEffect(() => {
-    return getExtensionStore().subscribe((state) => {
-      const newIds = state.slots[slotName]?.assignedExtensions.map((e) => e.id) ?? [];
-      if (!isEqual(newIds, ids)) {
-        setIds(newIds);
-      }
-    });
-  }, []);
-
-  return ids;
+  return useMemo(() => assignedExtensions.map((extension) => extension.id), [assignedExtensions]);
 }

--- a/packages/framework/esm-react-utils/src/useAssignedExtensions.ts
+++ b/packages/framework/esm-react-utils/src/useAssignedExtensions.ts
@@ -11,9 +11,10 @@ const selectSession = (state: SessionStore) => state.session;
 /**
  * Gets the assigned extensions for a given extension slot name.
  *
- * Pass `state` whenever the extensions are being displayed. The same slot can be rendered in
- * several places at once with different state, so display conditions are evaluated against the
- * state of this rendering; without it, extensions a condition would hide are included.
+ * Display conditions are always applied, so the result is what should actually be displayed. Pass
+ * `state` whenever you know it: the same slot can be rendered in several places at once with
+ * different state, so conditions are resolved against the state of this rendering. Omitting it
+ * resolves them against the session alone, hiding any extension whose condition depends on state.
  *
  * The returned array is a copy, so sorting or filtering it in place can't corrupt the extension
  * store. Its reference is stable for as long as the slot, the state and the session are.
@@ -28,7 +29,7 @@ export function useAssignedExtensions(slotName: string, state?: ExtensionSlotCus
   const stableState = useShallowStableValue(state);
 
   return useMemo(
-    () => filterExtensionsByDisplayConditions(assignedExtensions, stableState, session),
-    [assignedExtensions, stableState, session],
+    () => filterExtensionsByDisplayConditions(assignedExtensions, stableState, session, slotName),
+    [assignedExtensions, stableState, session, slotName],
   );
 }

--- a/packages/framework/esm-react-utils/src/useAssignedExtensions.ts
+++ b/packages/framework/esm-react-utils/src/useAssignedExtensions.ts
@@ -1,11 +1,34 @@
 /** @module @category Extension */
+import { useMemo } from 'react';
+import { sessionStore, type SessionStore } from '@openmrs/esm-api';
+import { type ExtensionSlotCustomState, filterExtensionsByDisplayConditions } from '@openmrs/esm-extensions';
+import { useShallowStableValue } from './useShallowStableValue';
 import { useExtensionSlotStore } from './useExtensionSlotStore';
+import { useStore } from './useStore';
+
+const selectSession = (state: SessionStore) => state.session;
 
 /**
  * Gets the assigned extensions for a given extension slot name.
+ *
+ * Pass `state` whenever the extensions are being displayed. The same slot can be rendered in
+ * several places at once with different state, so display conditions are evaluated against the
+ * state of this rendering; without it, extensions a condition would hide are included.
+ *
+ * The returned array is a copy, so sorting or filtering it in place can't corrupt the extension
+ * store. Its reference is stable for as long as the slot, the state and the session are.
+ *
  * @param slotName The name of the slot to get the assigned extensions for.
+ * @param state The state of this rendering of the slot.
  */
-export function useAssignedExtensions(slotName: string) {
-  const slotStore = useExtensionSlotStore(slotName);
-  return slotStore?.assignedExtensions ?? [];
+export function useAssignedExtensions(slotName: string, state?: ExtensionSlotCustomState) {
+  const { assignedExtensions } = useExtensionSlotStore(slotName);
+  // Display conditions may refer to `session`, so they have to be re-evaluated when it changes.
+  const session = useStore(sessionStore, selectSession);
+  const stableState = useShallowStableValue(state);
+
+  return useMemo(
+    () => filterExtensionsByDisplayConditions(assignedExtensions, stableState, session),
+    [assignedExtensions, stableState, session],
+  );
 }

--- a/packages/framework/esm-react-utils/src/useAssignedExtensions.ts
+++ b/packages/framework/esm-react-utils/src/useAssignedExtensions.ts
@@ -1,7 +1,7 @@
 /** @module @category Extension */
 import { useMemo } from 'react';
 import { sessionStore, type SessionStore } from '@openmrs/esm-api';
-import { type ExtensionSlotCustomState, filterExtensionsByDisplayConditions } from '@openmrs/esm-extensions';
+import { type ExtensionSlotCustomState, getAssignedExtensions } from '@openmrs/esm-extensions';
 import { useShallowStableValue } from './useShallowStableValue';
 import { useExtensionSlotStore } from './useExtensionSlotStore';
 import { useStore } from './useStore';
@@ -11,25 +11,28 @@ const selectSession = (state: SessionStore) => state.session;
 /**
  * Gets the assigned extensions for a given extension slot name.
  *
- * Display conditions are always applied, so the result is what should actually be displayed. Pass
- * `state` whenever you know it: the same slot can be rendered in several places at once with
- * different state, so conditions are resolved against the state of this rendering. Omitting it
- * resolves them against the session alone, hiding any extension whose condition depends on state.
+ * The reactive form of `getAssignedExtensions`, and it answers the same thing: display conditions
+ * are always applied, so the result is what should actually be displayed. Pass `state` whenever you
+ * know it: the same slot can be rendered in several places at once with different state, so
+ * conditions are resolved against the state of this rendering. Omitting it resolves them against
+ * the session alone, hiding any extension whose condition depends on state.
  *
  * The returned array is a copy, so sorting or filtering it in place can't corrupt the extension
- * store. Its reference is stable for as long as the slot, the state and the session are.
+ * store. Its reference is stable for as long as the slot's extensions, the state and the session are.
  *
  * @param slotName The name of the slot to get the assigned extensions for.
  * @param state The state of this rendering of the slot.
  */
 export function useAssignedExtensions(slotName: string, state?: ExtensionSlotCustomState) {
-  const { assignedExtensions } = useExtensionSlotStore(slotName);
+  // Subscribes so that this re-runs when the slot's extensions change; `getAssignedExtensions` reads
+  // the same store, so the value below is what it is about to return.
+  const { candidateExtensions } = useExtensionSlotStore(slotName);
   // Display conditions may refer to `session`, so they have to be re-evaluated when it changes.
   const session = useStore(sessionStore, selectSession);
   const stableState = useShallowStableValue(state);
 
   return useMemo(
-    () => filterExtensionsByDisplayConditions(assignedExtensions, stableState, session, slotName),
-    [assignedExtensions, stableState, session, slotName],
+    () => getAssignedExtensions(slotName, stableState),
+    [slotName, stableState, session, candidateExtensions],
   );
 }

--- a/packages/framework/esm-react-utils/src/useCandidateExtensions.ts
+++ b/packages/framework/esm-react-utils/src/useCandidateExtensions.ts
@@ -1,0 +1,20 @@
+/** @module @category Extension */
+import { getCandidateExtensions } from '@openmrs/esm-extensions';
+import { useExtensionSlotStore } from './useExtensionSlotStore';
+
+/**
+ * The reactive form of `getCandidateExtensions`: everything assigned to a slot, with no display
+ * condition evaluated. Intended for tools that present a slot's configuration rather than render it.
+ *
+ * Use {@link useAssignedExtensions} to decide what to display.
+ *
+ * @param slotName The name of the slot to get the candidate extensions for.
+ * @internal
+ */
+export function useCandidateExtensions(slotName: string) {
+  // Subscribes so this re-runs when the slot's extensions change; `getCandidateExtensions` reads the
+  // same store, and returns the array below.
+  useExtensionSlotStore(slotName);
+
+  return getCandidateExtensions(slotName);
+}

--- a/packages/framework/esm-react-utils/src/useCandidateExtensions.ts
+++ b/packages/framework/esm-react-utils/src/useCandidateExtensions.ts
@@ -1,5 +1,4 @@
 /** @module @category Extension */
-import { getCandidateExtensions } from '@openmrs/esm-extensions';
 import { useExtensionSlotStore } from './useExtensionSlotStore';
 
 /**
@@ -12,9 +11,5 @@ import { useExtensionSlotStore } from './useExtensionSlotStore';
  * @internal
  */
 export function useCandidateExtensions(slotName: string) {
-  // Subscribes so this re-runs when the slot's extensions change; `getCandidateExtensions` reads the
-  // same store, and returns the array below.
-  useExtensionSlotStore(slotName);
-
-  return getCandidateExtensions(slotName);
+  return useExtensionSlotStore(slotName).candidateExtensions;
 }

--- a/packages/framework/esm-react-utils/src/useExtensionSlot.ts
+++ b/packages/framework/esm-react-utils/src/useExtensionSlot.ts
@@ -1,4 +1,4 @@
-import { useContext, useEffect, useRef } from 'react';
+import { useContext, useEffect } from 'react';
 import { type ExtensionSlotCustomState, registerExtensionSlot } from '@openmrs/esm-extensions';
 import { ComponentContext } from './ComponentContext';
 import { useAssignedExtensions } from './useAssignedExtensions';
@@ -10,11 +10,6 @@ export function useExtensionSlot(slotName: string, state?: ExtensionSlotCustomSt
   if (!moduleName) {
     throw Error('ComponentContext has not been provided. This should come from @openmrs/esm-react-utils.');
   }
-
-  // Callers almost always pass `state` as an object literal, so its identity changes every render
-  // while its contents don't. Reading it from a ref keeps it out of the effect dependencies below.
-  const stateRef = useRef(state);
-  stateRef.current = state;
 
   useEffect(() => {
     registerExtensionSlot(moduleName, slotName);

--- a/packages/framework/esm-react-utils/src/useExtensionSlot.ts
+++ b/packages/framework/esm-react-utils/src/useExtensionSlot.ts
@@ -1,33 +1,30 @@
 import { useContext, useEffect, useRef } from 'react';
-import {
-  type ExtensionSlotCustomState,
-  registerExtensionSlot,
-  updateExtensionSlotState,
-} from '@openmrs/esm-extensions';
+import { type ExtensionSlotCustomState, registerExtensionSlot } from '@openmrs/esm-extensions';
 import { ComponentContext } from './ComponentContext';
 import { useAssignedExtensions } from './useAssignedExtensions';
 
 /** @internal */
 export function useExtensionSlot(slotName: string, state?: ExtensionSlotCustomState) {
   const { moduleName } = useContext(ComponentContext);
-  const isInitialRender = useRef(true);
 
   if (!moduleName) {
     throw Error('ComponentContext has not been provided. This should come from @openmrs/esm-react-utils.');
   }
 
-  useEffect(() => {
-    registerExtensionSlot(moduleName, slotName, state);
-    isInitialRender.current = false;
-  }, []);
+  // Callers almost always pass `state` as an object literal, so its identity changes every render
+  // while its contents don't. Reading it from a ref keeps it out of the effect dependencies below.
+  const stateRef = useRef(state);
+  stateRef.current = state;
 
   useEffect(() => {
-    if (!isInitialRender.current) {
-      updateExtensionSlotState(slotName, state);
-    }
-  }, [slotName, state]);
+    registerExtensionSlot(moduleName, slotName);
+  }, [moduleName, slotName]);
 
-  const extensions = useAssignedExtensions(slotName);
+  // `state` stays local to this rendering rather than being written to the slot: the same slot can
+  // be rendered many times at once — once per row of a list — and each rendering has its own state,
+  // so there is no single value the slot could hold. It is passed to `useAssignedExtensions`, which
+  // resolves this rendering's display conditions against it.
+  const extensions = useAssignedExtensions(slotName, state);
 
   return {
     extensions,

--- a/packages/framework/esm-react-utils/src/useExtensionSlot.ts
+++ b/packages/framework/esm-react-utils/src/useExtensionSlot.ts
@@ -15,10 +15,8 @@ export function useExtensionSlot(slotName: string, state?: ExtensionSlotCustomSt
     registerExtensionSlot(moduleName, slotName);
   }, [moduleName, slotName]);
 
-  // `state` stays local to this rendering rather than being written to the slot: the same slot can
-  // be rendered many times at once — once per row of a list — and each rendering has its own state,
-  // so there is no single value the slot could hold. It is passed to `useAssignedExtensions`, which
-  // resolves this rendering's display conditions against it.
+  // `state` must be local to the rendering rather than written to the store as state is
+  // render-specific
   const extensions = useAssignedExtensions(slotName, state);
 
   return {

--- a/packages/framework/esm-react-utils/src/useExtensionSlotStore.ts
+++ b/packages/framework/esm-react-utils/src/useExtensionSlotStore.ts
@@ -1,13 +1,23 @@
 /** @module @category Extension */
 import { useCallback } from 'react';
-import { type ExtensionSlotState, type ExtensionStore, getExtensionStore } from '@openmrs/esm-extensions';
+import {
+  type AssignedExtension,
+  type ExtensionSlotState,
+  type ExtensionStore,
+  getExtensionStore,
+} from '@openmrs/esm-extensions';
 import { useStore } from './useStore';
 
 /**
  * Stands in for a slot that has not been registered or attached to. Shared rather than built per
- * call, so the snapshot stays reference-stable across renders.
+ * call, so the snapshot stays reference-stable across renders — and frozen because that sharing
+ * means an in-place sort or push would otherwise corrupt every unregistered slot in the page.
  */
-const emptySlotState: ExtensionSlotState = { assignedExtensions: [] };
+const emptyCandidates: Array<AssignedExtension> = [];
+Object.freeze(emptyCandidates);
+
+const emptySlotState: ExtensionSlotState = { candidateExtensions: emptyCandidates };
+Object.freeze(emptySlotState);
 
 export const useExtensionSlotStore = (slot: string) => {
   // Memoized so that `useStore`'s snapshot function is stable across renders.

--- a/packages/framework/esm-react-utils/src/useExtensionSlotStore.ts
+++ b/packages/framework/esm-react-utils/src/useExtensionSlotStore.ts
@@ -1,6 +1,16 @@
 /** @module @category Extension */
+import { useCallback } from 'react';
 import { type ExtensionSlotState, type ExtensionStore, getExtensionStore } from '@openmrs/esm-extensions';
 import { useStore } from './useStore';
 
-export const useExtensionSlotStore = (slot: string) =>
-  useStore<ExtensionStore, ExtensionSlotState>(getExtensionStore(), (state) => state.slots?.[slot]);
+/**
+ * Stands in for a slot that has not been registered or attached to. Shared rather than built per
+ * call, so the snapshot stays reference-stable across renders.
+ */
+const emptySlotState: ExtensionSlotState = { assignedExtensions: [] };
+
+export const useExtensionSlotStore = (slot: string) => {
+  // Memoized so that `useStore`'s snapshot function is stable across renders.
+  const select = useCallback((state: ExtensionStore) => state.slots?.[slot] ?? emptySlotState, [slot]);
+  return useStore<ExtensionStore, ExtensionSlotState>(getExtensionStore(), select);
+};

--- a/packages/framework/esm-react-utils/src/useShallowStableValue.test.ts
+++ b/packages/framework/esm-react-utils/src/useShallowStableValue.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useShallowStableValue } from './useShallowStableValue';
+
+describe('useShallowStableValue', () => {
+  it('keeps its reference across an equal object literal', () => {
+    const { result, rerender } = renderHook(({ value }) => useShallowStableValue(value), {
+      initialProps: { value: { patientUuid: 'abc' } },
+    });
+    const first = result.current;
+
+    rerender({ value: { patientUuid: 'abc' } });
+
+    expect(result.current).toBe(first);
+  });
+
+  it('takes the new reference when a value changes', () => {
+    const { result, rerender } = renderHook(({ value }) => useShallowStableValue(value), {
+      initialProps: { value: { patientUuid: 'abc' } },
+    });
+    const first = result.current;
+    const next = { patientUuid: 'def' };
+
+    rerender({ value: next });
+
+    expect(result.current).not.toBe(first);
+    expect(result.current).toBe(next);
+  });
+
+  it('takes the new reference when a key is added or removed', () => {
+    const { result, rerender } = renderHook(({ value }) => useShallowStableValue(value), {
+      initialProps: { value: { a: 1 } as Record<string, number> },
+    });
+    const first = result.current;
+
+    rerender({ value: { a: 1, b: 2 } });
+    expect(result.current).not.toBe(first);
+
+    const both = result.current;
+    rerender({ value: { a: 1 } });
+    expect(result.current).not.toBe(both);
+  });
+
+  it('returns the latest of two equal values rather than the first one it ever saw', () => {
+    const { result, rerender } = renderHook(({ value }) => useShallowStableValue(value), {
+      initialProps: { value: { n: 1 } },
+    });
+    const first = result.current;
+
+    rerender({ value: { n: 2 } });
+    const third = { n: 1 };
+    rerender({ value: third });
+
+    // Equal to the first value, but the run of equal values was broken, so it is a new reference.
+    expect(result.current).toBe(third);
+    expect(result.current).not.toBe(first);
+  });
+
+  it('compares only one level deep', () => {
+    const { result, rerender } = renderHook(({ value }) => useShallowStableValue(value), {
+      initialProps: { value: { patient: { uuid: 'abc' } } },
+    });
+    const first = result.current;
+
+    rerender({ value: { patient: { uuid: 'abc' } } });
+
+    expect(result.current).not.toBe(first);
+  });
+});

--- a/packages/framework/esm-react-utils/src/useShallowStableValue.ts
+++ b/packages/framework/esm-react-utils/src/useShallowStableValue.ts
@@ -11,7 +11,7 @@ import { shallowEqual } from '@openmrs/esm-utils';
  * so a value nested more than one level deep still reads as a change.
  *
  * @param value The value to stabilize
- * @returns The first value shallowly equal to `value` that this hook was given
+ * @returns `value`, or the last value this hook returned if the two are shallowly equal
  */
 export function useShallowStableValue<T>(value: T): T {
   const stable = useRef(value);

--- a/packages/framework/esm-react-utils/src/useShallowStableValue.ts
+++ b/packages/framework/esm-react-utils/src/useShallowStableValue.ts
@@ -1,0 +1,24 @@
+/** @module @category Utility */
+import { useRef } from 'react';
+import { shallowEqual } from '@openmrs/esm-utils';
+
+/**
+ * Returns `value` with a reference that only changes when its contents do, so that it can be used
+ * as a dependency of `useMemo`, `useEffect` and friends.
+ *
+ * This exists for props that are almost always written as object literals — `state={{ patientUuid }}`
+ * — which get a new identity on every render while meaning the same thing. Comparison is shallow,
+ * so a value nested more than one level deep still reads as a change.
+ *
+ * @param value The value to stabilize
+ * @returns The first value shallowly equal to `value` that this hook was given
+ */
+export function useShallowStableValue<T>(value: T): T {
+  const stable = useRef(value);
+
+  if (!shallowEqual(stable.current, value)) {
+    stable.current = value;
+  }
+
+  return stable.current;
+}

--- a/packages/framework/esm-react-utils/src/useStore.test.ts
+++ b/packages/framework/esm-react-utils/src/useStore.test.ts
@@ -1,3 +1,4 @@
+import React from 'react';
 import { describe, expect, it } from 'vitest';
 import { act, renderHook } from '@testing-library/react';
 import { createGlobalStore } from '@openmrs/esm-state';
@@ -22,6 +23,44 @@ describe('useStore', () => {
       result.current.tally('good', 2);
     });
     expect(result.current.count).toBe(2);
+  });
+});
+
+describe('useStore reference stability', () => {
+  it('returns the store state itself when there are no actions to merge in', () => {
+    const store = createGlobalStore('stability-plain', { renderings: new Map<string, number>() });
+    const { result, rerender } = renderHook(() => useStore(store));
+
+    // Not a copy: consumers of the extension renderings store depend on this, because the map
+    // inside is mutated in place and only the state object around it changes identity.
+    expect(result.current).toBe(store.getState());
+
+    const before = result.current;
+    rerender();
+    expect(result.current).toBe(before);
+  });
+
+  it('keeps its reference across an unrelated re-render, so it can be a memo dependency', () => {
+    const store = createGlobalStore('stability-memo', { a: 1, b: 2 });
+    let memoRuns = 0;
+
+    const { result, rerender } = renderHook(() => {
+      const state = useStore(store);
+
+      const derived = React.useMemo(() => ++memoRuns, [state]);
+      return derived;
+    });
+
+    expect(memoRuns).toBe(1);
+    rerender();
+    expect(memoRuns).toBe(1);
+
+    act(() => {
+      store.setState({ a: 2 });
+    });
+
+    expect(memoRuns).toBe(2);
+    expect(result.current).toBe(2);
   });
 });
 

--- a/packages/framework/esm-react-utils/src/useStore.ts
+++ b/packages/framework/esm-react-utils/src/useStore.ts
@@ -44,10 +44,14 @@ function bindActions<T>(store: StoreApi<T>, actions: Actions<T>): BoundActions<T
   return bound;
 }
 
-const defaultSelectFunction =
-  <T, U>() =>
-  (x: T) =>
-    x as unknown as U;
+/**
+ * A single shared identity function, rather than one built per call: `getSnapshot` below takes
+ * the selector as a dependency, so a fresh default each render would leave it unstable for every
+ * caller that doesn't pass a selector of its own.
+ */
+const identitySelect = (x: unknown) => x;
+
+const defaultSelectFunction = <T, U>() => identitySelect as (x: T) => U;
 
 function useStore<T>(store: StoreApi<T>): T;
 function useStore<T, U>(store: StoreApi<T>, select: (state: T) => U): U;
@@ -79,12 +83,15 @@ function useStore<T, U, A extends Actions<T>>(
 
   const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
-  let boundActions: BoundActions<T, Actions<T>> = useMemo(
-    () => (actions ? bindActions(store, actions) : {}),
+  let boundActions: BoundActions<T, Actions<T>> | null = useMemo(
+    () => (actions ? bindActions(store, actions) : null),
     [store, actions],
   );
 
-  return { ...state, ...boundActions };
+  // Returned as-is when there are no actions to merge in, so the reference stays stable for as
+  // long as the selected value does. That value is not a copy — it is whatever the selector
+  // returned, usually the store's own state.
+  return useMemo(() => (boundActions ? { ...state, ...boundActions } : state), [state, boundActions]);
 }
 
 /**
@@ -110,12 +117,12 @@ function createUseStore<T>(store: StoreApi<T>) {
     const getSnapshot = useCallback(() => store.getState(), []);
     const state = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
-    let boundActions: BoundActions<T, Actions<T>> = useMemo(
-      () => (actions ? bindActions(store, actions) : {}),
+    let boundActions: BoundActions<T, Actions<T>> | null = useMemo(
+      () => (actions ? bindActions(store, actions) : null),
       [actions],
     );
 
-    return { ...state, ...boundActions };
+    return useMemo(() => (boundActions ? { ...state, ...boundActions } : state), [state, boundActions]);
   }
 
   return useStore;

--- a/packages/framework/esm-routes/src/loaders/pages.ts
+++ b/packages/framework/esm-routes/src/loaders/pages.ts
@@ -1,5 +1,6 @@
 import { type ActivityFn, pathToActiveWhen, registerApplication } from 'single-spa';
 import { registerModuleWithConfigSystem } from '@openmrs/esm-config';
+import { batchExtensionUpdates } from '@openmrs/esm-extensions';
 import {
   type WorkspaceGroupDefinition,
   type ExtensionDefinition,
@@ -97,6 +98,12 @@ function wrapPageActivityFn(
  * definition.
  */
 export function registerApp(appName: string, routes: OpenmrsAppRoutes) {
+  // An app registers every one of its extensions in one go, and each registration would
+  // otherwise re-derive the whole extension graph. Batching collapses that into one pass.
+  batchExtensionUpdates(() => registerAppRoutes(appName, routes));
+}
+
+function registerAppRoutes(appName: string, routes: OpenmrsAppRoutes) {
   if (appName && routes && typeof routes === 'object') {
     registerModuleWithConfigSystem(appName);
 

--- a/packages/framework/esm-state/mock-jest.ts
+++ b/packages/framework/esm-state/mock-jest.ts
@@ -32,6 +32,10 @@ export function createGlobalStore<T>(name: string, initialState: T): StoreApi<T>
 }
 
 export function registerGlobalStore<T>(name: string, store: StoreApi<T>): StoreApi<T> {
+  // Recorded so `resetMock()` has something to restore; an already-built store carries its initial
+  // state in itself rather than being handed one.
+  initialStates[name] = store.getState();
+
   availableStores[name] = {
     value: store,
     active: true,

--- a/packages/framework/esm-state/mock.ts
+++ b/packages/framework/esm-state/mock.ts
@@ -32,6 +32,10 @@ export function createGlobalStore<T>(name: string, initialState: T): StoreApi<T>
 }
 
 export function registerGlobalStore<T>(name: string, store: StoreApi<T>): StoreApi<T> {
+  // Recorded so `resetMock()` has something to restore; an already-built store carries its initial
+  // state in itself rather than being handed one.
+  initialStates[name] = store.getState();
+
   availableStores[name] = {
     value: store,
     active: true,

--- a/packages/framework/esm-styleguide/src/modals/index.tsx
+++ b/packages/framework/esm-styleguide/src/modals/index.tsx
@@ -4,7 +4,7 @@ import { createGlobalStore } from '@openmrs/esm-state';
 import { getModalRegistration, renderParcel } from '@openmrs/esm-extensions';
 import { reportError } from '@openmrs/esm-error-handling';
 
-type ModalInstanceState = 'NEW' | 'MOUNTED' | 'TO_BE_DELETED';
+type ModalInstanceState = 'NEW' | 'MOUNTING' | 'MOUNTED' | 'TO_BE_DELETED' | 'DELETED';
 type ModalSize = 'xs' | 'sm' | 'md' | 'lg';
 
 export interface ModalProps {
@@ -80,6 +80,16 @@ async function renderModalIntoDOM(
   return parcel;
 }
 
+function isClosing(instance: ModalInstance) {
+  return instance.state === 'TO_BE_DELETED' || instance.state === 'DELETED';
+}
+
+function unmountModalParcel(modalName: string, parcel: Parcel | null | undefined) {
+  parcel?.unmount?.().catch((err) => {
+    console.error(`The modal '${modalName}' failed to unmount`, err);
+  });
+}
+
 const original = window.getComputedStyle(document.body).overflow;
 
 function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
@@ -100,12 +110,29 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
         case 'NEW': {
           const modalFrame = createModalFrame({ size: instance.props?.size ?? 'md' });
           instance.container = modalFrame;
-          renderModalIntoDOM(modalFrame, instance.modalName, instance.props).then((parcel) => {
-            instance.parcel = parcel;
-            instance.state = 'MOUNTED';
-            modalContainer.prepend(modalFrame);
-            modalFrame.style.visibility = 'unset';
-          });
+          instance.state = 'MOUNTING';
+
+          renderModalIntoDOM(modalFrame, instance.modalName, instance.props).then(
+            (parcel) => {
+              // Release the parcel if it's been closed while mounting
+              if (isClosing(instance)) {
+                unmountModalParcel(instance.modalName, parcel);
+                return;
+              }
+
+              instance.parcel = parcel;
+              instance.state = 'MOUNTED';
+              modalContainer.prepend(modalFrame);
+              modalFrame.style.visibility = modalStore.getState().modalStack.indexOf(instance) ? 'hidden' : 'unset';
+            },
+            (err) => {
+              // Nothing is chained to this, so without a handler a modal that fails to load is
+              // only an unhandled rejection — and its instance holds the overlay open over a
+              // page the user can no longer reach.
+              reportError(err);
+              closeInstance(instance);
+            },
+          );
           break;
         }
 
@@ -116,17 +143,18 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
           break;
 
         case 'TO_BE_DELETED':
+          instance.state = 'DELETED';
           instance.onClose();
-          // A rejected unmount would otherwise be an unhandled rejection; the tear-down below runs
-          // either way.
-          instance.parcel?.unmount?.().catch((err) => {
-            console.error(`The modal '${instance.modalName}' failed to unmount`, err);
-          });
+          unmountModalParcel(instance.modalName, instance.parcel);
           instance.container?.remove();
           setTimeout(() => {
+            // Read now rather than closed over: modals opened since this was scheduled are in the
+            // store's stack but not in the one this pass saw, and would be dropped with it.
+            const current = modalStore.getState();
+
             modalStore.setState({
-              modalContainer,
-              modalStack: modalStack.filter((x) => x !== instance),
+              ...current,
+              modalStack: current.modalStack.filter((x) => x !== instance),
             });
           }, 0);
           break;
@@ -150,13 +178,18 @@ function openInstance(instance: ModalInstance) {
 }
 
 function closeInstance(instance: ModalInstance) {
+  if (isClosing(instance)) {
+    return;
+  }
+
+  // Mutated rather than replaced by a copy as an in-flight mount will close over this property
+  instance.state = 'TO_BE_DELETED';
+
   const state = modalStore.getState();
-  const modalStack = state.modalStack.map(
-    (x): ModalInstance => (x === instance ? { ...x, state: 'TO_BE_DELETED' } : x),
-  );
+
   modalStore.setState({
     ...state,
-    modalStack,
+    modalStack: [...state.modalStack],
   });
 }
 

--- a/packages/framework/esm-styleguide/src/modals/index.tsx
+++ b/packages/framework/esm-styleguide/src/modals/index.tsx
@@ -98,6 +98,26 @@ function unmountModalParcel(modalName: string, parcel: Parcel | null | undefined
   });
 }
 
+/**
+ * The modal the user is looking at: the frontmost one that isn't on its way out. Modals being torn
+ * down are skipped rather than counted, since their frames are already gone — counting them would
+ * leave the modal underneath hidden behind nothing until they finally left the stack.
+ */
+function frontmostModal(modalStack: Array<ModalInstance>) {
+  return modalStack.find((instance) => !isClosing(instance));
+}
+
+/**
+ * Only the frontmost modal is shown; the ones it was opened over stay in the DOM behind it. Applied
+ * both as the stack changes and as a frame is inserted, since a frame inserted after the last
+ * change to the stack would otherwise never be told.
+ */
+function applyModalVisibility(instance: ModalInstance, isFrontmost: boolean) {
+  if (instance.container) {
+    instance.container.style.visibility = isFrontmost ? 'unset' : 'hidden';
+  }
+}
+
 const original = window.getComputedStyle(document.body).overflow;
 
 function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
@@ -113,7 +133,11 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
       modalContainer.style.visibility = 'unset';
     }
 
-    modalStack.forEach((instance, index) => {
+    // Stable across the pass below: the only states it changes are `NEW` to `MOUNTING` and
+    // `TO_BE_DELETED` to `DELETED`, neither of which moves a modal in or out of the running.
+    const frontmost = frontmostModal(modalStack);
+
+    modalStack.forEach((instance) => {
       switch (instance.state) {
         case 'NEW': {
           const modalFrame = createModalFrame({ size: instance.props?.size ?? 'md' });
@@ -137,7 +161,9 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
 
               instance.parcel = parcel;
               modalContainer.prepend(modalFrame);
-              modalFrame.style.visibility = modalStore.getState().modalStack.indexOf(instance) ? 'hidden' : 'unset';
+              // The stack decides which modal is frontmost, not the DOM order this prepend just
+              // established: another modal opened while this one loaded belongs on top of it.
+              applyModalVisibility(instance, frontmostModal(modalStore.getState().modalStack) === instance);
 
               // The parcel is handed back before it has mounted, so this is where the modal is
               // really on screen.
@@ -165,10 +191,11 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
           break;
         }
 
+        // A frame is inserted as soon as the parcel exists, which is before it has mounted, so a
+        // modal opened over one still mounting has to hide it just the same.
+        case 'MOUNTING':
         case 'MOUNTED':
-          if (instance.container) {
-            instance.container.style.visibility = index ? 'hidden' : 'unset';
-          }
+          applyModalVisibility(instance, instance === frontmost);
           break;
 
         case 'TO_BE_DELETED':

--- a/packages/framework/esm-styleguide/src/modals/index.tsx
+++ b/packages/framework/esm-styleguide/src/modals/index.tsx
@@ -117,7 +117,11 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
 
         case 'TO_BE_DELETED':
           instance.onClose();
-          instance.parcel?.unmount?.();
+          // A rejected unmount would otherwise be an unhandled rejection; the tear-down below runs
+          // either way.
+          instance.parcel?.unmount?.().catch((err) => {
+            console.error(`The modal '${instance.modalName}' failed to unmount`, err);
+          });
           instance.container?.remove();
           setTimeout(() => {
             modalStore.setState({

--- a/packages/framework/esm-styleguide/src/modals/index.tsx
+++ b/packages/framework/esm-styleguide/src/modals/index.tsx
@@ -85,7 +85,15 @@ function isClosing(instance: ModalInstance) {
 }
 
 function unmountModalParcel(modalName: string, parcel: Parcel | null | undefined) {
-  parcel?.unmount?.().catch((err) => {
+  if (!parcel?.unmount) {
+    return;
+  }
+
+  // A failed unmount rejects `unmountPromise` as well as the promise the call returns. They are
+  // separate promises, so leaving either without a handler is an unhandled rejection, but one
+  // failure is worth reporting only once.
+  parcel.unmountPromise?.catch(() => {});
+  parcel.unmount().catch((err) => {
     console.error(`The modal '${modalName}' failed to unmount`, err);
   });
 }
@@ -120,10 +128,31 @@ function handleModalStateUpdate({ modalStack, modalContainer }: ModalState) {
                 return;
               }
 
+              if (!parcel) {
+                // `renderModalIntoDOM` only returns without one when it had nowhere to render it,
+                // which it has already reported.
+                closeInstance(instance);
+                return;
+              }
+
               instance.parcel = parcel;
-              instance.state = 'MOUNTED';
               modalContainer.prepend(modalFrame);
               modalFrame.style.visibility = modalStore.getState().modalStack.indexOf(instance) ? 'hidden' : 'unset';
+
+              // The parcel is handed back before it has mounted, so this is where the modal is
+              // really on screen.
+              parcel.mountPromise.then(
+                () => {
+                  if (!isClosing(instance)) {
+                    instance.state = 'MOUNTED';
+                  }
+                },
+                (err) => {
+                  reportError(err);
+                  instance.parcel = null;
+                  closeInstance(instance);
+                },
+              );
             },
             (err) => {
               // Nothing is chained to this, so without a handler a modal that fails to load is

--- a/packages/framework/esm-styleguide/src/modals/modals.test.ts
+++ b/packages/framework/esm-styleguide/src/modals/modals.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { type Parcel } from 'single-spa';
 
 vi.mock('@openmrs/esm-extensions', () => ({
@@ -6,6 +6,11 @@ vi.mock('@openmrs/esm-extensions', () => ({
   renderParcel: vi.fn(),
 }));
 
+vi.mock('@openmrs/esm-error-handling', () => ({
+  reportError: vi.fn(),
+}));
+
+import { reportError } from '@openmrs/esm-error-handling';
 import { getModalRegistration, renderParcel } from '@openmrs/esm-extensions';
 import { setupModals, showModal } from './index';
 
@@ -19,13 +24,65 @@ function fakeParcel(unmount: () => Promise<void>) {
   return { unmount: vi.fn(unmount) } as unknown as Parcel;
 }
 
+/**
+ * Registers `loads` by modal name, falling back to a modal that loads immediately. Naming them
+ * apart is what lets one modal be held in flight while another mounts.
+ */
+function registerModals(loads: Record<string, () => Promise<typeof lifecycle>> = {}) {
+  vi.mocked(getModalRegistration).mockImplementation(
+    (modalName: string) => ({ load: loads[modalName] ?? (() => Promise.resolve(lifecycle)) }) as never,
+  );
+}
+
+/** A load that stays in flight until `release()`, which is the window each race below opens in. */
+function gatedLoad() {
+  let release: () => void = () => {};
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+
+  return {
+    release,
+    load: vi.fn(async () => {
+      await gate;
+      return lifecycle;
+    }),
+  };
+}
+
 /** Lets the `.then()` chains inside the modal store's subscriber run. */
 const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
 
+function setUpModalContainer() {
+  const container = document.createElement('div');
+  document.body.append(container);
+  setupModals(container);
+
+  return container;
+}
+
 describe('modals', () => {
+  const openModals: Array<() => void> = [];
+
+  /** Records the handle so that {@link afterEach} can close whatever a test leaves open. */
+  function open(...args: Parameters<typeof showModal>) {
+    const close = showModal(...args);
+    openModals.push(close);
+
+    return close;
+  }
+
   beforeEach(() => {
     document.body.innerHTML = '';
-    vi.mocked(getModalRegistration).mockReturnValue({ load: () => Promise.resolve(lifecycle) } as never);
+    registerModals();
+  });
+
+  // The modal store is global, so a modal still on the stack belongs to the next test as well —
+  // which, among other things, holds the overlay open over it.
+  afterEach(async () => {
+    openModals.splice(0).forEach((close) => close());
+    await flush();
+    await flush();
   });
 
   /*
@@ -38,11 +95,9 @@ describe('modals', () => {
     const unmountError = new Error('parcel not mounted');
     vi.mocked(renderParcel).mockResolvedValue(fakeParcel(() => Promise.reject(unmountError)));
 
-    const container = document.createElement('div');
-    document.body.append(container);
-    setupModals(container);
+    const container = setUpModalContainer();
 
-    const close = showModal('a-modal');
+    const close = open('a-modal');
     await flush();
 
     close();
@@ -55,11 +110,9 @@ describe('modals', () => {
   it('tears the modal down even though unmounting failed', async () => {
     vi.mocked(renderParcel).mockResolvedValue(fakeParcel(() => Promise.reject(new Error('parcel not mounted'))));
 
-    const container = document.createElement('div');
-    document.body.append(container);
-    setupModals(container);
+    const container = setUpModalContainer();
 
-    const close = showModal('another-modal');
+    const close = open('another-modal');
     await flush();
 
     expect(container.childElementCount).toBe(1);
@@ -68,5 +121,104 @@ describe('modals', () => {
     await flush();
 
     expect(container.childElementCount).toBe(0);
+  });
+
+  it('does not mount a second copy when another modal opens while the first is still loading', async () => {
+    const { release, load } = gatedLoad();
+    registerModals({ 'slow-modal': load });
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel(() => Promise.resolve()));
+
+    const container = setUpModalContainer();
+
+    open('slow-modal');
+    await flush();
+
+    open('quick-modal');
+    await flush();
+
+    release();
+    await flush();
+
+    expect(load).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(renderParcel)).toHaveBeenCalledTimes(2);
+    expect(container.childElementCount).toBe(2);
+  });
+
+  it('hides a modal that finishes loading after another has opened on top of it', async () => {
+    const { release, load } = gatedLoad();
+    registerModals({ 'slow-modal': load });
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel(() => Promise.resolve()));
+
+    const container = setUpModalContainer();
+
+    open('slow-modal');
+    await flush();
+
+    open('quick-modal');
+    await flush();
+
+    release();
+    await flush();
+
+    // Each frame is prepended as it mounts, so the slow one — which mounted last — is first.
+    const [slowFrame, quickFrame] = Array.from(container.children);
+    expect(slowFrame).toHaveStyle({ visibility: 'hidden' });
+    expect(quickFrame).not.toHaveStyle({ visibility: 'hidden' });
+  });
+
+  it('unmounts a modal closed while it was still loading, and never shows it', async () => {
+    const { release, load } = gatedLoad();
+    const unmount = vi.fn(() => Promise.resolve());
+    registerModals({ 'slow-modal': load });
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel(unmount));
+
+    const container = setUpModalContainer();
+
+    const close = open('slow-modal');
+    await flush();
+
+    close();
+    await flush();
+
+    release();
+    await flush();
+
+    expect(container.childElementCount).toBe(0);
+    expect(unmount).toHaveBeenCalledTimes(1);
+  });
+
+  it('tears a modal down once even if another opens before it leaves the stack', async () => {
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel(() => Promise.resolve()));
+
+    setUpModalContainer();
+
+    const onClose = vi.fn();
+    const close = open('a-modal', {}, onClose);
+    await flush();
+
+    // Synchronous, so the second modal lands while the first is still awaiting its removal.
+    close();
+    open('b-modal');
+    await flush();
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a modal that fails to load and takes it off the stack, closing the overlay', async () => {
+    const loadError = new Error('bundle is missing');
+    registerModals({ 'broken-modal': () => Promise.reject(loadError) });
+
+    const container = setUpModalContainer();
+
+    const onClose = vi.fn();
+    open('broken-modal', {}, onClose);
+    await flush();
+    await flush();
+
+    expect(reportError).toHaveBeenCalledWith(loadError);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(container.childElementCount).toBe(0);
+    // An instance left on the stack holds the overlay over a page the user can no longer scroll.
+    expect(document.body).not.toHaveStyle({ overflow: 'hidden' });
   });
 });

--- a/packages/framework/esm-styleguide/src/modals/modals.test.ts
+++ b/packages/framework/esm-styleguide/src/modals/modals.test.ts
@@ -201,6 +201,53 @@ describe('modals', () => {
     expect(quickFrame).not.toHaveStyle({ visibility: 'hidden' });
   });
 
+  it('hides a modal already on screen when another opens before its parcel has mounted', async () => {
+    const mounting = deferred();
+    vi.mocked(renderParcel)
+      .mockResolvedValueOnce(fakeParcel({ mountPromise: mounting.promise }))
+      .mockResolvedValueOnce(fakeParcel());
+
+    const container = setUpModalContainer();
+
+    open('first-modal');
+    await flush();
+
+    // On screen, but its parcel has not finished mounting.
+    expect(container.childElementCount).toBe(1);
+
+    open('second-modal');
+    await flush();
+
+    const [secondFrame, firstFrame] = Array.from(container.children);
+    expect(firstFrame).toHaveStyle({ visibility: 'hidden' });
+    expect(secondFrame).not.toHaveStyle({ visibility: 'hidden' });
+
+    mounting.resolve();
+    await flush();
+  });
+
+  it('shows the modal underneath the moment the one over it is closed', async () => {
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel());
+
+    const container = setUpModalContainer();
+
+    open('under-modal');
+    await flush();
+
+    const closeOver = open('over-modal');
+    await flush();
+
+    const [overFrame, underFrame] = Array.from(container.children);
+    expect(overFrame).not.toHaveStyle({ visibility: 'hidden' });
+    expect(underFrame).toHaveStyle({ visibility: 'hidden' });
+
+    // Asserted without flushing: the closed modal stays on the stack until its removal timeout,
+    // and the one underneath must not wait on that to come back.
+    closeOver();
+
+    expect(underFrame).not.toHaveStyle({ visibility: 'hidden' });
+  });
+
   it('unmounts a modal closed while it was still loading, and never shows it', async () => {
     const { release, load } = gatedLoad();
     const parcel = fakeParcel();

--- a/packages/framework/esm-styleguide/src/modals/modals.test.ts
+++ b/packages/framework/esm-styleguide/src/modals/modals.test.ts
@@ -1,0 +1,72 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { type Parcel } from 'single-spa';
+
+vi.mock('@openmrs/esm-extensions', () => ({
+  getModalRegistration: vi.fn(),
+  renderParcel: vi.fn(),
+}));
+
+import { getModalRegistration, renderParcel } from '@openmrs/esm-extensions';
+import { setupModals, showModal } from './index';
+
+const lifecycle = {
+  bootstrap: () => Promise.resolve(),
+  mount: () => Promise.resolve(),
+  unmount: () => Promise.resolve(),
+};
+
+function fakeParcel(unmount: () => Promise<void>) {
+  return { unmount: vi.fn(unmount) } as unknown as Parcel;
+}
+
+/** Lets the `.then()` chains inside the modal store's subscriber run. */
+const flush = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('modals', () => {
+  beforeEach(() => {
+    document.body.innerHTML = '';
+    vi.mocked(getModalRegistration).mockReturnValue({ load: () => Promise.resolve(lifecycle) } as never);
+  });
+
+  /*
+   * `unmountThisParcel()` rejects for any status but `MOUNTED` — a modal closed while it is still
+   * mounting, or one single-spa has hard-failed — and nothing is chained to this call, so without a
+   * handler the failure is only ever an unhandled rejection.
+   */
+  it('logs a modal that fails to unmount', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const unmountError = new Error('parcel not mounted');
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel(() => Promise.reject(unmountError)));
+
+    const container = document.createElement('div');
+    document.body.append(container);
+    setupModals(container);
+
+    const close = showModal('a-modal');
+    await flush();
+
+    close();
+    await flush();
+
+    expect(consoleError).toHaveBeenCalledWith("The modal 'a-modal' failed to unmount", unmountError);
+    consoleError.mockRestore();
+  });
+
+  it('tears the modal down even though unmounting failed', async () => {
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel(() => Promise.reject(new Error('parcel not mounted'))));
+
+    const container = document.createElement('div');
+    document.body.append(container);
+    setupModals(container);
+
+    const close = showModal('another-modal');
+    await flush();
+
+    expect(container.childElementCount).toBe(1);
+
+    close();
+    await flush();
+
+    expect(container.childElementCount).toBe(0);
+  });
+});

--- a/packages/framework/esm-styleguide/src/modals/modals.test.ts
+++ b/packages/framework/esm-styleguide/src/modals/modals.test.ts
@@ -20,8 +20,43 @@ const lifecycle = {
   unmount: () => Promise.resolve(),
 };
 
-function fakeParcel(unmount: () => Promise<void>) {
-  return { unmount: vi.fn(unmount) } as unknown as Parcel;
+function deferred() {
+  let reject!: (err: unknown) => void;
+  let resolve!: () => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+
+  return { promise, resolve, reject };
+}
+
+/**
+ * A stand-in for a single-spa parcel, faithful in the two respects the modal code depends on:
+ * `mountPromise` settles after the handle is already in hand, and one failed `unmount()` rejects
+ * both the promise it returns and the separate `unmountPromise`.
+ */
+function fakeParcel({ mountPromise = Promise.resolve(), unmountError }: FakeParcelOptions = {}) {
+  const unmounted = deferred();
+
+  return {
+    mountPromise,
+    unmountPromise: unmounted.promise,
+    unmount: vi.fn(() => {
+      if (unmountError) {
+        unmounted.reject(unmountError);
+        return Promise.reject(unmountError);
+      }
+
+      unmounted.resolve();
+      return Promise.resolve();
+    }),
+  } as unknown as Parcel;
+}
+
+interface FakeParcelOptions {
+  mountPromise?: Promise<void>;
+  unmountError?: Error;
 }
 
 /**
@@ -93,7 +128,7 @@ describe('modals', () => {
   it('logs a modal that fails to unmount', async () => {
     const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
     const unmountError = new Error('parcel not mounted');
-    vi.mocked(renderParcel).mockResolvedValue(fakeParcel(() => Promise.reject(unmountError)));
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel({ unmountError }));
 
     const container = setUpModalContainer();
 
@@ -108,7 +143,7 @@ describe('modals', () => {
   });
 
   it('tears the modal down even though unmounting failed', async () => {
-    vi.mocked(renderParcel).mockResolvedValue(fakeParcel(() => Promise.reject(new Error('parcel not mounted'))));
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel({ unmountError: new Error('parcel not mounted') }));
 
     const container = setUpModalContainer();
 
@@ -126,7 +161,7 @@ describe('modals', () => {
   it('does not mount a second copy when another modal opens while the first is still loading', async () => {
     const { release, load } = gatedLoad();
     registerModals({ 'slow-modal': load });
-    vi.mocked(renderParcel).mockResolvedValue(fakeParcel(() => Promise.resolve()));
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel());
 
     const container = setUpModalContainer();
 
@@ -147,7 +182,7 @@ describe('modals', () => {
   it('hides a modal that finishes loading after another has opened on top of it', async () => {
     const { release, load } = gatedLoad();
     registerModals({ 'slow-modal': load });
-    vi.mocked(renderParcel).mockResolvedValue(fakeParcel(() => Promise.resolve()));
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel());
 
     const container = setUpModalContainer();
 
@@ -168,9 +203,9 @@ describe('modals', () => {
 
   it('unmounts a modal closed while it was still loading, and never shows it', async () => {
     const { release, load } = gatedLoad();
-    const unmount = vi.fn(() => Promise.resolve());
+    const parcel = fakeParcel();
     registerModals({ 'slow-modal': load });
-    vi.mocked(renderParcel).mockResolvedValue(fakeParcel(unmount));
+    vi.mocked(renderParcel).mockResolvedValue(parcel);
 
     const container = setUpModalContainer();
 
@@ -184,11 +219,65 @@ describe('modals', () => {
     await flush();
 
     expect(container.childElementCount).toBe(0);
-    expect(unmount).toHaveBeenCalledTimes(1);
+    expect(parcel.unmount).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports a modal whose parcel fails to mount and releases the overlay', async () => {
+    const mountError = new Error('mount blew up');
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel({ mountPromise: Promise.reject(mountError) }));
+
+    const container = setUpModalContainer();
+
+    const onClose = vi.fn();
+    open('unmountable-modal', {}, onClose);
+    await flush();
+    await flush();
+
+    expect(reportError).toHaveBeenCalledWith(mountError);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(container.childElementCount).toBe(0);
+    expect(document.body).not.toHaveStyle({ overflow: 'hidden' });
+  });
+
+  it('does not try to unmount a parcel that never mounted', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const parcel = fakeParcel({ mountPromise: Promise.reject(new Error('mount blew up')) });
+    vi.mocked(renderParcel).mockResolvedValue(parcel);
+
+    setUpModalContainer();
+
+    const close = open('unmountable-modal');
+    await flush();
+    await flush();
+
+    // The mount failure has already closed it, so this finds nothing left to do. Were the modal
+    // still on the stack, this is the close that would unmount a parcel single-spa marked broken.
+    close();
+    await flush();
+
+    expect(parcel.unmount).not.toHaveBeenCalled();
+    expect(consoleError).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it('reports one failed unmount once, over both of the promises it rejects', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel({ unmountError: new Error('parcel not mounted') }));
+
+    setUpModalContainer();
+
+    const close = open('a-modal');
+    await flush();
+
+    close();
+    await flush();
+
+    expect(consoleError).toHaveBeenCalledTimes(1);
+    consoleError.mockRestore();
   });
 
   it('tears a modal down once even if another opens before it leaves the stack', async () => {
-    vi.mocked(renderParcel).mockResolvedValue(fakeParcel(() => Promise.resolve()));
+    vi.mocked(renderParcel).mockResolvedValue(fakeParcel());
 
     setUpModalContainer();
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->

This is an attempt to reduce much of the churn described here: https://claude.ai/code/artifact/14b92358-1ef6-4152-a4ec-d220bae9e03e.

### PR Overview

This PR overhauls the extension system's internal recomputation model to eliminate O(n²) behavior where any single write (a config change, an extension registering, a slot mounting) triggered a full re-derivation of state for every module, extension, and slot in the app. Derived state is now cached per-entity keyed on its actual inputs, and stores only publish a new value when it actually changed, so consumers no longer re-render on unrelated updates elsewhere in the app. The config system's implementer-tools output is now computed lazily on read instead of eagerly on every write. This is a breaking change to the shape and timing of internal store updates.

Alongside that, the branch clarifies the extension system's data model by splitting what was previously a single "extension" concept into a registration (what a module registers, by name) and a rendering (one live, on-screen copy of a configured instance in a slot — since one instance can render many times, e.g. once per row in a list). Renderings are tracked in their own store, mutated in place for performance rather than copied on every mount/unmount. This also adds support for a per-rendering displayConditionExpression, evaluated against that specific rendering's local state rather than globally. Supporting hooks (useAssignedExtensions, useExtensionSlot, useStore, and a new useShallowStableValue) and Extension.tsx were updated to work with this model, along with substantial new test coverage validating the recomputation and config-propagation behavior.

### Relation to performance

The extension system recomputation this ameliorates is a cause of many of the performance issues we're aiming to fix, but not all of them. Specifically, this should mostly reduce re-render churn, reduce the CPU drag from constant re-computation, and save a little bit of memory due to reshaping of the store's internals. It does not, by itself, resolve all the performance short-comings.

### Notable breakages

* Store no longer tracks `assignedExtensions`. Instead, the store tracks `candidateExtensions`, which is the list of extensions assigned to a slot but which have not had their `Display conditions` `expression` property evaluated yet. This is because the evaluation has the ability to read the extension slot state, which can be different per instance of an extension slot. Use `getAssignedExtensions()` or `useAssignedExtensions()` to get the correct list.
* Relatedly `useAssignedExtensionIds()` is now implemented in terms of `useAssignedExtensions()` and has been deprecated as it is no longer a "fast-path" to get extension metadata.
* `useStore()` no longer returns a copy of the store's state, but the state directly. Use with caution.
* All parcels will hard fail if they do not render within 15 seconds of loading. This is necessary to ensure that we can clean them up. Note that this 15 seconds is purely for the `bootstrap()`, `mount()`, and `unmount()` functions, which are not network dependent.
* Extensions added through configuration now retain the order they are defined in configuration (although, this is the intended behavior).
* Extension rendering state is no longer tracked in the extension store.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

To make this explicit: the state of the extension system, other than as exposed through `getAssignedExtensions()` should be treated as framework internals. While there are valid use-cases for accessing this data, the shape of the data in the extension store is not part of the public API.
