### PR TITLE
(chore) Clean build outputs before bundle size comparison

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -33,4 +33,4 @@ jobs:
           minimum-change-threshold: 10000 # 10 KB
           install-script: "yarn install --immutable"
           build-script: "yarn turbo run build --color"
-          clean-script: "clean:dist"
+          clean-script: "yarn run clean:dist"

--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -33,3 +33,4 @@ jobs:
           minimum-change-threshold: 10000 # 10 KB
           install-script: "yarn install --immutable"
           build-script: "yarn turbo run build --color"
+          clean-script: "clean:dist"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "ci:publish": "yarn workspaces foreach --all --topological --exclude @openmrs/esm-core --exclude @openmrs/storybook --exclude @openmrs/integration-tests npm publish --tolerate-republish --access public --tag latest",
     "release": "yarn workspaces foreach --all --topological version",
     "build": "turbo run build",
+    "clean:dist": "turbo run clean --color --concurrency=5",
     "build:apps": "turbo run build --filter='@openmrs/*-app'",
     "document": "turbo run document",
     "setup": "yarn install && turbo run build",

--- a/packages/apps/esm-devtools-app/package.json
+++ b/packages/apps/esm-devtools-app/package.json
@@ -14,6 +14,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rspack --mode=production",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rspack --mode=development",
     "analyze": "rspack --mode=production --env analyze=true",
     "typescript": "tsc",

--- a/packages/apps/esm-help-menu-app/package.json
+++ b/packages/apps/esm-help-menu-app/package.json
@@ -14,6 +14,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rspack --mode=production",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rspack --mode=development",
     "analyze": "rspack --mode=production --env analyze=true",
     "typescript": "tsc",

--- a/packages/apps/esm-implementer-tools-app/package.json
+++ b/packages/apps/esm-implementer-tools-app/package.json
@@ -13,6 +13,7 @@
     "test": "cross-env TZ=UTC vitest run --passWithNoTests",
     "test:watch": "cross-env TZ=UTC vitest watch",
     "build": "rspack --mode=production",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rspack --mode=development",
     "analyze": "rspack --mode=production --env analyze=true",
     "typescript": "tsc",

--- a/packages/apps/esm-login-app/package.json
+++ b/packages/apps/esm-login-app/package.json
@@ -13,6 +13,7 @@
     "test": "cross-env TZ=UTC vitest run --passWithNoTests",
     "test:watch": "cross-env TZ=UTC vitest watch",
     "build": "rspack --mode=production",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rspack --mode=development",
     "analyze": "rspack --mode=production --env analyze=true",
     "typescript": "tsc",

--- a/packages/apps/esm-offline-tools-app/package.json
+++ b/packages/apps/esm-offline-tools-app/package.json
@@ -13,6 +13,7 @@
     "test": "cross-env TZ=UTC vitest run --passWithNoTests",
     "test:watch": "cross-env TZ=UTC vitest watch",
     "build": "rspack --mode=production",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rspack --mode=development",
     "analyze": "rspack --mode=production --env analyze=true",
     "typescript": "tsc",

--- a/packages/apps/esm-primary-navigation-app/package.json
+++ b/packages/apps/esm-primary-navigation-app/package.json
@@ -13,6 +13,7 @@
     "test": "cross-env TZ=UTC vitest run --passWithNoTests",
     "test:watch": "cross-env TZ=UTC vitest watch",
     "build": "rspack --mode=production",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rspack --mode=development",
     "analyze": "rspack --mode=production --env analyze=true",
     "typescript": "tsc",

--- a/packages/framework/esm-api/package.json
+++ b/packages/framework/esm-api/package.json
@@ -26,6 +26,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/framework/esm-config/package.json
+++ b/packages/framework/esm-config/package.json
@@ -26,6 +26,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/framework/esm-context/package.json
+++ b/packages/framework/esm-context/package.json
@@ -20,6 +20,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src",

--- a/packages/framework/esm-dynamic-loading/package.json
+++ b/packages/framework/esm-dynamic-loading/package.json
@@ -25,6 +25,7 @@
     "test": "cross-env TZ=UTC vitest run --passWithNoTests",
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src",

--- a/packages/framework/esm-emr-api/package.json
+++ b/packages/framework/esm-emr-api/package.json
@@ -26,6 +26,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/framework/esm-error-handling/package.json
+++ b/packages/framework/esm-error-handling/package.json
@@ -18,6 +18,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && swc --strip-leading-paths src -d dist && tsc --project tsconfig.build.json",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && swc --strip-leading-paths src -d dist && tsc --project tsconfig.build.json",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/framework/esm-expression-evaluator/package.json
+++ b/packages/framework/esm-expression-evaluator/package.json
@@ -23,6 +23,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/framework/esm-extensions/package.json
+++ b/packages/framework/esm-extensions/package.json
@@ -26,6 +26,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/framework/esm-feature-flags/package.json
+++ b/packages/framework/esm-feature-flags/package.json
@@ -18,6 +18,7 @@
   "source": true,
   "scripts": {
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/framework/esm-framework/package.json
+++ b/packages/framework/esm-framework/package.json
@@ -33,6 +33,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/framework/esm-globals/package.json
+++ b/packages/framework/esm-globals/package.json
@@ -18,6 +18,7 @@
   "source": true,
   "scripts": {
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "test": "vitest run --passWithNoTests",
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",

--- a/packages/framework/esm-navigation/package.json
+++ b/packages/framework/esm-navigation/package.json
@@ -22,6 +22,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/framework/esm-offline/package.json
+++ b/packages/framework/esm-offline/package.json
@@ -22,6 +22,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/framework/esm-react-utils/package.json
+++ b/packages/framework/esm-react-utils/package.json
@@ -25,6 +25,7 @@
     "test": "cross-env TZ=UTC vitest run --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/framework/esm-routes/package.json
+++ b/packages/framework/esm-routes/package.json
@@ -19,6 +19,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/framework/esm-state/package.json
+++ b/packages/framework/esm-state/package.json
@@ -27,6 +27,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/framework/esm-styleguide/package.json
+++ b/packages/framework/esm-styleguide/package.json
@@ -40,6 +40,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths --copy-files src -d dist && svgo -rf dist --quiet\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths --copy-files src -d dist\" \"tsc --project tsconfig.build.json\"",
     "lint": "eslint src"
   },

--- a/packages/framework/esm-translations/package.json
+++ b/packages/framework/esm-translations/package.json
@@ -26,6 +26,7 @@
   "source": true,
   "scripts": {
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src",

--- a/packages/framework/esm-utils/package.json
+++ b/packages/framework/esm-utils/package.json
@@ -23,6 +23,7 @@
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "build:development": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
     "typescript": "tsc --project tsconfig.build.json",
     "lint": "eslint src"

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -11,6 +11,7 @@
     "build:production": "cross-env OMRS_ESM_IMPORTMAP_URL=\"https://dev3.openmrs.org/openmrs/spa/importmap.json\" OMRS_OFFLINE=\"enable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"production\" rspack --mode production",
     "build:development": "cross-env OMRS_OFFLINE=\"enable\" OMRS_CLEAN_BEFORE_BUILD=\"true\" NODE_ENV=\"development\" rspack --mode development",
     "build": "yarn run build:production && yarn run build:development",
+    "clean": "git clean -fdX -- dist",
     "analyze": "rspack --mode=production --env analyze=true",
     "lint": "eslint src"
   },

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -32,6 +32,7 @@
     "test": "cross-env TZ=UTC vitest run --passWithNoTests",
     "test:watch": "cross-env TZ=UTC vitest watch",
     "build": "rimraf dist && concurrently \"swc --strip-leading-paths src -d dist\" \"tsc --project tsconfig.build.json\"",
+    "clean": "git clean -fdX -- dist",
     "lint": "eslint src"
   },
   "repository": {

--- a/packages/tooling/rspack-config/package.json
+++ b/packages/tooling/rspack-config/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "clean": "git clean -fdX -- dist",
     "build:development": "tsc",
     "lint": "eslint src"
   },

--- a/packages/tooling/storybook/package.json
+++ b/packages/tooling/storybook/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "storybook": "storybook dev -p 6006",
     "build": "storybook build -o dist",
+    "clean": "git clean -fdX -- dist",
     "lint": "eslint .storybook mocks"
   },
   "devDependencies": {

--- a/packages/tooling/typedoc-plugin-file-categories/package.json
+++ b/packages/tooling/typedoc-plugin-file-categories/package.json
@@ -8,7 +8,8 @@
     "test": "cross-env TZ=UTC vitest run --passWithNoTests",
     "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
     "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests",
-    "build": "rimraf dist && swc --strip-leading-paths src -d dist"
+    "build": "rimraf dist && swc --strip-leading-paths src -d dist",
+    "clean": "git clean -fdX -- dist"
   },
   "peerDependencies": {
     "typedoc": ">=0.28.0"

--- a/packages/tooling/webpack-config/package.json
+++ b/packages/tooling/webpack-config/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "build": "tsc",
+    "clean": "git clean -fdX -- dist",
     "build:development": "tsc",
     "lint": "eslint src"
   },

--- a/turbo.json
+++ b/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "https://turborepo.org/schema.json",
   "ui": "stream",
   "tasks": {
+    "clean": {
+      "cache": false
+    },
     "build": {
       "dependsOn": ["^build"],
       "inputs": [


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary

The compressed-size action builds the pull request and base revisions sequentially in the same workspace. When the base build is restored from the Turborepo cache, its build command is skipped and stale pull-request chunks can remain in `dist`. Those files are then incorrectly reported as removed, inflating the bundle-size change.

This adds the action-supported cleanup hook. Each of the 31 buildable packages owns a `clean` script scoped to its ignored `dist` directory, and the root script orchestrates those package tasks through a non-cacheable Turborepo task.

This follows the workflow fix validated in openmrs/openmrs-esm-patient-chart#3607.

## Screenshots

## Related Issue

Follow-up to openmrs/openmrs-esm-patient-chart#3607.

## Other

Validation included manifest parsing, configuration checks, `git diff --check`, and an ignored `dist` fixture that confirmed the cleanup command removes generated output.
