### PR TITLE
(feat) Remove `useVisitContextStore` re-render amplification

### DIFF
--- a/packages/framework/esm-emr-api/src/visit-utils.ts
+++ b/packages/framework/esm-emr-api/src/visit-utils.ts
@@ -25,15 +25,6 @@ export enum VisitStatus {
 export interface VisitStoreState {
   patientUuid: string | null;
   manuallySetVisitUuid: string | null;
-
-  /**
-   * Stores a record of SWR mutate callbacks that should be called when
-   * the Visit with the specified uuid is modified. The callbacks are keyed
-   * by unique component IDs.
-   */
-  mutateVisitCallbacks: {
-    [componentId: string]: () => void;
-  };
 }
 
 /**
@@ -56,7 +47,6 @@ export const defaultVisitCustomRepresentation =
 const initialState: VisitStoreState = getVisitSessionStorage() || {
   patientUuid: null,
   manuallySetVisitUuid: null,
-  mutateVisitCallbacks: {},
 };
 
 /**

--- a/packages/framework/esm-framework/docs/functions/getVisitStore.md
+++ b/packages/framework/esm-framework/docs/functions/getVisitStore.md
@@ -4,7 +4,7 @@
 
 > **getVisitStore**(): `StoreApi`\<[`VisitStoreState`](../interfaces/VisitStoreState.md)\>
 
-Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:78](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L78)
+Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:68](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L68)
 
 Returns the global visit store that manages the current visit state. The store
 contains information about the current patient's visit and provides methods

--- a/packages/framework/esm-framework/docs/functions/getVisitsForPatient.md
+++ b/packages/framework/esm-framework/docs/functions/getVisitsForPatient.md
@@ -4,7 +4,7 @@
 
 > **getVisitsForPatient**(`patientUuid`, `abortController`, `v?`): `Promise`\<[`FetchResponse`](../interfaces/FetchResponse.md)\<\{ `results`: [`Visit`](../interfaces/Visit.md)[]; \}\>\>
 
-Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:183](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L183)
+Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:173](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L173)
 
 ## Parameters
 

--- a/packages/framework/esm-framework/docs/functions/saveVisit.md
+++ b/packages/framework/esm-framework/docs/functions/saveVisit.md
@@ -4,7 +4,7 @@
 
 > **saveVisit**(`payload`, `abortController`): `Promise`\<[`FetchResponse`](../interfaces/FetchResponse.md)\<[`Visit`](../interfaces/Visit.md)\>\>
 
-Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:137](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L137)
+Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:127](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L127)
 
 Creates a new visit by sending a POST request to the OpenMRS REST API.
 

--- a/packages/framework/esm-framework/docs/functions/setCurrentVisit.md
+++ b/packages/framework/esm-framework/docs/functions/setCurrentVisit.md
@@ -4,7 +4,7 @@
 
 > **setCurrentVisit**(`patientUuid`, `visitUuid`): `void`
 
-Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:98](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L98)
+Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:88](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L88)
 
 Sets the current visit for a patient in the global visit store. This is used
 to manually specify which visit should be considered "active" for the given patient.

--- a/packages/framework/esm-framework/docs/functions/updateVisit.md
+++ b/packages/framework/esm-framework/docs/functions/updateVisit.md
@@ -4,7 +4,7 @@
 
 > **updateVisit**(`uuid`, `payload`, `abortController`): `Promise`\<[`FetchResponse`](../interfaces/FetchResponse.md)\<[`Visit`](../interfaces/Visit.md)\>\>
 
-Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:165](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L165)
+Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:155](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L155)
 
 Updates an existing visit by sending a POST request to the OpenMRS REST API.
 

--- a/packages/framework/esm-framework/docs/functions/useVisitContextStore.md
+++ b/packages/framework/esm-framework/docs/functions/useVisitContextStore.md
@@ -2,9 +2,9 @@
 
 # Function: useVisitContextStore()
 
-> **useVisitContextStore**(`mutateVisitCallback?`): [`VisitStoreState`](../interfaces/VisitStoreState.md) & `BindFunctionsIn`\<\{ `mutateVisit`: \{ \}; `setVisitContext`: \{ `manuallySetVisitUuid`: `null`; `patientUuid?`: `undefined`; \} \| \{ `manuallySetVisitUuid`: `string`; `patientUuid`: `undefined` \| `string`; \}; \}\>
+> **useVisitContextStore**(`mutateVisitCallback?`): `object`
 
-Defined in: [packages/framework/esm-react-utils/src/useVisitContextStore.ts:30](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisitContextStore.ts#L30)
+Defined in: [packages/framework/esm-react-utils/src/useVisitContextStore.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-react-utils/src/useVisitContextStore.ts#L44)
 
 A hook to return the visit context store and corresponding actions.
 
@@ -15,9 +15,43 @@ A hook to return the visit context store and corresponding actions.
 () => `void`
 
 An optional mutate callback to register. If provided, the
-store action's `mutateVisit` function will invoke this callback (along with any other
-callbacks also registered into the store)
+returned `mutateVisit` function will invoke this callback (along with any other
+callbacks registered by other components). Pass a callback with a stable identity;
+one that changes on every render re-registers on every render.
 
 ## Returns
 
-[`VisitStoreState`](../interfaces/VisitStoreState.md) & `BindFunctionsIn`\<\{ `mutateVisit`: \{ \}; `setVisitContext`: \{ `manuallySetVisitUuid`: `null`; `patientUuid?`: `undefined`; \} \| \{ `manuallySetVisitUuid`: `string`; `patientUuid`: `undefined` \| `string`; \}; \}\>
+### manuallySetVisitUuid
+
+> **manuallySetVisitUuid**: `null` \| `string`
+
+### mutateVisit()
+
+> **mutateVisit**: () => `void`
+
+Invokes every registered mutate callback, revalidating visit data across the application.
+
+Iterates over a copy so that a callback which registers or unregisters another does not
+disturb the traversal.
+
+#### Returns
+
+`void`
+
+### patientUuid
+
+> **patientUuid**: `null` \| `string`
+
+### setVisitContext()
+
+> **setVisitContext**(...`args`): `void`
+
+#### Parameters
+
+##### args
+
+...\[`null` \| [`Visit`](../interfaces/Visit.md)\]
+
+#### Returns
+
+`void`

--- a/packages/framework/esm-framework/docs/interfaces/VisitStoreState.md
+++ b/packages/framework/esm-framework/docs/interfaces/VisitStoreState.md
@@ -14,22 +14,6 @@ Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:27](https://githu
 
 ***
 
-### mutateVisitCallbacks
-
-> **mutateVisitCallbacks**: `object`
-
-Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:34](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L34)
-
-Stores a record of SWR mutate callbacks that should be called when
-the Visit with the specified uuid is modified. The callbacks are keyed
-by unique component IDs.
-
-#### Index Signature
-
-\[`componentId`: `string`\]: () => `void`
-
-***
-
 ### patientUuid
 
 > **patientUuid**: `null` \| `string`

--- a/packages/framework/esm-framework/docs/variables/defaultVisitCustomRepresentation.md
+++ b/packages/framework/esm-framework/docs/variables/defaultVisitCustomRepresentation.md
@@ -4,7 +4,7 @@
 
 > `const` **defaultVisitCustomRepresentation**: `string`
 
-Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:44](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L44)
+Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L35)
 
 The default custom representation string for fetching visit data from the REST API.
 This representation includes comprehensive visit details such as encounters, patient,

--- a/packages/framework/esm-framework/docs/variables/getStartedVisit.md
+++ b/packages/framework/esm-framework/docs/variables/getStartedVisit.md
@@ -4,6 +4,6 @@
 
 > `const` **getStartedVisit**: `BehaviorSubject`\<`null` \| [`VisitItem`](../interfaces/VisitItem.md)\>
 
-Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:200](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L200)
+Defined in: [packages/framework/esm-emr-api/src/visit-utils.ts:190](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-emr-api/src/visit-utils.ts#L190)
 
 ## Deprecated

--- a/packages/framework/esm-react-utils/src/useVisit.ts
+++ b/packages/framework/esm-react-utils/src/useVisit.ts
@@ -50,7 +50,17 @@ export interface VisitReturnType {
  * @param representation The custom representation of the visit
  */
 export function useVisit(patientUuid: string, representation = defaultVisitCustomRepresentation): VisitReturnType {
-  const { patientUuid: visitStorePatientUuid, manuallySetVisitUuid, setVisitContext } = useVisitContextStore();
+  // The callback we register has to exist before we read the store, but the mutate functions
+  // it calls come from SWR calls that are keyed off what the store holds. Registering a stable
+  // indirection through a ref breaks that cycle, so the store is read once per hook rather than
+  // once to get the key and again to register.
+  const mutateVisitRef = useRef<() => void>(undefined);
+  const registeredMutateVisit = useCallback(() => mutateVisitRef.current?.(), []);
+  const {
+    patientUuid: visitStorePatientUuid,
+    manuallySetVisitUuid,
+    setVisitContext,
+  } = useVisitContextStore(registeredMutateVisit);
   // Ignore the visit store data if it is not for this patient
   const retrospectiveVisitUuid = patientUuid && visitStorePatientUuid == patientUuid ? manuallySetVisitUuid : null;
   const activeVisitUrlSuffix = `?patient=${patientUuid}&v=${representation}&includeInactive=false`;
@@ -111,7 +121,9 @@ export function useVisit(patientUuid: string, representation = defaultVisitCusto
     retroMutate();
   }, [activeMutate, retroMutate]);
 
-  useVisitContextStore(mutateVisit);
+  useEffect(() => {
+    mutateVisitRef.current = mutateVisit;
+  }, [mutateVisit]);
 
   const waitingForData = Boolean(!activeData || (retrospectiveVisitUuid && !retroData));
   const hasRelevantError = Boolean(retrospectiveVisitUuid ? retroError : activeError);

--- a/packages/framework/esm-react-utils/src/useVisitContextStore.test.tsx
+++ b/packages/framework/esm-react-utils/src/useVisitContextStore.test.tsx
@@ -1,0 +1,128 @@
+import React, { useCallback } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { act, render, renderHook } from '@testing-library/react';
+import { getVisitStore } from '@openmrs/esm-emr-api';
+import { useVisitContextStore } from './useVisitContextStore';
+
+/** Counts calls to `setState` on the visit store for the duration of `run`. */
+function countStoreWrites(run: () => void) {
+  const store = getVisitStore();
+  const setState = store.setState;
+  let writes = 0;
+  store.setState = ((...args: Parameters<typeof setState>) => {
+    writes++;
+    return setState(...args);
+  }) as typeof setState;
+
+  try {
+    run();
+  } finally {
+    store.setState = setState;
+  }
+
+  return writes;
+}
+
+describe('useVisitContextStore', () => {
+  it('invokes every registered callback when mutateVisit is called', () => {
+    const first = vi.fn();
+    const second = vi.fn();
+
+    const { result } = renderHook(() => useVisitContextStore(first));
+    renderHook(() => useVisitContextStore(second));
+
+    act(() => result.current.mutateVisit());
+
+    expect(first).toHaveBeenCalledTimes(1);
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('stops invoking a callback once its component unmounts', () => {
+    const callback = vi.fn();
+
+    const { result } = renderHook(() => useVisitContextStore());
+    const { unmount } = renderHook(() => useVisitContextStore(callback));
+
+    act(() => result.current.mutateVisit());
+    expect(callback).toHaveBeenCalledTimes(1);
+
+    unmount();
+    act(() => result.current.mutateVisit());
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not write to the store when registering or unregistering a callback', () => {
+    let unmount = () => {};
+
+    const mountWrites = countStoreWrites(() => {
+      unmount = renderHook(() => useVisitContextStore(() => {})).unmount;
+    });
+    expect(mountWrites).toBe(0);
+
+    expect(countStoreWrites(unmount)).toBe(0);
+  });
+
+  it('does not write to the store when mutateVisit is called', () => {
+    const { result } = renderHook(() => useVisitContextStore(() => {}));
+
+    expect(countStoreWrites(() => act(() => result.current.mutateVisit()))).toBe(0);
+  });
+
+  it('keeps mutate callbacks out of the persisted store state', () => {
+    renderHook(() => useVisitContextStore(() => {}));
+
+    act(() => {
+      getVisitStore().setState({ patientUuid: 'patient-123' });
+    });
+
+    const persisted = JSON.parse(window.sessionStorage.getItem('openmrs:visitStoreState') ?? '{}');
+    expect(persisted).toEqual({ patientUuid: 'patient-123', manuallySetVisitUuid: null });
+  });
+
+  it('does not re-render already-mounted consumers as more consumers mount', () => {
+    const renderCounts: Array<number> = [];
+
+    // Memoized so that re-rendering the parent to add a row does not itself re-render the
+    // existing rows; anything counted here came from the store notifying its subscribers.
+    const Row = React.memo(function Row({ index }: { index: number }) {
+      renderCounts[index] = (renderCounts[index] ?? 0) + 1;
+      const mutate = useCallback(() => {}, []);
+      useVisitContextStore(mutate);
+      return null;
+    });
+
+    function Screen({ count }: { count: number }) {
+      return (
+        <>
+          {Array.from({ length: count }, (_, index) => (
+            <Row index={index} key={index} />
+          ))}
+        </>
+      );
+    }
+
+    const rows = 15;
+    const { rerender } = render(<Screen count={0} />);
+    for (let count = 1; count <= rows; count++) {
+      rerender(<Screen count={count} />);
+    }
+
+    // Each row should have rendered exactly once: mounting a row must not notify the rows
+    // already on screen, or filling a screen of N rows costs O(N²) renders.
+    expect(renderCounts).toEqual(Array.from({ length: rows }, () => 1));
+  });
+
+  it('re-renders consumers when the visit context itself changes', () => {
+    const { result } = renderHook(() => useVisitContextStore());
+
+    act(() => {
+      result.current.setVisitContext({
+        uuid: 'visit-1',
+        patient: { uuid: 'patient-123' },
+      } as Parameters<typeof result.current.setVisitContext>[0]);
+    });
+
+    expect(result.current.manuallySetVisitUuid).toBe('visit-1');
+    expect(result.current.patientUuid).toBe('patient-123');
+  });
+});

--- a/packages/framework/esm-react-utils/src/useVisitContextStore.ts
+++ b/packages/framework/esm-react-utils/src/useVisitContextStore.ts
@@ -2,6 +2,24 @@ import { useEffect, useId } from 'react';
 import { getVisitStore, type Visit, type VisitStoreState } from '@openmrs/esm-emr-api';
 import { type Actions, useStoreWithActions } from './useStore';
 
+/**
+ * The mutate callbacks to invoke when visit data changes, keyed by the `useId()` of the
+ * component that registered each one.
+ */
+const mutateVisitCallbacks = new Map<string, () => void>();
+
+/**
+ * Invokes every registered mutate callback, revalidating visit data across the application.
+ *
+ * Iterates over a copy so that a callback which registers or unregisters another does not
+ * disturb the traversal.
+ */
+function mutateVisit() {
+  for (const mutateCallback of Array.from(mutateVisitCallbacks.values())) {
+    mutateCallback();
+  }
+}
+
 const visitContextStoreActions = {
   setVisitContext(_: VisitStoreState, newSelectedVisit: Visit | null) {
     if (newSelectedVisit == null) {
@@ -12,46 +30,32 @@ const visitContextStoreActions = {
       patientUuid: newSelectedVisit.patient?.uuid,
     };
   },
-  mutateVisit(currState: VisitStoreState) {
-    for (const mutateCallback of Object.values(currState.mutateVisitCallbacks ?? {})) {
-      mutateCallback();
-    }
-    return {};
-  },
 } satisfies Actions<VisitStoreState>;
 
 /**
  * A hook to return the visit context store and corresponding actions.
+ *
  * @param mutateVisitCallback An optional mutate callback to register. If provided, the
- * store action's `mutateVisit` function will invoke this callback (along with any other
- * callbacks also registered into the store)
+ * returned `mutateVisit` function will invoke this callback (along with any other
+ * callbacks registered by other components). Pass a callback with a stable identity;
+ * one that changes on every render re-registers on every render.
  * @returns
  */
 export function useVisitContextStore(mutateVisitCallback?: () => void) {
   const id = useId();
 
   useEffect(() => {
-    const visitStore = getVisitStore();
-
-    // register the callback if it exists
-    if (mutateVisitCallback) {
-      visitStore.setState({
-        mutateVisitCallbacks: {
-          ...visitStore.getState().mutateVisitCallbacks,
-          [id]: mutateVisitCallback,
-        },
-      });
+    if (!mutateVisitCallback) {
+      return;
     }
 
-    // deregister the callback on unmount, if it exists
+    mutateVisitCallbacks.set(id, mutateVisitCallback);
     return () => {
-      if (mutateVisitCallback) {
-        const mutateVisitCallbacks = { ...visitStore.getState().mutateVisitCallbacks };
-        delete mutateVisitCallbacks[id];
-        visitStore.setState({ mutateVisitCallbacks });
-      }
+      mutateVisitCallbacks.delete(id);
     };
   }, [id, mutateVisitCallback]);
 
-  return useStoreWithActions(getVisitStore(), visitContextStoreActions);
+  const visitContextStore = useStoreWithActions(getVisitStore(), visitContextStoreActions);
+
+  return { ...visitContextStore, mutateVisit };
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->

This fixes a major request amplification issue with `useVisit` and `useVisitContextStore`. First, `useVisit` called the `useVisitContextStore` hook twice on every render, first to get some data and then to register a `mutateVisit` callback. Instead, we register a ref as the callback and fill in the refs contents with the actual function, so that `useVisit` only writes to the store once.

More critically, registering the callback required updating the store's state, which triggered re-renders in unrelated components just because we were registering a new `useVisit` hook. Measured with a test, 400 components using `useVisit` would cause 80,600 renders. Likewise, every call to `mutateVisit()`, because it was bound as an action, actually _writes_ to the store, causing re-renders even before invalidating the SWR cache.

Moving the callback tracking out of the store and into a global variable removes both of these re-render amplifications. Re-renders now should only occur when the active visit (or retrospective visit) is updated.

`mutateVisitCallbacks` has been removed from the VisitStoreState; I _think_ it's ok to treat the contents of the store as an internal detail. The implementation surface (including `useVisitContextStore()`) is identical. 

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

Ultimately, instead of storing functions globally, we should probably move to some kind of system for signally when mutations are need as that would involve much less book-keeping here and much less chance of triggering excessive renders.
