### PR TITLE
(feat) Add a guard for framework-internal guards

### DIFF
--- a/.changeset/perky-flowers-relate.md
+++ b/.changeset/perky-flowers-relate.md
@@ -4,4 +4,4 @@
 "openmrs": minor
 ---
 
-(feat) Add a guard for framework-internal guards
+(feat) Add a guard for framework-internal imports

--- a/.changeset/perky-flowers-relate.md
+++ b/.changeset/perky-flowers-relate.md
@@ -1,0 +1,7 @@
+---
+"@openmrs/rspack-config": minor
+"@openmrs/webpack-config": minor
+"openmrs": minor
+---
+
+(feat) Add a guard for framework-internal guards

--- a/packages/tooling/framework-import-guard/package.json
+++ b/packages/tooling/framework-import-guard/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@openmrs/framework-import-guard",
+  "version": "10.0.0",
+  "license": "MPL-2.0",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "engines": {
+    "node": ">= 20.0.0"
+  },
+  "scripts": {
+    "build": "tsc",
+    "build:development": "tsc",
+    "lint": "eslint src",
+    "test": "cross-env TZ=UTC vitest run --passWithNoTests",
+    "test:watch": "cross-env TZ=UTC vitest watch --passWithNoTests",
+    "coverage": "cross-env TZ=UTC vitest run --coverage --passWithNoTests"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/openmrs/openmrs-esm-core.git"
+  },
+  "bugs": {
+    "url": "https://github.com/openmrs/openmrs-esm-core/issues"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "openmrs",
+    "microfrontends",
+    "webpack",
+    "rspack",
+    "config"
+  ],
+  "homepage": "https://github.com/openmrs/openmrs-esm-core#readme",
+  "devDependencies": {
+    "cross-env": "^7.0.3",
+    "typescript": "^5.8.3",
+    "vitest": "^4.1.2"
+  }
+}

--- a/packages/tooling/framework-import-guard/package.json
+++ b/packages/tooling/framework-import-guard/package.json
@@ -34,8 +34,10 @@
   ],
   "homepage": "https://github.com/openmrs/openmrs-esm-core#readme",
   "devDependencies": {
+    "@rspack/core": "1.7.9",
     "cross-env": "^7.0.3",
     "typescript": "^5.8.3",
-    "vitest": "^4.1.2"
+    "vitest": "^4.1.2",
+    "webpack": "5.105.3"
   }
 }

--- a/packages/tooling/framework-import-guard/src/index.test.ts
+++ b/packages/tooling/framework-import-guard/src/index.test.ts
@@ -1,21 +1,24 @@
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import Module from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
 import { FrameworkImportGuardPlugin } from './index';
 
-const context = '/app';
+/** A real directory, so package discovery resolves the way it does in a build. */
+const context = process.cwd();
 const appModule = `${context}/src/index.ts`;
+const styleguide = '@openmrs/esm-styleguide';
 
 /**
  * Drives the plugin through the hooks it taps, feeding it resolutions in the shape webpack and
- * rspack hand over: a literal request plus the file that made it.
+ * rspack hand over: a literal request plus the file that made it. `compile()` starts a fresh
+ * compilation on the same plugin instance, as a watch rebuild does.
  */
-function run(
-  imports: Array<{ issuer: string; request: string }>,
-  options?: ConstructorParameters<typeof FrameworkImportGuardPlugin>[0],
-) {
-  const compilation = { errors: [] as Array<Error>, warnings: [] as Array<Error> };
+function hooks(options?: ConstructorParameters<typeof FrameworkImportGuardPlugin>[0]) {
   let afterResolve: ((data: { request: string; contextInfo: { issuer: string } }) => void) | undefined;
-  let startCompilation: ((compilation: typeof compilation) => void) | undefined;
-  let afterEmit: ((compilation: typeof compilation) => void) | undefined;
+  let startCompilation: ((value: unknown) => void) | undefined;
+  let afterCompile: ((compilation: { errors: Array<Error>; warnings: Array<Error> }) => void) | undefined;
 
   new FrameworkImportGuardPlugin(options).apply({
     context,
@@ -25,17 +28,31 @@ function run(
           callback({ hooks: { afterResolve: { tap: (_inner, onResolve) => void (afterResolve = onResolve) } } }),
       },
       thisCompilation: { tap: (_name, callback) => void (startCompilation = callback) },
-      afterEmit: { tap: (_name, callback) => void (afterEmit = callback) },
+      afterCompile: { tap: (_name, callback) => void (afterCompile = callback) },
     },
   });
 
-  startCompilation?.(compilation);
-  for (const { issuer, request } of imports) {
-    afterResolve?.({ request, contextInfo: { issuer } });
-  }
-  afterEmit?.(compilation);
+  return {
+    /** Runs one compilation over the given imports and returns its diagnostics. */
+    compile(imports: Array<{ issuer: string; request: string }>) {
+      const compilation = { errors: [] as Array<Error>, warnings: [] as Array<Error> };
+      startCompilation?.(undefined);
 
-  return { ...compilation, replay: () => (startCompilation?.(compilation), afterEmit?.(compilation), compilation) };
+      for (const { issuer, request } of imports) {
+        afterResolve?.({ request, contextInfo: { issuer } });
+      }
+      afterCompile?.(compilation);
+
+      return compilation;
+    },
+  };
+}
+
+function run(
+  imports: Array<{ issuer: string; request: string }>,
+  options?: ConstructorParameters<typeof FrameworkImportGuardPlugin>[0],
+) {
+  return hooks(options).compile(imports);
 }
 
 describe('FrameworkImportGuardPlugin', () => {
@@ -46,38 +63,58 @@ describe('FrameworkImportGuardPlugin', () => {
     expect(errors[0].message).toContain('./src/index.ts imports @openmrs/esm-state');
   });
 
-  it('allows @openmrs/esm-framework itself, including its subpaths', () => {
-    const { errors } = run([
-      { issuer: appModule, request: '@openmrs/esm-framework' },
-      { issuer: appModule, request: '@openmrs/esm-framework/src/internal' },
-    ]);
+  it('allows the facade and its subpaths even when the allow-list is emptied', () => {
+    const { errors } = run(
+      [
+        { issuer: appModule, request: '@openmrs/esm-framework' },
+        { issuer: appModule, request: '@openmrs/esm-framework/src/internal' },
+      ],
+      // The facade is allowed by construction, not by sitting in the default allow-list.
+      { allowedPackages: [], frameworkPackages: ['@openmrs/esm-framework', '@openmrs/esm-state'] },
+    );
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('allows a package named in allowedPackages', () => {
+    const { errors } = run([{ issuer: appModule, request: '@openmrs/esm-state' }], {
+      allowedPackages: ['@openmrs/esm-state'],
+    });
 
     expect(errors).toHaveLength(0);
   });
 
   it('allows the framework packages to import each other', () => {
     const { errors } = run([
-      {
-        issuer: `${context}/node_modules/@openmrs/esm-styleguide/dist/internal.js`,
-        request: '@openmrs/esm-state',
-      },
+      { issuer: `${context}/node_modules/@openmrs/esm-styleguide/dist/internal.js`, request: '@openmrs/esm-state' },
+      { issuer: `${context}/packages/framework/esm-styleguide/src/index.ts`, request: '@openmrs/esm-state' },
     ]);
 
     expect(errors).toHaveLength(0);
   });
 
-  it('allows a stylesheet to pull rules out of the styleguide', () => {
+  it('holds a package that merely looks like part of the framework to the rule', () => {
+    // These are bundled into the app, so a direct import duplicates state exactly as the app's own
+    // would. This is the case that motivated the guard in the first place.
     const { errors } = run([
-      { issuer: `${context}/src/root.styles.scss`, request: '@openmrs/esm-styleguide/src/vars' },
+      { issuer: `${context}/node_modules/@openmrs/esm-patient-common-lib/dist/index.js`, request: styleguide },
+      { issuer: `${context}/node_modules/@openmrs/esm-form-engine-lib/dist/index.js`, request: '@openmrs/esm-state' },
+      { issuer: `${context}/src/framework/esm-helpers/thing.ts`, request: '@openmrs/esm-state' },
     ]);
-
-    expect(errors).toHaveLength(0);
-  });
-
-  it('still fails a non-stylesheet import of the styleguide', () => {
-    const { errors } = run([{ issuer: appModule, request: '@openmrs/esm-styleguide' }]);
 
     expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('esm-patient-common-lib');
+    expect(errors[0].message).toContain('esm-form-engine-lib');
+    expect(errors[0].message).toContain('./src/framework/esm-helpers/thing.ts');
+  });
+
+  it('ignores the module federation wrappers around a share and its fallback', () => {
+    const { errors } = run([
+      { issuer: 'consume shared module (default) @openmrs/esm-framework@10.x', request: '@openmrs/esm-state' },
+      { issuer: 'provide shared module (default) @openmrs/esm-state@10.0.0', request: '@openmrs/esm-state' },
+    ]);
+
+    expect(errors).toHaveLength(0);
   });
 
   it('does not flag packages outside the framework', () => {
@@ -92,77 +129,209 @@ describe('FrameworkImportGuardPlugin', () => {
     expect(errors).toHaveLength(0);
   });
 
+  it('does not treat a near-miss package name as guarded', () => {
+    const { errors } = run([
+      { issuer: appModule, request: '@openmrs/esm-statement' },
+      { issuer: appModule, request: '@openmrs/esm-state-machine' },
+    ]);
+
+    expect(errors).toHaveLength(0);
+  });
+
   it('reports every offending import, grouped by the file that made it', () => {
     const { errors } = run([
       { issuer: appModule, request: '@openmrs/esm-state' },
       { issuer: appModule, request: '@openmrs/esm-state' },
-      { issuer: `${context}/src/app.tsx`, request: '@openmrs/esm-styleguide' },
+      { issuer: `${context}/src/app.tsx`, request: styleguide },
     ]);
 
     expect(errors).toHaveLength(1);
     expect(errors[0].message).toContain('./src/index.ts imports @openmrs/esm-state');
-    expect(errors[0].message).toContain('./src/app.tsx imports @openmrs/esm-styleguide');
+    expect(errors[0].message).toContain(`./src/app.tsx imports ${styleguide}`);
   });
 
-  it('forgets the previous compilation, so a watch rebuild starts clean', () => {
-    const result = run([{ issuer: appModule, request: '@openmrs/esm-state' }]);
-    expect(result.errors).toHaveLength(1);
-
-    result.errors.length = 0;
-    expect(result.replay().errors).toHaveLength(0);
-  });
-
-  // A single-app repo installs the framework into its own `node_modules` rather than resolving it
-  // through a workspace, and may nest it further depending on the package manager.
-  describe('outside a monorepo', () => {
-    it('fails the build on a direct import from a single-app repo', () => {
-      const { errors } = run([
-        { issuer: `${context}/src/dispensing.component.tsx`, request: '@openmrs/esm-styleguide' },
-      ]);
-
-      expect(errors).toHaveLength(1);
-      expect(errors[0].message).toContain('./src/dispensing.component.tsx imports @openmrs/esm-styleguide');
-    });
-
-    it("treats pnpm's nested layout as framework-internal", () => {
-      const { errors } = run([
-        {
-          issuer: `${context}/node_modules/.pnpm/@openmrs+esm-styleguide@10.0.0/node_modules/@openmrs/esm-styleguide/dist/internal.js`,
-          request: '@openmrs/esm-state',
-        },
-      ]);
+  describe('stylesheets', () => {
+    it('lets a stylesheet pull rules out of the styleguide', () => {
+      const { errors } = run([{ issuer: `${context}/src/root.styles.scss`, request: `${styleguide}/src/vars` }]);
 
       expect(errors).toHaveLength(0);
     });
 
-    it('recognises framework packages behind Windows path separators', () => {
-      const { errors } = run([
-        {
-          issuer: 'C:\\app\\node_modules\\@openmrs\\esm-api\\dist\\index.js',
-          request: '@openmrs/esm-state',
-        },
-      ]);
+    it('does not let a stylesheet import a sibling that is not the styleguide', () => {
+      const { errors } = run([{ issuer: `${context}/src/root.styles.scss`, request: '@openmrs/esm-state' }]);
 
-      expect(errors).toHaveLength(0);
-    });
-
-    it('checks the packages it is given when the framework manifest cannot be found', () => {
-      const { errors, warnings } = run([{ issuer: appModule, request: '@openmrs/esm-made-up' }], {
-        frameworkPackages: ['@openmrs/esm-made-up'],
-      });
-
-      expect(warnings).toHaveLength(0);
       expect(errors).toHaveLength(1);
     });
 
-    it('warns rather than passing silently when no framework packages are known', () => {
+    it('does not extend the exemption to a source file whose name merely contains a stylesheet extension', () => {
+      const { errors } = run([{ issuer: `${context}/src/theme.css.ts`, request: styleguide }]);
+
+      expect(errors).toHaveLength(1);
+    });
+
+    it('still fails a non-stylesheet import of the styleguide', () => {
+      const { errors } = run([{ issuer: appModule, request: styleguide }]);
+
+      expect(errors).toHaveLength(1);
+    });
+  });
+
+  describe('across compilations', () => {
+    it('keeps reporting an import from a file that was not rebuilt', () => {
+      // A watch rebuild only re-resolves what changed. Anything forgotten between compilations
+      // turns the gate green with the import still in the tree.
+      const harness = hooks();
+      expect(harness.compile([{ issuer: appModule, request: '@openmrs/esm-state' }]).errors).toHaveLength(1);
+
+      const rebuild = harness.compile([{ issuer: `${context}/src/unrelated.ts`, request: 'react' }]);
+
+      expect(rebuild.errors).toHaveLength(1);
+      expect(rebuild.errors[0].message).toContain('./src/index.ts imports @openmrs/esm-state');
+      expect(rebuild.errors[0].message).toContain('earlier compilation');
+    });
+
+    it('holds a finding even once the offending file resolves cleanly again', () => {
+      // `module.unsafeCache` serves node_modules straight from cache on a rebuild, so a
+      // compilation that re-resolves the file's other imports is no evidence the framework import
+      // is gone. Retracting on that basis is how the gate would go green with the import in place.
+      const harness = hooks();
+      expect(harness.compile([{ issuer: appModule, request: '@openmrs/esm-state' }]).errors).toHaveLength(1);
+
+      const rebuild = harness.compile([{ issuer: appModule, request: './sibling' }]);
+
+      expect(rebuild.errors).toHaveLength(1);
+      expect(rebuild.errors[0].message).toContain('earlier compilation');
+    });
+  });
+
+  describe('when it cannot check', () => {
+    it('fails the build if the framework packages cannot be discovered', () => {
+      // Discovery resolves the manifest from the app and then from this package, so an unreachable
+      // manifest is the only way both locations fail — which is what a missing install looks like.
+      const resolveFilename = Module['_resolveFilename'];
+
+      Module['_resolveFilename'] = function (request: string, ...rest: Array<unknown>) {
+        if (request === '@openmrs/esm-framework/package.json') {
+          throw new Error('MODULE_NOT_FOUND');
+        }
+
+        return resolveFilename.call(this, request, ...rest);
+      };
+
+      try {
+        const { errors, warnings } = run([{ issuer: appModule, request: '@openmrs/esm-state' }]);
+
+        expect(warnings).toHaveLength(0);
+        expect(errors).toHaveLength(1);
+        expect(errors[0].message).toContain('could not read the dependencies');
+      } finally {
+        Module['_resolveFilename'] = resolveFilename;
+      }
+    });
+
+    it('fails the build if it is never asked about a single resolution', () => {
+      // A guard that tapped successfully but observed nothing has checked nothing, and must not be
+      // mistaken for a clean build.
+      const { errors } = hooks().compile([]);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('saw no module resolutions');
+    });
+
+    it('guards nothing, quietly, when explicitly configured with no packages', () => {
       const { errors, warnings } = run([{ issuer: appModule, request: '@openmrs/esm-state' }], {
         frameworkPackages: [],
       });
 
       expect(errors).toHaveLength(0);
-      expect(warnings).toHaveLength(1);
-      expect(warnings[0].message).toContain('could not read the dependencies');
+      expect(warnings).toHaveLength(0);
     });
+
+    it('checks the packages it is given when discovery is bypassed', () => {
+      const { errors } = run([{ issuer: appModule, request: '@openmrs/esm-made-up' }], {
+        frameworkPackages: ['@openmrs/esm-made-up'],
+      });
+
+      expect(errors).toHaveLength(1);
+    });
+  });
+
+  describe('shared peers', () => {
+    /** An app root whose manifest declares the given peers, since peers are read from the context. */
+    function appWith(peerDependencies: Record<string, string>) {
+      const root = mkdtempSync(join(tmpdir(), 'framework-import-guard-'));
+      writeFileSync(join(root, 'package.json'), JSON.stringify({ name: 'an-app', peerDependencies }));
+      return root;
+    }
+
+    function compileIn(root: string, request: string) {
+      const compilation = { errors: [] as Array<Error>, warnings: [] as Array<Error> };
+      let onResolve: ((data: { request: string; contextInfo: { issuer: string } }) => void) | undefined;
+      let report: ((value: typeof compilation) => void) | undefined;
+
+      new FrameworkImportGuardPlugin().apply({
+        context: root,
+        hooks: {
+          normalModuleFactory: {
+            tap: (_name, callback) =>
+              callback({ hooks: { afterResolve: { tap: (_inner, tapped) => void (onResolve = tapped) } } }),
+          },
+          thisCompilation: { tap: () => {} },
+          afterCompile: { tap: (_name, callback) => void (report = callback) },
+        },
+      });
+
+      onResolve?.({ request, contextInfo: { issuer: `${root}/src/index.ts` } });
+      report?.(compilation);
+
+      return compilation;
+    }
+
+    it('allows a sibling the app peer-depends on, because that really is a share key', () => {
+      // The bundler config builds the Module Federation `shared` map out of peerDependencies, so
+      // such an import does dedupe onto the app shell's copy and is legitimate.
+      const root = appWith({ '@openmrs/esm-framework': '10.x', '@openmrs/esm-state': '10.x' });
+
+      expect(compileIn(root, '@openmrs/esm-state').errors).toHaveLength(0);
+    });
+
+    it('still guards a sibling the app does not peer-depend on', () => {
+      const root = appWith({ '@openmrs/esm-framework': '10.x' });
+
+      expect(compileIn(root, '@openmrs/esm-state').errors).toHaveLength(1);
+    });
+  });
+
+  it('does not look the framework packages up again for every import', () => {
+    // Discovery reads manifests off disk and `record` runs for every module in the build, so the
+    // lookup has to be memoised. Counting after the first import rather than in total keeps this
+    // independent of how many places discovery looks.
+    const resolveFilename = Module['_resolveFilename'];
+    let lookups = 0;
+
+    Module['_resolveFilename'] = function (request: string, ...rest: Array<unknown>) {
+      if (request === '@openmrs/esm-framework/package.json') {
+        lookups++;
+      }
+
+      return resolveFilename.call(this, request, ...rest);
+    };
+
+    try {
+      const harness = hooks();
+      const imports = [{ issuer: appModule, request: '@openmrs/esm-state' }];
+      harness.compile(imports);
+      const afterFirstCompilation = lookups;
+
+      for (let index = 0; index < 25; index++) {
+        imports.push({ issuer: `${context}/src/module-${index}.ts`, request: '@openmrs/esm-state' });
+      }
+      harness.compile(imports);
+
+      expect(afterFirstCompilation).toBeGreaterThan(0);
+      expect(lookups).toBe(afterFirstCompilation);
+    } finally {
+      Module['_resolveFilename'] = resolveFilename;
+    }
   });
 });

--- a/packages/tooling/framework-import-guard/src/index.test.ts
+++ b/packages/tooling/framework-import-guard/src/index.test.ts
@@ -1,44 +1,46 @@
 import { describe, expect, it } from 'vitest';
 import { FrameworkImportGuardPlugin } from './index';
 
-interface Reason {
-  moduleName: string;
-  userRequest: string;
-}
+const context = '/app';
+const appModule = `${context}/src/index.ts`;
 
 /**
- * Drives the plugin against a hand-built module graph. Real builds cover the common paths, but the
- * stylesheet exemption cannot be reached that way: sass resolves `@use '@openmrs/esm-styleguide/...'`
- * itself and inlines the result, so those imports never become module-graph edges.
+ * Drives the plugin through the hooks it taps, feeding it resolutions in the shape webpack and
+ * rspack hand over: a literal request plus the file that made it.
  */
 function run(
-  modules: Array<{ name: string; reasons: Array<Reason> }>,
+  imports: Array<{ issuer: string; request: string }>,
   options?: ConstructorParameters<typeof FrameworkImportGuardPlugin>[0],
 ) {
-  const compilation = {
-    errors: [] as Array<Error>,
-    warnings: [] as Array<Error>,
-    getStats: () => ({ toJson: () => ({ modules }) }),
-  };
+  const compilation = { errors: [] as Array<Error>, warnings: [] as Array<Error> };
+  let afterResolve: ((data: { request: string; contextInfo: { issuer: string } }) => void) | undefined;
+  let startCompilation: ((compilation: typeof compilation) => void) | undefined;
+  let afterEmit: ((compilation: typeof compilation) => void) | undefined;
 
-  let tapped: ((compilation: typeof compilation) => void) | undefined;
   new FrameworkImportGuardPlugin(options).apply({
-    context: process.cwd(),
-    hooks: { afterEmit: { tap: (_name, callback) => void (tapped = callback) } },
+    context,
+    hooks: {
+      normalModuleFactory: {
+        tap: (_name, callback) =>
+          callback({ hooks: { afterResolve: { tap: (_inner, onResolve) => void (afterResolve = onResolve) } } }),
+      },
+      thisCompilation: { tap: (_name, callback) => void (startCompilation = callback) },
+      afterEmit: { tap: (_name, callback) => void (afterEmit = callback) },
+    },
   });
-  tapped?.(compilation);
 
-  return compilation;
+  startCompilation?.(compilation);
+  for (const { issuer, request } of imports) {
+    afterResolve?.({ request, contextInfo: { issuer } });
+  }
+  afterEmit?.(compilation);
+
+  return { ...compilation, replay: () => (startCompilation?.(compilation), afterEmit?.(compilation), compilation) };
 }
-
-const styleguideModule = 'node_modules/@openmrs/esm-styleguide/dist/internal.js';
-const stateModule = 'node_modules/@openmrs/esm-state/dist/index.js';
 
 describe('FrameworkImportGuardPlugin', () => {
   it('fails the build when application code imports a framework package directly', () => {
-    const { errors } = run([
-      { name: stateModule, reasons: [{ moduleName: './src/index.ts', userRequest: '@openmrs/esm-state' }] },
-    ]);
+    const { errors } = run([{ issuer: appModule, request: '@openmrs/esm-state' }]);
 
     expect(errors).toHaveLength(1);
     expect(errors[0].message).toContain('./src/index.ts imports @openmrs/esm-state');
@@ -46,13 +48,8 @@ describe('FrameworkImportGuardPlugin', () => {
 
   it('allows @openmrs/esm-framework itself, including its subpaths', () => {
     const { errors } = run([
-      {
-        name: 'node_modules/@openmrs/esm-framework/dist/internal.js',
-        reasons: [
-          { moduleName: './src/index.ts', userRequest: '@openmrs/esm-framework' },
-          { moduleName: './src/other.ts', userRequest: '@openmrs/esm-framework/src/internal' },
-        ],
-      },
+      { issuer: appModule, request: '@openmrs/esm-framework' },
+      { issuer: appModule, request: '@openmrs/esm-framework/src/internal' },
     ]);
 
     expect(errors).toHaveLength(0);
@@ -60,7 +57,10 @@ describe('FrameworkImportGuardPlugin', () => {
 
   it('allows the framework packages to import each other', () => {
     const { errors } = run([
-      { name: stateModule, reasons: [{ moduleName: styleguideModule, userRequest: '@openmrs/esm-state' }] },
+      {
+        issuer: `${context}/node_modules/@openmrs/esm-styleguide/dist/internal.js`,
+        request: '@openmrs/esm-state',
+      },
     ]);
 
     expect(errors).toHaveLength(0);
@@ -68,53 +68,48 @@ describe('FrameworkImportGuardPlugin', () => {
 
   it('allows a stylesheet to pull rules out of the styleguide', () => {
     const { errors } = run([
-      {
-        name: 'node_modules/@openmrs/esm-styleguide/src/vars.scss',
-        reasons: [{ moduleName: './src/root.styles.scss', userRequest: '@openmrs/esm-styleguide/src/vars' }],
-      },
+      { issuer: `${context}/src/root.styles.scss`, request: '@openmrs/esm-styleguide/src/vars' },
     ]);
 
     expect(errors).toHaveLength(0);
   });
 
   it('still fails a non-stylesheet import of the styleguide', () => {
-    const { errors } = run([
-      { name: styleguideModule, reasons: [{ moduleName: './src/index.ts', userRequest: '@openmrs/esm-styleguide' }] },
-    ]);
+    const { errors } = run([{ issuer: appModule, request: '@openmrs/esm-styleguide' }]);
 
     expect(errors).toHaveLength(1);
-    expect(errors[0].message).toContain('@openmrs/esm-styleguide');
-  });
-
-  it('ignores the module federation wrappers around a share and its fallback', () => {
-    const { errors } = run([
-      {
-        name: 'consume shared module (default) @openmrs/esm-framework@10.x',
-        reasons: [{ moduleName: './src/index.ts', userRequest: '@openmrs/esm-state' }],
-      },
-      {
-        name: stateModule,
-        reasons: [
-          {
-            moduleName: 'provide shared module (default) @openmrs/esm-state@10.0.0',
-            userRequest: '@openmrs/esm-state',
-          },
-        ],
-      },
-    ]);
-
-    expect(errors).toHaveLength(0);
   });
 
   it('does not flag packages outside the framework', () => {
-    const { errors } = run([
-      {
-        name: 'node_modules/@openmrs/esm-patient-common-lib/dist/index.js',
-        reasons: [{ moduleName: './src/index.ts', userRequest: '@openmrs/esm-patient-common-lib' }],
-      },
-    ]);
+    const { errors } = run([{ issuer: appModule, request: '@openmrs/esm-patient-common-lib' }]);
 
     expect(errors).toHaveLength(0);
+  });
+
+  it('ignores a resolution with no issuer, such as an entry point', () => {
+    const { errors } = run([{ issuer: '', request: '@openmrs/esm-state' }]);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('reports every offending import, grouped by the file that made it', () => {
+    const { errors } = run([
+      { issuer: appModule, request: '@openmrs/esm-state' },
+      { issuer: appModule, request: '@openmrs/esm-state' },
+      { issuer: `${context}/src/app.tsx`, request: '@openmrs/esm-styleguide' },
+    ]);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('./src/index.ts imports @openmrs/esm-state');
+    expect(errors[0].message).toContain('./src/app.tsx imports @openmrs/esm-styleguide');
+  });
+
+  it('forgets the previous compilation, so a watch rebuild starts clean', () => {
+    const result = run([{ issuer: appModule, request: '@openmrs/esm-state' }]);
+    expect(result.errors).toHaveLength(1);
+
+    result.errors.length = 0;
+    expect(result.replay().errors).toHaveLength(0);
   });
 
   // A single-app repo installs the framework into its own `node_modules` rather than resolving it
@@ -122,10 +117,7 @@ describe('FrameworkImportGuardPlugin', () => {
   describe('outside a monorepo', () => {
     it('fails the build on a direct import from a single-app repo', () => {
       const { errors } = run([
-        {
-          name: 'node_modules/@openmrs/esm-styleguide/dist/internal.js',
-          reasons: [{ moduleName: './src/dispensing.component.tsx', userRequest: '@openmrs/esm-styleguide' }],
-        },
+        { issuer: `${context}/src/dispensing.component.tsx`, request: '@openmrs/esm-styleguide' },
       ]);
 
       expect(errors).toHaveLength(1);
@@ -135,14 +127,8 @@ describe('FrameworkImportGuardPlugin', () => {
     it("treats pnpm's nested layout as framework-internal", () => {
       const { errors } = run([
         {
-          name: stateModule,
-          reasons: [
-            {
-              moduleName:
-                'node_modules/.pnpm/@openmrs+esm-styleguide@10.0.0/node_modules/@openmrs/esm-styleguide/dist/internal.js',
-              userRequest: '@openmrs/esm-state',
-            },
-          ],
+          issuer: `${context}/node_modules/.pnpm/@openmrs+esm-styleguide@10.0.0/node_modules/@openmrs/esm-styleguide/dist/internal.js`,
+          request: '@openmrs/esm-state',
         },
       ]);
 
@@ -152,13 +138,8 @@ describe('FrameworkImportGuardPlugin', () => {
     it('recognises framework packages behind Windows path separators', () => {
       const { errors } = run([
         {
-          name: 'node_modules\\@openmrs\\esm-state\\dist\\index.js',
-          reasons: [
-            {
-              moduleName: 'node_modules\\@openmrs\\esm-api\\dist\\index.js',
-              userRequest: '@openmrs/esm-state',
-            },
-          ],
+          issuer: 'C:\\app\\node_modules\\@openmrs\\esm-api\\dist\\index.js',
+          request: '@openmrs/esm-state',
         },
       ]);
 
@@ -166,41 +147,22 @@ describe('FrameworkImportGuardPlugin', () => {
     });
 
     it('checks the packages it is given when the framework manifest cannot be found', () => {
-      const { errors, warnings } = run(
-        [{ name: 'whatever', reasons: [{ moduleName: './src/index.ts', userRequest: '@openmrs/esm-made-up' }] }],
-        { frameworkPackages: ['@openmrs/esm-made-up'] },
-      );
+      const { errors, warnings } = run([{ issuer: appModule, request: '@openmrs/esm-made-up' }], {
+        frameworkPackages: ['@openmrs/esm-made-up'],
+      });
 
       expect(warnings).toHaveLength(0);
       expect(errors).toHaveLength(1);
     });
 
     it('warns rather than passing silently when no framework packages are known', () => {
-      const { errors, warnings } = run(
-        [{ name: stateModule, reasons: [{ moduleName: './src/index.ts', userRequest: '@openmrs/esm-state' }] }],
-        { frameworkPackages: [] },
-      );
+      const { errors, warnings } = run([{ issuer: appModule, request: '@openmrs/esm-state' }], {
+        frameworkPackages: [],
+      });
 
       expect(errors).toHaveLength(0);
       expect(warnings).toHaveLength(1);
       expect(warnings[0].message).toContain('could not read the dependencies');
     });
-  });
-
-  it('reports every offending import, grouped by the module that made it', () => {
-    const { errors } = run([
-      {
-        name: stateModule,
-        reasons: [
-          { moduleName: './src/index.ts', userRequest: '@openmrs/esm-state' },
-          { moduleName: './src/index.ts', userRequest: '@openmrs/esm-state' },
-        ],
-      },
-      { name: styleguideModule, reasons: [{ moduleName: './src/app.tsx', userRequest: '@openmrs/esm-styleguide' }] },
-    ]);
-
-    expect(errors).toHaveLength(1);
-    expect(errors[0].message).toContain('./src/index.ts imports @openmrs/esm-state');
-    expect(errors[0].message).toContain('./src/app.tsx imports @openmrs/esm-styleguide');
   });
 });

--- a/packages/tooling/framework-import-guard/src/index.test.ts
+++ b/packages/tooling/framework-import-guard/src/index.test.ts
@@ -1,0 +1,206 @@
+import { describe, expect, it } from 'vitest';
+import { FrameworkImportGuardPlugin } from './index';
+
+interface Reason {
+  moduleName: string;
+  userRequest: string;
+}
+
+/**
+ * Drives the plugin against a hand-built module graph. Real builds cover the common paths, but the
+ * stylesheet exemption cannot be reached that way: sass resolves `@use '@openmrs/esm-styleguide/...'`
+ * itself and inlines the result, so those imports never become module-graph edges.
+ */
+function run(
+  modules: Array<{ name: string; reasons: Array<Reason> }>,
+  options?: ConstructorParameters<typeof FrameworkImportGuardPlugin>[0],
+) {
+  const compilation = {
+    errors: [] as Array<Error>,
+    warnings: [] as Array<Error>,
+    getStats: () => ({ toJson: () => ({ modules }) }),
+  };
+
+  let tapped: ((compilation: typeof compilation) => void) | undefined;
+  new FrameworkImportGuardPlugin(options).apply({
+    context: process.cwd(),
+    hooks: { afterEmit: { tap: (_name, callback) => void (tapped = callback) } },
+  });
+  tapped?.(compilation);
+
+  return compilation;
+}
+
+const styleguideModule = 'node_modules/@openmrs/esm-styleguide/dist/internal.js';
+const stateModule = 'node_modules/@openmrs/esm-state/dist/index.js';
+
+describe('FrameworkImportGuardPlugin', () => {
+  it('fails the build when application code imports a framework package directly', () => {
+    const { errors } = run([
+      { name: stateModule, reasons: [{ moduleName: './src/index.ts', userRequest: '@openmrs/esm-state' }] },
+    ]);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('./src/index.ts imports @openmrs/esm-state');
+  });
+
+  it('allows @openmrs/esm-framework itself, including its subpaths', () => {
+    const { errors } = run([
+      {
+        name: 'node_modules/@openmrs/esm-framework/dist/internal.js',
+        reasons: [
+          { moduleName: './src/index.ts', userRequest: '@openmrs/esm-framework' },
+          { moduleName: './src/other.ts', userRequest: '@openmrs/esm-framework/src/internal' },
+        ],
+      },
+    ]);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('allows the framework packages to import each other', () => {
+    const { errors } = run([
+      { name: stateModule, reasons: [{ moduleName: styleguideModule, userRequest: '@openmrs/esm-state' }] },
+    ]);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('allows a stylesheet to pull rules out of the styleguide', () => {
+    const { errors } = run([
+      {
+        name: 'node_modules/@openmrs/esm-styleguide/src/vars.scss',
+        reasons: [{ moduleName: './src/root.styles.scss', userRequest: '@openmrs/esm-styleguide/src/vars' }],
+      },
+    ]);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('still fails a non-stylesheet import of the styleguide', () => {
+    const { errors } = run([
+      { name: styleguideModule, reasons: [{ moduleName: './src/index.ts', userRequest: '@openmrs/esm-styleguide' }] },
+    ]);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('@openmrs/esm-styleguide');
+  });
+
+  it('ignores the module federation wrappers around a share and its fallback', () => {
+    const { errors } = run([
+      {
+        name: 'consume shared module (default) @openmrs/esm-framework@10.x',
+        reasons: [{ moduleName: './src/index.ts', userRequest: '@openmrs/esm-state' }],
+      },
+      {
+        name: stateModule,
+        reasons: [
+          {
+            moduleName: 'provide shared module (default) @openmrs/esm-state@10.0.0',
+            userRequest: '@openmrs/esm-state',
+          },
+        ],
+      },
+    ]);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  it('does not flag packages outside the framework', () => {
+    const { errors } = run([
+      {
+        name: 'node_modules/@openmrs/esm-patient-common-lib/dist/index.js',
+        reasons: [{ moduleName: './src/index.ts', userRequest: '@openmrs/esm-patient-common-lib' }],
+      },
+    ]);
+
+    expect(errors).toHaveLength(0);
+  });
+
+  // A single-app repo installs the framework into its own `node_modules` rather than resolving it
+  // through a workspace, and may nest it further depending on the package manager.
+  describe('outside a monorepo', () => {
+    it('fails the build on a direct import from a single-app repo', () => {
+      const { errors } = run([
+        {
+          name: 'node_modules/@openmrs/esm-styleguide/dist/internal.js',
+          reasons: [{ moduleName: './src/dispensing.component.tsx', userRequest: '@openmrs/esm-styleguide' }],
+        },
+      ]);
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain('./src/dispensing.component.tsx imports @openmrs/esm-styleguide');
+    });
+
+    it("treats pnpm's nested layout as framework-internal", () => {
+      const { errors } = run([
+        {
+          name: stateModule,
+          reasons: [
+            {
+              moduleName:
+                'node_modules/.pnpm/@openmrs+esm-styleguide@10.0.0/node_modules/@openmrs/esm-styleguide/dist/internal.js',
+              userRequest: '@openmrs/esm-state',
+            },
+          ],
+        },
+      ]);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('recognises framework packages behind Windows path separators', () => {
+      const { errors } = run([
+        {
+          name: 'node_modules\\@openmrs\\esm-state\\dist\\index.js',
+          reasons: [
+            {
+              moduleName: 'node_modules\\@openmrs\\esm-api\\dist\\index.js',
+              userRequest: '@openmrs/esm-state',
+            },
+          ],
+        },
+      ]);
+
+      expect(errors).toHaveLength(0);
+    });
+
+    it('checks the packages it is given when the framework manifest cannot be found', () => {
+      const { errors, warnings } = run(
+        [{ name: 'whatever', reasons: [{ moduleName: './src/index.ts', userRequest: '@openmrs/esm-made-up' }] }],
+        { frameworkPackages: ['@openmrs/esm-made-up'] },
+      );
+
+      expect(warnings).toHaveLength(0);
+      expect(errors).toHaveLength(1);
+    });
+
+    it('warns rather than passing silently when no framework packages are known', () => {
+      const { errors, warnings } = run(
+        [{ name: stateModule, reasons: [{ moduleName: './src/index.ts', userRequest: '@openmrs/esm-state' }] }],
+        { frameworkPackages: [] },
+      );
+
+      expect(errors).toHaveLength(0);
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0].message).toContain('could not read the dependencies');
+    });
+  });
+
+  it('reports every offending import, grouped by the module that made it', () => {
+    const { errors } = run([
+      {
+        name: stateModule,
+        reasons: [
+          { moduleName: './src/index.ts', userRequest: '@openmrs/esm-state' },
+          { moduleName: './src/index.ts', userRequest: '@openmrs/esm-state' },
+        ],
+      },
+      { name: styleguideModule, reasons: [{ moduleName: './src/app.tsx', userRequest: '@openmrs/esm-styleguide' }] },
+    ]);
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0].message).toContain('./src/index.ts imports @openmrs/esm-state');
+    expect(errors[0].message).toContain('./src/app.tsx imports @openmrs/esm-styleguide');
+  });
+});

--- a/packages/tooling/framework-import-guard/src/index.ts
+++ b/packages/tooling/framework-import-guard/src/index.ts
@@ -14,29 +14,28 @@
  * variables, which is a stylesheet-level dependency and carries no runtime state.
  */
 
-interface StatsModuleReason {
-  moduleName?: string | null;
-  userRequest?: string | null;
-}
-
-interface StatsModule {
-  name?: string | null;
-  reasons?: Array<StatsModuleReason>;
-}
-
 interface Compilation {
   errors: Array<Error>;
   warnings: Array<Error>;
-  getStats(): { toJson(options: Record<string, boolean>): { modules?: Array<StatsModule> } };
+}
+
+/** The subset of a resolution we need: what was asked for, and which file asked for it. */
+interface ResolveData {
+  request?: string;
+  contextInfo?: { issuer?: string };
+}
+
+interface Tap<T> {
+  tap(name: string, callback: (value: T) => void): void;
 }
 
 interface Compiler {
   /** The directory the build runs in, i.e. the root of the app being built. */
   context: string;
   hooks: {
-    afterEmit: {
-      tap(name: string, callback: (compilation: Compilation) => void): void;
-    };
+    normalModuleFactory: Tap<{ hooks: { afterResolve: Tap<ResolveData> } }>;
+    thisCompilation: Tap<Compilation>;
+    afterEmit: Tap<Compilation>;
   };
 }
 
@@ -82,7 +81,10 @@ const frameworkManifest = '@openmrs/esm-framework/package.json';
  * apps have no local copy of the framework.
  */
 function getFrameworkPackages(context: string): Array<string> {
-  const locations = [() => require.resolve(frameworkManifest, { paths: [context] }), () => require.resolve(frameworkManifest)];
+  const locations = [
+    () => require.resolve(frameworkManifest, { paths: [context] }),
+    () => require.resolve(frameworkManifest),
+  ];
 
   for (const locate of locations) {
     try {
@@ -107,84 +109,99 @@ function packageOf(request: string, packages: Array<string>) {
 
 export class FrameworkImportGuardPlugin {
   private readonly allowedPackages: Array<string>;
-  private readonly frameworkPackages: Array<string> | undefined;
+  private readonly configuredPackages: Array<string> | undefined;
 
-  constructor({
-    allowedPackages = ['@openmrs/esm-framework'],
-    frameworkPackages,
-  }: FrameworkImportGuardOptions = {}) {
+  /**
+   * Offending imports found in the compilation currently running, keyed by the file that made them.
+   * Reset for each compilation so a watch rebuild does not inherit the previous run's findings.
+   */
+  private offenders = new Map<string, Set<string>>();
+
+  constructor({ allowedPackages = ['@openmrs/esm-framework'], frameworkPackages }: FrameworkImportGuardOptions = {}) {
     this.allowedPackages = allowedPackages;
-    this.frameworkPackages = frameworkPackages;
+    this.configuredPackages = frameworkPackages;
   }
 
   apply(compiler: Compiler) {
+    // Imports are collected as they resolve rather than read back out of the finished module graph.
+    // By the time a build is sealed, `optimization.concatenateModules` has merged scope-hoisted
+    // modules into single stats entries whose nested modules carry no reasons at all, so a direct
+    // import of a framework package leaves no trace there — production builds would pass whatever
+    // they import. A resolution has not been optimised yet, and it names both the literal request
+    // and the file that made it.
+    compiler.hooks.normalModuleFactory.tap(pluginName, (factory) => {
+      factory.hooks.afterResolve.tap(pluginName, (resolveData) => {
+        this.record(compiler.context, resolveData);
+      });
+    });
+
+    compiler.hooks.thisCompilation.tap(pluginName, () => {
+      this.offenders = new Map();
+    });
+
     compiler.hooks.afterEmit.tap(pluginName, (compilation) => {
-      const known = this.frameworkPackages ?? getFrameworkPackages(compiler.context);
-      const guarded = known.filter((pkg) => !this.allowedPackages.includes(pkg));
+      this.report(compiler.context, compilation);
+    });
+  }
 
-      if (guarded.length === 0) {
-        compilation.warnings.push(
-          new Error(
-            `${pluginName} could not read the dependencies of @openmrs/esm-framework, so imports of ` +
-              'framework packages were not checked. Pass `frameworkPackages` to check them anyway.',
-          ),
-        );
-        return;
-      }
+  private guardedPackages(context: string) {
+    const known = this.configuredPackages ?? getFrameworkPackages(context);
+    return known.filter((pkg) => !this.allowedPackages.includes(pkg));
+  }
 
-      const { modules = [] } = compilation.getStats().toJson({ all: false, modules: true, reasons: true });
-      const offenders = new Map<string, Set<string>>();
+  private record(context: string, { request = '', contextInfo }: ResolveData) {
+    const issuer = contextInfo?.issuer ?? '';
+    const pkg = packageOf(request, this.guardedPackages(context));
 
-      for (const module of modules) {
-        const moduleName = module.name ?? '';
+    if (!pkg || !issuer) {
+      return;
+    }
 
-        if (isFederationModule(moduleName)) {
-          continue;
-        }
+    // Imports between framework packages are the framework's own business, as is anything Module
+    // Federation pulls in to build a share or the fallback behind it.
+    if (frameworkModulePattern.test(issuer) || isFederationModule(issuer)) {
+      return;
+    }
 
-        for (const reason of module.reasons ?? []) {
-          const request = reason.userRequest ?? '';
-          const issuer = reason.moduleName ?? '';
-          const pkg = packageOf(request, guarded);
+    // Stylesheets pull rules and variables straight out of the styleguide. That is a stylesheet
+    // dependency with no runtime state behind it, so it is allowed.
+    if (pkg === '@openmrs/esm-styleguide' && stylesheetPattern.test(issuer)) {
+      return;
+    }
 
-          if (!pkg) {
-            continue;
-          }
+    const relative = issuer.startsWith(context) ? `.${issuer.slice(context.length)}` : issuer;
+    const requests = this.offenders.get(relative) ?? new Set<string>();
+    requests.add(request);
+    this.offenders.set(relative, requests);
+  }
 
-          // Imports between framework packages are the framework's own business.
-          if (isFederationModule(issuer) || frameworkModulePattern.test(issuer)) {
-            continue;
-          }
-
-          // SCSS pulls rules and variables straight out of the styleguide. That is a stylesheet
-          // dependency with no runtime state behind it, so it is allowed.
-          if (
-            pkg === '@openmrs/esm-styleguide' &&
-            (stylesheetPattern.test(issuer) || stylesheetPattern.test(moduleName) || stylesheetPattern.test(request))
-          ) {
-            continue;
-          }
-
-          const requests = offenders.get(issuer) ?? new Set<string>();
-          requests.add(request);
-          offenders.set(issuer, requests);
-        }
-      }
-
-      if (offenders.size === 0) {
-        return;
-      }
-
-      const detail = Array.from(offenders, ([issuer, requests]) => `  ${issuer} imports ${[...requests].join(', ')}`);
-      compilation.errors.push(
+  private report(context: string, compilation: Compilation) {
+    if (this.guardedPackages(context).length === 0) {
+      compilation.warnings.push(
         new Error(
-          `${pluginName}: these imports reach into the internals of @openmrs/esm-framework, which bundles a ` +
-            "private copy of that package rather than sharing the app shell's. Import from " +
-            "'@openmrs/esm-framework' instead:\n" +
-            detail.join('\n'),
+          `${pluginName} could not read the dependencies of @openmrs/esm-framework, so imports of ` +
+            'framework packages were not checked. Pass `frameworkPackages` to check them anyway.',
         ),
       );
-    });
+      return;
+    }
+
+    if (this.offenders.size === 0) {
+      return;
+    }
+
+    const detail = Array.from(
+      this.offenders,
+      ([issuer, requests]) => `  ${issuer} imports ${[...requests].join(', ')}`,
+    );
+    compilation.errors.push(
+      new Error(
+        `${pluginName}: these imports reach into the internals of @openmrs/esm-framework, which bundles a ` +
+          "private copy of that package rather than sharing the app shell's. Import from " +
+          "'@openmrs/esm-framework' instead:\n" +
+          detail.join('\n'),
+      ),
+    );
   }
 }
 

--- a/packages/tooling/framework-import-guard/src/index.ts
+++ b/packages/tooling/framework-import-guard/src/index.ts
@@ -2,27 +2,39 @@
  * A webpack/rspack plugin that fails a build which reaches into the framework's internals.
  *
  * `@openmrs/esm-framework` is a facade over a set of sibling packages (`@openmrs/esm-state`,
- * `@openmrs/esm-styleguide`, `@openmrs/esm-api`, ...) and only the facade is a Module Federation
- * share key. Federation matches shares against the literal import request, so importing a sibling
- * by name never becomes a consume-share: it statically links that package into the app. Where the
- * package carries module-level state — `esm-state`'s store registry, the extension registry, the
- * config store — the app then runs against its own copy of state the framework treats as a
- * singleton. Nothing fails loudly; the app simply stops sharing stores with everything else on the
- * page.
+ * `@openmrs/esm-styleguide`, `@openmrs/esm-api`, ...). Module Federation matches shares against the
+ * literal import request, and it does so before the resolver runs — so no amount of aliasing turns
+ * an import of a sibling into a consume-share. Importing a sibling by name statically links it into
+ * the app instead, and where that package carries module-level state — `esm-state`'s store
+ * registry, the extension registry, the config store — the app then runs against its own copy of
+ * state the framework treats as a singleton. Nothing fails loudly; the app simply stops sharing
+ * with everything else on the page. Converting that into a build failure is the whole job.
  *
- * The one legitimate exception is SCSS reaching into `@openmrs/esm-styleguide` for rules and
- * variables, which is a stylesheet-level dependency and carries no runtime state.
+ * Two exceptions are legitimate. A sibling the app lists in its own `peerDependencies` really is a
+ * share key, because the bundler config builds the Module Federation `shared` map out of them. And
+ * a stylesheet may pull rules and variables out of `@openmrs/esm-styleguide`, which carries no
+ * runtime state.
+ *
+ * Because "found nothing" and "checked nothing" must not look alike, every path that leaves the
+ * guard unable to answer reports an error rather than passing quietly.
  */
+import { realpathSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 interface Compilation {
   errors: Array<Error>;
   warnings: Array<Error>;
 }
 
-/** The subset of a resolution we need: what was asked for, and which file asked for it. */
+/**
+ * The subset of a resolution we need: what was asked for, and which file asked for it. Both fields
+ * are required in webpack and in rspack, and declaring them so is what makes a bundler that stops
+ * supplying them a compile error at the packages that construct this plugin rather than a guard
+ * that silently sees nothing.
+ */
 interface ResolveData {
-  request?: string;
-  contextInfo?: { issuer?: string };
+  request: string;
+  contextInfo: { issuer: string };
 }
 
 interface Tap<T> {
@@ -34,41 +46,36 @@ interface Compiler {
   context: string;
   hooks: {
     normalModuleFactory: Tap<{ hooks: { afterResolve: Tap<ResolveData> } }>;
-    thisCompilation: Tap<Compilation>;
-    afterEmit: Tap<Compilation>;
+    thisCompilation: Tap<unknown>;
+    afterCompile: Tap<Compilation>;
   };
 }
 
 export interface FrameworkImportGuardOptions {
   /**
-   * Packages that may be imported directly. Anything else belonging to the framework is an error.
+   * Framework packages that may be imported directly, on top of the ones the app peer-depends on.
+   * Defaults to the `@openmrs/esm-framework` facade, which is always allowed.
    */
-  allowedPackages?: Array<string>;
+  allowedPackages?: ReadonlyArray<string>;
   /**
-   * The framework packages to guard. Only needed where they cannot be discovered from the
-   * framework's own manifest, such as an installation that hides transitive dependencies.
+   * The framework packages to guard, for an installation where they cannot be discovered from the
+   * framework's own manifest. Passing this suppresses discovery, so an empty array disables the
+   * guard deliberately and silently; omit it to have discovery failure reported as an error.
    */
-  frameworkPackages?: Array<string>;
+  frameworkPackages?: ReadonlyArray<string>;
 }
 
 const pluginName = 'FrameworkImportGuardPlugin';
+const frameworkManifest = '@openmrs/esm-framework/package.json';
+const facade = '@openmrs/esm-framework';
 
-/**
- * Matches a module belonging to a framework package. Covers an ordinary `node_modules/@openmrs/...`
- * install, pnpm's `node_modules/.pnpm/@openmrs+esm-state@.../node_modules/@openmrs/...` layout, and
- * the workspace paths (`../../framework/esm-styleguide/...`) used when the framework is built from
- * source alongside the app.
- */
-const frameworkModulePattern = /(?:node_modules[\\/]@openmrs[\\/]|[\\/]framework[\\/])esm-[a-z-]+[\\/]/;
-
-const stylesheetPattern = /\.(?:s[ac]ss|css)\b/;
+/** Anchored, so that a source file such as `theme.css.ts` does not inherit the styleguide exemption. */
+const stylesheetPattern = /\.(?:s[ac]ss|css)(?:\?.*)?$/;
 
 /** Module Federation's own wrappers; what they reach is the share or the fallback behind it. */
 function isFederationModule(name: string) {
   return name.startsWith('consume shared module') || name.startsWith('provide shared module');
 }
-
-const frameworkManifest = '@openmrs/esm-framework/package.json';
 
 /**
  * The framework's siblings, read from the framework's own dependencies so that a package added
@@ -80,7 +87,7 @@ const frameworkManifest = '@openmrs/esm-framework/package.json';
  * guaranteed to resolve at all. Resolution from this package is the fallback, for a monorepo whose
  * apps have no local copy of the framework.
  */
-function getFrameworkPackages(context: string): Array<string> {
+function discoverFrameworkPackages(context: string): Array<string> {
   const locations = [
     () => require.resolve(frameworkManifest, { paths: [context] }),
     () => require.resolve(frameworkManifest),
@@ -103,103 +110,214 @@ function getFrameworkPackages(context: string): Array<string> {
   return [];
 }
 
-function packageOf(request: string, packages: Array<string>) {
+/** Whatever the app peer-depends on ends up in the Module Federation `shared` map. */
+function discoverSharedPeers(context: string): Array<string> {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const { peerDependencies } = require(resolve(context, 'package.json'));
+    return Object.keys(peerDependencies ?? {});
+  } catch {
+    return [];
+  }
+}
+
+function packageOf(request: string, packages: ReadonlyArray<string>) {
   return packages.find((pkg) => request === pkg || request.startsWith(`${pkg}/`));
 }
 
+/**
+ * The prefixes an issuer may carry for the directory being built, so offending files are named
+ * relative to the project. A bundler reports resolved, symlink-free paths, which need not share a
+ * prefix with the context it was given — a project reached through a symlink, or anywhere under
+ * macOS's `/tmp`, differ. Without the resolved form the message falls back to absolute paths.
+ */
+function projectRoots(context: string): Array<string> {
+  const roots = [context.replace(/\\/g, '/')];
+
+  try {
+    const real = realpathSync.native(context).replace(/\\/g, '/');
+
+    if (!roots.includes(real)) {
+      roots.push(real);
+    }
+  } catch {
+    // The context need not exist on disk.
+  }
+
+  return roots;
+}
+
+/**
+ * Whether a file belongs to one of the framework's own packages, which are free to import each
+ * other. Matched against the known package names rather than a name shape, so that a package that
+ * merely looks like part of the framework — `@openmrs/esm-patient-common-lib`, an app consumed as a
+ * library — is still held to the rule; those are bundled into the app and duplicate state exactly
+ * as an app's own import would.
+ */
+function isFrameworkInternal(issuer: string, known: ReadonlyArray<string>) {
+  return known.some((pkg) => {
+    const unscoped = pkg.slice(pkg.indexOf('/') + 1);
+    return issuer.includes(`/node_modules/${pkg}/`) || issuer.includes(`/framework/${unscoped}/`);
+  });
+}
+
 export class FrameworkImportGuardPlugin {
-  private readonly allowedPackages: Array<string>;
-  private readonly configuredPackages: Array<string> | undefined;
+  private readonly allowedPackages: ReadonlyArray<string>;
+  private readonly configuredPackages: ReadonlyArray<string> | undefined;
 
-  /**
-   * Offending imports found in the compilation currently running, keyed by the file that made them.
-   * Reset for each compilation so a watch rebuild does not inherit the previous run's findings.
-   */
-  private offenders = new Map<string, Set<string>>();
-
-  constructor({ allowedPackages = ['@openmrs/esm-framework'], frameworkPackages }: FrameworkImportGuardOptions = {}) {
-    this.allowedPackages = allowedPackages;
-    this.configuredPackages = frameworkPackages;
+  constructor({ allowedPackages = [facade], frameworkPackages }: FrameworkImportGuardOptions = {}) {
+    // Copied because both are read again on every resolution behind a memo, and a caller mutating
+    // the array it passed would otherwise change the answer partway through a build.
+    this.allowedPackages = [...allowedPackages];
+    this.configuredPackages = frameworkPackages && [...frameworkPackages];
   }
 
   apply(compiler: Compiler) {
+    const { context } = compiler;
+    const roots = projectRoots(context);
+
+    /**
+     * Findings live for as long as the compiler and are never retracted, keyed by the file that
+     * made the import.
+     *
+     * A watch rebuild re-resolves only what changed, and `module.unsafeCache` — on by default in
+     * development — serves modules under `node_modules` straight from cache without factorizing
+     * them, which is where every framework package lives. So a rebuild sees neither the offending
+     * import nor evidence that it is gone, and there is no signal here that distinguishes "fixed"
+     * from "not looked at". Forgetting a finding therefore means the gate goes green with the
+     * import still in the tree, which is the silent failure this plugin exists to remove. Holding
+     * it instead costs a restart after a genuine fix, which the message says.
+     */
+    const offenders = new Map<string, Set<string>>();
+    /** Which findings this compilation saw for itself, as opposed to inherited from an earlier one. */
+    let confirmedThisCompilation = new Set<string>();
+    let sawAnyResolution = false;
+    let checkedCanary = false;
+    let packages: ReturnType<FrameworkImportGuardPlugin['collectPackages']> | undefined;
+
+    // Memoised: discovery reads manifests off disk and `record` runs for every resolved module.
+    const collect = () => (packages ??= this.collectPackages(context));
+
+    compiler.hooks.thisCompilation.tap(pluginName, () => {
+      confirmedThisCompilation = new Set();
+    });
+
     // Imports are collected as they resolve rather than read back out of the finished module graph.
-    // By the time a build is sealed, `optimization.concatenateModules` has merged scope-hoisted
-    // modules into single stats entries whose nested modules carry no reasons at all, so a direct
-    // import of a framework package leaves no trace there — production builds would pass whatever
-    // they import. A resolution has not been optimised yet, and it names both the literal request
-    // and the file that made it.
+    // Once a build is sealed, `optimization.concatenateModules` has folded scope-hoisted modules
+    // into a single module whose parts report no reasons, so a direct import of a framework package
+    // leaves no trace to find — production builds would pass whatever they imported.
     compiler.hooks.normalModuleFactory.tap(pluginName, (factory) => {
-      factory.hooks.afterResolve.tap(pluginName, (resolveData) => {
-        this.record(compiler.context, resolveData);
+      factory.hooks.afterResolve.tap(pluginName, ({ request, contextInfo }) => {
+        sawAnyResolution = true;
+        this.record(roots, collect(), offenders, confirmedThisCompilation, request, contextInfo?.issuer ?? '');
       });
     });
 
-    compiler.hooks.thisCompilation.tap(pluginName, () => {
-      this.offenders = new Map();
-    });
-
-    compiler.hooks.afterEmit.tap(pluginName, (compilation) => {
-      this.report(compiler.context, compilation);
+    // Reported before anything is written. `afterEmit` is too late twice over: production sets
+    // `optimization.emitOnErrors` to false, so a compilation that already has any other error skips
+    // emitting and never reaches it, and on a clean run the offending bundle is on disk by then.
+    compiler.hooks.afterCompile.tap(pluginName, (compilation) => {
+      const canary = !checkedCanary && !sawAnyResolution;
+      checkedCanary = true;
+      this.report(collect(), offenders, confirmedThisCompilation, canary, compilation);
     });
   }
 
-  private guardedPackages(context: string) {
-    const known = this.configuredPackages ?? getFrameworkPackages(context);
-    return known.filter((pkg) => !this.allowedPackages.includes(pkg));
+  private collectPackages(context: string) {
+    const discovered = this.configuredPackages ?? discoverFrameworkPackages(context);
+    const shared = new Set(discoverSharedPeers(context));
+    const allowed = [facade, ...this.allowedPackages, ...discovered.filter((pkg) => shared.has(pkg))];
+
+    return {
+      /** False only when discovery was attempted and found nothing, which is a broken install. */
+      known: this.configuredPackages !== undefined || discovered.length > 0,
+      /** Every package belonging to the framework, whether guarded or allowed. */
+      framework: [facade, ...discovered],
+      guarded: discovered.filter((pkg) => !allowed.includes(pkg)),
+    };
   }
 
-  private record(context: string, { request = '', contextInfo }: ResolveData) {
-    const issuer = contextInfo?.issuer ?? '';
-    const pkg = packageOf(request, this.guardedPackages(context));
-
-    if (!pkg || !issuer) {
+  private record(
+    roots: ReadonlyArray<string>,
+    { guarded, framework }: ReturnType<FrameworkImportGuardPlugin['collectPackages']>,
+    offenders: Map<string, Set<string>>,
+    confirmedThisCompilation: Set<string>,
+    request: string,
+    issuer: string,
+  ) {
+    if (!issuer) {
       return;
     }
 
-    // Imports between framework packages are the framework's own business, as is anything Module
-    // Federation pulls in to build a share or the fallback behind it.
-    if (frameworkModulePattern.test(issuer) || isFederationModule(issuer)) {
+    const path = issuer.replace(/\\/g, '/');
+    const root = roots.find((candidate) => path.startsWith(`${candidate}/`));
+    const file = root ? `.${path.slice(root.length)}` : path;
+
+    const pkg = packageOf(request ?? '', guarded);
+
+    if (!pkg || isFrameworkInternal(path, framework) || isFederationModule(issuer)) {
       return;
     }
 
-    // Stylesheets pull rules and variables straight out of the styleguide. That is a stylesheet
-    // dependency with no runtime state behind it, so it is allowed.
-    if (pkg === '@openmrs/esm-styleguide' && stylesheetPattern.test(issuer)) {
+    if (pkg === '@openmrs/esm-styleguide' && stylesheetPattern.test(path)) {
       return;
     }
 
-    const relative = issuer.startsWith(context) ? `.${issuer.slice(context.length)}` : issuer;
-    const requests = this.offenders.get(relative) ?? new Set<string>();
+    const requests = offenders.get(file) ?? new Set<string>();
     requests.add(request);
-    this.offenders.set(relative, requests);
+    offenders.set(file, requests);
+    confirmedThisCompilation.add(file);
   }
 
-  private report(context: string, compilation: Compilation) {
-    if (this.guardedPackages(context).length === 0) {
-      compilation.warnings.push(
+  private report(
+    { known, guarded }: ReturnType<FrameworkImportGuardPlugin['collectPackages']>,
+    offenders: Map<string, Set<string>>,
+    confirmedThisCompilation: Set<string>,
+    canary: boolean,
+    compilation: Compilation,
+  ) {
+    if (!known) {
+      compilation.errors.push(
         new Error(
-          `${pluginName} could not read the dependencies of @openmrs/esm-framework, so imports of ` +
-            'framework packages were not checked. Pass `frameworkPackages` to check them anyway.',
+          `${pluginName} could not read the dependencies of ${frameworkManifest}, so it cannot tell which ` +
+            'imports are allowed. Install @openmrs/esm-framework where the build runs, or pass ' +
+            '`frameworkPackages` to list the packages to guard.',
         ),
       );
       return;
     }
 
-    if (this.offenders.size === 0) {
+    if (guarded.length === 0) {
       return;
     }
 
-    const detail = Array.from(
-      this.offenders,
-      ([issuer, requests]) => `  ${issuer} imports ${[...requests].join(', ')}`,
-    );
+    if (canary) {
+      compilation.errors.push(
+        new Error(
+          `${pluginName} saw no module resolutions at all, so no import was checked. The bundler is not ` +
+            'calling `normalModuleFactory.afterResolve` as this plugin expects.',
+        ),
+      );
+      return;
+    }
+
+    if (offenders.size === 0) {
+      return;
+    }
+
+    const detail = Array.from(offenders, ([file, requests]) => `  ${file} imports ${[...requests].join(', ')}`);
+    const stale = Array.from(offenders.keys()).some((file) => !confirmedThisCompilation.has(file));
+
     compilation.errors.push(
       new Error(
-        `${pluginName}: these imports reach into the internals of @openmrs/esm-framework, which bundles a ` +
-          "private copy of that package rather than sharing the app shell's. Import from " +
-          "'@openmrs/esm-framework' instead:\n" +
-          detail.join('\n'),
+        `${pluginName}: these imports reach into the internals of @openmrs/esm-framework. Importing one of its ` +
+          "packages directly bundles a private copy of that package instead of sharing the app shell's, which " +
+          `duplicates the state the framework holds in it. Import from '${facade}' instead:\n` +
+          detail.join('\n') +
+          (stale
+            ? '\nSome of these were found in an earlier compilation of this build. Restart the build once they ' +
+              'are fixed.'
+            : ''),
       ),
     );
   }

--- a/packages/tooling/framework-import-guard/src/index.ts
+++ b/packages/tooling/framework-import-guard/src/index.ts
@@ -1,0 +1,191 @@
+/**
+ * A webpack/rspack plugin that fails a build which reaches into the framework's internals.
+ *
+ * `@openmrs/esm-framework` is a facade over a set of sibling packages (`@openmrs/esm-state`,
+ * `@openmrs/esm-styleguide`, `@openmrs/esm-api`, ...) and only the facade is a Module Federation
+ * share key. Federation matches shares against the literal import request, so importing a sibling
+ * by name never becomes a consume-share: it statically links that package into the app. Where the
+ * package carries module-level state — `esm-state`'s store registry, the extension registry, the
+ * config store — the app then runs against its own copy of state the framework treats as a
+ * singleton. Nothing fails loudly; the app simply stops sharing stores with everything else on the
+ * page.
+ *
+ * The one legitimate exception is SCSS reaching into `@openmrs/esm-styleguide` for rules and
+ * variables, which is a stylesheet-level dependency and carries no runtime state.
+ */
+
+interface StatsModuleReason {
+  moduleName?: string | null;
+  userRequest?: string | null;
+}
+
+interface StatsModule {
+  name?: string | null;
+  reasons?: Array<StatsModuleReason>;
+}
+
+interface Compilation {
+  errors: Array<Error>;
+  warnings: Array<Error>;
+  getStats(): { toJson(options: Record<string, boolean>): { modules?: Array<StatsModule> } };
+}
+
+interface Compiler {
+  /** The directory the build runs in, i.e. the root of the app being built. */
+  context: string;
+  hooks: {
+    afterEmit: {
+      tap(name: string, callback: (compilation: Compilation) => void): void;
+    };
+  };
+}
+
+export interface FrameworkImportGuardOptions {
+  /**
+   * Packages that may be imported directly. Anything else belonging to the framework is an error.
+   */
+  allowedPackages?: Array<string>;
+  /**
+   * The framework packages to guard. Only needed where they cannot be discovered from the
+   * framework's own manifest, such as an installation that hides transitive dependencies.
+   */
+  frameworkPackages?: Array<string>;
+}
+
+const pluginName = 'FrameworkImportGuardPlugin';
+
+/**
+ * Matches a module belonging to a framework package. Covers an ordinary `node_modules/@openmrs/...`
+ * install, pnpm's `node_modules/.pnpm/@openmrs+esm-state@.../node_modules/@openmrs/...` layout, and
+ * the workspace paths (`../../framework/esm-styleguide/...`) used when the framework is built from
+ * source alongside the app.
+ */
+const frameworkModulePattern = /(?:node_modules[\\/]@openmrs[\\/]|[\\/]framework[\\/])esm-[a-z-]+[\\/]/;
+
+const stylesheetPattern = /\.(?:s[ac]ss|css)\b/;
+
+/** Module Federation's own wrappers; what they reach is the share or the fallback behind it. */
+function isFederationModule(name: string) {
+  return name.startsWith('consume shared module') || name.startsWith('provide shared module');
+}
+
+const frameworkManifest = '@openmrs/esm-framework/package.json';
+
+/**
+ * The framework's siblings, read from the framework's own dependencies so that a package added
+ * upstream is covered without a change here.
+ *
+ * Resolution starts from the directory being built rather than from this package. That is the copy
+ * of `@openmrs/esm-framework` whose internals the app could reach into, and in a single-app repo
+ * this plugin arrives as a transitive dependency of `openmrs`, from where the framework is not
+ * guaranteed to resolve at all. Resolution from this package is the fallback, for a monorepo whose
+ * apps have no local copy of the framework.
+ */
+function getFrameworkPackages(context: string): Array<string> {
+  const locations = [() => require.resolve(frameworkManifest, { paths: [context] }), () => require.resolve(frameworkManifest)];
+
+  for (const locate of locations) {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const { dependencies } = require(locate());
+      const siblings = Object.keys(dependencies ?? {}).filter((dependency) => dependency.startsWith('@openmrs/'));
+
+      if (siblings.length > 0) {
+        return siblings;
+      }
+    } catch {
+      // Try the next location.
+    }
+  }
+
+  return [];
+}
+
+function packageOf(request: string, packages: Array<string>) {
+  return packages.find((pkg) => request === pkg || request.startsWith(`${pkg}/`));
+}
+
+export class FrameworkImportGuardPlugin {
+  private readonly allowedPackages: Array<string>;
+  private readonly frameworkPackages: Array<string> | undefined;
+
+  constructor({
+    allowedPackages = ['@openmrs/esm-framework'],
+    frameworkPackages,
+  }: FrameworkImportGuardOptions = {}) {
+    this.allowedPackages = allowedPackages;
+    this.frameworkPackages = frameworkPackages;
+  }
+
+  apply(compiler: Compiler) {
+    compiler.hooks.afterEmit.tap(pluginName, (compilation) => {
+      const known = this.frameworkPackages ?? getFrameworkPackages(compiler.context);
+      const guarded = known.filter((pkg) => !this.allowedPackages.includes(pkg));
+
+      if (guarded.length === 0) {
+        compilation.warnings.push(
+          new Error(
+            `${pluginName} could not read the dependencies of @openmrs/esm-framework, so imports of ` +
+              'framework packages were not checked. Pass `frameworkPackages` to check them anyway.',
+          ),
+        );
+        return;
+      }
+
+      const { modules = [] } = compilation.getStats().toJson({ all: false, modules: true, reasons: true });
+      const offenders = new Map<string, Set<string>>();
+
+      for (const module of modules) {
+        const moduleName = module.name ?? '';
+
+        if (isFederationModule(moduleName)) {
+          continue;
+        }
+
+        for (const reason of module.reasons ?? []) {
+          const request = reason.userRequest ?? '';
+          const issuer = reason.moduleName ?? '';
+          const pkg = packageOf(request, guarded);
+
+          if (!pkg) {
+            continue;
+          }
+
+          // Imports between framework packages are the framework's own business.
+          if (isFederationModule(issuer) || frameworkModulePattern.test(issuer)) {
+            continue;
+          }
+
+          // SCSS pulls rules and variables straight out of the styleguide. That is a stylesheet
+          // dependency with no runtime state behind it, so it is allowed.
+          if (
+            pkg === '@openmrs/esm-styleguide' &&
+            (stylesheetPattern.test(issuer) || stylesheetPattern.test(moduleName) || stylesheetPattern.test(request))
+          ) {
+            continue;
+          }
+
+          const requests = offenders.get(issuer) ?? new Set<string>();
+          requests.add(request);
+          offenders.set(issuer, requests);
+        }
+      }
+
+      if (offenders.size === 0) {
+        return;
+      }
+
+      const detail = Array.from(offenders, ([issuer, requests]) => `  ${issuer} imports ${[...requests].join(', ')}`);
+      compilation.errors.push(
+        new Error(
+          `${pluginName}: these imports reach into the internals of @openmrs/esm-framework, which bundles a ` +
+            "private copy of that package rather than sharing the app shell's. Import from " +
+            "'@openmrs/esm-framework' instead:\n" +
+            detail.join('\n'),
+        ),
+      );
+    });
+  }
+}
+
+export default FrameworkImportGuardPlugin;

--- a/packages/tooling/framework-import-guard/src/integration.test.ts
+++ b/packages/tooling/framework-import-guard/src/integration.test.ts
@@ -1,0 +1,152 @@
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { rspack } from '@rspack/core';
+import { describe, expect, it } from 'vitest';
+import webpack from 'webpack';
+import { FrameworkImportGuardPlugin } from './index';
+
+/**
+ * The unit tests drive the plugin's hooks directly, which means they assert the shape the plugin
+ * assumes rather than the shape a bundler supplies. These build a real fixture with each bundler
+ * instead, which is the only way to cover what the stubs cannot: that the hooks exist and fire in
+ * the expected order, that a resolution really does carry the literal request and its issuer, that
+ * an error raised where the plugin raises it fails the build, and that none of it is undone by
+ * production optimisations. Every regression these catch was one the stubs let through.
+ *
+ * The fixture carries its own `node_modules`, so the tests neither build nor resolve any workspace
+ * package and run in about a second each.
+ */
+
+interface Fixture {
+  root: string;
+  entry: string;
+}
+
+function fixture({ entry, peerDependencies = {} }: { entry: string; peerDependencies?: Record<string, string> }) {
+  const root = mkdtempSync(join(tmpdir(), 'framework-import-guard-'));
+
+  const addPackage = (name: string, manifest: Record<string, unknown>, source: string) => {
+    const dir = join(root, 'node_modules', ...name.split('/'));
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, 'package.json'),
+      JSON.stringify({ name, version: '10.0.0', main: 'index.js', ...manifest }),
+    );
+    writeFileSync(join(dir, 'index.js'), source);
+  };
+
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({ name: 'fixture-app', version: '1.0.0', peerDependencies }),
+  );
+  writeFileSync(join(root, 'entry.js'), entry);
+  writeFileSync(join(root, 'unrelated.js'), 'export const unrelated = 1;\n');
+
+  // A stand-in framework: the facade plus the two siblings the tests reach for. Discovery reads the
+  // sibling list out of this manifest exactly as it would from a real install.
+  addPackage(
+    '@openmrs/esm-framework',
+    { dependencies: { '@openmrs/esm-state': '*', '@openmrs/esm-styleguide': '*' } },
+    "export { createGlobalStore } from '@openmrs/esm-state';\n",
+  );
+  addPackage('@openmrs/esm-state', {}, 'export const createGlobalStore = () => ({});\n');
+  addPackage('@openmrs/esm-styleguide', {}, 'export const showToast = () => {};\n');
+
+  return { root, entry: join(root, 'entry.js') };
+}
+
+function config({ root, entry }: Fixture) {
+  return {
+    mode: 'production' as const,
+    context: root,
+    entry,
+    output: { path: join(root, 'out'), filename: 'bundle.js' },
+    resolve: { modules: [join(root, 'node_modules'), 'node_modules'] },
+    plugins: [new FrameworkImportGuardPlugin()],
+  };
+}
+
+/** Returns the guard's messages, plus whether the build failed at all. */
+function build(bundler: typeof webpack | typeof rspack, target: Fixture) {
+  return new Promise<{ failed: boolean; guard: Array<string>; other: Array<string> }>((settle, fail) => {
+    // Both bundlers accept this config; their types disagree only on fields the fixture omits.
+    (bundler as typeof webpack)(config(target) as Parameters<typeof webpack>[0], (error, stats) => {
+      if (error || !stats) {
+        fail(error ?? new Error('no stats'));
+        return;
+      }
+
+      const messages = (stats.toJson({ all: false, errors: true }).errors ?? []).map(({ message }) => message ?? '');
+      settle({
+        failed: stats.hasErrors(),
+        guard: messages.filter((message) => message.includes('FrameworkImportGuardPlugin')),
+        other: messages.filter((message) => !message.includes('FrameworkImportGuardPlugin')),
+      });
+    });
+  });
+}
+
+const bundlers: Array<[string, typeof webpack | typeof rspack]> = [
+  ['webpack', webpack],
+  ['rspack', rspack],
+];
+
+describe.each(bundlers)('%s', (name, bundler) => {
+  it('fails a production build that imports a framework package directly', async () => {
+    // Production means `concatenateModules` is on, which folds the offending import into a
+    // scope-hoisted module. Detection has to survive that.
+    const { failed, guard } = await build(
+      bundler,
+      fixture({
+        entry: "import { createGlobalStore } from '@openmrs/esm-state';\n\nconsole.log(createGlobalStore);\n",
+      }),
+    );
+
+    expect(guard).toHaveLength(1);
+    expect(guard[0]).toContain('./entry.js imports @openmrs/esm-state');
+    expect(failed).toBe(true);
+  }, 60_000);
+
+  it('passes a build that goes through the facade', async () => {
+    const { failed, guard } = await build(
+      bundler,
+      fixture({
+        entry:
+          "import { createGlobalStore } from '@openmrs/esm-framework';\nimport { unrelated } from './unrelated.js';\n\nconsole.log(createGlobalStore, unrelated);\n",
+      }),
+    );
+
+    expect(guard).toHaveLength(0);
+    expect(failed).toBe(false);
+  }, 60_000);
+
+  it('allows a sibling the app peer-depends on', async () => {
+    const { failed, guard } = await build(
+      bundler,
+      fixture({
+        entry: "import { createGlobalStore } from '@openmrs/esm-state';\n\nconsole.log(createGlobalStore);\n",
+        peerDependencies: { '@openmrs/esm-framework': '10.x', '@openmrs/esm-state': '10.x' },
+      }),
+    );
+
+    expect(guard).toHaveLength(0);
+    expect(failed).toBe(false);
+  }, 60_000);
+
+  it('reports the import even when the build has an unrelated error', async () => {
+    // `optimization.emitOnErrors` is false in production, so a compilation carrying any other error
+    // never reaches `afterEmit`. Reporting from there hid the violation until everything else was
+    // fixed.
+    const { guard, other } = await build(
+      bundler,
+      fixture({
+        entry:
+          "import { createGlobalStore } from '@openmrs/esm-state';\nimport 'a-package-that-does-not-exist';\n\nconsole.log(createGlobalStore);\n",
+      }),
+    );
+
+    expect(other.length).toBeGreaterThan(0);
+    expect(guard).toHaveLength(1);
+  }, 60_000);
+});

--- a/packages/tooling/framework-import-guard/tsconfig.json
+++ b/packages/tooling/framework-import-guard/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "declaration": true,
+    "esModuleInterop": true,
+    "module": "CommonJS",
+    "target": "es2015",
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "strictNullChecks": true,
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "lib": ["es5", "es2015", "es2015.promise", "es2016.array.include", "es2018"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["src/**/*.test.ts"]
+}

--- a/packages/tooling/framework-import-guard/vitest.config.ts
+++ b/packages/tooling/framework-import-guard/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    mockReset: true,
+  },
+});

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -52,6 +52,7 @@
   "dependencies": {
     "@inquirer/prompts": "8.3.2",
     "@openmrs/esm-app-shell": "workspace:*",
+    "@openmrs/framework-import-guard": "workspace:*",
     "@openmrs/rspack-config": "workspace:*",
     "@openmrs/webpack-config": "workspace:*",
     "@pnpm/npm-conf": "^3.0.2",

--- a/packages/tooling/rspack-config/package.json
+++ b/packages/tooling/rspack-config/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/openmrs/openmrs-esm-core#readme",
   "dependencies": {
     "@module-federation/enhanced": "2.8.1",
+    "@openmrs/framework-import-guard": "workspace:*",
     "@rspack/cli": "1.7.9",
     "@rspack/core": "1.7.9",
     "@swc/core": "1.15.21",

--- a/packages/tooling/rspack-config/src/index.ts
+++ b/packages/tooling/rspack-config/src/index.ts
@@ -44,6 +44,7 @@ import { TsCheckerRspackPlugin } from 'ts-checker-rspack-plugin';
 import { isArray, merge, mergeWith } from 'lodash';
 import { inc, parse } from 'semver';
 import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
+import { FrameworkImportGuardPlugin } from '@openmrs/framework-import-guard';
 import rspack, {
   CopyRspackPlugin,
   DefinePlugin,
@@ -420,6 +421,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
           chunks: true,
         },
       }),
+      new FrameworkImportGuardPlugin(),
     ].filter(Boolean),
     resolve: {
       extensions: ['.tsx', '.ts', '.jsx', '.js', '.scss', '.json'],

--- a/packages/tooling/rspack-config/src/index.ts
+++ b/packages/tooling/rspack-config/src/index.ts
@@ -421,7 +421,6 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
           chunks: true,
         },
       }),
-      new FrameworkImportGuardPlugin(),
     ].filter(Boolean),
     resolve: {
       extensions: ['.tsx', '.ts', '.jsx', '.js', '.scss', '.json'],
@@ -442,5 +441,12 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
     }),
     ...overrides,
   };
-  return mergeWith(baseConfig, additionalConfig, mergeFunction);
+  const config = mergeWith(baseConfig, additionalConfig, mergeFunction);
+
+  // Appended after the merge rather than listed above, because `overrides.plugins` replaces the
+  // plugin array wholesale and an app doing that would drop the guard without noticing. Same
+  // reasoning as the `ExternalsPlugin` block above, which avoids `externals` for the same reason.
+  config.plugins = [...(config.plugins ?? []), new FrameworkImportGuardPlugin()];
+
+  return config;
 };

--- a/packages/tooling/webpack-config/package.json
+++ b/packages/tooling/webpack-config/package.json
@@ -32,6 +32,7 @@
   "homepage": "https://github.com/openmrs/openmrs-esm-core#readme",
   "dependencies": {
     "@module-federation/enhanced": "2.8.1",
+    "@openmrs/framework-import-guard": "workspace:*",
     "@swc/core": "1.15.21",
     "clean-webpack-plugin": "4.0.0",
     "copy-webpack-plugin": "11.0.0",

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -45,6 +45,7 @@ import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 import { isArray, merge, mergeWith } from 'lodash';
 import { inc, parse } from 'semver';
 import { ModuleFederationPlugin } from '@module-federation/enhanced/webpack';
+import { FrameworkImportGuardPlugin } from '@openmrs/framework-import-guard';
 import {
   BannerPlugin,
   DefinePlugin,
@@ -414,6 +415,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
           chunks: true,
         },
       }),
+      new FrameworkImportGuardPlugin(),
     ].filter(Boolean),
     resolve: {
       extensions: ['.tsx', '.ts', '.jsx', '.js', '.scss', '.json'],

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -415,7 +415,6 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
           chunks: true,
         },
       }),
-      new FrameworkImportGuardPlugin(),
     ].filter(Boolean),
     resolve: {
       extensions: ['.tsx', '.ts', '.jsx', '.js', '.scss', '.json'],
@@ -429,5 +428,12 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
     },
     ...overrides,
   };
-  return mergeWith(baseConfig, additionalConfig, mergeFunction);
+  const config = mergeWith(baseConfig, additionalConfig, mergeFunction);
+
+  // Appended after the merge rather than listed above, because `overrides.plugins` replaces the
+  // plugin array wholesale and an app doing that would drop the guard without noticing. Same
+  // reasoning as the `ExternalsPlugin` block above, which avoids `externals` for the same reason.
+  config.plugins = [...(config.plugins ?? []), new FrameworkImportGuardPlugin()];
+
+  return config;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3854,9 +3854,11 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@openmrs/framework-import-guard@workspace:packages/tooling/framework-import-guard"
   dependencies:
+    "@rspack/core": "npm:1.7.9"
     cross-env: "npm:^7.0.3"
     typescript: "npm:^5.8.3"
     vitest: "npm:^4.1.2"
+    webpack: "npm:5.105.3"
   languageName: unknown
   linkType: soft
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3850,6 +3850,16 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@openmrs/framework-import-guard@workspace:*, @openmrs/framework-import-guard@workspace:packages/tooling/framework-import-guard":
+  version: 0.0.0-use.local
+  resolution: "@openmrs/framework-import-guard@workspace:packages/tooling/framework-import-guard"
+  dependencies:
+    cross-env: "npm:^7.0.3"
+    typescript: "npm:^5.8.3"
+    vitest: "npm:^4.1.2"
+  languageName: unknown
+  linkType: soft
+
 "@openmrs/integration-tests@workspace:packages/tooling/integration-tests":
   version: 0.0.0-use.local
   resolution: "@openmrs/integration-tests@workspace:packages/tooling/integration-tests"
@@ -3874,6 +3884,7 @@ __metadata:
   resolution: "@openmrs/rspack-config@workspace:packages/tooling/rspack-config"
   dependencies:
     "@module-federation/enhanced": "npm:2.8.1"
+    "@openmrs/framework-import-guard": "workspace:*"
     "@rspack/cli": "npm:1.7.9"
     "@rspack/core": "npm:1.7.9"
     "@swc/core": "npm:1.15.21"
@@ -3955,6 +3966,7 @@ __metadata:
   resolution: "@openmrs/webpack-config@workspace:packages/tooling/webpack-config"
   dependencies:
     "@module-federation/enhanced": "npm:2.8.1"
+    "@openmrs/framework-import-guard": "workspace:*"
     "@swc/core": "npm:1.15.21"
     "@types/lodash-es": "npm:4.17.12"
     "@types/semver": "npm:^7.7.3"
@@ -9936,7 +9948,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
+"cross-env@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "cross-env@npm:7.0.3"
+  dependencies:
+    cross-spawn: "npm:^7.0.1"
+  bin:
+    cross-env: src/bin/cross-env.js
+    cross-env-shell: src/bin/cross-env-shell.js
+  checksum: 10/e99911f0d31c20e990fd92d6fd001f4b01668a303221227cc5cb42ed155f086351b1b3bd2699b200e527ab13011b032801f8ce638e6f09f854bdf744095e604c
+  languageName: node
+  linkType: hard
+
+"cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.3, cross-spawn@npm:^7.0.6":
   version: 7.0.6
   resolution: "cross-spawn@npm:7.0.6"
   dependencies:
@@ -15821,6 +15845,7 @@ __metadata:
     "@inquirer/prompts": "npm:8.3.2"
     "@inquirer/testing": "npm:^3.3.2"
     "@openmrs/esm-app-shell": "workspace:*"
+    "@openmrs/framework-import-guard": "workspace:*"
     "@openmrs/rspack-config": "workspace:*"
     "@openmrs/webpack-config": "workspace:*"
     "@pnpm/npm-conf": "npm:^3.0.2"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->

Our Module Federation setup for the framework library relies on the framework only being included once and being included via imports from `@openmrs/esm-framework` (or `@openmrs/esm-framework/src/internal`). Patterns other than these, i.e., directly importing `@openmrs/esm-styleguide` is Typescript code do not properly exclude the code imported that way from the bundle. Thus, resulting bundles end up with relatively large, unnecessary and in some cases harmful extra copies of the framework library.

This PR aims to stop that behaviour through a RSpack / Webpack plugin that analyzes dependencies and fails the build if any direct imports of framework components are found.

There is one case we do allow these imports, Sass files. Our examples, documentation, and at least the template app all have stuff like this:

```scss
@uses @openmrs/esm-styleguide/var as *;
```

This continues to be supported.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

### Notes on Sass support

Technically, with `@uses` (as opposed to the deprecated `@import`), Sass itself does the resolution, so there's no pathway for this plugin to interfere. Nevertheless, it includes and explicit exclusion in case Sass or the Sass Loader revert to using RSpack / Webpack's resolution instead of their own.

### Rejected Changes

Initially, I thought, the easy way to do this would just be to federate all the framework sub-parts as well. Things would be re-written so that at runtime, everything pointed to the same copy. This turned out to be a bad idea because marking each sub-part of the framework as a MF share means not only does it have to become a separate "chunk", but ultimately a separate JS file in the final bundle. Thus, making this change would force the shell to fetch 30 more JS files before starting which is likely to cause the shell to appear to perform worse.