### PR TITLE
(fix) Match workspace scopes relative to SPA base

### DIFF
--- a/.changeset/fix-workspace-scope-pattern.md
+++ b/.changeset/fix-workspace-scope-pattern.md
@@ -1,0 +1,6 @@
+---
+'@openmrs/esm-globals': patch
+'@openmrs/esm-styleguide': patch
+---
+
+Match workspace scope patterns against pathnames relative to the configured SPA base while preserving legacy full-path patterns.

--- a/packages/framework/esm-framework/docs/interfaces/FeatureFlagDefinition.md
+++ b/packages/framework/esm-framework/docs/interfaces/FeatureFlagDefinition.md
@@ -2,7 +2,7 @@
 
 # Interface: FeatureFlagDefinition
 
-Defined in: [packages/framework/esm-globals/src/types.ts:350](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L350)
+Defined in: [packages/framework/esm-globals/src/types.ts:354](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L354)
 
 A definition of a feature flag extracted from the routes.json
 
@@ -12,7 +12,7 @@ A definition of a feature flag extracted from the routes.json
 
 > **description**: `string`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:356](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L356)
+Defined in: [packages/framework/esm-globals/src/types.ts:360](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L360)
 
 An explanation of what the flag does, which will be displayed in the Implementer Tools
 
@@ -22,7 +22,7 @@ An explanation of what the flag does, which will be displayed in the Implementer
 
 > **flagName**: `string`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:352](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L352)
+Defined in: [packages/framework/esm-globals/src/types.ts:356](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L356)
 
 A code-friendly name for the flag, which will be used to reference it in code
 
@@ -32,6 +32,6 @@ A code-friendly name for the flag, which will be used to reference it in code
 
 > **label**: `string`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:354](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L354)
+Defined in: [packages/framework/esm-globals/src/types.ts:358](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L358)
 
 A human-friendly name which will be displayed in the Implementer Tools

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsAppRoutes.md
@@ -2,7 +2,7 @@
 
 # Interface: OpenmrsAppRoutes
 
-Defined in: [packages/framework/esm-globals/src/types.ts:360](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L360)
+Defined in: [packages/framework/esm-globals/src/types.ts:364](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L364)
 
 This interface describes the format of the routes provided by an app
 
@@ -12,7 +12,7 @@ This interface describes the format of the routes provided by an app
 
 > `optional` **backendDependencies**: `Record`\<`string`, `string`\>
 
-Defined in: [packages/framework/esm-globals/src/types.ts:364](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L364)
+Defined in: [packages/framework/esm-globals/src/types.ts:368](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L368)
 
 A list of backend modules necessary for this frontend module and the corresponding required versions.
 
@@ -22,7 +22,7 @@ A list of backend modules necessary for this frontend module and the correspondi
 
 > `optional` **extensions**: [`ExtensionDefinition`](../type-aliases/ExtensionDefinition.md)[]
 
-Defined in: [packages/framework/esm-globals/src/types.ts:380](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L380)
+Defined in: [packages/framework/esm-globals/src/types.ts:384](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L384)
 
 An array of all extensions supported by this frontend module. Extensions can be mounted in extension slots, either via declarations in this file or configuration.
 
@@ -32,7 +32,7 @@ An array of all extensions supported by this frontend module. Extensions can be 
 
 > `optional` **featureFlags**: [`FeatureFlagDefinition`](FeatureFlagDefinition.md)[]
 
-Defined in: [packages/framework/esm-globals/src/types.ts:382](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L382)
+Defined in: [packages/framework/esm-globals/src/types.ts:386](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L386)
 
 An array of all feature flags for any beta-stage features this module provides.
 
@@ -42,7 +42,7 @@ An array of all feature flags for any beta-stage features this module provides.
 
 > `optional` **modals**: [`ModalDefinition`](../type-aliases/ModalDefinition.md)[]
 
-Defined in: [packages/framework/esm-globals/src/types.ts:384](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L384)
+Defined in: [packages/framework/esm-globals/src/types.ts:388](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L388)
 
 An array of all modals supported by this frontend module. Modals can be launched by name.
 
@@ -52,7 +52,7 @@ An array of all modals supported by this frontend module. Modals can be launched
 
 > `optional` **optionalBackendDependencies**: `object`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:366](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L366)
+Defined in: [packages/framework/esm-globals/src/types.ts:370](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L370)
 
 A list of backend modules that may enable optional functionality in this frontend module if available and the corresponding required versions.
 
@@ -68,7 +68,7 @@ The name of the backend dependency and either the required version or an object 
 
 > `optional` **pages**: [`PageDefinition`](../type-aliases/PageDefinition.md)[]
 
-Defined in: [packages/framework/esm-globals/src/types.ts:378](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L378)
+Defined in: [packages/framework/esm-globals/src/types.ts:382](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L382)
 
 An array of all pages supported by this frontend module. Pages are automatically mounted based on a route.
 
@@ -78,7 +78,7 @@ An array of all pages supported by this frontend module. Pages are automatically
 
 > `optional` **version**: `string`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:362](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L362)
+Defined in: [packages/framework/esm-globals/src/types.ts:366](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L366)
 
 The version of this frontend module.
 
@@ -88,7 +88,7 @@ The version of this frontend module.
 
 > `optional` **workspaceGroups**: [`WorkspaceGroupDefinition`](WorkspaceGroupDefinition.md)[]
 
-Defined in: [packages/framework/esm-globals/src/types.ts:388](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L388)
+Defined in: [packages/framework/esm-globals/src/types.ts:392](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L392)
 
 An array of all workspace groups supported by this frontend module.
 
@@ -98,7 +98,7 @@ An array of all workspace groups supported by this frontend module.
 
 > `optional` **workspaceGroups2**: [`WorkspaceGroupDefinition2`](WorkspaceGroupDefinition2.md)[]
 
-Defined in: [packages/framework/esm-globals/src/types.ts:391](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L391)
+Defined in: [packages/framework/esm-globals/src/types.ts:395](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L395)
 
 An array of all workspace groups (v2) supported by this frontend module.
 
@@ -108,7 +108,7 @@ An array of all workspace groups (v2) supported by this frontend module.
 
 > `optional` **workspaces**: [`WorkspaceDefinition`](../type-aliases/WorkspaceDefinition.md)[]
 
-Defined in: [packages/framework/esm-globals/src/types.ts:386](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L386)
+Defined in: [packages/framework/esm-globals/src/types.ts:390](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L390)
 
 An array of all workspaces supported by this frontend module. Workspaces can be launched by name.
 
@@ -118,7 +118,7 @@ An array of all workspaces supported by this frontend module. Workspaces can be 
 
 > `optional` **workspaces2**: [`WorkspaceDefinition2`](WorkspaceDefinition2.md)[]
 
-Defined in: [packages/framework/esm-globals/src/types.ts:397](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L397)
+Defined in: [packages/framework/esm-globals/src/types.ts:401](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L401)
 
 An array of all workspaces (v2) supported by this frontend module.
 
@@ -128,6 +128,6 @@ An array of all workspaces (v2) supported by this frontend module.
 
 > `optional` **workspaceWindows2**: [`WorkspaceWindowDefinition2`](WorkspaceWindowDefinition2.md)[]
 
-Defined in: [packages/framework/esm-globals/src/types.ts:394](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L394)
+Defined in: [packages/framework/esm-globals/src/types.ts:398](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L398)
 
 An array of all workspace windows (v2) supported by this frontend module.

--- a/packages/framework/esm-framework/docs/interfaces/OpenmrsRoutes.md
+++ b/packages/framework/esm-framework/docs/interfaces/OpenmrsRoutes.md
@@ -2,7 +2,7 @@
 
 # Interface: OpenmrsRoutes
 
-Defined in: [packages/framework/esm-globals/src/types.ts:404](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L404)
+Defined in: [packages/framework/esm-globals/src/types.ts:408](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L408)
 
 This interfaces describes the format of the overall routes.json loaded by the app shell.
 Basically, this is the same as the app routes, with each routes definition keyed by the app's name
@@ -13,7 +13,7 @@ Basically, this is the same as the app routes, with each routes definition keyed
 
 > **routes**: `Record`\<`Exclude`\<`string`, `"version"`\>, [`OpenmrsAppRoutes`](OpenmrsAppRoutes.md)\>
 
-Defined in: [packages/framework/esm-globals/src/types.ts:408](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L408)
+Defined in: [packages/framework/esm-globals/src/types.ts:412](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L412)
 
 The routes associated with this application keyed by module id
 
@@ -23,6 +23,6 @@ The routes associated with this application keyed by module id
 
 > `optional` **version**: `string`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:406](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L406)
+Defined in: [packages/framework/esm-globals/src/types.ts:410](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L410)
 
 The overall version for this application

--- a/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
+++ b/packages/framework/esm-framework/docs/interfaces/ResourceLoader.md
@@ -2,7 +2,7 @@
 
 # Interface: ResourceLoader()\<T\>
 
-Defined in: [packages/framework/esm-globals/src/types.ts:411](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L411)
+Defined in: [packages/framework/esm-globals/src/types.ts:415](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L415)
 
 ## Type Parameters
 
@@ -12,7 +12,7 @@ Defined in: [packages/framework/esm-globals/src/types.ts:411](https://github.com
 
 > **ResourceLoader**(): `Promise`\<`T`\>
 
-Defined in: [packages/framework/esm-globals/src/types.ts:412](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L412)
+Defined in: [packages/framework/esm-globals/src/types.ts:416](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L416)
 
 ## Returns
 

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceDefinition2.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceDefinition2.md
@@ -2,7 +2,7 @@
 
 # Interface: WorkspaceDefinition2
 
-Defined in: [packages/framework/esm-globals/src/types.ts:341](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L341)
+Defined in: [packages/framework/esm-globals/src/types.ts:345](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L345)
 
 ## Properties
 
@@ -10,7 +10,7 @@ Defined in: [packages/framework/esm-globals/src/types.ts:341](https://github.com
 
 > **component**: `string`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:343](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L343)
+Defined in: [packages/framework/esm-globals/src/types.ts:347](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L347)
 
 ***
 
@@ -18,7 +18,7 @@ Defined in: [packages/framework/esm-globals/src/types.ts:343](https://github.com
 
 > **name**: `string`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:342](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L342)
+Defined in: [packages/framework/esm-globals/src/types.ts:346](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L346)
 
 ***
 
@@ -26,4 +26,4 @@ Defined in: [packages/framework/esm-globals/src/types.ts:342](https://github.com
 
 > **window**: `string`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:344](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L344)
+Defined in: [packages/framework/esm-globals/src/types.ts:348](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L348)

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceGroupDefinition2.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceGroupDefinition2.md
@@ -50,9 +50,13 @@ with any opened windows / workspaces.
 
 > `optional` **scopePattern**: `string`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:329](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L329)
+Defined in: [packages/framework/esm-globals/src/types.ts:333](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L333)
 
 URL pattern that defines the scope where workspaces in this group should persist.
+The pattern is matched against the pathname relative to the configured SPA base path.
+Navigating outside the configured SPA base path closes the workspace group.
+For backward compatibility, if the pattern does not match both SPA-relative pathnames, it is
+retried against both full pathnames.
 - If not defined: workspaces close only when navigating to a different app
 - If defined without capture groups: workspaces close when URL doesn't match pattern
 - If defined with capture groups: workspaces close when captured values change

--- a/packages/framework/esm-framework/docs/interfaces/WorkspaceWindowDefinition2.md
+++ b/packages/framework/esm-framework/docs/interfaces/WorkspaceWindowDefinition2.md
@@ -2,7 +2,7 @@
 
 # Interface: WorkspaceWindowDefinition2
 
-Defined in: [packages/framework/esm-globals/src/types.ts:332](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L332)
+Defined in: [packages/framework/esm-globals/src/types.ts:336](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L336)
 
 ## Properties
 
@@ -10,7 +10,7 @@ Defined in: [packages/framework/esm-globals/src/types.ts:332](https://github.com
 
 > `optional` **canMaximize**: `boolean`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:335](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L335)
+Defined in: [packages/framework/esm-globals/src/types.ts:339](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L339)
 
 ***
 
@@ -18,7 +18,7 @@ Defined in: [packages/framework/esm-globals/src/types.ts:335](https://github.com
 
 > **group**: `string`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:336](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L336)
+Defined in: [packages/framework/esm-globals/src/types.ts:340](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L340)
 
 ***
 
@@ -26,7 +26,7 @@ Defined in: [packages/framework/esm-globals/src/types.ts:336](https://github.com
 
 > `optional` **icon**: `string`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:334](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L334)
+Defined in: [packages/framework/esm-globals/src/types.ts:338](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L338)
 
 ***
 
@@ -34,7 +34,7 @@ Defined in: [packages/framework/esm-globals/src/types.ts:334](https://github.com
 
 > **name**: `string`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:333](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L333)
+Defined in: [packages/framework/esm-globals/src/types.ts:337](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L337)
 
 ***
 
@@ -42,7 +42,7 @@ Defined in: [packages/framework/esm-globals/src/types.ts:333](https://github.com
 
 > `optional` **order**: `number`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:337](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L337)
+Defined in: [packages/framework/esm-globals/src/types.ts:341](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L341)
 
 ***
 
@@ -50,4 +50,4 @@ Defined in: [packages/framework/esm-globals/src/types.ts:337](https://github.com
 
 > `optional` **width**: `"narrow"` \| `"wider"` \| `"extra-wide"`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:338](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L338)
+Defined in: [packages/framework/esm-globals/src/types.ts:342](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L342)

--- a/packages/framework/esm-framework/docs/type-aliases/NameUse.md
+++ b/packages/framework/esm-framework/docs/type-aliases/NameUse.md
@@ -4,4 +4,4 @@
 
 > **NameUse** = `"usual"` \| `"official"` \| `"temp"` \| `"nickname"` \| `"anonymous"` \| `"old"` \| `"maiden"`
 
-Defined in: [packages/framework/esm-globals/src/types.ts:418](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L418)
+Defined in: [packages/framework/esm-globals/src/types.ts:422](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-globals/src/types.ts#L422)

--- a/packages/framework/esm-globals/src/types.ts
+++ b/packages/framework/esm-globals/src/types.ts
@@ -319,6 +319,7 @@ export interface WorkspaceGroupDefinition2 {
 
   /**
    * URL pattern that defines the scope where workspaces in this group should persist.
+   * The pattern is matched against the pathname relative to the configured SPA base path.
    * - If not defined: workspaces close only when navigating to a different app
    * - If defined without capture groups: workspaces close when URL doesn't match pattern
    * - If defined with capture groups: workspaces close when captured values change

--- a/packages/framework/esm-globals/src/types.ts
+++ b/packages/framework/esm-globals/src/types.ts
@@ -320,6 +320,9 @@ export interface WorkspaceGroupDefinition2 {
   /**
    * URL pattern that defines the scope where workspaces in this group should persist.
    * The pattern is matched against the pathname relative to the configured SPA base path.
+   * Navigating outside the configured SPA base path closes the workspace group.
+   * For backward compatibility, if the pattern does not match both SPA-relative pathnames, it is
+   * retried against both full pathnames.
    * - If not defined: workspaces close only when navigating to a different app
    * - If defined without capture groups: workspaces close when URL doesn't match pattern
    * - If defined with capture groups: workspaces close when captured values change

--- a/packages/framework/esm-styleguide/src/workspaces2/scope-utils.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces2/scope-utils.test.ts
@@ -134,6 +134,13 @@ describe('shouldCloseOnUrlChange', () => {
 
   it.each([
     [
+      'stays open: navigation from the exact SPA base remains in a root scope',
+      '^/',
+      'http://localhost/openmrs/spa',
+      'http://localhost/openmrs/spa/home',
+      false,
+    ],
+    [
       'stays open: same patient under the configured SPA base',
       '^/patient/([^/]+)/chart(?:/|$)',
       'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
@@ -176,6 +183,13 @@ describe('shouldCloseOnUrlChange', () => {
       false,
     ],
     [
+      'stays open: legacy pattern matches both full pathnames when only one relative pathname matches',
+      '^/openmrs',
+      'http://localhost/openmrs/spa/home',
+      'http://localhost/openmrs/spa/openmrs-lab',
+      false,
+    ],
+    [
       'closes: legacy pattern captures a different patient',
       '^/openmrs/spa/patient/([^/]+)/chart(?:/|$)',
       'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
@@ -186,6 +200,21 @@ describe('shouldCloseOnUrlChange', () => {
     withSpaBase('/openmrs/spa/', () => {
       expect(shouldCloseOnUrlChange(pattern, oldUrl, newUrl)).toBe(expected);
     });
+  });
+
+  it('matches against full pathnames when getOpenmrsSpaBase is not defined', () => {
+    const originalGetOpenmrsSpaBase = window.getOpenmrsSpaBase;
+    // @ts-expect-error simulating an environment without the app shell globals
+    delete window.getOpenmrsSpaBase;
+
+    try {
+      expect(shouldCloseOnUrlChange('^/home/appointments', '/home/appointments', '/home/appointments/details')).toBe(
+        false,
+      );
+      expect(shouldCloseOnUrlChange('^/home/appointments', '/home/appointments', '/home/service-queues')).toBe(true);
+    } finally {
+      window.getOpenmrsSpaBase = originalGetOpenmrsSpaBase;
+    }
   });
 
   it('matches against a custom SPA base', () => {

--- a/packages/framework/esm-styleguide/src/workspaces2/scope-utils.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces2/scope-utils.test.ts
@@ -49,6 +49,48 @@ describe('shouldCloseOnUrlChange', () => {
       false,
     ],
     [
+      'stays open: same patient under the configured SPA base',
+      '^/patient/([^/]+)/chart(?:/|$)',
+      'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
+      'http://localhost/openmrs/spa/patient/abc-123/chart/conditions',
+      false,
+    ],
+    [
+      'closes: different patient under the configured SPA base',
+      '^/patient/([^/]+)/chart(?:/|$)',
+      'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
+      'http://localhost/openmrs/spa/patient/def-456/chart/vitals',
+      true,
+    ],
+    [
+      'closes: route only shares the SPA base as a string prefix',
+      '^/patient/([^/]+)/chart(?:/|$)',
+      'http://localhost/openmrs/spa2/patient/abc-123/chart/vitals',
+      'http://localhost/openmrs/spa2/patient/abc-123/chart/conditions',
+      true,
+    ],
+    [
+      'closes: route only shares the patient chart prefix',
+      '^/patient/([^/]+)/chart(?:/|$)',
+      'http://localhost/openmrs/spa/patient/abc-123/chart',
+      'http://localhost/openmrs/spa/patient/abc-123/chart-extra',
+      true,
+    ],
+    [
+      'stays open: legacy pattern includes the configured SPA base',
+      '^/openmrs/spa/patient/([^/]+)/chart(?:/|$)',
+      'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
+      'http://localhost/openmrs/spa/patient/abc-123/chart/conditions',
+      false,
+    ],
+    [
+      'closes: legacy pattern captures a different patient',
+      '^/openmrs/spa/patient/([^/]+)/chart(?:/|$)',
+      'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
+      'http://localhost/openmrs/spa/patient/def-456/chart/vitals',
+      true,
+    ],
+    [
       'stays open: same patient chart URL',
       '^/patient/([^/]+)/chart',
       'http://localhost/patient/abc-123/chart',
@@ -128,5 +170,22 @@ describe('shouldCloseOnUrlChange', () => {
     ['closes: relative URLs leaving scope', '^/home/appointments', '/home/appointments', '/home/service-queues', true],
   ])('%s', (_desc, pattern, oldUrl, newUrl, expected) => {
     expect(shouldCloseOnUrlChange(pattern, oldUrl, newUrl)).toBe(expected);
+  });
+
+  it('matches against a custom SPA base', () => {
+    const originalGetOpenmrsSpaBase = window.getOpenmrsSpaBase;
+    window.getOpenmrsSpaBase = () => '/custom/spa/';
+
+    try {
+      expect(
+        shouldCloseOnUrlChange(
+          '^/patient/([^/]+)/chart(?:/|$)',
+          '/custom/spa/patient/abc-123/chart/vitals',
+          '/custom/spa/patient/abc-123/chart/conditions',
+        ),
+      ).toBe(false);
+    } finally {
+      window.getOpenmrsSpaBase = originalGetOpenmrsSpaBase;
+    }
   });
 });

--- a/packages/framework/esm-styleguide/src/workspaces2/scope-utils.test.ts
+++ b/packages/framework/esm-styleguide/src/workspaces2/scope-utils.test.ts
@@ -49,48 +49,6 @@ describe('shouldCloseOnUrlChange', () => {
       false,
     ],
     [
-      'stays open: same patient under the configured SPA base',
-      '^/patient/([^/]+)/chart(?:/|$)',
-      'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
-      'http://localhost/openmrs/spa/patient/abc-123/chart/conditions',
-      false,
-    ],
-    [
-      'closes: different patient under the configured SPA base',
-      '^/patient/([^/]+)/chart(?:/|$)',
-      'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
-      'http://localhost/openmrs/spa/patient/def-456/chart/vitals',
-      true,
-    ],
-    [
-      'closes: route only shares the SPA base as a string prefix',
-      '^/patient/([^/]+)/chart(?:/|$)',
-      'http://localhost/openmrs/spa2/patient/abc-123/chart/vitals',
-      'http://localhost/openmrs/spa2/patient/abc-123/chart/conditions',
-      true,
-    ],
-    [
-      'closes: route only shares the patient chart prefix',
-      '^/patient/([^/]+)/chart(?:/|$)',
-      'http://localhost/openmrs/spa/patient/abc-123/chart',
-      'http://localhost/openmrs/spa/patient/abc-123/chart-extra',
-      true,
-    ],
-    [
-      'stays open: legacy pattern includes the configured SPA base',
-      '^/openmrs/spa/patient/([^/]+)/chart(?:/|$)',
-      'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
-      'http://localhost/openmrs/spa/patient/abc-123/chart/conditions',
-      false,
-    ],
-    [
-      'closes: legacy pattern captures a different patient',
-      '^/openmrs/spa/patient/([^/]+)/chart(?:/|$)',
-      'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
-      'http://localhost/openmrs/spa/patient/def-456/chart/vitals',
-      true,
-    ],
-    [
       'stays open: same patient chart URL',
       '^/patient/([^/]+)/chart',
       'http://localhost/patient/abc-123/chart',
@@ -169,14 +127,69 @@ describe('shouldCloseOnUrlChange', () => {
     ],
     ['closes: relative URLs leaving scope', '^/home/appointments', '/home/appointments', '/home/service-queues', true],
   ])('%s', (_desc, pattern, oldUrl, newUrl, expected) => {
-    expect(shouldCloseOnUrlChange(pattern, oldUrl, newUrl)).toBe(expected);
+    withSpaBase('/', () => {
+      expect(shouldCloseOnUrlChange(pattern, oldUrl, newUrl)).toBe(expected);
+    });
+  });
+
+  it.each([
+    [
+      'stays open: same patient under the configured SPA base',
+      '^/patient/([^/]+)/chart(?:/|$)',
+      'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
+      'http://localhost/openmrs/spa/patient/abc-123/chart/conditions',
+      false,
+    ],
+    [
+      'closes: different patient under the configured SPA base',
+      '^/patient/([^/]+)/chart(?:/|$)',
+      'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
+      'http://localhost/openmrs/spa/patient/def-456/chart/vitals',
+      true,
+    ],
+    [
+      'closes: route only shares the SPA base as a string prefix',
+      '^/patient/([^/]+)/chart(?:/|$)',
+      'http://localhost/openmrs/spa2/patient/abc-123/chart/vitals',
+      'http://localhost/openmrs/spa2/patient/abc-123/chart/conditions',
+      true,
+    ],
+    [
+      'closes: navigation leaves the configured SPA base',
+      '^/patient/([^/]+)/chart(?:/|$)',
+      'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
+      'http://localhost/patient/abc-123/chart/conditions',
+      true,
+    ],
+    [
+      'closes: route only shares the patient chart prefix',
+      '^/patient/([^/]+)/chart(?:/|$)',
+      'http://localhost/openmrs/spa/patient/abc-123/chart',
+      'http://localhost/openmrs/spa/patient/abc-123/chart-extra',
+      true,
+    ],
+    [
+      'stays open: legacy pattern includes the configured SPA base',
+      '^/openmrs/spa/patient/([^/]+)/chart(?:/|$)',
+      'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
+      'http://localhost/openmrs/spa/patient/abc-123/chart/conditions',
+      false,
+    ],
+    [
+      'closes: legacy pattern captures a different patient',
+      '^/openmrs/spa/patient/([^/]+)/chart(?:/|$)',
+      'http://localhost/openmrs/spa/patient/abc-123/chart/vitals',
+      'http://localhost/openmrs/spa/patient/def-456/chart/vitals',
+      true,
+    ],
+  ])('%s', (_desc, pattern, oldUrl, newUrl, expected) => {
+    withSpaBase('/openmrs/spa/', () => {
+      expect(shouldCloseOnUrlChange(pattern, oldUrl, newUrl)).toBe(expected);
+    });
   });
 
   it('matches against a custom SPA base', () => {
-    const originalGetOpenmrsSpaBase = window.getOpenmrsSpaBase;
-    window.getOpenmrsSpaBase = () => '/custom/spa/';
-
-    try {
+    withSpaBase('/custom/spa/', () => {
       expect(
         shouldCloseOnUrlChange(
           '^/patient/([^/]+)/chart(?:/|$)',
@@ -184,8 +197,17 @@ describe('shouldCloseOnUrlChange', () => {
           '/custom/spa/patient/abc-123/chart/conditions',
         ),
       ).toBe(false);
-    } finally {
-      window.getOpenmrsSpaBase = originalGetOpenmrsSpaBase;
-    }
+    });
   });
 });
+
+function withSpaBase<T>(spaBase: string, callback: () => T): T {
+  const originalGetOpenmrsSpaBase = window.getOpenmrsSpaBase;
+  window.getOpenmrsSpaBase = () => spaBase;
+
+  try {
+    return callback();
+  } finally {
+    window.getOpenmrsSpaBase = originalGetOpenmrsSpaBase;
+  }
+}

--- a/packages/framework/esm-styleguide/src/workspaces2/scope-utils.ts
+++ b/packages/framework/esm-styleguide/src/workspaces2/scope-utils.ts
@@ -1,19 +1,26 @@
 /**
  * Determines whether workspaces should close based on a scope pattern and URL change.
  *
- * @param scopePattern - A regex pattern defining the scope. May include capture groups.
+ * @param scopePattern - A regex pattern matched against the SPA-relative pathname. May include capture groups.
  * @param oldUrl - The URL being navigated away from.
  * @param newUrl - The URL being navigated to.
  * @returns `true` if the workspace should close, `false` if it should stay open.
  */
 export function shouldCloseOnUrlChange(scopePattern: string, oldUrl: string, newUrl: string): boolean {
   try {
-    const oldPathname = new URL(oldUrl, window.location.origin).pathname;
-    const newPathname = new URL(newUrl, window.location.origin).pathname;
     const regex = new RegExp(scopePattern);
+    const oldPathnames = getPathnames(oldUrl);
+    const newPathnames = getPathnames(newUrl);
 
-    const oldMatch = oldPathname.match(regex);
-    const newMatch = newPathname.match(regex);
+    const oldRelativeMatch = oldPathnames.spaRelative.match(regex);
+    const newRelativeMatch = newPathnames.spaRelative.match(regex);
+    const useSpaRelativePathnames = Boolean(oldRelativeMatch || newRelativeMatch);
+
+    // scopePattern is defined against the SPA-relative pathname. Fall back to
+    // the full pathname when neither relative pathname matches so that existing
+    // patterns containing the SPA base path continue to work.
+    const oldMatch = useSpaRelativePathnames ? oldRelativeMatch : oldPathnames.full.match(regex);
+    const newMatch = useSpaRelativePathnames ? newRelativeMatch : newPathnames.full.match(regex);
 
     if (!oldMatch || !newMatch) {
       // One or both URLs don't match the pattern - close workspace
@@ -32,4 +39,13 @@ export function shouldCloseOnUrlChange(scopePattern: string, oldUrl: string, new
     // If regex is invalid or URL parsing fails, close as a safety measure
     return true;
   }
+}
+
+function getPathnames(url: string) {
+  const full = new URL(url, window.location.origin).pathname;
+  const spaBase = new URL(window.getOpenmrsSpaBase(), window.location.origin).pathname.replace(/\/+$/, '');
+  const spaRelative =
+    !spaBase || spaBase === full ? '/' : full.startsWith(`${spaBase}/`) ? full.slice(spaBase.length) : full;
+
+  return { full, spaRelative };
 }

--- a/packages/framework/esm-styleguide/src/workspaces2/scope-utils.ts
+++ b/packages/framework/esm-styleguide/src/workspaces2/scope-utils.ts
@@ -16,16 +16,12 @@ export function shouldCloseOnUrlChange(scopePattern: string, oldUrl: string, new
       return true;
     }
 
-    const oldRelativeMatch = regex.exec(oldPathnames.spaRelative);
-    const newRelativeMatch = regex.exec(newPathnames.spaRelative);
-    const useSpaRelativePathnames = Boolean(oldRelativeMatch || newRelativeMatch);
-
     // scopePattern is defined against the SPA-relative pathname. Fall back to
-    // the full pathname when neither relative pathname matches so that existing
-    // patterns containing the SPA base path continue to work.
-    let oldMatch = oldRelativeMatch;
-    let newMatch = newRelativeMatch;
-    if (!useSpaRelativePathnames) {
+    // the full pathnames when the relative pathnames don't both match, so that
+    // patterns containing the SPA base path also work.
+    let oldMatch = regex.exec(oldPathnames.spaRelative);
+    let newMatch = regex.exec(newPathnames.spaRelative);
+    if (!oldMatch || !newMatch) {
       oldMatch = regex.exec(oldPathnames.full);
       newMatch = regex.exec(newPathnames.full);
     }
@@ -51,7 +47,7 @@ export function shouldCloseOnUrlChange(scopePattern: string, oldUrl: string, new
 
 function getPathnames(url: string) {
   const full = new URL(url, window.location.origin).pathname;
-  const spaBasePathname = new URL(window.getOpenmrsSpaBase(), window.location.origin).pathname;
+  const spaBasePathname = new URL(window.getOpenmrsSpaBase?.() ?? '/', window.location.origin).pathname;
   const spaBase = spaBasePathname.endsWith('/') ? spaBasePathname.slice(0, -1) : spaBasePathname;
   let spaRelative: string | null = null;
 

--- a/packages/framework/esm-styleguide/src/workspaces2/scope-utils.ts
+++ b/packages/framework/esm-styleguide/src/workspaces2/scope-utils.ts
@@ -12,15 +12,23 @@ export function shouldCloseOnUrlChange(scopePattern: string, oldUrl: string, new
     const oldPathnames = getPathnames(oldUrl);
     const newPathnames = getPathnames(newUrl);
 
-    const oldRelativeMatch = oldPathnames.spaRelative.match(regex);
-    const newRelativeMatch = newPathnames.spaRelative.match(regex);
+    if (oldPathnames.spaRelative === null || newPathnames.spaRelative === null) {
+      return true;
+    }
+
+    const oldRelativeMatch = regex.exec(oldPathnames.spaRelative);
+    const newRelativeMatch = regex.exec(newPathnames.spaRelative);
     const useSpaRelativePathnames = Boolean(oldRelativeMatch || newRelativeMatch);
 
     // scopePattern is defined against the SPA-relative pathname. Fall back to
     // the full pathname when neither relative pathname matches so that existing
     // patterns containing the SPA base path continue to work.
-    const oldMatch = useSpaRelativePathnames ? oldRelativeMatch : oldPathnames.full.match(regex);
-    const newMatch = useSpaRelativePathnames ? newRelativeMatch : newPathnames.full.match(regex);
+    let oldMatch = oldRelativeMatch;
+    let newMatch = newRelativeMatch;
+    if (!useSpaRelativePathnames) {
+      oldMatch = regex.exec(oldPathnames.full);
+      newMatch = regex.exec(newPathnames.full);
+    }
 
     if (!oldMatch || !newMatch) {
       // One or both URLs don't match the pattern - close workspace
@@ -43,9 +51,17 @@ export function shouldCloseOnUrlChange(scopePattern: string, oldUrl: string, new
 
 function getPathnames(url: string) {
   const full = new URL(url, window.location.origin).pathname;
-  const spaBase = new URL(window.getOpenmrsSpaBase(), window.location.origin).pathname.replace(/\/+$/, '');
-  const spaRelative =
-    !spaBase || spaBase === full ? '/' : full.startsWith(`${spaBase}/`) ? full.slice(spaBase.length) : full;
+  const spaBasePathname = new URL(window.getOpenmrsSpaBase(), window.location.origin).pathname;
+  const spaBase = spaBasePathname.endsWith('/') ? spaBasePathname.slice(0, -1) : spaBasePathname;
+  let spaRelative: string | null = null;
+
+  if (!spaBase) {
+    spaRelative = full;
+  } else if (spaBase === full) {
+    spaRelative = '/';
+  } else if (full.startsWith(`${spaBase}/`)) {
+    spaRelative = full.slice(spaBase.length);
+  }
 
   return { full, spaRelative };
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary

Workspace `scopePattern` values are route patterns, but core currently matches them against the browser's full pathname. On the default deployment, an anchored patient-chart pattern such as `^/patient/([^/]+)/chart` is therefore tested against `/openmrs/spa/patient/...` and never matches. The current unanchored pattern only works because the regex finds `/patient/...` in the middle of that full path, which is also why core repeatedly warns that the pattern should start with `^`. Adding the recommended anchor without changing core would make the workspace close on every same-app navigation.

Downstream code already treats this as a SPA-relative contract. [Patient chart](https://github.com/openmrs/openmrs-esm-patient-chart/blob/main/packages/esm-patient-chart-app/src/routes.json) uses a dynamic patient scope. Bed management, patient lists, wards, service queues, and appointments in [patient management](https://github.com/openmrs/openmrs-esm-patient-management/tree/main/packages) use static SPA-relative scopes, as does [laboratory](https://github.com/openmrs/openmrs-esm-laboratory-app/blob/main/src/routes.json). In total, those seven public apps define nine workspace groups this way. The [workspace documentation](https://github.com/openmrs/openmrs-contrib-o3-docs/blob/main/content/en-US/docs/workspaces/creating-workspaces.mdx) also shows an anchored SPA-relative pattern, and [`create-o3-app`](https://github.com/openmrs/create-o3-app/blob/main/src/templates/engine.ts) generates one from the module's first route.

This changes `shouldCloseOnUrlChange` to remove the configured SPA base before matching. The matching contract now works at `/openmrs/spa`, a custom base, or the domain root. Navigation outside the configured SPA base closes the workspace even when the destination has the same route shape. If the pattern does not match both SPA-relative pathnames, core retries the full path so existing private or downstream patterns that include the SPA base keep working. The public type documentation now states the same contract explicitly.

The new tests cover:

- navigation within the same patient scope and between different patients;
- the domain root, the default SPA base, and a custom SPA base;
- navigation from a URL exactly equal to the configured SPA base;
- navigation outside the configured SPA base;
- SPA-base prefix collisions such as `/openmrs/spa2`;
- route-boundary collisions such as `/chart-extra`; and
- legacy patterns that include `/openmrs/spa`.

## Screenshots

Grabbed from the console when running the app shell locally:

<img width="960" height="466" alt="Screenshot 2026-08-28 at 13 04 00" src="https://github.com/user-attachments/assets/5463181f-5cdc-44cd-a9e0-73c56c9aa614" />

## Related Issue

## Other
