### PR TITLE
(feat) Improve guards in dynamic-loading to prevent duplicate requests

### DIFF
--- a/packages/framework/esm-dynamic-loading/src/dynamic-loading.test.ts
+++ b/packages/framework/esm-dynamic-loading/src/dynamic-loading.test.ts
@@ -58,6 +58,7 @@ describe('dynamic-loading', () => {
   beforeEach(() => {
     localStorage.clear();
     document.head.querySelectorAll('script').forEach((el) => el.remove());
+    delete (window as any)[Symbol.for('__openmrs_script_loading')];
     (globalThis as any).__webpack_share_scopes__ = { default: {} };
     (window as any).spaBase = '/openmrs/spa';
     mockGetImportMapOverrideMap.mockReturnValue({ imports: {} });
@@ -128,7 +129,7 @@ describe('dynamic-loading', () => {
 
       script.dispatchEvent(new Event('load'));
 
-      await expect(promise).resolves.toBeNull();
+      await expect(promise).resolves.toBeUndefined();
     });
 
     it('rejects when the script fails to load', async () => {
@@ -201,7 +202,7 @@ describe('dynamic-loading', () => {
 
       script.dispatchEvent(new Event('load'));
 
-      await expect(promise).resolves.toBeNull();
+      await expect(promise).resolves.toBeUndefined();
       expect(mockGetCurrentPageMap).not.toHaveBeenCalled();
     });
 
@@ -216,24 +217,89 @@ describe('dynamic-loading', () => {
       expect(script).not.toBeNull();
       script.dispatchEvent(new Event('load'));
 
-      await expect(promise).resolves.toBeNull();
+      await expect(promise).resolves.toBeUndefined();
     });
 
-    it('does not reload a script that is already in the DOM and finished loading', async () => {
+    it('does not re-request a script that has already loaded', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       mockGetCurrentPageMap.mockResolvedValue({
         imports: { '@openmrs/esm-foo': 'http://localhost/foo.js' },
       });
 
-      // First load
       const firstPromise = preloadImport('@openmrs/esm-foo');
       const script = await waitForScript('http://localhost/foo.js');
       script.dispatchEvent(new Event('load'));
       await firstPromise;
 
-      // Second load — script is in DOM but slug not on window, so it resolves with a warning
-      await expect(preloadImport('@openmrs/esm-foo')).resolves.toBeNull();
+      // the package defines no container global, so this is decided by the script registry alone
+      await expect(preloadImport('@openmrs/esm-foo')).resolves.toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(document.head.querySelectorAll('script[src="http://localhost/foo.js"]')).toHaveLength(1);
+    });
+
+    it('shares the request with a caller that reaches it after the script loaded', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const importMap = { imports: { '@openmrs/esm-foo': 'http://localhost/foo.js' } };
+
+      let releaseSecondMap!: () => void;
+      const secondMap = new Promise((resolve) => {
+        releaseSecondMap = () => resolve(importMap);
+      });
+      mockGetCurrentPageMap.mockResolvedValueOnce(importMap).mockReturnValueOnce(secondMap);
+
+      const first = preloadImport('@openmrs/esm-foo');
+      const second = preloadImport('@openmrs/esm-foo');
+
+      const script = await waitForScript('http://localhost/foo.js');
+      script.dispatchEvent(new Event('load'));
+      await first;
+
+      // the second caller only learns the URL now, long after the load event it needed to see
+      releaseSecondMap();
+
+      await expect(second).resolves.toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(document.head.querySelectorAll('script[src="http://localhost/foo.js"]')).toHaveLength(1);
+    });
+
+    it('warns about, and does not re-request, a script it did not load itself', async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockGetCurrentPageMap.mockResolvedValue({
+        imports: { '@openmrs/esm-foo': 'http://localhost/foo.js' },
+      });
+
+      const foreign = document.createElement('script');
+      foreign.src = 'http://localhost/foo.js';
+      document.head.appendChild(foreign);
+
+      await expect(preloadImport('@openmrs/esm-foo')).resolves.toBeUndefined();
       expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('already loaded'));
+      expect(document.head.querySelectorAll('script[src="http://localhost/foo.js"]')).toHaveLength(1);
+    });
+
+    it('retries a script that failed to load', async () => {
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      mockGetCurrentPageMap.mockResolvedValue({
+        imports: { '@openmrs/esm-foo': 'http://localhost/foo.js' },
+      });
+
+      const firstPromise = preloadImport('@openmrs/esm-foo');
+      const failed = await waitForScript('http://localhost/foo.js');
+      failed.dispatchEvent(new ErrorEvent('error', { message: 'net::ERR_FAILED' }));
+      await expect(firstPromise).rejects.toBe('net::ERR_FAILED');
+
+      // the dead element is gone, so the retry is a real request rather than a false success
+      expect(document.head.querySelector('script[src="http://localhost/foo.js"]')).toBeNull();
+
+      const secondPromise = preloadImport('@openmrs/esm-foo');
+      const retried = await waitForScript('http://localhost/foo.js');
+      expect(retried).not.toBe(failed);
+
+      retried.dispatchEvent(new Event('load'));
+
+      await expect(secondPromise).resolves.toBeUndefined();
+      expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it('resolves both callers when the same script is preloaded concurrently', async () => {
@@ -248,8 +314,8 @@ describe('dynamic-loading', () => {
       const script = await waitForScript('http://localhost/foo.js');
       script.dispatchEvent(new Event('load'));
 
-      await expect(first).resolves.toBeNull();
-      await expect(second).resolves.toBeNull();
+      await expect(first).resolves.toBeUndefined();
+      await expect(second).resolves.toBeUndefined();
     });
 
     it('rejects both callers when a concurrently-loaded script fails', async () => {

--- a/packages/framework/esm-dynamic-loading/src/dynamic-loading.ts
+++ b/packages/framework/esm-dynamic-loading/src/dynamic-loading.ts
@@ -109,7 +109,8 @@ function humanReadableMs(ms: number) {
  * @internal
  *
  * This internal method is used to ensure that the script belonging
- * to the given package is loaded and added to the head.
+ * to the given package is loaded and added to the head. Concurrent and
+ * repeat calls for the same package share a single request for it.
  *
  * @param jsPackage The package to load
  * @param importMap The import map to use for loading this package.
@@ -140,9 +141,7 @@ export async function preloadImport(jsPackage: string, importMap?: ImportMap) {
 
     const isOverridden = jsPackage in getImportMapOverrideMap().imports;
     try {
-      return await new Promise<void>((resolve, reject) => {
-        loadScript(url, resolve, reject);
-      });
+      return await loadScript(url);
     } catch (err: any) {
       if (isOverridden) {
         dispatchToastShown({
@@ -198,99 +197,81 @@ function isFederatedModule(a: unknown): a is FederatedModule {
 }
 
 // internals to track script loading
-// basically, if we're already loading a script, we should wait until the script is loaded
-// we use a global to track this
-const OPENMRS_SCRIPT_LOADING = Symbol('__openmrs_script_loading');
+
+// if we're already loading a script, we should wait until the script is loaded
+// we use a global to track this; we use `Symbol.for()` in case this gets loaded
+// twice
+const OPENMRS_SCRIPT_LOADING = Symbol.for('__openmrs_script_loading');
 
 /**
- * Appends a `<script>` to the DOM with the given URL.
+ * The scripts this loader has requested, keyed by URL. A pending entry is in flight and a settled
+ * one has loaded; failed requests are removed, so any entry can be awaited rather than re-requested.
  */
-function loadScript(
-  url: string,
-  resolve: (value: unknown | PromiseLike<unknown>) => void,
-  reject: (reason?: any) => void,
-) {
-  const scriptElement = document.head.querySelector(`script[src="${url}"]`);
-  let scriptLoading: Set<string> = window[OPENMRS_SCRIPT_LOADING];
-  if (!scriptLoading) {
-    scriptLoading = window[OPENMRS_SCRIPT_LOADING] = new Set([]);
+function getScriptRegistry(): Map<string, Promise<void>> {
+  return (window[OPENMRS_SCRIPT_LOADING] ??= new Map<string, Promise<void>>());
+}
+
+/**
+ * Appends a `<script>` to the DOM with the given URL, unless it has been requested already, and
+ * resolves once it has loaded. Callers arriving at any point in a script's lifecycle share one
+ * request for it.
+ *
+ * A script which fails loading is removed from the DOM and can be retried. A script which throws
+ * when loading, however, will remain in the DOM as the script loaded.
+ */
+function loadScript(url: string): Promise<void> {
+  const registry = getScriptRegistry();
+
+  const requested = registry.get(url);
+  if (requested) {
+    return requested;
   }
 
-  if (!scriptElement) {
-    scriptLoading.add(url);
-    const element = document.createElement('script');
-    element.src = url;
-    element.type = 'text/javascript';
-    element.async = true;
+  if (document.head.querySelector(`script[src="${url}"]`)) {
+    // something other than this loader put the script in the document, so assume it's usable
+    console.warn(`Script at ${url} already loaded. Not loading it again.`);
+    return Promise.resolve();
+  }
 
-    // loadTime() displays an error if a script takes more than 5 seconds to load
+  const element = document.createElement('script');
+  element.src = url;
+  element.type = 'text/javascript';
+  element.async = true;
+
+  const request = new Promise<void>((resolve, reject) => {
+    // displays an error if a script takes more than 5 seconds to load
     const loadTimeout = setTimeout(() => {
       console.error(
         `The script at ${url} did not load within 5 seconds. This may indicate an issue with the imports in the script's entry-point file or with the script's bundler configuration.`,
       );
     }, 5_000); // 5 seconds; this is arbitrary
 
-    let loadFn: () => void, errFn: (ev: ErrorEvent) => void, finishScriptLoading: () => void;
-
-    finishScriptLoading = () => {
+    function finishScriptLoading() {
       clearTimeout(loadTimeout);
-      scriptLoading.delete(url);
+      element.removeEventListener('load', loadFn);
+      element.removeEventListener('error', errFn);
+    }
 
-      if (loadFn) {
-        element.removeEventListener('load', loadFn);
-      }
-
-      if (errFn) {
-        element.removeEventListener('error', errFn);
-      }
-    };
-
-    loadFn = () => {
+    function loadFn() {
       finishScriptLoading();
-      resolve(null);
-    };
+      resolve();
+    }
 
-    errFn = (ev: ErrorEvent) => {
+    function errFn(ev: ErrorEvent) {
       finishScriptLoading();
+      registry.delete(url);
+      element.remove();
       const msg = `Failed to load script from ${url}`;
       console.error(msg, ev);
       reject(ev.message ?? msg);
-    };
+    }
 
     element.addEventListener('load', loadFn);
     element.addEventListener('error', errFn);
 
     document.head.appendChild(element);
-  } else {
-    if (scriptLoading.has(url)) {
-      let loadFn: () => void, errFn: (ev: ErrorEvent) => void, finishScriptLoading: () => void;
+  });
 
-      finishScriptLoading = () => {
-        if (loadFn) {
-          scriptElement.removeEventListener('load', loadFn);
-        }
-
-        if (errFn) {
-          scriptElement.removeEventListener('error', errFn);
-        }
-      };
-
-      loadFn = () => {
-        finishScriptLoading();
-        resolve(null);
-      };
-
-      // this errFn does not log anything
-      errFn = (ev: ErrorEvent) => {
-        finishScriptLoading();
-        reject(ev.message);
-      };
-
-      scriptElement.addEventListener('load', loadFn);
-      scriptElement.addEventListener('error', errFn);
-    } else {
-      console.warn(`Script at ${url} already loaded. Not loading it again.`);
-      resolve(null);
-    }
-  }
+  registry.set(url, request);
+  return request;
 }


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->

This is just patching `dynamicImport()` to make things saner and fix a race condition.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
