### PR TITLE
(BREAKING) O3-5853: Use browserslist to compile JS in modern format

### DIFF
--- a/.changeset/little-toes-know.md
+++ b/.changeset/little-toes-know.md
@@ -1,0 +1,8 @@
+---
+"@openmrs/esm-app-shell": patch
+"@openmrs/rspack-config": major
+"@openmrs/webpack-config": major
+"openmrs": major
+---
+
+(BREAKING) O3-5853: Use browserslist to compile JS in modern format

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -43,6 +43,7 @@
     "@openmrs/esm-styleguide": "workspace:*",
     "@rspack/cli": "1.7.9",
     "@rspack/core": "1.7.9",
+    "browserslist-config-openmrs": "^1.0.1",
     "dayjs": "^1.11.13",
     "dexie": "^3.0.3",
     "html-webpack-plugin": "5.6.6",

--- a/packages/shell/esm-app-shell/package.json
+++ b/packages/shell/esm-app-shell/package.json
@@ -19,9 +19,6 @@
     "openmrs",
     "microfrontends"
   ],
-  "browserslist": [
-    "extends browserslist-config-openmrs"
-  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/openmrs/openmrs-esm-core.git"
@@ -64,6 +61,7 @@
   },
   "devDependencies": {
     "@module-federation/runtime-core": "2.8.1",
+    "browserslist": "4.28.9",
     "cross-env": "^10.1.0",
     "vitest": "^4.1.2"
   }

--- a/packages/shell/esm-app-shell/rspack.config.js
+++ b/packages/shell/esm-app-shell/rspack.config.js
@@ -21,6 +21,16 @@ const frameworkVersion = require('@openmrs/esm-framework/package.json').version;
 
 const timestamp = getTimestamp();
 const production = 'production';
+
+/**
+ * The browserslist queries swc compiles the app shell for. Given no target, swc down-levels to ES5 and
+ * every supported browser pays for transform helpers it doesn't need.
+ *
+ * Read from `browserslist-config-openmrs` rather than through this package's own `browserslist` field,
+ * as swc can't follow the extends we were using.
+ */
+const browserTargets = require('browserslist-config-openmrs');
+
 const allowedSuffixes = ['-app', '-widgets'];
 
 const openmrsAddCookie = process.env.OMRS_ADD_COOKIE;
@@ -237,7 +247,9 @@ module.exports = (env, argv = []) => {
       publicPath: '',
       hashFunction: 'xxhash64',
     },
-    target: 'web',
+    // set targets for the rspack runtime code which is not run through swc
+    // targets are expanded here because rspack can't properly handle browserlist extends
+    target: ['web', `browserslist:${browserTargets.join(', ')}`],
     // Module Federation v1.5 is incompatible with lazy compilation
     lazyCompilation: false,
     devServer: {
@@ -369,6 +381,12 @@ module.exports = (env, argv = []) => {
           use: [
             {
               loader: 'builtin:swc-loader',
+              options: {
+                // No `jsc.parser`, so that swc keeps inferring syntax from each file's extension.
+                env: {
+                  targets: browserTargets,
+                },
+              },
             },
           ],
         },

--- a/packages/shell/esm-app-shell/rspack.config.js
+++ b/packages/shell/esm-app-shell/rspack.config.js
@@ -23,11 +23,13 @@ const timestamp = getTimestamp();
 const production = 'production';
 
 /**
- * The browserslist queries swc compiles the app shell for. Given no target, swc down-levels to ES5 and
- * every supported browser pays for transform helpers it doesn't need.
+ * The browserslist queries the app shell is built for, driving both swc and rspack's own runtime. Given
+ * no target at all swc down-levels to ES5, and every supported browser pays for transform helpers it
+ * doesn't need.
  *
- * Read from `browserslist-config-openmrs` rather than through this package's own `browserslist` field,
- * as swc can't follow the extends we were using.
+ * Read straight from `browserslist-config-openmrs`, so frontend RFC 0003 is the single source of truth
+ * here as it is for the modules built by the shared configs. Those resolve a module's own browserslist
+ * config first; the app shell has no reason to differ from the policy, and doesn't declare one.
  */
 const browserTargets = require('browserslist-config-openmrs');
 
@@ -247,8 +249,10 @@ module.exports = (env, argv = []) => {
       publicPath: '',
       hashFunction: 'xxhash64',
     },
-    // set targets for the rspack runtime code which is not run through swc
-    // targets are expanded here because rspack can't properly handle browserlist extends
+    // Governs the runtime and chunk-loading glue rspack writes itself, which swc never sees. The
+    // queries are inlined because this package declares no browserslist config of its own, and rspack
+    // answers a bare `browserslist` target with browserslist's `defaults` — browsers far older than O3
+    // supports — rather than reporting that it found nothing.
     target: ['web', `browserslist:${browserTargets.join(', ')}`],
     // Module Federation v1.5 is incompatible with lazy compilation
     lazyCompilation: false,

--- a/packages/shell/esm-app-shell/src/browser-targets.test.ts
+++ b/packages/shell/esm-app-shell/src/browser-targets.test.ts
@@ -1,0 +1,75 @@
+// The app shell is the one bundle every O3 page loads, and it configures its own browser targets rather
+// than going through `@openmrs/rspack-config`, so the checks over there don't cover it. These pin that
+// it compiles and generates its runtime for the browsers frontend RFC 0003 names, rather than falling
+// back to swc's ES5 default or rspack's conservative `web` runtime.
+import { resolve } from 'node:path';
+import browserslist from 'browserslist';
+import { describe, expect, it } from 'vitest';
+
+const shellRoot = resolve(__dirname, '..');
+
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const openmrsQueries: string[] = require('browserslist-config-openmrs');
+
+/**
+ * The app shell's rspack config, as a production build produces it.
+ *
+ * Loaded from `shellRoot` because the config resolves paths and the styleguide stylesheet relative to
+ * its own directory.
+ */
+async function loadShellConfig() {
+  const originalCwd = process.cwd();
+  process.chdir(shellRoot);
+
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require('../rspack.config.js')({}, { mode: 'production' }) as Record<string, any>;
+  } finally {
+    process.chdir(originalCwd);
+  }
+}
+
+describe('the app shell build', () => {
+  it('compiles its sources for the browsers RFC 0003 supports', async () => {
+    const config = await loadShellConfig();
+    const rule = config.module.rules.find((candidate: { test?: RegExp }) => candidate.test?.test?.('index.ts'));
+    const options = Array.isArray(rule.use) ? rule.use[0].options : rule.options ?? rule.use?.options;
+
+    // Queries, not resolved versions: swc resolves them with a Rust port of browserslist whose bundled
+    // browser data is older than this repo's.
+    expect(options.env.targets).toEqual(openmrsQueries);
+
+    // swc rejects the two together, so a `jsc.target` creeping in would break the build outright.
+    expect(options.jsc?.target).toBeUndefined();
+  });
+
+  it('generates its runtime for those browsers too', async () => {
+    const config = await loadShellConfig();
+    expect(config.target).toEqual(['web', `browserslist:${openmrsQueries.join(', ')}`]);
+
+    const { default: rspack } = await import('@rspack/core');
+    const compiler = (rspack as unknown as (options: unknown) => any)({
+      context: shellRoot,
+      target: config.target,
+    });
+    const { environment } = compiler.options.output;
+    await new Promise<void>((res) => compiler.close(() => res()));
+
+    // What a bare `web` target leaves off, and the reason the target is set at all.
+    expect(environment.dynamicImport).toBe(true);
+    expect(environment.globalThis).toBe(true);
+    expect(environment.arrowFunction).toBe(true);
+  });
+
+  it('targets the same browsers the shared module configs do', async () => {
+    // The app shell reads the policy package directly while the shared configs resolve a module's own
+    // browserslist config first. Nothing forces those to agree, so this is what catches them drifting.
+    const config = await loadShellConfig();
+    const rule = config.module.rules.find((candidate: { test?: RegExp }) => candidate.test?.test?.('index.ts'));
+    const options = Array.isArray(rule.use) ? rule.use[0].options : rule.options ?? rule.use?.options;
+
+    expect(browserslist(options.env.targets)).toEqual(
+      browserslist(['extends browserslist-config-openmrs'], { path: shellRoot }),
+    );
+  });
+});

--- a/packages/shell/esm-app-shell/src/events.test.ts
+++ b/packages/shell/esm-app-shell/src/events.test.ts
@@ -1,0 +1,58 @@
+// `getCurrentUser()` hands a new subscriber the session store's current state during `subscribe()`, so
+// an already-authenticated session arrives before `subscribe()` returns. This file pins what has to hold
+// on that synchronous first emission, which is where naming the subscription in order to stop it from
+// inside its own callback used to fail — the binding is still in its temporal dead zone, and the throw
+// took `setupOptionalDependencies()` with it. ES5 output hid the whole thing behind `var` hoisting.
+import { describe, expect, it, vi } from 'vitest';
+
+const harness = vi.hoisted(() => ({
+  startedHandlers: [] as Array<() => void>,
+  setupCount: 0,
+  teardownCount: 0,
+  pushSession: null as null | ((session: { authenticated: boolean }) => void),
+}));
+
+vi.mock('./optionaldeps', () => ({
+  setupOptionalDependencies: () => {
+    harness.setupCount++;
+  },
+}));
+
+vi.mock('@openmrs/esm-framework/src/internal', async () => {
+  const { Observable } = await import('rxjs');
+
+  return {
+    cleanupObsoleteFeatureFlags: () => {},
+    subscribeOpenmrsEvent: (name: string, handler: () => void) => {
+      if (name === 'started') {
+        harness.startedHandlers.push(handler);
+      }
+    },
+    // Mirrors `current-user.ts`, which calls its store handler before returning the teardown.
+    getCurrentUser: () =>
+      new Observable<{ authenticated: boolean }>((subscriber) => {
+        subscriber.next({ authenticated: true });
+        harness.pushSession = (session) => subscriber.next(session);
+
+        return () => {
+          harness.teardownCount++;
+        };
+      }),
+  };
+});
+
+describe('the started event', () => {
+  it('sets up optional dependencies once, and stops listening, on a synchronous session', async () => {
+    await import('./events');
+    harness.startedHandlers.forEach((handler) => handler());
+
+    // Reading the subscription during this emission throws, which is what left the app shell showing an
+    // error and no optional dependencies registered.
+    expect(harness.setupCount).toBe(1);
+    expect(harness.teardownCount).toBe(1);
+
+    // And the run under ES5 output, where the failed `unsubscribe()` let a later session set up again.
+    harness.pushSession?.({ authenticated: true });
+    expect(harness.setupCount).toBe(1);
+  });
+});

--- a/packages/shell/esm-app-shell/src/events.test.ts
+++ b/packages/shell/esm-app-shell/src/events.test.ts
@@ -1,8 +1,9 @@
 // `getCurrentUser()` hands a new subscriber the session store's current state during `subscribe()`, so
-// an already-authenticated session arrives before `subscribe()` returns. This file pins what has to hold
-// on that synchronous first emission, which is where naming the subscription in order to stop it from
-// inside its own callback used to fail — the binding is still in its temporal dead zone, and the throw
-// took `setupOptionalDependencies()` with it. ES5 output hid the whole thing behind `var` hoisting.
+// its first emission arrives before `subscribe()` returns, and is usually an unauthenticated session.
+// Both of those shape the code under test: the first is why the subscription cannot be stopped by name
+// from inside its own callback, and the second is why the authenticated filter has to run before
+// `take(1)`. These pin optional dependencies being set up exactly once, on the first authenticated
+// session, whichever emission that turns out to be.
 import { describe, expect, it, vi } from 'vitest';
 
 const harness = vi.hoisted(() => ({
@@ -10,6 +11,8 @@ const harness = vi.hoisted(() => ({
   setupCount: 0,
   teardownCount: 0,
   pushSession: null as null | ((session: { authenticated: boolean }) => void),
+  /** What the store already holds when a subscriber arrives, emitted synchronously. */
+  initialSession: { authenticated: true },
 }));
 
 vi.mock('./optionaldeps', () => ({
@@ -31,8 +34,8 @@ vi.mock('@openmrs/esm-framework/src/internal', async () => {
     // Mirrors `current-user.ts`, which calls its store handler before returning the teardown.
     getCurrentUser: () =>
       new Observable<{ authenticated: boolean }>((subscriber) => {
-        subscriber.next({ authenticated: true });
         harness.pushSession = (session) => subscriber.next(session);
+        subscriber.next(harness.initialSession);
 
         return () => {
           harness.teardownCount++;
@@ -41,17 +44,49 @@ vi.mock('@openmrs/esm-framework/src/internal', async () => {
   };
 });
 
-describe('the started event', () => {
-  it('sets up optional dependencies once, and stops listening, on a synchronous session', async () => {
-    await import('./events');
-    harness.startedHandlers.forEach((handler) => handler());
+/** Imports `events.ts` fresh and fires the `started` handlers it registered. */
+async function startAppShell() {
+  vi.resetModules();
+  harness.startedHandlers.length = 0;
+  harness.setupCount = 0;
+  harness.teardownCount = 0;
+  harness.pushSession = null;
 
-    // Reading the subscription during this emission throws, which is what left the app shell showing an
-    // error and no optional dependencies registered.
+  await import('./events');
+  harness.startedHandlers.forEach((handler) => handler());
+}
+
+describe('the started event', () => {
+  it('sets up optional dependencies once when the session is authenticated already', async () => {
+    harness.initialSession = { authenticated: true };
+    await startAppShell();
+
+    // Reading the subscription during this emission throws, which left the app shell showing an error
+    // and no optional dependencies registered.
     expect(harness.setupCount).toBe(1);
     expect(harness.teardownCount).toBe(1);
 
-    // And the run under ES5 output, where the failed `unsubscribe()` let a later session set up again.
+    harness.pushSession?.({ authenticated: true });
+    expect(harness.setupCount).toBe(1);
+  });
+
+  it('waits for authentication when the first session is anonymous', async () => {
+    // The ordinary startup path. With `take(1)` ahead of the filter this emission is consumed and
+    // nothing is ever set up.
+    harness.initialSession = { authenticated: false };
+    await startAppShell();
+
+    expect(harness.setupCount).toBe(0);
+    expect(harness.teardownCount).toBe(0);
+
+    harness.pushSession?.({ authenticated: false });
+    expect(harness.setupCount).toBe(0);
+
+    harness.pushSession?.({ authenticated: true });
+    expect(harness.setupCount).toBe(1);
+    expect(harness.teardownCount).toBe(1);
+
+    // And it stops listening, rather than setting up again on every later session update.
     harness.pushSession?.({ authenticated: true });
     expect(harness.setupCount).toBe(1);
   });

--- a/packages/shell/esm-app-shell/src/events.ts
+++ b/packages/shell/esm-app-shell/src/events.ts
@@ -3,14 +3,15 @@ import {
   getCurrentUser,
   subscribeOpenmrsEvent,
 } from '@openmrs/esm-framework/src/internal';
+import { filter, take } from 'rxjs/operators';
 import { setupOptionalDependencies } from './optionaldeps';
 
 subscribeOpenmrsEvent('started', () => cleanupObsoleteFeatureFlags());
 subscribeOpenmrsEvent('started', () => {
-  const subscription = getCurrentUser().subscribe((session) => {
-    if (session.authenticated) {
-      subscription?.unsubscribe();
-      setupOptionalDependencies();
-    }
-  });
+  getCurrentUser()
+    .pipe(
+      filter((session) => session.authenticated),
+      take(1),
+    )
+    .subscribe(() => setupOptionalDependencies());
 });

--- a/packages/tooling/integration-tests/__fixtures__/remote-app/src/index.ts
+++ b/packages/tooling/integration-tests/__fixtures__/remote-app/src/index.ts
@@ -1,5 +1,13 @@
-// The smallest thing that still produces a Module Federation remote entry: the app shell only requires
-// that a remote expose `./start`.
-export function startupApp() {
-  return 'started';
+// Body is written to produce a minimal ./start chunk and to be
+// rewritten if things are newer than ES5
+class Startup {
+  #state = 'started';
+
+  get state() {
+    return this.#state;
+  }
+}
+
+export async function startupApp(options?: { state?: string }) {
+  return options?.state ?? new Startup().state;
 }

--- a/packages/tooling/integration-tests/__fixtures__/remote-app/src/index.ts
+++ b/packages/tooling/integration-tests/__fixtures__/remote-app/src/index.ts
@@ -1,5 +1,9 @@
-// Body is written to produce a minimal ./start chunk and to be
-// rewritten if things are newer than ES5
+// The smallest thing that still produces a Module Federation remote entry: the app shell only requires
+// that a remote expose `./start`.
+//
+// The private field, `async` and optional chaining are deliberate. Each is syntax a target older than
+// the browsers O3 supports has to rewrite, which is what lets `browser-targets.test.ts` tell a build
+// compiled for those browsers from one down-levelled to ES5. Don't simplify them away.
 class Startup {
   #state = 'started';
 

--- a/packages/tooling/integration-tests/package.json
+++ b/packages/tooling/integration-tests/package.json
@@ -29,6 +29,8 @@
     "@openmrs/webpack-config": "workspace:*",
     "@rspack/core": "1.7.9",
     "@types/semver": "^7.7.3",
+    "browserslist": "4.28.9",
+    "browserslist-config-openmrs": "^1.0.1",
     "cross-env": "^10.1.0",
     "semver": "^7.7.3",
     "typescript": "^5.8.3",

--- a/packages/tooling/integration-tests/src/browser-targets.test.ts
+++ b/packages/tooling/integration-tests/src/browser-targets.test.ts
@@ -97,6 +97,22 @@ function scratchApp(packageJson: Record<string, unknown>) {
   return root;
 }
 
+/**
+ * A scratch module that reaches the policy through `extends <name>`, alongside a shared config package
+ * of that name exporting `moduleExports`.
+ *
+ * Written into the scratch module's own `node_modules` so the `extends` query resolves from the module
+ * being built, which is where browserslist looks.
+ */
+function scratchAppExtending(name: string, moduleExports: string) {
+  const root = scratchApp({ browserslist: [`extends ${name}`] });
+  const configDir = join(root, 'node_modules', name);
+  mkdirSync(configDir, { recursive: true });
+  writeFileSync(join(configDir, 'package.json'), JSON.stringify({ name, version: '1.0.0', main: 'index.js' }));
+  writeFileSync(join(configDir, 'index.js'), moduleExports);
+  return root;
+}
+
 describe.each(bundlers)('the %s config', (bundler) => {
   it('compiles for the browsers RFC 0003 supports', async () => {
     const options = scriptLoaderOptions(await loadConfigFrom(bundler, fixtureRoot));
@@ -124,6 +140,86 @@ describe.each(bundlers)('the %s config', (bundler) => {
 
     expect(options.env.targets).toEqual(openmrsQueries);
     expect(options.env.targets.some((query: string) => query.startsWith('extends '))).toBe(false);
+  });
+
+  // A shared config is not simply an array of queries, and getting any of this wrong reads as the
+  // module's policy being silently swapped for the OpenMRS default. Each case is pinned against what
+  // browserslist itself resolves, which is also what would fail if the loader borrowed from its internal
+  // `node` entry point ever moved.
+  describe('a shared browserslist config', () => {
+    // Sections keyed by environment, which is the shape Greptile flagged: read as a flat array this
+    // throws, and the catch below would report the module's policy as unloadable and quietly build for
+    // OpenMRS's instead.
+    const envConfig =
+      "module.exports = { production: ['chrome 120'], development: ['chrome 90'], defaults: ['chrome 100'] };";
+
+    it.each([
+      ['production', ['chrome 120']],
+      ['development', ['chrome 90']],
+      // No section of this name, so browserslist falls to `defaults`.
+      ['staging', ['chrome 100']],
+    ])('is read as the %s section when it exports an object of envs', async (env, expected) => {
+      const root = scratchAppExtending('browserslist-config-envs', envConfig);
+      const previous = process.env.BROWSERSLIST_ENV;
+      // Set explicitly rather than left to `NODE_ENV`, which vitest pins to `test`.
+      process.env.BROWSERSLIST_ENV = env;
+      browserslist.clearCaches();
+
+      try {
+        const options = scriptLoaderOptions(await loadConfigFrom(bundler, root));
+
+        expect(options.env.targets).toEqual(expected);
+        // The same section browserslist itself would have picked.
+        expect(browserslist(options.env.targets)).toEqual(
+          browserslist(['extends browserslist-config-envs'], { path: root }),
+        );
+      } finally {
+        process.env.BROWSERSLIST_ENV = previous;
+        browserslist.clearCaches();
+      }
+    });
+
+    it('is unwrapped when it is a transpiled ES module', async () => {
+      const root = scratchAppExtending(
+        'browserslist-config-esm',
+        "exports.__esModule = true;\nexports.default = ['chrome 118'];",
+      );
+      const options = scriptLoaderOptions(await loadConfigFrom(bundler, root));
+
+      expect(options.env.targets).toEqual(['chrome 118']);
+    });
+
+    it('is refused, not loaded, when its name lacks the browserslist-config- prefix', async () => {
+      const root = scratchAppExtending('sneaky-config', "module.exports = ['chrome 100'];");
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        // browserslist declines to `require` a package not named as a browserslist config, and so must
+        // this: an `extends` query otherwise executes whatever package it names.
+        const options = scriptLoaderOptions(await loadConfigFrom(bundler, root));
+        expect(options.env.targets).toEqual(openmrsQueries);
+        expect(options.env.targets).not.toContain('chrome 100');
+      } finally {
+        warn.mockRestore();
+      }
+    });
+
+    it('resolves a config that extends another config', async () => {
+      const root = scratchAppExtending(
+        'browserslist-config-outer',
+        "module.exports = ['extends browserslist-config-inner'];",
+      );
+      const inner = join(root, 'node_modules', 'browserslist-config-inner');
+      mkdirSync(inner, { recursive: true });
+      writeFileSync(
+        join(inner, 'package.json'),
+        JSON.stringify({ name: 'browserslist-config-inner', version: '1.0.0', main: 'index.js' }),
+      );
+      writeFileSync(join(inner, 'index.js'), "module.exports = ['chrome 117'];");
+
+      const options = scriptLoaderOptions(await loadConfigFrom(bundler, root));
+      expect(options.env.targets).toEqual(['chrome 117']);
+    });
   });
 
   it('warns and keeps building when an app names a browserslist config that will not load', async () => {

--- a/packages/tooling/integration-tests/src/browser-targets.test.ts
+++ b/packages/tooling/integration-tests/src/browser-targets.test.ts
@@ -1,0 +1,254 @@
+// Guards that the shared configs compile for the browsers O3 supports rather than letting swc fall back
+// to its ES5 default, which shipped transform helpers and down-levelled syntax to every browser in the
+// support policy. Checks both the targets the configs hand swc and the code a real build emits, since
+// the first can be right while the second is not.
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import browserslist from 'browserslist';
+import { afterAll, describe, expect, it, vi } from 'vitest';
+import { buildFixtureApp, cleanUpFixtureBuilds, fixtureRoot } from './build-fixture';
+
+const bundlers = ['rspack', 'webpack'] as const;
+
+// The policy's queries, as the configs are expected to pass them along.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const openmrsQueries: string[] = require('browserslist-config-openmrs');
+
+// The same policy as concrete browser versions, reached through browserslist's own `extends` handling —
+// the way an OpenMRS module declares it, and a route the configs deliberately don't use. Checks that
+// need to ask what a browser actually supports go through this.
+const openmrsTargets = browserslist(['extends browserslist-config-openmrs'], { path: fixtureRoot });
+
+// Named exactly as swc emits them. Each is the helper for one of the constructs the fixture uses, so if a
+// build stops declaring a target these reappear alongside the syntax checks below failing.
+const es5Helpers = [
+  '_async_to_generator',
+  '_class_call_check',
+  '_class_private_field_get',
+  '_create_class',
+  '_ts_generator',
+];
+
+const tempDirs: string[] = [];
+
+afterAll(() => {
+  cleanUpFixtureBuilds();
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  rmSync(join(__dirname, '..', 'node_modules', '.scratch-apps'), { recursive: true, force: true });
+});
+
+/** The `swc-loader` / `builtin:swc-loader` options a config puts on its JS/TS rule. */
+function scriptLoaderOptions(config: Record<string, any>) {
+  const rule = config.module.rules.find((candidate: { test?: RegExp }) => candidate.test?.test?.('example.tsx'));
+  // rspack sets `loader`/`options` on the rule; webpack nests them under `use`.
+  return rule.options ?? rule.use?.options;
+}
+
+/**
+ * Loads a shared config as an app in `root` would get it.
+ *
+ * Sequential use only: both configs read the app's `package.json` from `process.cwd()`, and they
+ * `process.exit` when it has no `routes.json` alongside it.
+ */
+async function loadConfigFrom(bundler: (typeof bundlers)[number], root: string) {
+  const originalCwd = process.cwd();
+  process.chdir(root);
+
+  try {
+    const configModule =
+      bundler === 'rspack'
+        ? await import('@openmrs/rspack-config/src/index')
+        : /* webpack */ await import('@openmrs/webpack-config/src/index');
+    return configModule.default({}, { mode: 'production' }) as Record<string, any>;
+  } finally {
+    process.chdir(originalCwd);
+  }
+}
+
+/**
+ * A throwaway app directory, complete enough that the shared configs will load for it.
+ *
+ * Placed inside this package's `node_modules` rather than the system temp directory so that node
+ * resolution from it reaches the repo's packages — an `extends` query names a config that has to be
+ * resolvable from the module being built — and so that a crashed run leaves nothing git tracks.
+ */
+function scratchApp(packageJson: Record<string, unknown>) {
+  const scratchBase = join(__dirname, '..', 'node_modules', '.scratch-apps');
+  mkdirSync(scratchBase, { recursive: true });
+  const root = mkdtempSync(join(scratchBase, 'app-'));
+  tempDirs.push(root);
+  mkdirSync(join(root, 'src'));
+  writeFileSync(join(root, 'src', 'routes.json'), '{}');
+  writeFileSync(join(root, 'src', 'index.ts'), 'export function startupApp() {}');
+  writeFileSync(
+    join(root, 'package.json'),
+    JSON.stringify({
+      name: '@openmrs/esm-scratch-app',
+      version: '1.0.0',
+      browser: 'dist/openmrs-esm-scratch-app.js',
+      main: 'src/index.ts',
+      types: 'src/index.ts',
+      peerDependencies: {},
+      ...packageJson,
+    }),
+  );
+  return root;
+}
+
+describe.each(bundlers)('the %s config', (bundler) => {
+  it('compiles for the browsers RFC 0003 supports', async () => {
+    const options = scriptLoaderOptions(await loadConfigFrom(bundler, fixtureRoot));
+
+    expect(options.env.targets).toEqual(openmrsQueries);
+
+    // Whatever representation, it has to still mean the browsers RFC 0003 names.
+    expect(browserslist(options.env.targets, { path: fixtureRoot })).toEqual(openmrsTargets);
+
+    // swc rejects the two together, so a `jsc.target` creeping in would break every build outright.
+    expect(options.jsc?.target).toBeUndefined();
+  });
+
+  it('lets an app override the targets through its own browserslist config', async () => {
+    const root = scratchApp({ browserslist: ['chrome 91'] });
+    const options = scriptLoaderOptions(await loadConfigFrom(bundler, root));
+
+    expect(options.env.targets).toEqual(['chrome 91']);
+  });
+
+  it("expands an app's `extends` query, which swc itself cannot follow", async () => {
+    // How every OpenMRS module in practice names the policy.
+    const root = scratchApp({ browserslist: ['extends browserslist-config-openmrs'] });
+    const options = scriptLoaderOptions(await loadConfigFrom(bundler, root));
+
+    expect(options.env.targets).toEqual(openmrsQueries);
+    expect(options.env.targets.some((query: string) => query.startsWith('extends '))).toBe(false);
+  });
+
+  it('warns and keeps building when an app names a browserslist config that will not load', async () => {
+    const root = scratchApp({ browserslist: ['extends browserslist-config-nonexistent'] });
+    const warnings: string[] = [];
+    const warn = vi.spyOn(console, 'warn').mockImplementation((message) => void warnings.push(String(message)));
+
+    try {
+      // Loading the config at all is the assertion.
+      const options = scriptLoaderOptions(await loadConfigFrom(bundler, root));
+      expect(options.env.targets).toEqual(openmrsQueries);
+    } finally {
+      warn.mockRestore();
+    }
+
+    expect(warnings.join('\n')).toContain('browserslist-config-nonexistent');
+  });
+
+  it('falls back to the OpenMRS policy for an app that declares no browsers', async () => {
+    const root = scratchApp({});
+    const options = scriptLoaderOptions(await loadConfigFrom(bundler, root));
+
+    expect(options.env.targets).toEqual(openmrsQueries);
+    // Not browserslist's own `defaults`, which reaches years further back than O3 supports.
+    expect(browserslist(options.env.targets)).not.toEqual(browserslist(['defaults']));
+  });
+
+  it('emits the modern syntax it was given rather than ES5', async () => {
+    const { scripts } = await buildFixtureApp(bundler);
+
+    // The exposed module gets its own chunk, under a name that depends on chunk ids, so it's found by the
+    // export it carries. Asserting there is exactly one keeps this from silently checking nothing.
+    const carriers = Object.entries(scripts).filter(([, contents]) => contents.includes('startupApp'));
+    expect(carriers).toHaveLength(1);
+
+    const [, exposedChunk] = carriers[0];
+
+    // The fixture's private field, `async` function and optional chaining, all of which swc rewrites for
+    // an ES5 target. Minifiers rename a private field but cannot remove the `#`.
+    expect(exposedChunk).toMatch(/#[A-Za-z_$]/);
+    expect(exposedChunk).toMatch(/\basync\b/);
+    expect(exposedChunk).toMatch(/\?\./);
+
+    for (const helper of es5Helpers) {
+      expect(exposedChunk).not.toContain(helper);
+    }
+  }, 180_000);
+});
+
+describe('the bundler runtime target', () => {
+  // `output.environment` is what decides the syntax of the runtime and chunk-loading glue the bundler
+  // writes itself, which swc never sees. Both configs derive it from the module's browserslist, and the
+  // two bundlers resolve those queries with different browser data — webpack with this repo's, rspack
+  // with the older set its Rust port bundles — so these checks are what hold the two together.
+  async function environmentFor(bundler: (typeof bundlers)[number], target: unknown) {
+    const { default: bundlerModule } = bundler === 'rspack' ? await import('@rspack/core') : await import('webpack');
+    const compiler = (bundlerModule as (options: unknown) => any)({ context: fixtureRoot, target });
+    const { environment } = compiler.options.output;
+    await new Promise<void>((res) => compiler.close(() => res()));
+    return Object.fromEntries(
+      Object.entries(environment as Record<string, boolean>).filter(([key]) => key !== 'nodePrefixForCoreModules'),
+    );
+  }
+
+  it('is derived from the policy rather than pinned to an ES level', async () => {
+    const { target } = await loadConfigFrom('rspack', fixtureRoot);
+
+    // Inlined, not a bare `browserslist`, which would send rspack back to a config it can't fully read.
+    expect(target).toEqual(['web', `browserslist:${openmrsQueries.join(', ')}`]);
+  });
+
+  it('narrows to match a module that supports older browsers', async () => {
+    // The reason for deriving this rather than pinning a level: an ES2020 runtime shipped to a browser
+    // this old is a syntax error, however correctly swc compiled the module's own sources.
+    const root = scratchApp({ browserslist: ['ie 11'] });
+    const { target } = await loadConfigFrom('rspack', root);
+    const environment = await environmentFor('rspack', target);
+
+    expect(environment.arrowFunction).toBe(false);
+    expect(environment.dynamicImport).toBe(false);
+    expect(environment.optionalChaining).toBe(false);
+  });
+
+  it('claims no ES feature the supported browsers lack', async () => {
+    // Taken from the config rather than restated, so this tracks whatever the config declares.
+    const { target } = await loadConfigFrom('rspack', fixtureRoot);
+    const configured = await environmentFor('rspack', target);
+
+    // What webpack derives from the resolved policy: the browser data's own verdict, and the only place
+    // in this repo that can read it, since rspack's port cannot.
+    const supported = await environmentFor('webpack', `browserslist:${openmrsTargets.join(', ')}`);
+
+    // Proves `supported` is a real reading of the browser data rather than something empty that would
+    // make the comparison below vacuous.
+    expect(supported.arrowFunction).toBe(true);
+
+    const overclaimed = Object.keys(configured).filter((feature) => configured[feature] && !supported[feature]);
+    expect(overclaimed).toEqual([]);
+  });
+
+  it('is identical between the two bundlers', async () => {
+    const { target: rspackTarget } = await loadConfigFrom('rspack', fixtureRoot);
+    const { target: webpackTarget } = await loadConfigFrom('webpack', fixtureRoot);
+    expect(rspackTarget).toEqual(webpackTarget);
+
+    const [rspackEnvironment, webpackEnvironment] = [
+      await environmentFor('rspack', rspackTarget),
+      await environmentFor('webpack', webpackTarget),
+    ];
+
+    expect(rspackEnvironment).toEqual(webpackEnvironment);
+    // The features a bare `web` target leaves off, which is the point of setting this at all. Also what
+    // fails if rspack's bundled browser data ever ages far enough to stop resolving the policy.
+    expect(rspackEnvironment.dynamicImport).toBe(true);
+    expect(rspackEnvironment.globalThis).toBe(true);
+  });
+});
+
+it('hands both bundlers the same targets', async () => {
+  // The two configs are published separately and resolve their targets from copies of the same code, so
+  // this is what catches them drifting apart and emitting differently for the same app.
+  const [rspackOptions, webpackOptions] = [
+    scriptLoaderOptions(await loadConfigFrom('rspack', fixtureRoot)),
+    scriptLoaderOptions(await loadConfigFrom('webpack', fixtureRoot)),
+  ];
+
+  expect(rspackOptions.env.targets).toEqual(webpackOptions.env.targets);
+});

--- a/packages/tooling/integration-tests/src/browser-targets.test.ts
+++ b/packages/tooling/integration-tests/src/browser-targets.test.ts
@@ -19,15 +19,11 @@ const openmrsQueries: string[] = require('browserslist-config-openmrs');
 // need to ask what a browser actually supports go through this.
 const openmrsTargets = browserslist(['extends browserslist-config-openmrs'], { path: fixtureRoot });
 
-// Named exactly as swc emits them. Each is the helper for one of the constructs the fixture uses, so if a
-// build stops declaring a target these reappear alongside the syntax checks below failing.
-const es5Helpers = [
-  '_async_to_generator',
-  '_class_call_check',
-  '_class_private_field_get',
-  '_create_class',
-  '_ts_generator',
-];
+// Text from the body of swc's `_class_call_check` helper, which it emits to down-level the fixture's
+// class. The helper *names* are useless for this: the production minifier inlines and renames every one
+// of them, so asserting on `_class_call_check` passes against genuinely ES5 output. This string is
+// inside a `throw new TypeError(...)` and survives minification.
+const es5HelperMarker = 'Cannot call a class as a function';
 
 const tempDirs: string[] = [];
 
@@ -38,6 +34,29 @@ afterAll(() => {
   }
   rmSync(join(__dirname, '..', 'node_modules', '.scratch-apps'), { recursive: true, force: true });
 });
+
+/**
+ * The messages a config's browserslist plugin would push onto a compilation, without running a build.
+ *
+ * The plugin is what carries these to somewhere a developer sees them, so this reaches into it with a
+ * stub compilation rather than asserting on a `console.warn` the factory only ever emits once.
+ */
+function compilationWarnings(config: Record<string, any>): string {
+  const plugin = config.plugins.find(
+    (candidate: { constructor?: { name?: string } }) => candidate?.constructor?.name === 'BrowserslistWarningsPlugin',
+  );
+
+  if (!plugin) {
+    return '';
+  }
+
+  const compilation = { warnings: [] as Array<{ message: string }> };
+  plugin.apply({
+    hooks: { thisCompilation: { tap: (_name: string, fn: (c: typeof compilation) => void) => fn(compilation) } },
+  });
+
+  return compilation.warnings.map((warning) => warning.message).join('\n');
+}
 
 /** The `swc-loader` / `builtin:swc-loader` options a config puts on its JS/TS rule. */
 function scriptLoaderOptions(config: Record<string, any>) {
@@ -133,8 +152,10 @@ describe.each(bundlers)('the %s config', (bundler) => {
     expect(options.env.targets).toEqual(['chrome 91']);
   });
 
-  it("expands an app's `extends` query, which swc itself cannot follow", async () => {
-    // How every OpenMRS module in practice names the policy.
+  it("expands an app's `extends` query rather than leaving it to swc", async () => {
+    // How every OpenMRS module in practice names the policy. swc resolves an `extends` query relative
+    // to `process.cwd()` rather than the module it compiles, and aborts the process when it cannot, so
+    // the expansion is what makes this independent of where the build ran from.
     const root = scratchApp({ browserslist: ['extends browserslist-config-openmrs'] });
     const options = scriptLoaderOptions(await loadConfigFrom(bundler, root));
 
@@ -147,9 +168,8 @@ describe.each(bundlers)('the %s config', (bundler) => {
   // browserslist itself resolves, which is also what would fail if the loader borrowed from its internal
   // `node` entry point ever moved.
   describe('a shared browserslist config', () => {
-    // Sections keyed by environment, which is the shape Greptile flagged: read as a flat array this
-    // throws, and the catch below would report the module's policy as unloadable and quietly build for
-    // OpenMRS's instead.
+    // Sections keyed by environment. Read as a flat array this throws, and the catch below would then
+    // report the module's policy as unloadable and quietly build for OpenMRS's instead.
     const envConfig =
       "module.exports = { production: ['chrome 120'], development: ['chrome 90'], defaults: ['chrome 100'] };";
 
@@ -224,18 +244,23 @@ describe.each(bundlers)('the %s config', (bundler) => {
 
   it('warns and keeps building when an app names a browserslist config that will not load', async () => {
     const root = scratchApp({ browserslist: ['extends browserslist-config-nonexistent'] });
-    const warnings: string[] = [];
-    const warn = vi.spyOn(console, 'warn').mockImplementation((message) => void warnings.push(String(message)));
 
-    try {
-      // Loading the config at all is the assertion.
-      const options = scriptLoaderOptions(await loadConfigFrom(bundler, root));
-      expect(options.env.targets).toEqual(openmrsQueries);
-    } finally {
-      warn.mockRestore();
-    }
+    // Loading the config at all is half the assertion: how a module's browsers are chosen is not worth
+    // taking down a build, let alone a running dev server.
+    const config = await loadConfigFrom(bundler, root);
+    expect(scriptLoaderOptions(config).env.targets).toEqual(openmrsQueries);
 
-    expect(warnings.join('\n')).toContain('browserslist-config-nonexistent');
+    // Reported as a compilation warning, not `console.warn`: the config factory runs once, before a
+    // compiler exists, so a logged message appears at startup and never again on rebuild.
+    expect(compilationWarnings(config)).toContain('browserslist-config-nonexistent');
+  });
+
+  it('fails the build, rather than guessing, when a config is malformed', async () => {
+    // browserslist's own errors for these are clear and the developer has to act on them, so they are
+    // deliberately not swallowed the way an unloadable *named* config is.
+    const root = scratchApp({ browserslist: [1, 2] as unknown as string[] });
+
+    await expect(loadConfigFrom(bundler, root)).rejects.toThrow(/browserslist/i);
   });
 
   it('falls back to the OpenMRS policy for an app that declares no browsers', async () => {
@@ -263,57 +288,93 @@ describe.each(bundlers)('the %s config', (bundler) => {
     expect(exposedChunk).toMatch(/\basync\b/);
     expect(exposedChunk).toMatch(/\?\./);
 
-    for (const helper of es5Helpers) {
-      expect(exposedChunk).not.toContain(helper);
-    }
+    expect(exposedChunk).not.toContain(es5HelperMarker);
   }, 180_000);
 });
 
 describe('the bundler runtime target', () => {
-  // `output.environment` is what decides the syntax of the runtime and chunk-loading glue the bundler
-  // writes itself, which swc never sees. Both configs derive it from the module's browserslist, and the
-  // two bundlers resolve those queries with different browser data — webpack with this repo's, rspack
-  // with the older set its Rust port bundles — so these checks are what hold the two together.
-  async function environmentFor(bundler: (typeof bundlers)[number], target: unknown) {
+  // `output.environment` decides the syntax of the runtime and chunk-loading glue a bundler writes
+  // itself, which swc never sees. The two configs reach it differently — webpack-config sets
+  // `output.environment` from webpack's own browserslist target handler; rspack-config passes the
+  // queries as a `browserslist:` target, which rspack does resolve as queries. These checks are what
+  // hold the two results together.
+  const esFeatures = (environment: Record<string, unknown>) =>
+    Object.fromEntries(
+      Object.entries(environment).filter(([key, value]) => key !== 'nodePrefixForCoreModules' && value != null),
+    ) as Record<string, boolean>;
+
+  /**
+   * The ES features a bundler ends up allowing itself for a module in `root`.
+   *
+   * `context` has to be that same root: webpack re-reads the module's own browserslist config from it,
+   * so pointing this at a directory without one would only ever exercise webpack's fallback branch and
+   * never what a real build does.
+   */
+  async function environmentFor(bundler: (typeof bundlers)[number], root: string) {
+    const config = await loadConfigFrom(bundler, root);
     const { default: bundlerModule } = bundler === 'rspack' ? await import('@rspack/core') : await import('webpack');
-    const compiler = (bundlerModule as (options: unknown) => any)({ context: fixtureRoot, target });
+    const compiler = (bundlerModule as (options: unknown) => any)({
+      context: root,
+      target: config.target,
+      output: { environment: config.output?.environment },
+    });
     const { environment } = compiler.options.output;
     await new Promise<void>((res) => compiler.close(() => res()));
-    return Object.fromEntries(
-      Object.entries(environment as Record<string, boolean>).filter(([key]) => key !== 'nodePrefixForCoreModules'),
-    );
+
+    return esFeatures(environment as Record<string, unknown>);
   }
 
-  it('is derived from the policy rather than pinned to an ES level', async () => {
-    const { target } = await loadConfigFrom('rspack', fixtureRoot);
+  it.each(bundlers)('lets %s use everything the supported browsers allow', async (bundler) => {
+    const environment = await environmentFor(bundler, fixtureRoot);
 
-    // Inlined, not a bare `browserslist`, which would send rspack back to a config it can't fully read.
-    expect(target).toEqual(['web', `browserslist:${openmrsQueries.join(', ')}`]);
+    // The features a bare `web` target leaves off, which is the point of setting this at all.
+    expect(environment.dynamicImport).toBe(true);
+    expect(environment.globalThis).toBe(true);
+    expect(environment.arrowFunction).toBe(true);
   });
 
-  it('narrows to match a module that supports older browsers', async () => {
-    // The reason for deriving this rather than pinning a level: an ES2020 runtime shipped to a browser
-    // this old is a syntax error, however correctly swc compiled the module's own sources.
-    const root = scratchApp({ browserslist: ['ie 11'] });
-    const { target } = await loadConfigFrom('rspack', root);
-    const environment = await environmentFor('rspack', target);
+  it.each(bundlers)('narrows %s to match a module that supports older browsers', async (bundler) => {
+    // An ES2020 runtime shipped to a browser this old is a syntax error, however correctly swc compiled
+    // the module's own sources.
+    const root = scratchApp({ browserslist: ['chrome 60'] });
+    const environment = await environmentFor(bundler, root);
 
-    expect(environment.arrowFunction).toBe(false);
     expect(environment.dynamicImport).toBe(false);
     expect(environment.optionalChaining).toBe(false);
   });
 
+  it.each(bundlers)("reads the right env section of a module's config in %s", async (bundler) => {
+    // The case that was silently wrong: webpack took the inlined query list as an env name, failed to
+    // match a section by it, fell back to `defaults`, and built a modern runtime for a module whose
+    // production browsers were ancient — while swc correctly down-levelled that module's own sources.
+    const root = scratchApp({ browserslist: { production: ['chrome 60'], defaults: ['chrome 120'] } });
+    const previous = process.env.BROWSERSLIST_ENV;
+    process.env.BROWSERSLIST_ENV = 'production';
+    browserslist.clearCaches();
+
+    try {
+      const options = scriptLoaderOptions(await loadConfigFrom(bundler, root));
+      expect(options.env.targets).toEqual(['chrome 60']);
+
+      const environment = await environmentFor(bundler, root);
+      expect(environment.optionalChaining).toBe(false);
+      expect(environment.dynamicImport).toBe(false);
+    } finally {
+      process.env.BROWSERSLIST_ENV = previous;
+      browserslist.clearCaches();
+    }
+  });
+
   it('claims no ES feature the supported browsers lack', async () => {
-    // Taken from the config rather than restated, so this tracks whatever the config declares.
-    const { target } = await loadConfigFrom('rspack', fixtureRoot);
-    const configured = await environmentFor('rspack', target);
+    const configured = await environmentFor('rspack', fixtureRoot);
 
-    // What webpack derives from the resolved policy: the browser data's own verdict, and the only place
-    // in this repo that can read it, since rspack's port cannot.
-    const supported = await environmentFor('webpack', `browserslist:${openmrsTargets.join(', ')}`);
+    // webpack's reading of the resolved policy, straight from the browser data.
+    const { default: webpack } = await import('webpack');
+    const oracle = webpack({ context: fixtureRoot, target: `browserslist:${openmrsTargets.join(', ')}` } as never);
+    const supported = esFeatures(oracle.options.output.environment as Record<string, unknown>);
+    await new Promise<void>((res) => oracle.close(() => res()));
 
-    // Proves `supported` is a real reading of the browser data rather than something empty that would
-    // make the comparison below vacuous.
+    // Proves `supported` is a real reading rather than something empty that would make this vacuous.
     expect(supported.arrowFunction).toBe(true);
 
     const overclaimed = Object.keys(configured).filter((feature) => configured[feature] && !supported[feature]);
@@ -321,20 +382,12 @@ describe('the bundler runtime target', () => {
   });
 
   it('is identical between the two bundlers', async () => {
-    const { target: rspackTarget } = await loadConfigFrom('rspack', fixtureRoot);
-    const { target: webpackTarget } = await loadConfigFrom('webpack', fixtureRoot);
-    expect(rspackTarget).toEqual(webpackTarget);
-
     const [rspackEnvironment, webpackEnvironment] = [
-      await environmentFor('rspack', rspackTarget),
-      await environmentFor('webpack', webpackTarget),
+      await environmentFor('rspack', fixtureRoot),
+      await environmentFor('webpack', fixtureRoot),
     ];
 
     expect(rspackEnvironment).toEqual(webpackEnvironment);
-    // The features a bare `web` target leaves off, which is the point of setting this at all. Also what
-    // fails if rspack's bundled browser data ever ages far enough to stop resolving the policy.
-    expect(rspackEnvironment.dynamicImport).toBe(true);
-    expect(rspackEnvironment.globalThis).toBe(true);
   });
 });
 

--- a/packages/tooling/integration-tests/src/build-fixture.ts
+++ b/packages/tooling/integration-tests/src/build-fixture.ts
@@ -1,0 +1,116 @@
+// Builds the `remote-app` fixture with one of the shared bundler configs, for tests that need to inspect
+// what a real OpenMRS app build emits rather than what its config says it will.
+import { mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+
+export const fixtureRoot = resolve(__dirname, '..', '__fixtures__', 'remote-app');
+export const fixturePackageName = '@openmrs/esm-fixture-app';
+export const entryFilename = 'openmrs-esm-fixture-app.js';
+
+export type FixtureBuild = {
+  /** The remote entry the app shell loads, `openmrs-esm-fixture-app.js`. */
+  entry: string;
+  /** Every emitted JavaScript file, keyed by filename. */
+  scripts: Record<string, string>;
+  /** Module identifiers from the build's stats, flattened through concatenated modules. */
+  moduleIdentifiers: string[];
+};
+
+const builds = new Map<string, Promise<FixtureBuild>>();
+const tempDirs: string[] = [];
+
+/** Call from `afterAll`. Deletes the output directories the builds in this process wrote. */
+export function cleanUpFixtureBuilds() {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+  // Module Federation generates its entry module inside the fixture rather than in `output.path`.
+  rmSync(join(fixtureRoot, 'node_modules', '.federation'), { recursive: true, force: true });
+}
+
+/**
+ * Builds the fixture app with one of the shared configs, memoized per bundler and mode.
+ */
+export function buildFixtureApp(bundler: 'rspack' | 'webpack', mode = 'production'): Promise<FixtureBuild> {
+  const key = `${bundler}:${mode}`;
+  const cached = builds.get(key);
+  if (cached) {
+    return cached;
+  }
+
+  const build = (async () => {
+    const outDir = mkdtempSync(join(tmpdir(), 'openmrs-fixture-build-'));
+    tempDirs.push(outDir);
+
+    const originalCwd = process.cwd();
+    process.chdir(fixtureRoot);
+
+    try {
+      // From source, not `dist`, so this can't pass against a stale build; resolvable only because neither
+      // config package declares an `exports` map. Imported here rather than at the top of the file because
+      // `@module-federation/enhanced` derives its scratch directory from `process.cwd()` on first import.
+      const configModule =
+        bundler === 'rspack'
+          ? await import('@openmrs/rspack-config/src/index')
+          : /* webpack */ await import('@openmrs/webpack-config/src/index');
+      const config = configModule.default({}, { mode }) as Record<string, any>;
+
+      config.output.path = outDir;
+      // Type checking the fixture is not what these tests are about, and the plugin would report on the
+      // repo's own sources from here.
+      config.plugins = config.plugins.filter(
+        (plugin: { constructor?: { name?: string } }) =>
+          plugin?.constructor?.name !== 'TsCheckerRspackPlugin' &&
+          plugin?.constructor?.name !== 'ForkTsCheckerWebpackPlugin',
+      );
+
+      const { default: bundlerModule } = bundler === 'rspack' ? await import('@rspack/core') : await import('webpack');
+
+      // The two bundlers' call signatures don't unify, hence the cast.
+      const compiler = (bundlerModule as (options: unknown) => any)(config);
+      const stats = await new Promise<any>((res, rej) => {
+        compiler.run((err: unknown, result: any) => {
+          if (err) {
+            rej(err);
+            return;
+          }
+          if (result?.hasErrors()) {
+            rej(new Error(result.toString({ all: false, errors: true })));
+            return;
+          }
+          res(result);
+        });
+      });
+      // Unclosed compilers keep worker threads alive, which surfaces as a vitest hang.
+      await new Promise<void>((res) => compiler.close(() => res()));
+
+      // `ids` populates `identifier`; without `nestedModules` scope hoisting hides concatenated modules
+      // behind a "… + n modules" entry, which made this blind on the webpack path.
+      const { modules = [] } = stats.toJson({ all: false, modules: true, ids: true, nestedModules: true });
+
+      const collectIdentifiers = (list: { identifier?: string; name?: string; modules?: unknown[] }[]): string[] =>
+        list.flatMap((module) => [
+          module.identifier ?? module.name ?? '',
+          ...collectIdentifiers((module.modules ?? []) as typeof list),
+        ]);
+
+      const scripts = Object.fromEntries(
+        readdirSync(outDir)
+          .filter((file) => file.endsWith('.js'))
+          .map((file) => [file, readFileSync(join(outDir, file), 'utf8')]),
+      );
+
+      return {
+        entry: scripts[entryFilename],
+        scripts,
+        moduleIdentifiers: collectIdentifiers(modules),
+      };
+    } finally {
+      process.chdir(originalCwd);
+    }
+  })();
+
+  builds.set(key, build);
+  return build;
+}

--- a/packages/tooling/integration-tests/src/build-fixture.ts
+++ b/packages/tooling/integration-tests/src/build-fixture.ts
@@ -101,8 +101,19 @@ export function buildFixtureApp(bundler: 'rspack' | 'webpack', mode = 'productio
           .map((file) => [file, readFileSync(join(outDir, file), 'utf8')]),
       );
 
+      const entry = scripts[entryFilename];
+
+      // Checked rather than handed on as `undefined`: `new Script(undefined)` compiles the source text
+      // `"undefined"` and runs without complaint, so a change to the emitted filename would leave the
+      // tests that execute the entry passing while executing nothing.
+      if (!entry) {
+        throw new Error(
+          `The ${bundler} build emitted no ${entryFilename}. Emitted: ${Object.keys(scripts).join(', ')}`,
+        );
+      }
+
       return {
-        entry: scripts[entryFilename],
+        entry,
         scripts,
         moduleIdentifiers: collectIdentifiers(modules),
       };

--- a/packages/tooling/integration-tests/src/federation-runtime.test.ts
+++ b/packages/tooling/integration-tests/src/federation-runtime.test.ts
@@ -5,14 +5,8 @@ import * as errorCodes from '@module-federation/error-codes';
 import * as runtimeCore from '@module-federation/runtime-core';
 import * as sdk from '@module-federation/sdk';
 import { createContext, Script } from 'node:vm';
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
-import { tmpdir } from 'node:os';
-import { join, resolve } from 'node:path';
 import { afterAll, describe, expect, it } from 'vitest';
-
-const fixtureRoot = resolve(__dirname, '..', '__fixtures__', 'remote-app');
-const entryFilename = 'openmrs-esm-fixture-app.js';
-const fixturePackageName = '@openmrs/esm-fixture-app';
+import { buildFixtureApp, cleanUpFixtureBuilds, fixturePackageName, fixtureRoot } from './build-fixture';
 
 // Mirrors `slugify` in `@openmrs/esm-dynamic-loading`, which is how the app shell finds a container.
 const slugify = (name: string) => name.replace(/[\/\-@]/g, '_');
@@ -54,105 +48,11 @@ const bundlableModules = [
 // the check below into a silent no-op.
 const expectedBundledModule = '@module-federation/webpack-bundler-runtime';
 
-type BuildResult = { contents: string; moduleIdentifiers: string[] };
-
-const builds = new Map<string, Promise<BuildResult>>();
-const tempDirs: string[] = [];
-
-afterAll(() => {
-  for (const dir of tempDirs) {
-    rmSync(dir, { recursive: true, force: true });
-  }
-  // Module Federation generates its entry module inside the fixture rather than in `output.path`.
-  rmSync(join(fixtureRoot, 'node_modules', '.federation'), { recursive: true, force: true });
-});
-
-/**
- * Builds the fixture app with one of the shared configs and returns the remote entry it emitted, memoized.
- *
- * Both configs read the app's `package.json` from `process.cwd()`, so the build runs from the fixture
- * directory with `output.path` pointed at a temp dir. Module Federation writes its generated entry into
- * the fixture's `node_modules/.federation/`, so parallel runs of this file aren't isolated. `chdir` needs
- * Vitest's `forks` pool, the default here.
- */
-function buildRemoteEntry(bundler: 'rspack' | 'webpack'): Promise<BuildResult> {
-  const cached = builds.get(bundler);
-  if (cached) {
-    return cached;
-  }
-
-  const build = (async () => {
-    const outDir = mkdtempSync(join(tmpdir(), 'openmrs-federation-runtime-'));
-    tempDirs.push(outDir);
-
-    const originalCwd = process.cwd();
-    process.chdir(fixtureRoot);
-
-    try {
-      // From source, not `dist`, so this can't pass against a stale build; resolvable only because neither
-      // config package declares an `exports` map. Imported here rather than at the top of the file because
-      // `@module-federation/enhanced` derives its scratch directory from `process.cwd()` on first import.
-      const configModule =
-        bundler === 'rspack'
-          ? await import('@openmrs/rspack-config/src/index')
-          : /* webpack */ await import('@openmrs/webpack-config/src/index');
-      const config = configModule.default({}, { mode: 'production' }) as Record<string, any>;
-
-      config.output.path = outDir;
-      // Type checking the fixture is not what this test is about, and the plugin would report on the
-      // repo's own sources from here.
-      config.plugins = config.plugins.filter(
-        (plugin: { constructor?: { name?: string } }) =>
-          plugin?.constructor?.name !== 'TsCheckerRspackPlugin' &&
-          plugin?.constructor?.name !== 'ForkTsCheckerWebpackPlugin',
-      );
-
-      const { default: bundlerModule } = bundler === 'rspack' ? await import('@rspack/core') : await import('webpack');
-
-      // The two bundlers' call signatures don't unify, hence the cast.
-      const compiler = (bundlerModule as (options: unknown) => any)(config);
-      const stats = await new Promise<any>((res, rej) => {
-        compiler.run((err: unknown, result: any) => {
-          if (err) {
-            rej(err);
-            return;
-          }
-          if (result?.hasErrors()) {
-            rej(new Error(result.toString({ all: false, errors: true })));
-            return;
-          }
-          res(result);
-        });
-      });
-      // Unclosed compilers keep worker threads alive, which surfaces as a vitest hang.
-      await new Promise<void>((res) => compiler.close(() => res()));
-
-      // `ids` populates `identifier`; without `nestedModules` scope hoisting hides concatenated modules
-      // behind a "… + n modules" entry, which made this blind on the webpack path.
-      const { modules = [] } = stats.toJson({ all: false, modules: true, ids: true, nestedModules: true });
-
-      const collectIdentifiers = (list: { identifier?: string; name?: string; modules?: unknown[] }[]): string[] =>
-        list.flatMap((module) => [
-          module.identifier ?? module.name ?? '',
-          ...collectIdentifiers((module.modules ?? []) as typeof list),
-        ]);
-
-      return {
-        contents: readFileSync(join(outDir, entryFilename), 'utf8'),
-        moduleIdentifiers: collectIdentifiers(modules),
-      };
-    } finally {
-      process.chdir(originalCwd);
-    }
-  })();
-
-  builds.set(bundler, build);
-  return build;
-}
+afterAll(cleanUpFixtureBuilds);
 
 describe.each(['rspack', 'webpack'] as const)('%s remote entries', (bundler) => {
   it('read the Module Federation runtime from the app shell instead of bundling it', async () => {
-    const { moduleIdentifiers } = await buildRemoteEntry(bundler);
+    const { moduleIdentifiers } = await buildFixtureApp(bundler);
 
     // Proves the matching below can see into this build's module list at all.
     expect(moduleIdentifiers.filter((id) => id.includes(`node_modules/${expectedBundledModule}/`))).not.toEqual([]);
@@ -178,21 +78,21 @@ describe.each(['rspack', 'webpack'] as const)('%s remote entries', (bundler) => 
   }, 180_000);
 
   it('refuses to start, with a diagnosable error, when no app shell published the runtime', async () => {
-    const { contents } = await buildRemoteEntry(bundler);
+    const { entry } = await buildFixtureApp(bundler);
 
     // A bare global is what an app shell too old to publish the runtime looks like. Executing the entry
     // also proves the guard landed in this chunk, ahead of the code that reads the runtime.
     const context = createContext({ console, self: {} });
-    expect(() => new Script(contents).runInContext(context)).toThrow(/does not provide the Module Federation runtime/);
+    expect(() => new Script(entry).runInContext(context)).toThrow(/does not provide the Module Federation runtime/);
   }, 180_000);
 
   it('starts and exposes its container when the app shell has published the runtime', async () => {
-    const { contents } = await buildRemoteEntry(bundler);
+    const { entry } = await buildFixtureApp(bundler);
     const context = publishedRuntimeContext();
 
     // Without this, a guard checking a global nobody publishes — `_OPENMRS_FEDERATION_SDK`, say — would satisfy
     // every other assertion here while making every app in the distribution permanently unstartable.
-    expect(() => new Script(contents).runInContext(context)).not.toThrow();
+    expect(() => new Script(entry).runInContext(context)).not.toThrow();
 
     // The container protocol `esm-dynamic-loading` uses: a `var` named for the slugified package.
     const container = context[slugify(fixturePackageName)];

--- a/packages/tooling/openmrs/package.json
+++ b/packages/tooling/openmrs/package.json
@@ -60,6 +60,7 @@
     "@rspack/dev-server": "1.1.5",
     "@swc/core": "1.15.21",
     "autoprefixer": "10.4.20",
+    "browserslist": "4.28.9",
     "browserslist-config-openmrs": "^1.0.1",
     "chalk": "5.6.2",
     "clean-webpack-plugin": "4.0.0",

--- a/packages/tooling/rspack-config/package.json
+++ b/packages/tooling/rspack-config/package.json
@@ -35,6 +35,8 @@
     "@rspack/cli": "1.7.9",
     "@rspack/core": "1.7.9",
     "@swc/core": "1.15.21",
+    "browserslist": "4.28.9",
+    "browserslist-config-openmrs": "^1.0.1",
     "clean-webpack-plugin": "4.0.0",
     "copy-webpack-plugin": "11.0.0",
     "css-loader": "5.2.7",

--- a/packages/tooling/rspack-config/src/index.ts
+++ b/packages/tooling/rspack-config/src/index.ts
@@ -38,6 +38,7 @@
  */
 import { existsSync, statSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
+import browserslist from 'browserslist';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 import { TsCheckerRspackPlugin } from 'ts-checker-rspack-plugin';
 // eslint-disable-next-line no-restricted-imports
@@ -66,6 +67,10 @@ const production = 'production';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const moduleFederationPin: string = require('../package.json').dependencies['@module-federation/enhanced'];
 const moduleFederationVersion = parse(moduleFederationPin);
+
+// Used when a module declares no browserslist of its own, and when one it names can't be loaded.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const defaultBrowserslistQueries: Array<string> = require('browserslist-config-openmrs');
 
 /**
  * Prepended to this app's entry chunks. Without it, an app running under an app shell too old to
@@ -106,6 +111,56 @@ function getFrameworkVersion() {
   } catch {
     return '5.x';
   }
+}
+
+/**
+ * The browserslist queries this module's output is compiled and minified against, falling back to
+ * OpenMRS's shared config when the module declares none, so that frontend RFC 0003 stays the single
+ * source of truth. Without any of this swc down-levels to ES5, and every supported browser pays for
+ * transform helpers it doesn't need.
+ *
+ * Queries rather than resolved versions, and `extends` expanded here rather than left to the consumer,
+ * because these are resolved by Rust ports of browserslist — swc's, and rspack's Lightning CSS — which
+ * do not implement `extends` and reject version numbers newer than the browser data they bundle. swc
+ * aborts the process rather than reporting an error when a query defeats it.
+ *
+ * @param root The directory of the module being built
+ */
+function browserslistQueries(root: string): Array<string> {
+  const loaded = browserslist.loadConfig({ path: root });
+  const configured = loaded === undefined ? [] : Array.isArray(loaded) ? loaded : [loaded];
+
+  return expandBrowserslistExtends(configured.length > 0 ? configured : defaultBrowserslistQueries, root);
+}
+
+function expandBrowserslistExtends(queries: Array<string>, root: string, seen = new Set<string>()): Array<string> {
+  return queries.flatMap((query) => {
+    const extended = /^extends\s+(\S+)$/.exec(query.trim());
+
+    if (!extended || seen.has(extended[1])) {
+      return extended ? [] : [query];
+    }
+
+    seen.add(extended[1]);
+
+    try {
+      // Resolved from the module being built, so that it picks up that module's own shared config.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const resolved = require(require.resolve(extended[1], { paths: [root] }));
+
+      return expandBrowserslistExtends(Array.isArray(resolved) ? resolved : [resolved], root, seen);
+    } catch {
+      // A config that can't be loaded shouldn't take the whole build — or the dev server — down over
+      // which browsers it targets. Fall back to the default queries and say so.
+      console.warn(
+        `Could not load the browserslist config "${extended[1]}". Targeting ${defaultBrowserslistQueries.join(
+          ', ',
+        )} instead.`,
+      );
+
+      return defaultBrowserslistQueries;
+    }
+  });
 }
 
 function makeIdent(name: string): string {
@@ -200,6 +255,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
   const outDir = dirname(browser || main);
   const srcFile = resolve(root, browser ? main : types);
   const ident = makeIdent(name);
+  const browserTargets = browserslistQueries(root);
   const frameworkVersion = getFrameworkVersion();
   const routes = resolve(root, 'src', 'routes.json');
   const hasRoutesDefined = fileExistsSync(routes);
@@ -240,6 +296,9 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
             exclude: /node_modules/,
             loader: 'builtin:swc-loader',
             options: {
+              env: {
+                targets: browserTargets,
+              },
               jsc: {
                 parser: {
                   syntax: 'typescript',
@@ -289,6 +348,10 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
       ],
     },
     mode,
+    // Governs rspack's own runtime and chunk-loading glue, which the swc targets above don't reach —
+    // swc only compiles module sources. Derived from the same queries, so the policy is stated once and
+    // a module that supports older browsers gets a runtime to match.
+    target: ['web', `browserslist:${browserTargets.join(', ')}`],
     devtool: mode === production ? 'hidden-nosources-source-map' : 'source-map',
     devServer: {
       headers: {

--- a/packages/tooling/rspack-config/src/index.ts
+++ b/packages/tooling/rspack-config/src/index.ts
@@ -39,6 +39,8 @@
 import { existsSync, statSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
 import browserslist from 'browserslist';
+import { loadQueries } from 'browserslist/node';
+import { default as defaultBrowserslistQueries } from 'browserslist-config-openmrs';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 import { TsCheckerRspackPlugin } from 'ts-checker-rspack-plugin';
 // eslint-disable-next-line no-restricted-imports
@@ -67,10 +69,6 @@ const production = 'production';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const moduleFederationPin: string = require('../package.json').dependencies['@module-federation/enhanced'];
 const moduleFederationVersion = parse(moduleFederationPin);
-
-// Used when a module declares no browserslist of its own, and when one it names can't be loaded.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const defaultBrowserslistQueries: Array<string> = require('browserslist-config-openmrs');
 
 /**
  * Prepended to this app's entry chunks. Without it, an app running under an app shell too old to
@@ -144,9 +142,9 @@ function expandBrowserslistExtends(queries: Array<string>, root: string, seen = 
     seen.add(extended[1]);
 
     try {
-      // Resolved from the module being built, so that it picks up that module's own shared config.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const resolved = require(require.resolve(extended[1], { paths: [root] }));
+      // Resolved from the module being built, so that it picks up that module's own shared config. A
+      // config naming a further `extends` recurses, which is what `seen` keeps from looping.
+      const resolved = loadQueries({ path: root }, extended[1]);
 
       return expandBrowserslistExtends(Array.isArray(resolved) ? resolved : [resolved], root, seen);
     } catch {

--- a/packages/tooling/rspack-config/src/index.ts
+++ b/packages/tooling/rspack-config/src/index.ts
@@ -40,7 +40,7 @@ import { existsSync, statSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
 import browserslist from 'browserslist';
 import { loadQueries } from 'browserslist/node';
-import { default as defaultBrowserslistQueries } from 'browserslist-config-openmrs';
+import defaultBrowserslistQueries from 'browserslist-config-openmrs';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 import { TsCheckerRspackPlugin } from 'ts-checker-rspack-plugin';
 // eslint-disable-next-line no-restricted-imports

--- a/packages/tooling/rspack-config/src/index.ts
+++ b/packages/tooling/rspack-config/src/index.ts
@@ -48,6 +48,7 @@ import { isArray, merge, mergeWith } from 'lodash';
 import { inc, parse } from 'semver';
 import { ModuleFederationPlugin } from '@module-federation/enhanced/rspack';
 import rspack, {
+  type Compiler,
   CopyRspackPlugin,
   DefinePlugin,
   type ModuleOptions,
@@ -111,54 +112,107 @@ function getFrameworkVersion() {
   }
 }
 
+/** What a module's browsers resolved to, plus anything worth telling the developer about getting there. */
+type BrowserPolicy = { queries: Array<string>; warnings: Array<string> };
+
 /**
- * The browserslist queries this module's output is compiled and minified against, falling back to
- * OpenMRS's shared config when the module declares none, so that frontend RFC 0003 stays the single
- * source of truth. Without any of this swc down-levels to ES5, and every supported browser pays for
- * transform helpers it doesn't need.
+ * The browserslist queries swc compiles this module against, falling back to OpenMRS's shared config
+ * when the module declares none, so that frontend RFC 0003 stays the single source of truth. Given no
+ * target at all swc down-levels to ES5, and every supported browser pays for transform helpers it
+ * doesn't need.
  *
- * Queries rather than resolved versions, and `extends` expanded here rather than left to the consumer,
- * because these are resolved by Rust ports of browserslist — swc's, and rspack's Lightning CSS — which
- * do not implement `extends` and reject version numbers newer than the browser data they bundle. swc
- * aborts the process rather than reporting an error when a query defeats it.
+ * `@openmrs/webpack-config` has a copy of this; keep them in step. `browser-targets.test.ts` compares
+ * what the two hand their loaders and fails if they drift.
  *
  * @param root The directory of the module being built
  */
-function browserslistQueries(root: string): Array<string> {
+function browserslistQueries(root: string): BrowserPolicy {
+  const warnings: Array<string> = [];
+  // deliberately unguarded
   const loaded = browserslist.loadConfig({ path: root });
   const configured = loaded === undefined ? [] : Array.isArray(loaded) ? loaded : [loaded];
 
-  return expandBrowserslistExtends(configured.length > 0 ? configured : defaultBrowserslistQueries, root);
+  if (loaded !== undefined && configured.length === 0) {
+    // warn when a browserlist config is empty
+    warnings.push(
+      `This module declares a browserslist config, but it resolves to no queries for the ` +
+        `${process.env.BROWSERSLIST_ENV ?? process.env.NODE_ENV ?? production} environment. ` +
+        `Targeting ${defaultBrowserslistQueries.join(', ')} instead.`,
+    );
+  }
+
+  const expanded = expandBrowserslistExtends(
+    configured.length > 0 ? configured : defaultBrowserslistQueries,
+    root,
+    warnings,
+  );
+
+  return { queries: expanded.length > 0 ? expanded : defaultBrowserslistQueries, warnings };
 }
 
-function expandBrowserslistExtends(queries: Array<string>, root: string, seen = new Set<string>()): Array<string> {
-  return queries.flatMap((query) => {
-    const extended = /^extends\s+(\S+)$/.exec(query.trim());
+function expandBrowserslistExtends(
+  queries: Array<string>,
+  root: string,
+  warnings: Array<string>,
+  seen = new Set<string>(),
+): Array<string> {
+  // Split on commas because a browserslist config may be a single string of them
+  return queries.flatMap((query) =>
+    query
+      .split(',')
+      .flatMap((part) => {
+        const extended = /^extends\s+(.+)$/i.exec(part.trim());
 
-    if (!extended || seen.has(extended[1])) {
-      return extended ? [] : [query];
-    }
+        if (!extended) {
+          return [part.trim()];
+        }
 
-    seen.add(extended[1]);
+        const name = extended[1].trim();
 
-    try {
-      // Resolved from the module being built, so that it picks up that module's own shared config. A
-      // config naming a further `extends` recurses, which is what `seen` keeps from looping.
-      const resolved = loadQueries({ path: root }, extended[1]);
+        if (seen.has(name)) {
+          return [];
+        }
 
-      return expandBrowserslistExtends(Array.isArray(resolved) ? resolved : [resolved], root, seen);
-    } catch {
-      // A config that can't be loaded shouldn't take the whole build — or the dev server — down over
-      // which browsers it targets. Fall back to the default queries and say so.
-      console.warn(
-        `Could not load the browserslist config "${extended[1]}". Targeting ${defaultBrowserslistQueries.join(
-          ', ',
-        )} instead.`,
-      );
+        seen.add(name);
 
-      return defaultBrowserslistQueries;
-    }
-  });
+        try {
+          // browserslist's own loader, rather than a bare `require` so we handle the same syntax
+          const resolved = loadQueries({ path: root }, name);
+
+          return expandBrowserslistExtends(Array.isArray(resolved) ? resolved : [resolved], root, warnings, seen);
+        } catch (err) {
+          // Only browserslist's own verdict on a named config is survivable: not installed, or refused
+          // for its name.
+          const notInstalled = (err as { code?: string })?.code === 'MODULE_NOT_FOUND';
+          const refused = (err as { browserslist?: boolean })?.browserslist === true;
+
+          if (!notInstalled && !refused) {
+            throw err;
+          }
+
+          warnings.push(
+            `Could not load the browserslist config "${name}" (${(err as Error).message}). ` +
+              `Targeting ${defaultBrowserslistQueries.join(', ')} instead.`,
+          );
+
+          return defaultBrowserslistQueries;
+        }
+      })
+      .filter((part) => part.length > 0),
+  );
+}
+
+/** Reports how a module's browsers were worked out, where a developer will actually see it. */
+class BrowserslistWarningsPlugin {
+  constructor(private readonly messages: Array<string>) {}
+
+  apply(compiler: Compiler) {
+    compiler.hooks.thisCompilation.tap('OpenmrsBrowserslistWarnings', (compilation) => {
+      for (const message of this.messages) {
+        compilation.warnings.push(new rspack.WebpackError(message));
+      }
+    });
+  }
 }
 
 function makeIdent(name: string): string {
@@ -253,7 +307,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
   const outDir = dirname(browser || main);
   const srcFile = resolve(root, browser ? main : types);
   const ident = makeIdent(name);
-  const browserTargets = browserslistQueries(root);
+  const { queries: browserTargets, warnings: browserslistWarnings } = browserslistQueries(root);
   const frameworkVersion = getFrameworkVersion();
   const routes = resolve(root, 'src', 'routes.json');
   const hasRoutesDefined = fileExistsSync(routes);
@@ -346,9 +400,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
       ],
     },
     mode,
-    // Governs rspack's own runtime and chunk-loading glue, which the swc targets above don't reach —
-    // swc only compiles module sources. Derived from the same queries, so the policy is stated once and
-    // a module that supports older browsers gets a runtime to match.
+    // governs rspack's own runtime and chunk-loading glue
     target: ['web', `browserslist:${browserTargets.join(', ')}`],
     devtool: mode === production ? 'hidden-nosources-source-map' : 'source-map',
     devServer: {
@@ -379,6 +431,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
       optimizationConfig,
     ),
     plugins: [
+      browserslistWarnings.length > 0 && new BrowserslistWarningsPlugin(browserslistWarnings),
       new TsCheckerRspackPlugin(),
       new CleanWebpackPlugin(),
       new BundleAnalyzerPlugin({

--- a/packages/tooling/webpack-config/package.json
+++ b/packages/tooling/webpack-config/package.json
@@ -33,6 +33,8 @@
   "dependencies": {
     "@module-federation/enhanced": "2.8.1",
     "@swc/core": "1.15.21",
+    "browserslist": "4.28.9",
+    "browserslist-config-openmrs": "^1.0.1",
     "clean-webpack-plugin": "4.0.0",
     "copy-webpack-plugin": "11.0.0",
     "css-loader": "5.2.7",

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -39,6 +39,8 @@
 import { existsSync, statSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
 import browserslist from 'browserslist';
+import { loadQueries } from 'browserslist/node';
+import { default as defaultBrowserslistQueries } from 'browserslist-config-openmrs';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
@@ -70,10 +72,6 @@ const production = 'production';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const moduleFederationPin: string = require('../package.json').dependencies['@module-federation/enhanced'];
 const moduleFederationVersion = parse(moduleFederationPin);
-
-// Used when a module declares no browserslist of its own, and when one it names can't be loaded.
-// eslint-disable-next-line @typescript-eslint/no-require-imports
-const defaultBrowserslistQueries: Array<string> = require('browserslist-config-openmrs');
 
 /**
  * Prepended to this app's entry chunks. Without it, an app running under an app shell too old to
@@ -147,9 +145,9 @@ function expandBrowserslistExtends(queries: Array<string>, root: string, seen = 
     seen.add(extended[1]);
 
     try {
-      // Resolved from the module being built, so that it picks up that module's own shared config.
-      // eslint-disable-next-line @typescript-eslint/no-require-imports
-      const resolved = require(require.resolve(extended[1], { paths: [root] }));
+      // Resolved from the module being built, so that it picks up that module's own shared config. A
+      // config naming a further `extends` recurses, which is what `seen` keeps from looping.
+      const resolved = loadQueries({ path: root }, extended[1]);
 
       return expandBrowserslistExtends(Array.isArray(resolved) ? resolved : [resolved], root, seen);
     } catch {

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -38,6 +38,7 @@
  */
 import { existsSync, statSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
+import browserslist from 'browserslist';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
@@ -69,6 +70,10 @@ const production = 'production';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const moduleFederationPin: string = require('../package.json').dependencies['@module-federation/enhanced'];
 const moduleFederationVersion = parse(moduleFederationPin);
+
+// Used when a module declares no browserslist of its own, and when one it names can't be loaded.
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const defaultBrowserslistQueries: Array<string> = require('browserslist-config-openmrs');
 
 /**
  * Prepended to this app's entry chunks. Without it, an app running under an app shell too old to
@@ -109,6 +114,56 @@ function getFrameworkVersion() {
   } catch {
     return '5.x';
   }
+}
+
+/**
+ * The browserslist queries this module's output is compiled and minified against, falling back to
+ * OpenMRS's shared config when the module declares none, so that frontend RFC 0003 stays the single
+ * source of truth. Without any of this swc down-levels to ES5, and every supported browser pays for
+ * transform helpers it doesn't need.
+ *
+ * Queries rather than resolved versions, and `extends` expanded here rather than left to the consumer,
+ * because these are resolved by Rust ports of browserslist — swc's, and rspack's Lightning CSS — which
+ * do not implement `extends` and reject version numbers newer than the browser data they bundle. swc
+ * aborts the process rather than reporting an error when a query defeats it.
+ *
+ * @param root The directory of the module being built
+ */
+function browserslistQueries(root: string): Array<string> {
+  const loaded = browserslist.loadConfig({ path: root });
+  const configured = loaded === undefined ? [] : Array.isArray(loaded) ? loaded : [loaded];
+
+  return expandBrowserslistExtends(configured.length > 0 ? configured : defaultBrowserslistQueries, root);
+}
+
+function expandBrowserslistExtends(queries: Array<string>, root: string, seen = new Set<string>()): Array<string> {
+  return queries.flatMap((query) => {
+    const extended = /^extends\s+(\S+)$/.exec(query.trim());
+
+    if (!extended || seen.has(extended[1])) {
+      return extended ? [] : [query];
+    }
+
+    seen.add(extended[1]);
+
+    try {
+      // Resolved from the module being built, so that it picks up that module's own shared config.
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const resolved = require(require.resolve(extended[1], { paths: [root] }));
+
+      return expandBrowserslistExtends(Array.isArray(resolved) ? resolved : [resolved], root, seen);
+    } catch {
+      // A config that can't be loaded shouldn't take the whole build — or the dev server — down over
+      // which browsers it targets. Fall back to the default queries and say so.
+      console.warn(
+        `Could not load the browserslist config "${extended[1]}". Targeting ${defaultBrowserslistQueries.join(
+          ', ',
+        )} instead.`,
+      );
+
+      return defaultBrowserslistQueries;
+    }
+  });
 }
 
 function makeIdent(name: string): string {
@@ -201,6 +256,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
   const outDir = dirname(browser || main);
   const srcFile = resolve(root, browser ? main : types);
   const ident = makeIdent(name);
+  const browserTargets = browserslistQueries(root);
   const frameworkVersion = getFrameworkVersion();
   const routes = resolve(root, 'src', 'routes.json');
   const hasRoutesDefined = fileExistsSync(routes);
@@ -239,7 +295,16 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
           {
             test: /\.m?(js|ts|tsx)$/,
             exclude: /node_modules/,
-            use: require.resolve('swc-loader'),
+            use: {
+              loader: require.resolve('swc-loader'),
+              options: {
+                env: {
+                  targets: browserTargets,
+                },
+                // ignore a project .swcrc to match rspack behavior
+                swcrc: false,
+              },
+            },
           },
           scriptRuleConfig,
         ),
@@ -282,6 +347,10 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
       ],
     },
     mode,
+    // Governs webpack's own runtime and chunk-loading glue, which the swc targets above don't reach —
+    // swc only compiles module sources. Derived from the same queries, so the policy is stated once and
+    // a module that supports older browsers gets a runtime to match.
+    target: ['web', `browserslist:${browserTargets.join(', ')}`],
     devtool: mode === production ? 'hidden-nosources-source-map' : 'source-map',
     devServer: {
       headers: {

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -40,7 +40,7 @@ import { existsSync, statSync } from 'fs';
 import { basename, dirname, resolve } from 'path';
 import browserslist from 'browserslist';
 import { loadQueries } from 'browserslist/node';
-import { default as defaultBrowserslistQueries } from 'browserslist-config-openmrs';
+import defaultBrowserslistQueries from 'browserslist-config-openmrs';
 import { CleanWebpackPlugin } from 'clean-webpack-plugin';
 import CopyWebpackPlugin from 'copy-webpack-plugin';
 import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';

--- a/packages/tooling/webpack-config/src/index.ts
+++ b/packages/tooling/webpack-config/src/index.ts
@@ -47,17 +47,21 @@ import ForkTsCheckerWebpackPlugin from 'fork-ts-checker-webpack-plugin';
 // eslint-disable-next-line no-restricted-imports
 import { isArray, merge, mergeWith } from 'lodash';
 import { inc, parse } from 'semver';
-import { ModuleFederationPlugin } from '@module-federation/enhanced/webpack';
 import {
   BannerPlugin,
+  type Compiler,
   DefinePlugin,
   ExternalsPlugin,
   type ModuleOptions,
   type RuleSetRule,
+  WebpackError,
   type WebpackOptionsNormalized as WebpackConfiguration,
 } from 'webpack';
+// webpack's own browsers-to-features mapping
+import browserslistTargetHandler from 'webpack/lib/config/browserslistTargetHandler';
 import { BundleAnalyzerPlugin } from 'webpack-bundle-analyzer';
 import { StatsWriterPlugin } from 'webpack-stats-plugin';
+import { ModuleFederationPlugin } from '@module-federation/enhanced/webpack';
 
 type OpenmrsWebpackConfig = Omit<Partial<WebpackConfiguration>, 'module' | 'output'> & {
   module: ModuleOptions;
@@ -72,6 +76,26 @@ const production = 'production';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 const moduleFederationPin: string = require('../package.json').dependencies['@module-federation/enhanced'];
 const moduleFederationVersion = parse(moduleFederationPin);
+
+// The subset of what `browserslistTargetHandler.resolve` reports that `output.environment` accepts;
+// the rest describe the platform and available APIs, and webpack's schema rejects them here.
+const environmentFlags = [
+  'arrowFunction',
+  'asyncFunction',
+  'bigIntLiteral',
+  'const',
+  'destructuring',
+  'document',
+  'dynamicImport',
+  'dynamicImportInWorker',
+  'forOf',
+  'globalThis',
+  'importMetaDirnameAndFilename',
+  'methodShorthand',
+  'module',
+  'optionalChaining',
+  'templateLiteral',
+] as const;
 
 /**
  * Prepended to this app's entry chunks. Without it, an app running under an app shell too old to
@@ -114,54 +138,130 @@ function getFrameworkVersion() {
   }
 }
 
+/** What a module's browsers resolved to, plus anything worth telling the developer about getting there. */
+type BrowserPolicy = { queries: Array<string>; warnings: Array<string> };
+
 /**
- * The browserslist queries this module's output is compiled and minified against, falling back to
- * OpenMRS's shared config when the module declares none, so that frontend RFC 0003 stays the single
- * source of truth. Without any of this swc down-levels to ES5, and every supported browser pays for
- * transform helpers it doesn't need.
+ * The browserslist queries swc compiles this module against, falling back to OpenMRS's shared config
+ * when the module declares none, so that frontend RFC 0003 stays the single source of truth. Given no
+ * target at all swc down-levels to ES5, and every supported browser pays for transform helpers it
+ * doesn't need.
  *
- * Queries rather than resolved versions, and `extends` expanded here rather than left to the consumer,
- * because these are resolved by Rust ports of browserslist — swc's, and rspack's Lightning CSS — which
- * do not implement `extends` and reject version numbers newer than the browser data they bundle. swc
- * aborts the process rather than reporting an error when a query defeats it.
+ * `@openmrs/rspack-config` has a copy of this; keep them in step. `browser-targets.test.ts` compares
+ * what the two hand their loaders and fails if they drift.
  *
  * @param root The directory of the module being built
  */
-function browserslistQueries(root: string): Array<string> {
+function browserslistQueries(root: string): BrowserPolicy {
+  const warnings: Array<string> = [];
+  // deliberately unguarded
   const loaded = browserslist.loadConfig({ path: root });
   const configured = loaded === undefined ? [] : Array.isArray(loaded) ? loaded : [loaded];
 
-  return expandBrowserslistExtends(configured.length > 0 ? configured : defaultBrowserslistQueries, root);
+  if (loaded !== undefined && configured.length === 0) {
+    // warn when a browserlist config is empty
+    warnings.push(
+      `This module declares a browserslist config, but it resolves to no queries for the ` +
+        `${process.env.BROWSERSLIST_ENV ?? process.env.NODE_ENV ?? production} environment. ` +
+        `Targeting ${defaultBrowserslistQueries.join(', ')} instead.`,
+    );
+  }
+
+  const expanded = expandBrowserslistExtends(
+    configured.length > 0 ? configured : defaultBrowserslistQueries,
+    root,
+    warnings,
+  );
+
+  return { queries: expanded.length > 0 ? expanded : defaultBrowserslistQueries, warnings };
 }
 
-function expandBrowserslistExtends(queries: Array<string>, root: string, seen = new Set<string>()): Array<string> {
-  return queries.flatMap((query) => {
-    const extended = /^extends\s+(\S+)$/.exec(query.trim());
+function expandBrowserslistExtends(
+  queries: Array<string>,
+  root: string,
+  warnings: Array<string>,
+  seen = new Set<string>(),
+): Array<string> {
+  // Split on commas because a browserslist config may be a single string of them
+  return queries.flatMap((query) =>
+    query
+      .split(',')
+      .flatMap((part) => {
+        const extended = /^extends\s+(.+)$/i.exec(part.trim());
 
-    if (!extended || seen.has(extended[1])) {
-      return extended ? [] : [query];
-    }
+        if (!extended) {
+          return [part.trim()];
+        }
 
-    seen.add(extended[1]);
+        const name = extended[1].trim();
 
-    try {
-      // Resolved from the module being built, so that it picks up that module's own shared config. A
-      // config naming a further `extends` recurses, which is what `seen` keeps from looping.
-      const resolved = loadQueries({ path: root }, extended[1]);
+        if (seen.has(name)) {
+          return [];
+        }
 
-      return expandBrowserslistExtends(Array.isArray(resolved) ? resolved : [resolved], root, seen);
-    } catch {
-      // A config that can't be loaded shouldn't take the whole build — or the dev server — down over
-      // which browsers it targets. Fall back to the default queries and say so.
-      console.warn(
-        `Could not load the browserslist config "${extended[1]}". Targeting ${defaultBrowserslistQueries.join(
-          ', ',
-        )} instead.`,
-      );
+        seen.add(name);
 
-      return defaultBrowserslistQueries;
-    }
-  });
+        try {
+          // browserslist's own loader, rather than a bare `require` so we handle the same syntax
+          const resolved = loadQueries({ path: root }, name);
+
+          return expandBrowserslistExtends(Array.isArray(resolved) ? resolved : [resolved], root, warnings, seen);
+        } catch (err) {
+          // Only browserslist's own verdict on a named config is survivable: not installed, or refused
+          // for its name.
+          const notInstalled = (err as { code?: string })?.code === 'MODULE_NOT_FOUND';
+          const refused = (err as { browserslist?: boolean })?.browserslist === true;
+
+          if (!notInstalled && !refused) {
+            throw err;
+          }
+
+          warnings.push(
+            `Could not load the browserslist config "${name}" (${(err as Error).message}). ` +
+              `Targeting ${defaultBrowserslistQueries.join(', ')} instead.`,
+          );
+
+          return defaultBrowserslistQueries;
+        }
+      })
+      .filter((part) => part.length > 0),
+  );
+}
+
+/** Reports how a module's browsers were worked out, where a developer will actually see it. */
+class BrowserslistWarningsPlugin {
+  constructor(private readonly messages: Array<string>) {}
+
+  apply(compiler: Compiler) {
+    compiler.hooks.thisCompilation.tap('OpenmrsBrowserslistWarnings', (compilation) => {
+      for (const message of this.messages) {
+        compilation.warnings.push(new WebpackError(message));
+      }
+    });
+  }
+}
+
+/**
+ * The `output.environment` flags for a set of browserslist queries: which JavaScript features webpack
+ * may use in the runtime it generates.
+ *
+ * Derived with webpack's own browserslist target handler, so the browsers-to-features mapping is the
+ * caniuse-backed one webpack uses for `target: 'browserslist'` rather than a table maintained here.
+ * `resolve` also reports platform and API properties that `output.environment` rejects, hence the
+ * filter to the flags webpack's schema accepts.
+ *
+ * @param queries Browserslist queries, already `extends`-expanded
+ * @param root The directory of the module being built, for resolving relative queries
+ */
+function browserEnvironment(queries: Array<string>, root: string): WebpackConfiguration['output']['environment'] {
+  const supported = browserslistTargetHandler.resolve(browserslist(queries, { path: root })) as Record<
+    string,
+    boolean | null | undefined
+  >;
+
+  return Object.fromEntries(
+    environmentFlags.filter((flag) => typeof supported[flag] === 'boolean').map((flag) => [flag, supported[flag]]),
+  );
 }
 
 function makeIdent(name: string): string {
@@ -254,7 +354,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
   const outDir = dirname(browser || main);
   const srcFile = resolve(root, browser ? main : types);
   const ident = makeIdent(name);
-  const browserTargets = browserslistQueries(root);
+  const { queries: browserTargets, warnings: browserslistWarnings } = browserslistQueries(root);
   const frameworkVersion = getFrameworkVersion();
   const routes = resolve(root, 'src', 'routes.json');
   const hasRoutesDefined = fileExistsSync(routes);
@@ -286,6 +386,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
       publicPath: 'auto',
       path: resolve(root, outDir),
       hashFunction: 'xxhash64',
+      environment: browserEnvironment(browserTargets, root),
     },
     module: {
       rules: [
@@ -345,10 +446,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
       ],
     },
     mode,
-    // Governs webpack's own runtime and chunk-loading glue, which the swc targets above don't reach —
-    // swc only compiles module sources. Derived from the same queries, so the policy is stated once and
-    // a module that supports older browsers gets a runtime to match.
-    target: ['web', `browserslist:${browserTargets.join(', ')}`],
+    target: 'web',
     devtool: mode === production ? 'hidden-nosources-source-map' : 'source-map',
     devServer: {
       headers: {
@@ -380,6 +478,7 @@ export default (env: Record<string, string>, argv: Record<string, string> = {}) 
       optimizationConfig,
     ),
     plugins: [
+      browserslistWarnings.length > 0 && new BrowserslistWarningsPlugin(browserslistWarnings),
       new ForkTsCheckerWebpackPlugin({
         issue: {
           exclude: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -3125,6 +3125,7 @@ __metadata:
     "@openmrs/esm-styleguide": "workspace:*"
     "@rspack/cli": "npm:1.7.9"
     "@rspack/core": "npm:1.7.9"
+    browserslist-config-openmrs: "npm:^1.0.1"
     cross-env: "npm:^10.1.0"
     dayjs: "npm:^1.11.13"
     dexie: "npm:^3.0.3"
@@ -3861,6 +3862,8 @@ __metadata:
     "@openmrs/webpack-config": "workspace:*"
     "@rspack/core": "npm:1.7.9"
     "@types/semver": "npm:^7.7.3"
+    browserslist: "npm:4.28.9"
+    browserslist-config-openmrs: "npm:^1.0.1"
     cross-env: "npm:^10.1.0"
     semver: "npm:^7.7.3"
     typescript: "npm:^5.8.3"
@@ -3879,6 +3882,8 @@ __metadata:
     "@swc/core": "npm:1.15.21"
     "@types/lodash-es": "npm:^4.17.12"
     "@types/semver": "npm:^7.7.3"
+    browserslist: "npm:4.28.9"
+    browserslist-config-openmrs: "npm:^1.0.1"
     clean-webpack-plugin: "npm:4.0.0"
     copy-webpack-plugin: "npm:11.0.0"
     css-loader: "npm:5.2.7"
@@ -3958,6 +3963,8 @@ __metadata:
     "@swc/core": "npm:1.15.21"
     "@types/lodash-es": "npm:4.17.12"
     "@types/semver": "npm:^7.7.3"
+    browserslist: "npm:4.28.9"
+    browserslist-config-openmrs: "npm:^1.0.1"
     clean-webpack-plugin: "npm:4.0.0"
     copy-webpack-plugin: "npm:11.0.0"
     css-loader: "npm:5.2.7"
@@ -8898,12 +8905,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"baseline-browser-mapping@npm:^2.9.0":
-  version: 2.10.0
-  resolution: "baseline-browser-mapping@npm:2.10.0"
+"baseline-browser-mapping@npm:^2.11.20":
+  version: 2.11.21
+  resolution: "baseline-browser-mapping@npm:2.11.21"
   bin:
     baseline-browser-mapping: dist/cli.cjs
-  checksum: 10/8145e076e4299f04c7a412e6ea63803e330153cd89c47b5303f9b56b58078f4c3d5a5b5332c1069da889e76facacca4d43f8940375f7e73ce0a4d96214332953
+  checksum: 10/b4d223df8dbb8deeaa3dae3b9b60ad48b24c57a5473827b5a6ee1c21917e7c37af2185224c5366f2932654ec5fb1a9fee4f95fe7213cc29f4347550f25e4234b
   languageName: node
   linkType: hard
 
@@ -9111,18 +9118,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"browserslist@npm:^4.23.3, browserslist@npm:^4.24.0, browserslist@npm:^4.28.1":
-  version: 4.28.1
-  resolution: "browserslist@npm:4.28.1"
+"browserslist@npm:4.28.9, browserslist@npm:^4.23.3, browserslist@npm:^4.24.0, browserslist@npm:^4.28.1":
+  version: 4.28.9
+  resolution: "browserslist@npm:4.28.9"
   dependencies:
-    baseline-browser-mapping: "npm:^2.9.0"
-    caniuse-lite: "npm:^1.0.30001759"
-    electron-to-chromium: "npm:^1.5.263"
-    node-releases: "npm:^2.0.27"
-    update-browserslist-db: "npm:^1.2.0"
+    baseline-browser-mapping: "npm:^2.11.20"
+    caniuse-lite: "npm:^1.0.30001810"
+    electron-to-chromium: "npm:^1.5.420"
+    node-releases: "npm:^2.0.54"
+    update-browserslist-db: "npm:^1.3.2"
   bin:
     browserslist: cli.js
-  checksum: 10/64f2a97de4bce8473c0e5ae0af8d76d1ead07a5b05fc6bc87b848678bb9c3a91ae787b27aa98cdd33fc00779607e6c156000bed58fefb9cf8e4c5a183b994cdb
+  checksum: 10/493e5e3c11d4bdd34ce8cb7ed5edc98bc5948457e6a3cc1268b253d0ff9a616033b10980515e0e6faeddae745fb9c330cd4510189d681ad86f9ce0b2da3c840e
   languageName: node
   linkType: hard
 
@@ -9319,10 +9326,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"caniuse-lite@npm:^1.0.30001646, caniuse-lite@npm:^1.0.30001759":
-  version: 1.0.30001770
-  resolution: "caniuse-lite@npm:1.0.30001770"
-  checksum: 10/a85fb0895881d31f0b7ae246725a8b67ab8590601a08027439be1d53418352b58896418145b4da2eaae7130d59877b487eeef9e4434fa1069225b9e50d00f79b
+"caniuse-lite@npm:^1.0.30001646, caniuse-lite@npm:^1.0.30001810":
+  version: 1.0.30001810
+  resolution: "caniuse-lite@npm:1.0.30001810"
+  checksum: 10/47d7db627c3f3d1a10e06eef9efbb84295c6ef9d959b585b64032cc293637ca7b9b6af7e5d5752972b3e690d9561f14b9561db03890fbc6e38dc1aaa54e51d97
   languageName: node
   linkType: hard
 
@@ -10957,10 +10964,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron-to-chromium@npm:^1.5.263":
-  version: 1.5.286
-  resolution: "electron-to-chromium@npm:1.5.286"
-  checksum: 10/530ae36571f3f737431dc1f97ab176d9ec38d78e7a14a78fff78540769ef139e9011200a886864111ee26d64e647136531ff004f368f5df8cdd755c45ad97649
+"electron-to-chromium@npm:^1.5.420":
+  version: 1.5.422
+  resolution: "electron-to-chromium@npm:1.5.422"
+  checksum: 10/a4cc1bd7204bdb3da063f1ad8103f9990e03da3d0dae0aaf75e1669f2c36a9ae807498c5b27eed61fa98d6b10baf7fe05ff6038a99a4a85a0285e623825253d6
   languageName: node
   linkType: hard
 
@@ -15457,10 +15464,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"node-releases@npm:^2.0.27":
-  version: 2.0.27
-  resolution: "node-releases@npm:2.0.27"
-  checksum: 10/f6c78ddb392ae500719644afcbe68a9ea533242c02312eb6a34e8478506eb7482a3fb709c70235b01c32fe65625b68dfa9665113f816d87f163bc3819b62b106
+"node-releases@npm:^2.0.54":
+  version: 2.0.54
+  resolution: "node-releases@npm:2.0.54"
+  checksum: 10/36380abbe4ce6f5bfec7dab13fa8174e67d2c316a9cbedcd01196bd37dbec99ca7214caf7a91f05d27ae17657d5cb55f39c53db216a7992fd9a2e29966ebd2ba
   languageName: node
   linkType: hard
 
@@ -15837,6 +15844,7 @@ __metadata:
     "@types/semver": "npm:^7"
     "@types/yargs": "npm:^17.0.0"
     autoprefixer: "npm:10.4.20"
+    browserslist: "npm:4.28.9"
     browserslist-config-openmrs: "npm:^1.0.1"
     chalk: "npm:5.6.2"
     clean-webpack-plugin: "npm:4.0.0"
@@ -20139,9 +20147,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"update-browserslist-db@npm:^1.2.0":
-  version: 1.2.3
-  resolution: "update-browserslist-db@npm:1.2.3"
+"update-browserslist-db@npm:^1.3.2":
+  version: 1.3.2
+  resolution: "update-browserslist-db@npm:1.3.2"
   dependencies:
     escalade: "npm:^3.2.0"
     picocolors: "npm:^1.1.1"
@@ -20149,7 +20157,7 @@ __metadata:
     browserslist: ">= 4.21.0"
   bin:
     update-browserslist-db: cli.js
-  checksum: 10/059f774300efb4b084a49293143c511f3ae946d40397b5c30914e900cd5691a12b8e61b41dd54ed73d3b56c8204165a0333107dd784ccf8f8c81790bcc423175
+  checksum: 10/ca883e9d0fca1b5bfb9d5e7d9468c5ddd1d66ea827566f474875171381ad33b84aa555c138094fb2c6297c680e06482ad8b4c1ad931e8bfab9a4cf36ea9cf006
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3125,6 +3125,7 @@ __metadata:
     "@openmrs/esm-styleguide": "workspace:*"
     "@rspack/cli": "npm:1.7.9"
     "@rspack/core": "npm:1.7.9"
+    browserslist: "npm:4.28.9"
     browserslist-config-openmrs: "npm:^1.0.1"
     cross-env: "npm:^10.1.0"
     dayjs: "npm:^1.11.13"


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->

When we switched to swc, we accidentally lost support for the browserlist, which means our code has been compiled for ES5 for a while. This fixes that by resolving the browserlist and injecting it at appropriate points into the rspack / webpack builds.

One breakage: webpack no longer honors .swcrc in order to match rspack's behavior.

The idea here is that this will help us output somewhat less convoluted and easier-to-read JS, though as the bundle-size check shows, this is a pretty small effect.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
https://issues.openmrs.org/browse/O3-5853

## Other
<!-- Anything not covered above -->
