### PR TITLE
(fix) Mount all single-spa parcels in a single long-lived parcel

### DIFF
--- a/.changeset/bright-teeth-design.md
+++ b/.changeset/bright-teeth-design.md
@@ -1,5 +1,5 @@
 ---
-"@openmrs/esm-extensions": minor
+"@openmrs/esm-extensions": patch
 "@openmrs/esm-framework": patch
 ---
 

--- a/.changeset/bright-teeth-design.md
+++ b/.changeset/bright-teeth-design.md
@@ -1,0 +1,6 @@
+---
+"@openmrs/esm-extensions": minor
+"@openmrs/esm-framework": patch
+---
+
+(fix) Mount all single-spa parcels in a single long-lived parcel

--- a/packages/framework/esm-extensions/mock.ts
+++ b/packages/framework/esm-extensions/mock.ts
@@ -1,6 +1,5 @@
 import { vi } from 'vitest';
 import { getGlobalStore } from '@openmrs/esm-state/mock';
-import { type WorkspaceGroupRegistration, type WorkspaceRegistration } from '.';
 
 export const attach = vi.fn();
 export const detach = vi.fn();

--- a/packages/framework/esm-extensions/src/render.test.ts
+++ b/packages/framework/esm-extensions/src/render.test.ts
@@ -1,0 +1,129 @@
+/* eslint-disable testing-library/render-result-naming-convention -- these tests render extensions, not components */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Parcel, ParcelConfig } from 'single-spa';
+
+const hostParcelName = 'openmrs-extension-host';
+
+vi.mock('single-spa', () => ({ mountRootParcel: vi.fn() }));
+
+vi.mock('./extensions', () => ({
+  getExtensionNameFromId: (extensionId: string) => extensionId,
+  getExtensionRegistration: () => ({
+    name: 'test-extension',
+    moduleName: 'test-module',
+    meta: {},
+    load: () => Promise.resolve(lifecycles),
+  }),
+}));
+
+vi.mock('./helpers', () => ({ checkStatus: () => true }));
+
+vi.mock('./store', () => ({ updateInternalExtensionStore: vi.fn() }));
+
+const lifecycles = {
+  bootstrap: () => Promise.resolve(),
+  mount: () => Promise.resolve(),
+  unmount: () => Promise.resolve(),
+};
+
+/** A stand-in for the external parcel representation single-spa returns. */
+function fakeParcel(): Parcel {
+  return {
+    mount: () => Promise.resolve(),
+    unmount: () => Promise.resolve(),
+    getStatus: () => 'MOUNTED',
+    loadPromise: Promise.resolve(),
+    bootstrapPromise: Promise.resolve(),
+    mountPromise: Promise.resolve(),
+    unmountPromise: Promise.resolve(),
+  } as unknown as Parcel;
+}
+
+/**
+ * Loads a fresh copy of the module under test, which caches the host parcel's mounter in module
+ * scope, wired to a fake single-spa whose host parcel either mounts or fails to mount.
+ */
+async function loadRenderExtension({ hostMountFails = false } = {}) {
+  vi.resetModules();
+
+  const { mountRootParcel } = await import('single-spa');
+  const hostMountParcel = vi.fn(() => fakeParcel());
+
+  vi.mocked(mountRootParcel).mockImplementation(((config: ParcelConfig, props: Record<string, unknown>) => {
+    if ('name' in config && config.name === hostParcelName) {
+      if (hostMountFails) {
+        return { ...fakeParcel(), mountPromise: Promise.reject(new Error('mount failed')) };
+      }
+
+      const mountPromise = Promise.resolve()
+        .then(() => (config as { bootstrap: (props: unknown) => Promise<void> }).bootstrap(props))
+        .then(() =>
+          (config as { mount: (props: unknown) => Promise<void> }).mount({ ...props, mountParcel: hostMountParcel }),
+        );
+
+      return { ...fakeParcel(), mountPromise };
+    }
+
+    return fakeParcel();
+  }) as typeof mountRootParcel);
+
+  const { renderExtension } = await import('./render');
+
+  const mountTestExtension = () =>
+    renderExtension(document.createElement('div'), 'test-slot', 'slot-module', 'test-extension#instance');
+
+  return { mountRootParcel: vi.mocked(mountRootParcel), hostMountParcel, mountTestExtension };
+}
+
+describe('renderExtension', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('mounts extensions through the host parcel rather than as root parcels', async () => {
+    const { mountRootParcel, hostMountParcel, mountTestExtension } = await loadRenderExtension();
+
+    const parcel = await mountTestExtension();
+
+    expect(hostMountParcel).toHaveBeenCalledTimes(1);
+    expect(parcel).toBe(hostMountParcel.mock.results[0].value);
+    expect(mountRootParcel).toHaveBeenCalledTimes(1);
+    expect(mountRootParcel).toHaveBeenCalledWith(
+      expect.objectContaining({ name: hostParcelName }),
+      expect.objectContaining({ domElement: expect.anything() }),
+    );
+  });
+
+  it('mounts the host parcel only once, including for concurrent renders', async () => {
+    const { mountRootParcel, hostMountParcel, mountTestExtension } = await loadRenderExtension();
+
+    await Promise.all([mountTestExtension(), mountTestExtension(), mountTestExtension()]);
+    await mountTestExtension();
+
+    expect(mountRootParcel).toHaveBeenCalledTimes(1);
+    expect(hostMountParcel).toHaveBeenCalledTimes(4);
+  });
+
+  it('falls back to mounting root parcels if the host parcel cannot be mounted', async () => {
+    const { mountRootParcel, hostMountParcel, mountTestExtension } = await loadRenderExtension({
+      hostMountFails: true,
+    });
+
+    const parcel = await mountTestExtension();
+
+    expect(parcel).not.toBeNull();
+    expect(hostMountParcel).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalled();
+    expect(mountRootParcel).toHaveBeenCalledTimes(2);
+    expect(mountRootParcel).toHaveBeenLastCalledWith(
+      expect.objectContaining({ name: 'test-slot/test-extension#instance-0' }),
+      expect.objectContaining({
+        _extensionContext: expect.objectContaining({ extensionId: 'test-extension#instance' }),
+      }),
+    );
+
+    // a second render must not retry mounting the host parcel
+    await mountTestExtension();
+    expect(mountRootParcel).toHaveBeenCalledTimes(3);
+  });
+});

--- a/packages/framework/esm-extensions/src/render.test.ts
+++ b/packages/framework/esm-extensions/src/render.test.ts
@@ -26,11 +26,15 @@ const lifecycles = {
   unmount: () => Promise.resolve(),
 };
 
-/** A stand-in for the external parcel representation single-spa returns. */
-function fakeParcel(): Parcel {
+/**
+ * A stand-in for the external parcel representation single-spa returns. single-spa only provides
+ * `update()` for a config that has an update lifecycle, so `hasUpdate` allows omitting it.
+ */
+function fakeParcel({ hasUpdate = true } = {}): Parcel {
   return {
-    mount: () => Promise.resolve(),
-    unmount: () => Promise.resolve(),
+    mount: vi.fn(() => Promise.resolve()),
+    unmount: vi.fn(() => Promise.resolve()),
+    ...(hasUpdate ? { update: vi.fn(() => Promise.resolve()) } : {}),
     getStatus: () => 'MOUNTED',
     loadPromise: Promise.resolve(),
     bootstrapPromise: Promise.resolve(),
@@ -43,7 +47,7 @@ function fakeParcel(): Parcel {
  * Loads a fresh copy of the module under test, which caches the host parcel's mounter in module
  * scope, wired to a fake single-spa whose host parcel either mounts or fails to mount.
  */
-async function loadRenderExtension({ hostMountFails = false } = {}) {
+async function loadRenderModule({ hostMountFails = false } = {}) {
   vi.resetModules();
 
   const { mountRootParcel } = await import('single-spa');
@@ -67,12 +71,18 @@ async function loadRenderExtension({ hostMountFails = false } = {}) {
     return fakeParcel();
   }) as typeof mountRootParcel);
 
-  const { renderExtension } = await import('./render');
+  const { createParcelMounter, renderExtension, renderParcel } = await import('./render');
 
   const mountTestExtension = () =>
     renderExtension(document.createElement('div'), 'test-slot', 'slot-module', 'test-extension#instance');
 
-  return { mountRootParcel: vi.mocked(mountRootParcel), hostMountParcel, mountTestExtension };
+  return {
+    mountRootParcel: vi.mocked(mountRootParcel),
+    hostMountParcel,
+    mountTestExtension,
+    renderParcel,
+    createParcelMounter,
+  };
 }
 
 describe('renderExtension', () => {
@@ -81,7 +91,7 @@ describe('renderExtension', () => {
   });
 
   it('mounts extensions through the host parcel rather than as root parcels', async () => {
-    const { mountRootParcel, hostMountParcel, mountTestExtension } = await loadRenderExtension();
+    const { mountRootParcel, hostMountParcel, mountTestExtension } = await loadRenderModule();
 
     const parcel = await mountTestExtension();
 
@@ -95,7 +105,7 @@ describe('renderExtension', () => {
   });
 
   it('mounts the host parcel only once, including for concurrent renders', async () => {
-    const { mountRootParcel, hostMountParcel, mountTestExtension } = await loadRenderExtension();
+    const { mountRootParcel, hostMountParcel, mountTestExtension } = await loadRenderModule();
 
     await Promise.all([mountTestExtension(), mountTestExtension(), mountTestExtension()]);
     await mountTestExtension();
@@ -105,7 +115,7 @@ describe('renderExtension', () => {
   });
 
   it('falls back to mounting root parcels if the host parcel cannot be mounted', async () => {
-    const { mountRootParcel, hostMountParcel, mountTestExtension } = await loadRenderExtension({
+    const { mountRootParcel, hostMountParcel, mountTestExtension } = await loadRenderModule({
       hostMountFails: true,
     });
 
@@ -125,5 +135,89 @@ describe('renderExtension', () => {
     // a second render must not retry mounting the host parcel
     await mountTestExtension();
     expect(mountRootParcel).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('renderParcel', () => {
+  it('mounts the parcel through the host parcel', async () => {
+    const { mountRootParcel, hostMountParcel, renderParcel } = await loadRenderModule();
+    const domElement = document.createElement('div');
+
+    const parcel = await renderParcel(lifecycles, { domElement, someProp: 'value' });
+
+    expect(hostMountParcel).toHaveBeenCalledWith(lifecycles, { domElement, someProp: 'value' });
+    expect(parcel).toBe(hostMountParcel.mock.results[0].value);
+    expect(mountRootParcel).toHaveBeenCalledTimes(1);
+    expect(mountRootParcel).toHaveBeenCalledWith(expect.objectContaining({ name: hostParcelName }), expect.anything());
+  });
+});
+
+describe('createParcelMounter', () => {
+  it('returns the parcel synchronously and forwards to the real parcel once it has mounted', async () => {
+    const { hostMountParcel, createParcelMounter } = await loadRenderModule();
+    const domElement = document.createElement('div');
+
+    const parcel = createParcelMounter()(lifecycles, { domElement });
+
+    // the host parcel's mounter is only resolved asynchronously, so nothing is mounted yet
+    expect(hostMountParcel).not.toHaveBeenCalled();
+    expect(parcel.getStatus()).toBe('LOADING_SOURCE_CODE');
+
+    await parcel.mountPromise;
+
+    expect(hostMountParcel).toHaveBeenCalledWith(lifecycles, { domElement });
+    expect(parcel.getStatus()).toBe('MOUNTED');
+  });
+
+  it('forwards update and unmount to the real parcel', async () => {
+    const { hostMountParcel, createParcelMounter } = await loadRenderModule();
+    const domElement = document.createElement('div');
+
+    const parcel = createParcelMounter()(lifecycles, { domElement });
+    await parcel.mountPromise;
+    await parcel.update?.({ domElement, someProp: 'value' });
+    await parcel.unmount();
+
+    const realParcel = hostMountParcel.mock.results[0].value;
+    expect(realParcel.update).toHaveBeenCalledWith({ domElement, someProp: 'value' });
+    expect(realParcel.unmount).toHaveBeenCalledTimes(1);
+    await expect(parcel.unmountPromise).resolves.toBeUndefined();
+  });
+
+  it('resolves update as a no-op if the real parcel has no update lifecycle', async () => {
+    const { hostMountParcel, createParcelMounter } = await loadRenderModule();
+    hostMountParcel.mockImplementationOnce(() => fakeParcel({ hasUpdate: false }));
+    const domElement = document.createElement('div');
+
+    const parcel = createParcelMounter()(lifecycles, { domElement });
+    await parcel.mountPromise;
+
+    await expect(parcel.update?.({ domElement })).resolves.toBeUndefined();
+  });
+
+  it('reports a failure to mount on mountPromise rather than throwing synchronously', async () => {
+    const { hostMountParcel, createParcelMounter } = await loadRenderModule();
+    hostMountParcel.mockImplementationOnce(() => {
+      throw new Error('parcel cannot be mounted without a domElement');
+    });
+
+    const parcel = createParcelMounter()(lifecycles, { domElement: document.createElement('div') });
+
+    await expect(parcel.mountPromise).rejects.toThrow('parcel cannot be mounted without a domElement');
+    // callers unmount only a MOUNTED parcel, so a parcel that never mounted must not claim to be
+    expect(parcel.getStatus()).not.toBe('MOUNTED');
+  });
+
+  it('mounts through the same host parcel as renderParcel', async () => {
+    const { mountRootParcel, hostMountParcel, renderParcel, createParcelMounter } = await loadRenderModule();
+    const domElement = document.createElement('div');
+
+    await Promise.all([
+      renderParcel(lifecycles, { domElement }),
+      createParcelMounter()(lifecycles, { domElement }).mountPromise,
+    ]);
+
+    expect(mountRootParcel).toHaveBeenCalledTimes(1);
+    expect(hostMountParcel).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/framework/esm-extensions/src/render.ts
+++ b/packages/framework/esm-extensions/src/render.ts
@@ -1,5 +1,5 @@
 /** @module @category Extension */
-import { mountRootParcel, type Parcel, type ParcelConfig } from 'single-spa';
+import { mountRootParcel, type AppProps, type Parcel, type ParcelConfig } from 'single-spa';
 import { getExtensionNameFromId, getExtensionRegistration } from './extensions';
 import { checkStatus } from './helpers';
 import { updateInternalExtensionStore } from './store';
@@ -8,7 +8,53 @@ export interface CancelLoading {
   (): void;
 }
 
+type MountParcel = AppProps['mountParcel'];
+
 let parcelCount = 0;
+let parcelMounter: Promise<MountParcel> | null = null;
+
+/**
+ * Resolves the function used to mount extensions, which is the `mountParcel()` of a long-lived
+ * parcel of our own rather than single-spa's `mountRootParcel()`.
+ *
+ * single-spa only removes a parcel from its owner's registry when it unmounts if that owner has a
+ * name, and the internal object backing `mountRootParcel()` has none (fixed in single-spa 7).
+ * Anything mounted with it is therefore retained for the lifetime of the page, along with the
+ * `domElement` it was given and the whole subtree rendered into it. Extensions mounted through a
+ * named owner are pruned as they should be.
+ *
+ * The host parcel is mounted at most once, lazily, and never unmounted; if mounting it fails we
+ * fall back to `mountRootParcel()`, since leaking is better than not rendering.
+ */
+function getParcelMounter(): Promise<MountParcel> {
+  parcelMounter ??= new Promise<MountParcel>((resolve, reject) => {
+    const host = mountRootParcel(
+      {
+        name: 'openmrs-extension-host',
+        bootstrap: () => Promise.resolve(),
+        mount: (props) => {
+          // single-spa types a parcel's lifecycle props as only the custom props it was mounted
+          // with, but they also carry the props single-spa itself injects, `mountParcel` included.
+          resolve((props as unknown as AppProps).mountParcel);
+          return Promise.resolve();
+        },
+        unmount: () => Promise.resolve(),
+      },
+      { domElement: document.createElement('div') },
+    );
+
+    host.mountPromise.catch(reject);
+  }).catch((err) => {
+    console.error(
+      'The host parcel used to mount extensions could not be mounted. Falling back to mounting ' +
+        'extensions as root parcels, which leaks their DOM elements.',
+      err,
+    );
+    return mountRootParcel;
+  });
+
+  return parcelMounter;
+}
 
 /**
  * Mounts into a DOM node (representing an extension slot)
@@ -56,7 +102,8 @@ export async function renderExtension(
 
       const lifecycle = await load();
       const id = parcelCount++;
-      parcel = mountRootParcel(
+      const mountParcel = await getParcelMounter();
+      parcel = mountParcel(
         renderFunction({
           ...lifecycle,
           name: `${extensionSlotName}/${extensionName}-${id}`,

--- a/packages/framework/esm-extensions/src/render.ts
+++ b/packages/framework/esm-extensions/src/render.ts
@@ -1,5 +1,12 @@
 /** @module @category Extension */
-import { mountRootParcel, type AppProps, type Parcel, type ParcelConfig } from 'single-spa';
+import {
+  mountRootParcel,
+  type AppProps,
+  type CustomProps,
+  type Parcel,
+  type ParcelConfig,
+  type ParcelProps,
+} from 'single-spa';
 import { getExtensionNameFromId, getExtensionRegistration } from './extensions';
 import { checkStatus } from './helpers';
 import { updateInternalExtensionStore } from './store';
@@ -57,6 +64,71 @@ function getParcelMounter(): Promise<MountParcel> {
 }
 
 /**
+ * Mounts a parcel through the framework's host parcel, which lets single-spa release the parcel,
+ * its `domElement` and everything rendered into it once it unmounts. Prefer this to single-spa's
+ * `mountRootParcel()`, which retains all three for the lifetime of the page.
+ *
+ * @param parcelConfig The parcel config, or a function that loads one
+ * @param customProps The props to mount the parcel with, including the `domElement` to render into
+ * @returns The parcel handle; mounting completes with its `mountPromise`
+ */
+export async function renderParcel<T = CustomProps>(
+  parcelConfig: ParcelConfig,
+  customProps: ParcelProps & T,
+): Promise<ReturnType<MountParcel>> {
+  const mountParcel = await getParcelMounter();
+  return mountParcel(parcelConfig, customProps);
+}
+
+/**
+ * Provides the equivalent of {@link renderParcel} for callers that need a `mountParcel()` they can
+ * call synchronously, single-spa-react's `<Parcel mountParcel={...} />` being the usual case.
+ *
+ * The parcel it returns is a stand-in until the real one exists, so its `getStatus()` reports
+ * `LOADING_SOURCE_CODE` rather than the real status for a short while after mounting. Prefer
+ * {@link renderParcel} wherever the caller can await it.
+ *
+ * @returns A `mountParcel()` that mounts through the host parcel
+ */
+export function createParcelMounter(): MountParcel {
+  return mountParcel;
+}
+
+/**
+ * Adapts the asynchronous `renderParcel()` to single-spa's synchronous `mountParcel()` signature,
+ * by returning an object that stands in for the parcel and forwards each call to the real one once
+ * it resolves. A caller that serialises its calls on `mountPromise`, as single-spa-react's
+ * `<Parcel>` does, never observes the stand-in; one that doesn't sees `getStatus()` report
+ * `LOADING_SOURCE_CODE` until the parcel is mounted, and an unmounted parcel's `update()` and
+ * `unmount()` deferred rather than rejected.
+ */
+function mountParcel(config: ParcelConfig, props: ParcelProps & CustomProps): Parcel {
+  let mounted: Parcel | undefined;
+  const pending = renderParcel(config, props).then((parcel) => (mounted = parcel));
+
+  return {
+    mount: () => pending.then((parcel) => parcel.mount()),
+    unmount: () => pending.then((parcel) => parcel.unmount()),
+    update: (customProps) => pending.then((parcel) => parcel.update?.(customProps)),
+    getStatus: () => mounted?.getStatus() ?? 'LOADING_SOURCE_CODE',
+    // Derived lazily so a mount failure surfaces only on the promise the caller actually reads,
+    // instead of becoming an unhandled rejection on the ones it ignores.
+    get loadPromise() {
+      return pending.then((parcel) => parcel.loadPromise);
+    },
+    get bootstrapPromise() {
+      return pending.then((parcel) => parcel.bootstrapPromise);
+    },
+    get mountPromise() {
+      return pending.then((parcel) => parcel.mountPromise);
+    },
+    get unmountPromise() {
+      return pending.then((parcel) => parcel.unmountPromise);
+    },
+  };
+}
+
+/**
  * Mounts into a DOM node (representing an extension slot)
  * a lazy-loaded component from *any* frontend module
  * that registered an extension component for this slot.
@@ -102,8 +174,7 @@ export async function renderExtension(
 
       const lifecycle = await load();
       const id = parcelCount++;
-      const mountParcel = await getParcelMounter();
-      parcel = mountParcel(
+      parcel = await renderParcel(
         renderFunction({
           ...lifecycle,
           name: `${extensionSlotName}/${extensionName}-${id}`,

--- a/packages/framework/esm-framework/docs/functions/renderExtension.md
+++ b/packages/framework/esm-framework/docs/functions/renderExtension.md
@@ -4,7 +4,7 @@
 
 > **renderExtension**(`domElement`, `extensionSlotName`, `extensionSlotModuleName`, `extensionId`, `renderFunction`, `additionalProps`): `Promise`\<`null` \| `Parcel`\>
 
-Defined in: [packages/framework/esm-extensions/src/render.ts:18](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L18)
+Defined in: [packages/framework/esm-extensions/src/render.ts:136](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L136)
 
 Mounts into a DOM node (representing an extension slot)
 a lazy-loaded component from *any* frontend module

--- a/packages/framework/esm-framework/docs/interfaces/CancelLoading.md
+++ b/packages/framework/esm-framework/docs/interfaces/CancelLoading.md
@@ -2,11 +2,11 @@
 
 # Interface: CancelLoading()
 
-Defined in: [packages/framework/esm-extensions/src/render.ts:7](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L7)
+Defined in: [packages/framework/esm-extensions/src/render.ts:14](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L14)
 
 > **CancelLoading**(): `void`
 
-Defined in: [packages/framework/esm-extensions/src/render.ts:8](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L8)
+Defined in: [packages/framework/esm-extensions/src/render.ts:15](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-extensions/src/render.ts#L15)
 
 ## Returns
 

--- a/packages/framework/esm-styleguide/src/modals/index.tsx
+++ b/packages/framework/esm-styleguide/src/modals/index.tsx
@@ -1,7 +1,7 @@
 /** @module @category UI */
-import { mountRootParcel, type Parcel } from 'single-spa';
+import { type Parcel } from 'single-spa';
 import { createGlobalStore } from '@openmrs/esm-state';
-import { getModalRegistration } from '@openmrs/esm-extensions';
+import { getModalRegistration, renderParcel } from '@openmrs/esm-extensions';
 import { reportError } from '@openmrs/esm-error-handling';
 
 type ModalInstanceState = 'NEW' | 'MOUNTED' | 'TO_BE_DELETED';
@@ -63,7 +63,7 @@ async function renderModalIntoDOM(
 
     const lifecycle = await load();
     const id = parcelCount++;
-    parcel = mountRootParcel(
+    parcel = await renderParcel(
       {
         ...lifecycle,
         name: `${modalName}-${id}`,

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
@@ -2,11 +2,11 @@ import React, { useEffect, useState, useMemo } from 'react';
 import { type ParcelConfig } from 'single-spa';
 import Parcel from 'single-spa-react/parcel';
 import { InlineLoading } from '@carbon/react';
+import { createParcelMounter } from '@openmrs/esm-extensions';
 import { getCoreTranslation } from '@openmrs/esm-translations';
 import styles from './workspace.module.scss';
 import { type OpenWorkspace } from '../workspaces';
 import { useWorkspaceGroupStore } from '../workspace-sidebar-store/useWorkspaceGroupStore';
-import { createParcelMounter } from '@openmrs/esm-extensions';
 
 interface WorkspaceRendererProps {
   workspace: OpenWorkspace;

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.component.tsx
@@ -1,16 +1,19 @@
 import React, { useEffect, useState, useMemo } from 'react';
-import { mountRootParcel, type ParcelConfig } from 'single-spa';
+import { type ParcelConfig } from 'single-spa';
 import Parcel from 'single-spa-react/parcel';
 import { InlineLoading } from '@carbon/react';
 import { getCoreTranslation } from '@openmrs/esm-translations';
 import styles from './workspace.module.scss';
 import { type OpenWorkspace } from '../workspaces';
 import { useWorkspaceGroupStore } from '../workspace-sidebar-store/useWorkspaceGroupStore';
+import { createParcelMounter } from '@openmrs/esm-extensions';
 
 interface WorkspaceRendererProps {
   workspace: OpenWorkspace;
   additionalPropsFromPage?: object;
 }
+
+const mountParcel = createParcelMounter();
 
 export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: WorkspaceRendererProps) {
   const [lifecycle, setLifecycle] = useState<ParcelConfig | undefined>();
@@ -43,7 +46,7 @@ export function WorkspaceRenderer({ workspace, additionalPropsFromPage }: Worksp
   );
 
   return lifecycle ? (
-    <Parcel key={workspace.name} config={lifecycle} mountParcel={mountRootParcel} {...props} />
+    <Parcel key={workspace.name} config={lifecycle} mountParcel={mountParcel} {...props} />
   ) : (
     <InlineLoading className={styles.loader} description={`${getCoreTranslation('loading', 'Loading')} ...`} />
   );

--- a/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.test.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces/container/workspace-renderer.test.tsx
@@ -1,8 +1,8 @@
 import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import '@testing-library/jest-dom/vitest';
+import { createParcelMounter } from '@openmrs/esm-extensions';
 import { render, screen } from '@testing-library/react';
-import { mountRootParcel } from 'single-spa';
 import { WorkspaceRenderer } from './workspace-renderer.component';
 import { getWorkspaceGroupStore } from '../workspaces';
 
@@ -22,6 +22,7 @@ describe('WorkspaceRenderer', () => {
     const mockPromptBeforeClosing = vi.fn();
     const mockSetTitle = vi.fn();
     const mockLoadFn = vi.fn().mockImplementation(() => Promise.resolve('file-content'));
+    const mountParcel = createParcelMounter();
 
     getWorkspaceGroupStore('test-sidebar-store')?.setState({
       // Testing that the workspace group state should be overrided by additionalProps
@@ -54,7 +55,7 @@ describe('WorkspaceRenderer', () => {
 
     expect(mockFn).toHaveBeenCalledWith({
       config: 'file-content',
-      mountParcel: mountRootParcel,
+      mountParcel: mountParcel,
       closeWorkspace: mockCloseWorkspace,
       closeWorkspaceWithSavedChanges: mockCloseWorkspaceWithSavedChanges,
       promptBeforeClosing: mockPromptBeforeClosing,

--- a/packages/framework/esm-styleguide/src/workspaces2/active-workspace-window.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces2/active-workspace-window.component.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import classNames from 'classnames';
 import Parcel from 'single-spa-react/parcel';
 import { type ParcelConfig } from 'single-spa';

--- a/packages/framework/esm-styleguide/src/workspaces2/active-workspace-window.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces2/active-workspace-window.component.tsx
@@ -3,7 +3,7 @@ import classNames from 'classnames';
 import Parcel from 'single-spa-react/parcel';
 import { type ParcelConfig } from 'single-spa';
 import { InlineLoading } from '@carbon/react';
-import { type OpenedWindow, type OpenedWorkspace, workspace2Store, createParcelMounter } from '@openmrs/esm-extensions';
+import { type OpenedWindow, type OpenedWorkspace, createParcelMounter, workspace2Store } from '@openmrs/esm-extensions';
 import { loadLifeCycles } from '@openmrs/esm-routes';
 import { getCoreTranslation } from '@openmrs/esm-translations';
 import { promptForClosingWorkspaces, useWorkspace2Store } from './workspace2';

--- a/packages/framework/esm-styleguide/src/workspaces2/active-workspace-window.component.tsx
+++ b/packages/framework/esm-styleguide/src/workspaces2/active-workspace-window.component.tsx
@@ -1,9 +1,9 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import classNames from 'classnames';
 import Parcel from 'single-spa-react/parcel';
-import { mountRootParcel, type ParcelConfig } from 'single-spa';
+import { type ParcelConfig } from 'single-spa';
 import { InlineLoading } from '@carbon/react';
-import { type OpenedWindow, type OpenedWorkspace, workspace2Store } from '@openmrs/esm-extensions';
+import { type OpenedWindow, type OpenedWorkspace, workspace2Store, createParcelMounter } from '@openmrs/esm-extensions';
 import { loadLifeCycles } from '@openmrs/esm-routes';
 import { getCoreTranslation } from '@openmrs/esm-translations';
 import { promptForClosingWorkspaces, useWorkspace2Store } from './workspace2';
@@ -71,6 +71,8 @@ interface ActiveWorkspaceProps {
   isLeafWorkspace: boolean;
   showActionMenu: boolean;
 }
+
+const mountParcel = createParcelMounter();
 
 const ActiveWorkspace: React.FC<ActiveWorkspaceProps> = ({
   lifeCycle,
@@ -195,7 +197,7 @@ const ActiveWorkspace: React.FC<ActiveWorkspaceProps> = ({
     );
   }
 
-  return <Parcel key={openedWorkspace.workspaceName} config={lifeCycle} mountParcel={mountRootParcel} {...props} />;
+  return <Parcel key={openedWorkspace.workspaceName} config={lifeCycle} mountParcel={mountParcel} {...props} />;
 };
 
 export default ActiveWorkspaceWindow;


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->

single-spa@6 has a bug with root parcels where it does not appropriately clean-up its internal tracking when a _root_ parcel unmounts though it does clean-up after non-root parcels. This is fixed in the as-yet unreleased single-spa@7. However, here we move to using a single long-running root parcel and mount all other parcels as children of that parcel.

Because single-spa, among other things, tracks the DOM node that belongs to the parcel, without this, we end up with a large number of detached DOM nodes cached in the single-spa registry.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
