### PR TITLE
(fix) Pin framework to app shell version

### DIFF
--- a/.changeset/tall-donuts-peel.md
+++ b/.changeset/tall-donuts-peel.md
@@ -1,0 +1,8 @@
+---
+"@openmrs/esm-app-shell": patch
+"@openmrs/esm-state": patch
+---
+
+(fix) Pin framework to app shell version
+
+Ensures that Module Federation always loads the framework from the app shell's copy.

--- a/packages/framework/esm-framework/docs/functions/createGlobalStore.md
+++ b/packages/framework/esm-framework/docs/functions/createGlobalStore.md
@@ -4,7 +4,7 @@
 
 > **createGlobalStore**\<`T`\>(`name`, `initialState`, `storageType`): `StoreApi`\<`T`\>
 
-Defined in: [packages/framework/esm-state/src/state.ts:35](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-state/src/state.ts#L35)
+Defined in: [packages/framework/esm-state/src/state.ts:59](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-state/src/state.ts#L59)
 
 Creates a Zustand store.
 

--- a/packages/framework/esm-framework/docs/functions/getGlobalStore.md
+++ b/packages/framework/esm-framework/docs/functions/getGlobalStore.md
@@ -4,7 +4,7 @@
 
 > **getGlobalStore**\<`T`\>(`name`, `fallbackState?`, `fallbackStorageType?`): `StoreApi`\<`T`\>
 
-Defined in: [packages/framework/esm-state/src/state.ts:102](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-state/src/state.ts#L102)
+Defined in: [packages/framework/esm-state/src/state.ts:126](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-state/src/state.ts#L126)
 
 Returns the existing store named `name`,
 or creates a new store named `name` if none exists.

--- a/packages/framework/esm-framework/docs/functions/subscribeTo.md
+++ b/packages/framework/esm-framework/docs/functions/subscribeTo.md
@@ -6,7 +6,7 @@
 
 > **subscribeTo**\<`T`, `U`\>(`store`, `handle`): () => `void`
 
-Defined in: [packages/framework/esm-state/src/state.ts:137](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-state/src/state.ts#L137)
+Defined in: [packages/framework/esm-state/src/state.ts:161](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-state/src/state.ts#L161)
 
 Subscribes to a store and invokes a callback when the state changes.
 The callback is also immediately invoked with the current state upon subscription.
@@ -54,7 +54,7 @@ An unsubscribe function to stop listening for changes.
 
 > **subscribeTo**\<`T`, `U`\>(`store`, `select`, `handle`): () => `void`
 
-Defined in: [packages/framework/esm-state/src/state.ts:138](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-state/src/state.ts#L138)
+Defined in: [packages/framework/esm-state/src/state.ts:162](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-state/src/state.ts#L162)
 
 Subscribes to a store and invokes a callback when the state changes.
 The callback is also immediately invoked with the current state upon subscription.

--- a/packages/framework/esm-state/src/state.ts
+++ b/packages/framework/esm-state/src/state.ts
@@ -13,6 +13,30 @@ interface StoreEntity {
 
 const availableStores: Record<string, StoreEntity> = {};
 
+/**
+ * Each copy of this module owns a separate `availableStores`, so a page running more than one copy
+ * has stores, config and extension state that cannot see each other. Nothing fails outright, which
+ * is what makes it expensive: the symptoms are missing state and "store already exists" errors far
+ * from the cause. The count lives on a global registry key rather than in module scope, since a
+ * second copy would not share module scope — that is the whole problem being detected.
+ *
+ * A hot reload re-evaluates this module and so also trips this, which is the honest answer: after a
+ * hot reload the page really is running two copies.
+ */
+const instanceCountKey = Symbol.for('openmrs.esm-state.instanceCount');
+const globalCounters = globalThis as unknown as Record<symbol, number | undefined>;
+const instanceCount = (globalCounters[instanceCountKey] ?? 0) + 1;
+globalCounters[instanceCountKey] = instanceCount;
+
+if (instanceCount > 1 && !isTestEnvironment()) {
+  console.error(
+    `Detected ${instanceCount} copies of @openmrs/esm-framework running on this page. Each copy keeps ` +
+      'its own store registry, so stores, configuration and extension state are not shared between ' +
+      'them. This usually means a frontend module loaded its own bundled framework instead of the one ' +
+      'the app shell provides.',
+  );
+}
+
 // spaEnv isn't available immediately. Wait a bit before making stores available
 // on window in development mode.
 globalThis.setTimeout?.(() => {

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -62,6 +62,7 @@
     "webpack-pwa-manifest": "4.3.0"
   },
   "devDependencies": {
+    "@module-federation/runtime-core": "2.8.1",
     "cross-env": "^10.1.0",
     "vitest": "^4.1.2"
   }

--- a/packages/shell/esm-app-shell/src/federation-plugins.ts
+++ b/packages/shell/esm-app-shell/src/federation-plugins.ts
@@ -1,0 +1,59 @@
+import type { Federation, ModuleFederationRuntimePlugin } from '@module-federation/runtime-core';
+import type { Shared, ShareScopeMap } from '@module-federation/runtime-core/types';
+
+/**
+ * Plumbing for Module Federation runtime plugins registered by the app shell.
+ */
+
+/** Providers of a single shared module, keyed by the version each one provides. */
+export type ShareVersionMap = ShareScopeMap[string][string];
+
+export type { ModuleFederationRuntimePlugin, Shared };
+
+/**
+ * The Module Federation runtime's global bookkeeping, or `undefined` if the runtime was never
+ * published — in which case `federation-runtime.ts` has already reported it and no frontend module
+ * is going to start anyway. Module Federation declares the global as always present, which is only
+ * true once its runtime has loaded.
+ */
+export function getFederationGlobal(): Federation | undefined {
+  return typeof __FEDERATION__ === 'undefined' ? undefined : __FEDERATION__;
+}
+
+function isLoaded(entry: Shared | undefined) {
+  return Boolean(entry && (entry.loaded || typeof entry.lib === 'function'));
+}
+
+/**
+ * Finds the version of a shared module provided by a particular frontend module, preferring one
+ * that is already loaded, since that is the copy currently backing the page.
+ *
+ * @param versions The providers of one shared module, i.e. `shareScopeMap[scope][pkgName]`.
+ * @param from The name of the providing build, as it appears in a share entry's `from`.
+ * @returns The version key to use, or `undefined` if that build provides none.
+ */
+export function findProviderVersion(versions: ShareVersionMap, from: string) {
+  const provided = Object.keys(versions).filter((version) => versions[version]?.from === from);
+  return provided.find((version) => isLoaded(versions[version])) ?? provided[0];
+}
+
+/**
+ * Registers a runtime plugin with every federation instance in the page, present and future.
+ *
+ * Call before any frontend module is loaded.
+ *
+ * @param plugin The plugin to register. Registering a name twice is a no-op.
+ * @returns Whether the plugin was registered.
+ */
+export function registerFederationPlugin(plugin: ModuleFederationRuntimePlugin) {
+  const federation = getFederationGlobal();
+  const globalPlugins = federation?.__GLOBAL_PLUGIN__;
+
+  if (!globalPlugins || globalPlugins.some((registered) => registered.name === plugin.name)) {
+    return false;
+  }
+
+  globalPlugins.push(plugin);
+  federation?.__INSTANCES__?.forEach((instance) => instance.registerPlugins([plugin]));
+  return true;
+}

--- a/packages/shell/esm-app-shell/src/federation-plugins.ts
+++ b/packages/shell/esm-app-shell/src/federation-plugins.ts
@@ -20,21 +20,17 @@ export function getFederationGlobal(): Federation | undefined {
   return typeof __FEDERATION__ === 'undefined' ? undefined : __FEDERATION__;
 }
 
-function isLoaded(entry: Shared | undefined) {
-  return Boolean(entry && (entry.loaded || typeof entry.lib === 'function'));
+function isLoaded(entry: Shared) {
+  return Boolean(entry.loaded || typeof entry.lib === 'function');
 }
 
 /**
- * Finds the version of a shared module provided by a particular frontend module, preferring one
- * that is already loaded, since that is the copy currently backing the page.
+ * Picks the provider already backing the page, or the first one if none has loaded yet.
  *
- * @param versions The providers of one shared module, i.e. `shareScopeMap[scope][pkgName]`.
- * @param from The name of the providing build, as it appears in a share entry's `from`.
- * @returns The version key to use, or `undefined` if that build provides none.
+ * @param providers Candidate providers of one shared module. Must not be empty.
  */
-export function findProviderVersion(versions: ShareVersionMap, from: string) {
-  const provided = Object.keys(versions).filter((version) => versions[version]?.from === from);
-  return provided.find((version) => isLoaded(versions[version])) ?? provided[0];
+export function preferLoadedProvider(providers: Array<Shared>) {
+  return providers.find(isLoaded) ?? providers[0];
 }
 
 /**

--- a/packages/shell/esm-app-shell/src/federation-plugins.ts
+++ b/packages/shell/esm-app-shell/src/federation-plugins.ts
@@ -34,6 +34,38 @@ export function preferLoadedProvider(providers: Array<Shared>) {
 }
 
 /**
+ * A share entry that also answers to the newer `{ shared, useTreesShaking }` shape, so it satisfies
+ * either generation of the `resolveShare` contract. See `asResolvedShare`.
+ */
+export type ResolvedShare = Shared & { shared: Shared; useTreesShaking: boolean };
+
+/**
+ * Prepares a share entry to be returned from a `resolveShare` resolver, in a form every Module
+ * Federation runtime on the page can use.
+ *
+ * The contract changed: runtimes up to 0.x expect the resolver to return the share entry itself and
+ * then read `lib`, `loading` and `get` off it, while 2.x expects `{ shared, useTreesShaking }`. A
+ * plugin registered on `__GLOBAL_PLUGIN__` is applied to *every* runtime in the page, including the
+ * copy embedded in a frontend module built before the app shell began publishing the runtime — so
+ * returning only the newer shape kills those modules with `get is not a function` the moment they
+ * consume the framework. Answering to both shapes is what keeps the app shell's promise that older
+ * modules go on working under a newer app shell.
+ *
+ * The added properties are non-enumerable so that `setShared`'s rest-spread does not copy them into
+ * the share scope, and idempotent so a resolver can call this on every resolution.
+ */
+export function asResolvedShare(entry: Shared): ResolvedShare {
+  if (!Object.getOwnPropertyDescriptor(entry, 'useTreesShaking')) {
+    Object.defineProperties(entry, {
+      shared: { get: () => entry, configurable: true },
+      useTreesShaking: { value: false, configurable: true },
+    });
+  }
+
+  return entry as ResolvedShare;
+}
+
+/**
  * Registers a runtime plugin with every federation instance in the page, present and future.
  *
  * Call before any frontend module is loaded.

--- a/packages/shell/esm-app-shell/src/framework-share.test.ts
+++ b/packages/shell/esm-app-shell/src/framework-share.test.ts
@@ -1,0 +1,220 @@
+// Reproduces the duplicate-framework bug against Module Federation's own resolver rather than a model
+// of it, so the tests still mean something if Module Federation changes how it picks a provider. Each
+// "without the pin" case is the bug: the resolver hands the consuming module a provider other than the
+// app shell's, and taking that provider loads a second copy of the framework — a second store
+// registry, a second config store, a second set of extensions, and roughly a megabyte of duplicated
+// download. Nothing throws when that happens, which is why it needs a test rather than a smoke check.
+import { getRegisteredShare } from '@module-federation/runtime-core';
+import type { Shared, ShareScopeMap } from '@module-federation/runtime-core/types';
+import type { ResolvedShare } from './federation-plugins';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { pinFrameworkToAppShell } from './framework-share';
+
+const appShell = '@openmrs/esm-app-shell';
+const frontendModule = '@openmrs/esm-ward-app';
+const publicKey = '@openmrs/esm-framework';
+const internalKey = '@openmrs/esm-framework/src/internal';
+const pluginName = 'openmrs-pin-framework-to-app-shell';
+
+type VersionMap = Record<string, Shared>;
+
+function provider(version: string, from: string, { loaded = false } = {}) {
+  return {
+    version,
+    from,
+    loaded: loaded || undefined,
+    loading: null,
+    lib: null,
+    get: () => Promise.resolve(() => ({})),
+    scope: ['default'],
+    strategy: 'version-first',
+    useIn: [],
+    deps: [],
+    shareConfig: { requiredVersion: `^${version}`, singleton: true, eager: false, strictVersion: false },
+  } as unknown as Shared;
+}
+
+/** What a published frontend module asks for, as its remote entry declares it. */
+function consumer(pkgName = publicKey) {
+  return {
+    from: frontendModule,
+    version: '10.0.1-pre.5263',
+    scope: ['default'],
+    strategy: 'version-first',
+    shareConfig: { requiredVersion: '10.x', singleton: true, eager: false, strictVersion: false },
+  } as unknown as Shared & { pkgName?: string };
+}
+
+function federationGlobal() {
+  return globalThis.__FEDERATION__ as unknown as {
+    __GLOBAL_PLUGIN__: Array<{ name: string; resolveShare?: (args: unknown) => unknown }>;
+    __INSTANCES__: Array<{ registerPlugins: (plugins: Array<unknown>) => void }>;
+  };
+}
+
+/**
+ * Sets the page up the way `initializeSpa` does: the app shell has registered its framework and
+ * nothing else has loaded yet, so this is the only moment the app shell's own entry is identifiable.
+ * The two keys share one version map because `initializeSpa` aliases them onto each other.
+ */
+function pinWithAppShellProvider() {
+  const appShellEntry = provider('10.0.0', appShell);
+  const versions: VersionMap = { '10.0.0': appShellEntry };
+  pinFrameworkToAppShell({ [publicKey]: versions, [internalKey]: versions });
+  return { appShellEntry, versions };
+}
+
+/** Runs the real resolver, with the registered plugin tapped into `resolveShare` or not. */
+function resolveShareResult(versions: VersionMap, { pinned }: { pinned: boolean }) {
+  const plugin = federationGlobal().__GLOBAL_PLUGIN__.find((candidate) => candidate.name === pluginName);
+  const resolveShare = pinned ? { emit: (args: unknown) => plugin?.resolveShare?.(args) } : { emit: () => undefined };
+  const shareScopeMap = { default: { [publicKey]: versions, [internalKey]: versions } } as unknown as ShareScopeMap;
+
+  return getRegisteredShare(shareScopeMap, publicKey, consumer(), resolveShare as never);
+}
+
+function resolveProvider(versions: VersionMap, options: { pinned: boolean }) {
+  return resolveShareResult(versions, options)?.shared;
+}
+
+describe('pinning @openmrs/esm-framework to the app shell', () => {
+  // Importing the runtime defines `__FEDERATION__` as non-configurable, so it can be reassigned but
+  // not removed. Each test gets an empty one and the real value goes back afterwards.
+  const runtimeFederation = globalThis.__FEDERATION__;
+
+  beforeEach(() => {
+    (globalThis as Record<string, unknown>).__FEDERATION__ = { __GLOBAL_PLUGIN__: [], __INSTANCES__: [] };
+  });
+
+  afterEach(() => {
+    (globalThis as Record<string, unknown>).__FEDERATION__ = runtimeFederation;
+  });
+
+  it('leaves a healthy page alone: the app shell already wins when its copy loaded first', () => {
+    // Documents why this is a latent hazard rather than a constant failure — and why a smoke test
+    // would never catch it.
+    const { appShellEntry, versions } = pinWithAppShellProvider();
+    appShellEntry.loaded = true;
+    versions['10.0.1-pre.5263'] = provider('10.0.1-pre.5263', frontendModule);
+
+    expect(resolveProvider(versions, { pinned: false })?.from).toBe(appShell);
+    expect(resolveProvider(versions, { pinned: true })?.from).toBe(appShell);
+  });
+
+  it("takes the module's own higher version while the app shell's copy is still loading", () => {
+    const { appShellEntry, versions } = pinWithAppShellProvider();
+    appShellEntry.loading = Promise.resolve() as never;
+    versions['10.0.1-pre.5263'] = provider('10.0.1-pre.5263', frontendModule);
+
+    // `version-first` does not count "loading" as loaded, so the higher version wins.
+    expect(resolveProvider(versions, { pinned: false })?.from).toBe(frontendModule);
+    expect(resolveProvider(versions, { pinned: true })?.from).toBe(appShell);
+  });
+
+  it("takes the module's own copy when it was registered first, even against a loaded app shell", () => {
+    // `findVersion` seeds its reduce with the first key unconditionally and then only asks whether
+    // *that* entry is loaded, so an unloaded module entry sitting first is never displaced.
+    const { appShellEntry } = pinWithAppShellProvider();
+    appShellEntry.loaded = true;
+    const reordered: VersionMap = {
+      '10.0.1-pre.5263': provider('10.0.1-pre.5263', frontendModule),
+      '10.0.0': appShellEntry,
+    };
+
+    expect(resolveProvider(reordered, { pinned: false })?.from).toBe(frontendModule);
+    expect(resolveProvider(reordered, { pinned: true })?.from).toBe(appShell);
+  });
+
+  it("takes the module's own copy after it takes over the app shell's slot at the same version", () => {
+    // Any locally built module provides the workspace version, which is the app shell's own, so
+    // `register` replaces the app shell's not-yet-loaded entry and inherits its `from`. Nothing
+    // identifying the app shell is left in the scope, which is why the pin holds the entry itself.
+    const { appShellEntry, versions } = pinWithAppShellProvider();
+    versions['10.0.0'] = provider('10.0.0', frontendModule);
+
+    expect(resolveProvider(versions, { pinned: false })?.from).toBe(frontendModule);
+
+    const pinnedTo = resolveProvider(versions, { pinned: true });
+    expect(pinnedTo?.from).toBe(appShell);
+    expect(pinnedTo).toBe(appShellEntry);
+  });
+
+  it('pins a module whose federation instance has a share scope of its own', () => {
+    // Divergent scopes hold only the module's own provider, so there is nothing to look up.
+    const { appShellEntry } = pinWithAppShellProvider();
+    const divergent: VersionMap = { '10.0.1-pre.5263': provider('10.0.1-pre.5263', frontendModule) };
+
+    expect(resolveProvider(divergent, { pinned: false })?.from).toBe(frontendModule);
+    expect(resolveProvider(divergent, { pinned: true })).toBe(appShellEntry);
+  });
+
+  it("prefers whichever of the app shell's providers is already backing the page", () => {
+    const older = provider('10.0.0', appShell);
+    const newer = provider('10.0.1', appShell, { loaded: true });
+    const versions: VersionMap = { '10.0.0': older, '10.0.1': newer };
+    pinFrameworkToAppShell({ [publicKey]: versions, [internalKey]: versions });
+
+    expect(resolveProvider(versions, { pinned: true })).toBe(newer);
+  });
+
+  it('returns a provider that every Module Federation runtime generation can use', () => {
+    // The plugin is registered globally, so it is also applied to the runtime embedded in a frontend
+    // module built before the app shell started publishing one. Those runtimes use the resolver's
+    // return value as the share entry itself and immediately reach for `get`; 2.x instead destructures
+    // `{ shared, useTreesShaking }`. Returning only the newer shape kills the older modules with
+    // `get is not a function`, which is the compatibility the app shell promises them.
+    const { appShellEntry, versions } = pinWithAppShellProvider();
+    versions['10.0.1-pre.5263'] = provider('10.0.1-pre.5263', frontendModule);
+
+    const resolved = resolveShareResult(versions, { pinned: true }) as unknown as ResolvedShare;
+
+    // What 2.x reads.
+    expect(resolved.shared).toBe(appShellEntry);
+    expect(resolved.useTreesShaking).toBe(false);
+
+    // What an older runtime reads.
+    expect(resolved).toBe(appShellEntry);
+    expect(typeof resolved.get).toBe('function');
+
+    // `setShared` copies a share entry with a rest-spread, so neither key may be enumerable or it
+    // ends up stored in the share scope.
+    const { version, scope, ...shareInfo } = resolved;
+    expect(shareInfo).not.toHaveProperty('shared');
+    expect(shareInfo).not.toHaveProperty('useTreesShaking');
+  });
+
+  it('leaves every other shared module to Module Federation', () => {
+    // The plugin is applied to every federation instance in the page, so it sees every resolution.
+    pinWithAppShellProvider();
+    const plugin = federationGlobal().__GLOBAL_PLUGIN__.find((candidate) => candidate.name === pluginName);
+    const args = { pkgName: 'react', scope: 'default', resolver: () => 'untouched' };
+
+    expect(plugin?.resolveShare?.(args)).toBe(args);
+    expect(args.resolver()).toBe('untouched');
+  });
+
+  it('reaches federation instances that already exist', () => {
+    // The app shell's own instance is built by the webpack runtime before any of this code runs, so
+    // the global plugin list alone would miss it.
+    const registered: Array<Array<unknown>> = [];
+    federationGlobal().__INSTANCES__.push({ registerPlugins: (plugins) => registered.push(plugins) });
+
+    pinWithAppShellProvider();
+
+    expect(registered).toHaveLength(1);
+    expect((registered[0][0] as { name: string }).name).toBe(pluginName);
+  });
+
+  it('registers once, however many times it is called', () => {
+    pinWithAppShellProvider();
+    pinWithAppShellProvider();
+
+    expect(federationGlobal().__GLOBAL_PLUGIN__.filter((p) => p.name === pluginName)).toHaveLength(1);
+  });
+
+  it('leaves resolution alone when the app shell provides no framework at all', () => {
+    pinFrameworkToAppShell({});
+
+    expect(federationGlobal().__GLOBAL_PLUGIN__).toHaveLength(0);
+  });
+});

--- a/packages/shell/esm-app-shell/src/framework-share.test.ts
+++ b/packages/shell/esm-app-shell/src/framework-share.test.ts
@@ -6,8 +6,8 @@
 // download. Nothing throws when that happens, which is why it needs a test rather than a smoke check.
 import { getRegisteredShare } from '@module-federation/runtime-core';
 import type { Shared, ShareScopeMap } from '@module-federation/runtime-core/types';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ResolvedShare } from './federation-plugins';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { pinFrameworkToAppShell } from './framework-share';
 
 const appShell = '@openmrs/esm-app-shell';
@@ -213,8 +213,18 @@ describe('pinning @openmrs/esm-framework to the app shell', () => {
   });
 
   it('leaves resolution alone when the app shell provides no framework at all', () => {
-    pinFrameworkToAppShell({});
+    const consoleMock = vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
-    expect(federationGlobal().__GLOBAL_PLUGIN__).toHaveLength(0);
+    try {
+      pinFrameworkToAppShell({});
+
+      expect(federationGlobal().__GLOBAL_PLUGIN__).toHaveLength(0);
+      expect(consoleMock).toHaveBeenCalledOnce();
+      expect(consoleMock).toHaveBeenCalledWith(
+        'The app shell has not registered @openmrs/esm-framework as a shared module, so frontend modules may each load their own copy of the framework. This is a bug in the app shell build.',
+      );
+    } finally {
+      consoleMock.mockReset();
+    }
   });
 });

--- a/packages/shell/esm-app-shell/src/framework-share.ts
+++ b/packages/shell/esm-app-shell/src/framework-share.ts
@@ -1,8 +1,9 @@
 import {
-  findProviderVersion,
   getFederationGlobal,
+  preferLoadedProvider,
   registerFederationPlugin,
   type ModuleFederationRuntimePlugin,
+  type Shared,
   type ShareVersionMap,
 } from './federation-plugins';
 
@@ -45,13 +46,13 @@ export function pinFrameworkToAppShell(shareScope: Record<string, unknown>) {
     return;
   }
 
-  // Read while the app shell is the only registered provider, so this identifies the app shell
-  // without hard-coding its name.
+  // Read while the app shell is the only registered provider, so these are its own entries and
+  // recognising them later needs neither a name nor a lookup.
   const provided = shareScope['@openmrs/esm-framework/src/internal'] as ShareVersionMap | undefined;
-  const appShellName = Object.values(provided ?? {}).find((entry) => entry?.from)?.from;
+  const appShellProviders = Object.values(provided ?? {}).filter((entry): entry is Shared => Boolean(entry));
 
   // Paranoia
-  if (!appShellName) {
+  if (appShellProviders.length === 0) {
     console.error(
       'The app shell has not registered @openmrs/esm-framework as a shared module, so frontend ' +
         'modules may each load their own copy of the framework. This is a bug in the app shell build.',
@@ -66,15 +67,8 @@ export function pinFrameworkToAppShell(shareScope: Record<string, unknown>) {
         return args;
       }
 
-      const versions = args.shareScopeMap[args.scope]?.[args.pkgName];
-      const version = versions && findProviderVersion(versions, appShellName);
-
-      if (!versions || !version) {
-        return args;
-      }
-
       // The framework is not shared with tree shaking enabled, so there is no shaken variant to pick.
-      args.resolver = () => ({ shared: versions[version], useTreesShaking: false });
+      args.resolver = () => ({ shared: preferLoadedProvider(appShellProviders), useTreesShaking: false });
       return args;
     },
   };

--- a/packages/shell/esm-app-shell/src/framework-share.ts
+++ b/packages/shell/esm-app-shell/src/framework-share.ts
@@ -11,8 +11,8 @@ import {
  * openmrs-pin-framework-to-app-shell
  *
  * This is a runtime Module Federation plugin to induce Module Federation to work as we expect.
- * Specifically, e expect the version of @openmrs/esm-framework used to match the version loaded
- * by the shell regardless of the versions available elsewhere. With Module Fedderation v2's
+ * Specifically, we expect the version of @openmrs/esm-framework used to match the version loaded
+ * by the shell regardless of the versions available elsewhere. With Module Federation v2's
  * default "version-first" loading strategy, the exact version of a resolution can be changed as
  * new apps are added. This runtime plugin ensures we only ever load the framework from the shell.
  */

--- a/packages/shell/esm-app-shell/src/framework-share.ts
+++ b/packages/shell/esm-app-shell/src/framework-share.ts
@@ -1,4 +1,5 @@
 import {
+  asResolvedShare,
   getFederationGlobal,
   preferLoadedProvider,
   registerFederationPlugin,
@@ -67,8 +68,9 @@ export function pinFrameworkToAppShell(shareScope: Record<string, unknown>) {
         return args;
       }
 
-      // The framework is not shared with tree shaking enabled, so there is no shaken variant to pick.
-      args.resolver = () => ({ shared: preferLoadedProvider(appShellProviders), useTreesShaking: false });
+      // `asResolvedShare` is what keeps frontend modules carrying an older Module Federation runtime
+      // working; the app shell's plugin is applied to theirs too, and they expect the older shape.
+      args.resolver = () => asResolvedShare(preferLoadedProvider(appShellProviders));
       return args;
     },
   };

--- a/packages/shell/esm-app-shell/src/framework-share.ts
+++ b/packages/shell/esm-app-shell/src/framework-share.ts
@@ -1,0 +1,83 @@
+import {
+  findProviderVersion,
+  getFederationGlobal,
+  registerFederationPlugin,
+  type ModuleFederationRuntimePlugin,
+  type ShareVersionMap,
+} from './federation-plugins';
+
+/**
+ * openmrs-pin-framework-to-app-shell
+ *
+ * This is a runtime Module Federation plugin to induce Module Federation to work as we expect.
+ * Specifically, e expect the version of @openmrs/esm-framework used to match the version loaded
+ * by the shell regardless of the versions available elsewhere. With Module Fedderation v2's
+ * default "version-first" loading strategy, the exact version of a resolution can be changed as
+ * new apps are added. This runtime plugin ensures we only ever load the framework from the shell.
+ */
+
+const pluginName = 'openmrs-pin-framework-to-app-shell';
+
+/**
+ * Both keys name the same providers: the app shell shares the framework under its `/src/internal`
+ * entry point, and `initializeSpa` aliases the public name onto it for frontend modules to consume.
+ */
+const frameworkShareKeys = new Set(['@openmrs/esm-framework', '@openmrs/esm-framework/src/internal']);
+
+/**
+ * Makes every consume of `@openmrs/esm-framework` in the page resolve to the copy the app shell
+ * provides, regardless of what versions frontend modules offer or what order they registered in.
+ *
+ * No version check is needed on the way through: the app shell's framework is the one every module
+ * in the distribution is meant to run against, so it wins unconditionally. A rule pinning to some
+ * other provider could not assume that.
+ *
+ * Call this once, after `__webpack_init_sharing__` has run and before any frontend module is
+ * loaded; later calls are ignored.
+ *
+ * If the app shell somehow provides no framework at all, resolution is left alone rather than
+ * broken — a module falling back to its own copy is better than a module that cannot start.
+ *
+ * @param shareScope The `default` share scope, i.e. `__webpack_share_scopes__.default`.
+ */
+export function pinFrameworkToAppShell(shareScope: Record<string, unknown>) {
+  if (!getFederationGlobal()) {
+    return;
+  }
+
+  // Read while the app shell is the only registered provider, so this identifies the app shell
+  // without hard-coding its name.
+  const provided = shareScope['@openmrs/esm-framework/src/internal'] as ShareVersionMap | undefined;
+  const appShellName = Object.values(provided ?? {}).find((entry) => entry?.from)?.from;
+
+  // Paranoia
+  if (!appShellName) {
+    console.error(
+      'The app shell has not registered @openmrs/esm-framework as a shared module, so frontend ' +
+        'modules may each load their own copy of the framework. This is a bug in the app shell build.',
+    );
+    return;
+  }
+
+  const plugin: ModuleFederationRuntimePlugin = {
+    name: pluginName,
+    resolveShare(args) {
+      if (!frameworkShareKeys.has(args.pkgName)) {
+        return args;
+      }
+
+      const versions = args.shareScopeMap[args.scope]?.[args.pkgName];
+      const version = versions && findProviderVersion(versions, appShellName);
+
+      if (!versions || !version) {
+        return args;
+      }
+
+      // The framework is not shared with tree shaking enabled, so there is no shaken variant to pick.
+      args.resolver = () => ({ shared: versions[version], useTreesShaking: false });
+      return args;
+    },
+  };
+
+  registerFederationPlugin(plugin);
+}

--- a/packages/shell/esm-app-shell/src/index.ts
+++ b/packages/shell/esm-app-shell/src/index.ts
@@ -1,4 +1,5 @@
 import { publishFederationRuntime } from './federation-runtime';
+import { pinFrameworkToAppShell } from './framework-share';
 import type { SpaConfig } from '@openmrs/esm-framework/src/internal';
 
 // Before anything else: every frontend module reads the Module Federation runtime from the globals
@@ -110,6 +111,10 @@ function initializeSpa(config: SpaConfig) {
     if (shareScope['@openmrs/esm-framework/src/internal'] && !shareScope['@openmrs/esm-framework']) {
       shareScope['@openmrs/esm-framework'] = shareScope['@openmrs/esm-framework/src/internal'];
     }
+
+    // Frontend modules also register their own framework into this scope; this keeps them resolving
+    // to the app shell's copy no matter what version they bring.
+    pinFrameworkToAppShell(shareScope);
 
     const { configUrls = [], offline = false } = config;
     Object.defineProperty(window, 'offlineEnabled', {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3119,6 +3119,7 @@ __metadata:
     "@internationalized/date": "npm:^3.8.0"
     "@module-federation/enhanced": "npm:2.8.1"
     "@module-federation/error-codes": "npm:2.8.1"
+    "@module-federation/runtime-core": "npm:2.8.1"
     "@module-federation/sdk": "npm:2.8.1"
     "@openmrs/esm-framework": "workspace:*"
     "@openmrs/esm-styleguide": "workspace:*"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->

With Module Federation v1, the default resolution scheme with singleton shares was that the first-loaded wins. This served as our guarantee that `@openmrs/esm-framework` would always be loaded from the App Shell. With Module Federation v2, this changes to a policy that the highest-loaded version wins by default. Unfortunately, this means that the "loaded" version can change mid-application, so we add a plugin to pin things to the "correct" framework version.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

@denniskigen This is the other release blocker I'm aware of.

This is written in maybe a slightly more convoluted way than would be expected as I wanted to explore using the same machinery to pin other versions, e.g., `@openmrs/esm-patient-common-lib` to the copy from `@openmrs/esm-patient-chart-app`. That, however, would be a behavioural change, so it's not supported here. This is only restoring the implicit v1 behaviour.