### PR TITLE
(fix) Ensure slot-specific configuration are correctly passed everywhere

### DIFF
--- a/.changeset/wet-pugs-refuse.md
+++ b/.changeset/wet-pugs-refuse.md
@@ -1,0 +1,6 @@
+---
+"@openmrs/esm-config": patch
+"@openmrs/esm-framework": patch
+---
+
+(fix) Ensure slot-specific configuration are correctly passed everywhere

--- a/packages/apps/esm-primary-navigation-app/src/components/dashboard/dashboard.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/dashboard/dashboard.test.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import {
+  defineConfigSchema,
+  defineExtensionConfigSchema,
+  ExtensionSlot,
+  getSyncLifecycle,
+  openmrsComponentDecorator,
+  provide,
+  registerExtension,
+  updateInternalExtensionStore,
+} from '@openmrs/esm-framework/src/internal';
+import Dashboard, { dashboardConfigSchema } from './dashboard.component';
+
+const chartApp = '@openmrs/esm-patient-chart-app';
+const navApp = '@openmrs/esm-primary-navigation-app';
+
+function registerDashboard() {
+  registerExtension({
+    name: 'dashboard',
+    moduleName: navApp,
+    load: getSyncLifecycle(Dashboard, { moduleName: navApp, featureName: 'dashboard', disableTranslations: true }),
+    meta: {},
+  });
+}
+
+function renderSlot(slotName: string) {
+  const Host = openmrsComponentDecorator({
+    moduleName: chartApp,
+    featureName: 'patient chart',
+    disableTranslations: true,
+  })(() => <ExtensionSlot name={slotName} state={{ basePath: '/patient/123/chart' }} />);
+
+  return render(<Host />);
+}
+
+describe('the dashboard extension', () => {
+  beforeAll(() => {
+    defineConfigSchema(chartApp, {});
+    defineExtensionConfigSchema('dashboard', dashboardConfigSchema);
+  });
+
+  beforeEach(() => {
+    updateInternalExtensionStore(() => ({ slots: {}, extensions: {} }));
+    registerDashboard();
+  });
+
+  it('renders a link to its path', async () => {
+    provide(
+      {
+        [chartApp]: {
+          extensionSlots: {
+            'linked-dashboard-slot': {
+              add: ['dashboard#ckd'],
+              configure: { 'dashboard#ckd': { title: 'CKD Specific', path: 'ckd-specific' } },
+            },
+          },
+        },
+      },
+      'test',
+    );
+
+    renderSlot('linked-dashboard-slot');
+
+    const link = await screen.findByRole('link', { name: 'CKD Specific' });
+    expect(link).toHaveAttribute('href', '/patient/123/chart/ckd-specific');
+  });
+
+  it('reports the missing path when it has no path configured', async () => {
+    provide(
+      {
+        [chartApp]: {
+          extensionSlots: {
+            'pathless-dashboard-slot': {
+              add: ['dashboard#nowhere'],
+              configure: { 'dashboard#nowhere': { title: 'Nowhere' } },
+            },
+          },
+        },
+      },
+      'test',
+    );
+
+    renderSlot('pathless-dashboard-slot');
+
+    expect(await screen.findByText(/without the property "path" being set/)).toBeInTheDocument();
+  });
+});

--- a/packages/apps/esm-primary-navigation-app/src/components/dashboard/dashboard.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/dashboard/dashboard.test.tsx
@@ -25,10 +25,13 @@ function registerDashboard() {
   });
 }
 
+// Hosted by this app rather than the chart app, so the slot belongs to this app while the
+// configuration below is written by the app that put the dashboard there. That is the arrangement
+// a nav group produces, and the one the dashboard has to work under.
 function renderSlot(slotName: string) {
   const Host = openmrsComponentDecorator({
-    moduleName: chartApp,
-    featureName: 'patient chart',
+    moduleName: navApp,
+    featureName: 'primary navigation',
     disableTranslations: true,
   })(() => <ExtensionSlot name={slotName} state={{ basePath: '/patient/123/chart' }} />);
 
@@ -37,6 +40,7 @@ function renderSlot(slotName: string) {
 
 describe('the dashboard extension', () => {
   beforeAll(() => {
+    defineConfigSchema(navApp, {});
     defineConfigSchema(chartApp, {});
     defineExtensionConfigSchema('dashboard', dashboardConfigSchema);
   });

--- a/packages/apps/esm-primary-navigation-app/src/components/nav-group/nav-group.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/nav-group/nav-group.test.tsx
@@ -1,0 +1,123 @@
+import React from 'react';
+import { beforeAll, beforeEach, describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import {
+  defineConfigSchema,
+  defineExtensionConfigSchema,
+  ExtensionSlot,
+  getSyncLifecycle,
+  openmrsComponentDecorator,
+  provide,
+  registerExtension,
+  updateInternalExtensionStore,
+} from '@openmrs/esm-framework/src/internal';
+import Dashboard, { dashboardConfigSchema } from '../dashboard/dashboard.component';
+import { NavGroup, navGroupConfigSchema } from './nav-group.component';
+
+const chartApp = '@openmrs/esm-patient-chart-app';
+const navApp = '@openmrs/esm-primary-navigation-app';
+
+function renderChartSlot(slotName: string) {
+  const Host = openmrsComponentDecorator({
+    moduleName: chartApp,
+    featureName: 'patient chart',
+    disableTranslations: true,
+  })(() => <ExtensionSlot name={slotName} state={{ basePath: '/patient/123/chart' }} />);
+
+  return render(<Host />);
+}
+
+describe('the nav group extension', () => {
+  beforeAll(() => {
+    // The nav group renders in this app's own module context, so its config store has to be
+    // loaded or `useConfig` suspends for ever.
+    defineConfigSchema(navApp, {});
+    defineConfigSchema(chartApp, {});
+    defineExtensionConfigSchema('nav-group', navGroupConfigSchema);
+    defineExtensionConfigSchema('dashboard', dashboardConfigSchema);
+  });
+
+  beforeEach(() => {
+    updateInternalExtensionStore(() => ({ slots: {}, extensions: {} }));
+
+    registerExtension({
+      name: 'nav-group',
+      moduleName: navApp,
+      load: getSyncLifecycle(NavGroup, { moduleName: navApp, featureName: 'nav group', disableTranslations: true }),
+      meta: {},
+    });
+
+    registerExtension({
+      name: 'dashboard',
+      moduleName: navApp,
+      load: getSyncLifecycle(Dashboard, { moduleName: navApp, featureName: 'dashboard', disableTranslations: true }),
+      meta: {},
+    });
+  });
+
+  it('opens the slot named by its configuration', async () => {
+    registerExtension({
+      name: 'group-member',
+      moduleName: navApp,
+      load: getSyncLifecycle(() => <div>a link in the group</div>, {
+        moduleName: navApp,
+        featureName: 'group member',
+        disableTranslations: true,
+      }),
+      meta: {},
+    });
+
+    provide(
+      {
+        [chartApp]: {
+          extensionSlots: {
+            'titled-group-outer-slot': {
+              add: ['nav-group#titled'],
+              configure: {
+                'nav-group#titled': { title: 'Clinical Views', slotName: 'titled-group-slot' },
+              },
+            },
+            'titled-group-slot': { add: ['group-member'] },
+          },
+        },
+      },
+      'test',
+    );
+
+    renderChartSlot('titled-group-outer-slot');
+
+    expect(await screen.findByText('Clinical Views')).toBeInTheDocument();
+    expect(await screen.findByText('a link in the group')).toBeInTheDocument();
+  });
+
+  // The reported regression: the slot a nav group opens belongs to this app, because this app
+  // renders the group, but the implementer only ever sees the app they added the group to.
+  // Configuration for the group's contents has to be honored from there.
+  it("applies the configuration the outer slot's module gives to extensions inside the group", async () => {
+    provide(
+      {
+        [chartApp]: {
+          extensionSlots: {
+            'patient-chart-dashboard-slot': {
+              add: ['nav-group#clinical-views'],
+              configure: {
+                'nav-group#clinical-views': { title: 'Clinical Views', slotName: 'clinical-views-group-slot' },
+              },
+            },
+            'clinical-views-group-slot': {
+              add: ['dashboard#ckd'],
+              configure: { 'dashboard#ckd': { title: 'CKD Specific', path: 'ckd-specific' } },
+            },
+          },
+        },
+      },
+      'test',
+    );
+
+    renderChartSlot('patient-chart-dashboard-slot');
+
+    const link = await screen.findByRole('link', { name: 'CKD Specific' });
+    expect(link).toHaveAttribute('href', '/patient/123/chart/ckd-specific');
+    expect(screen.queryByText(/without the property "path" being set/)).not.toBeInTheDocument();
+  });
+});

--- a/packages/apps/esm-primary-navigation-app/src/components/nav-group/nav-group.test.tsx
+++ b/packages/apps/esm-primary-navigation-app/src/components/nav-group/nav-group.test.tsx
@@ -9,7 +9,9 @@ import {
   openmrsComponentDecorator,
   provide,
   registerExtension,
+  Type,
   updateInternalExtensionStore,
+  useConfig,
 } from '@openmrs/esm-framework/src/internal';
 import Dashboard, { dashboardConfigSchema } from '../dashboard/dashboard.component';
 import { NavGroup, navGroupConfigSchema } from './nav-group.component';
@@ -56,10 +58,16 @@ describe('the nav group extension', () => {
   });
 
   it('opens the slot named by its configuration', async () => {
+    function GroupMember() {
+      const { label } = useConfig<{ label: string }>();
+      return <div>a link labelled {label}</div>;
+    }
+
+    defineExtensionConfigSchema('group-member', { label: { _type: Type.String, _default: 'nothing' } });
     registerExtension({
       name: 'group-member',
       moduleName: navApp,
-      load: getSyncLifecycle(() => <div>a link in the group</div>, {
+      load: getSyncLifecycle(GroupMember, {
         moduleName: navApp,
         featureName: 'group member',
         disableTranslations: true,
@@ -77,7 +85,9 @@ describe('the nav group extension', () => {
                 'nav-group#titled': { title: 'Clinical Views', slotName: 'titled-group-slot' },
               },
             },
-            'titled-group-slot': { add: ['group-member'] },
+            // The group's own slot belongs to the nav app, so configuring its contents from here
+            // is the case that has to keep working.
+            'titled-group-slot': { add: ['group-member'], configure: { 'group-member': { label: 'Vitals' } } },
           },
         },
       },
@@ -87,12 +97,12 @@ describe('the nav group extension', () => {
     renderChartSlot('titled-group-outer-slot');
 
     expect(await screen.findByText('Clinical Views')).toBeInTheDocument();
-    expect(await screen.findByText('a link in the group')).toBeInTheDocument();
+    expect(await screen.findByText(/a link labelled/)).toHaveTextContent('a link labelled Vitals');
   });
 
-  // The reported regression: the slot a nav group opens belongs to this app, because this app
-  // renders the group, but the implementer only ever sees the app they added the group to.
-  // Configuration for the group's contents has to be honored from there.
+  // The slot a nav group opens belongs to the nav app, since the nav app renders the group, but
+  // the implementer only sees the app they added the group to. Configuration written there has to
+  // reach the group's contents.
   it("applies the configuration the outer slot's module gives to extensions inside the group", async () => {
     provide(
       {

--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -1341,12 +1341,10 @@ describe('extension config', () => {
     expect(console.error).not.toHaveBeenCalled();
   });
 
+  // The module that renders an extension owns the slot it opens, which need not be the module an
+  // implementer configures that slot from.
   it("uses the 'configure' config written by a module other than the one owning the slot", () => {
     updateConfigExtensionStore('fooExt#id6');
-    // A slot opened by an extension belongs to the module that renders that extension, which is
-    // not the module an implementer configures the slot's contents from. A nav group is the case
-    // in point: the group comes from the primary navigation app, the links in it are configured
-    // by whichever app the group was added to.
     const configureConfig = {
       'ext-mod': { bar: 'qux' },
       'other-mod': {
@@ -1371,17 +1369,17 @@ describe('extension config', () => {
   it("prefers the slot-owning module's 'configure' config to another module's", () => {
     updateConfigExtensionStore('fooExt#id7');
     const configureConfig = {
-      'other-mod': {
-        extensionSlots: {
-          barSlot: {
-            configure: { 'fooExt#id7': { bar: 'from-other', baz: 'from-other' } },
-          },
-        },
-      },
       'slot-mod': {
         extensionSlots: {
           barSlot: {
             configure: { 'fooExt#id7': { baz: 'from-owner' } },
+          },
+        },
+      },
+      'other-mod': {
+        extensionSlots: {
+          barSlot: {
+            configure: { 'fooExt#id7': { bar: 'from-other', baz: 'from-other' } },
           },
         },
       },
@@ -1397,25 +1395,43 @@ describe('extension config', () => {
     expect(console.error).not.toHaveBeenCalled();
   });
 
-  it('keeps the slot configuration of every module that configures the slot', () => {
+  it("gathers 'configure' from every module but leaves 'add' to the last one to declare the slot", () => {
     updateConfigExtensionStore('fooExt#id8');
     Config.provide({
-      'adding-mod': { extensionSlots: { barSlot: { add: ['fooExt#id8'] } } },
-      'configuring-mod': {
-        extensionSlots: { barSlot: { configure: { 'fooExt#id8': { baz: 'quiz' } } } },
+      'first-mod': {
+        extensionSlots: {
+          barSlot: { add: ['fooExt#unwanted'], configure: { 'fooExt#id8': { bar: 'from-first' } } },
+        },
+      },
+      'last-mod': {
+        extensionSlots: {
+          barSlot: { add: ['fooExt#id8'], configure: { 'fooExt#id8': { baz: 'from-last' } } },
+        },
       },
     });
 
-    expect(getExtensionSlotsConfigStore().getState().slots['barSlot'].config).toStrictEqual({
-      add: ['fooExt#id8'],
-      configure: { 'fooExt#id8': { baz: 'quiz' } },
-    });
+    // Composing `add` across modules would resurrect entries another module had removed, so the
+    // last module to name the slot still supplies it whole.
+    expect(getExtensionSlotsConfigStore().getState().slots['barSlot'].config.add).toStrictEqual(['fooExt#id8']);
     expect(getExtensionConfig('barSlot', 'fooExt#id8').getState().config).toStrictEqual({
-      bar: 'barry',
-      baz: 'quiz',
+      bar: 'from-first',
+      baz: 'from-last',
       'Display conditions': { expression: undefined, privileges: [] },
       'Translation overrides': {},
     });
+  });
+
+  it('releases a cross-module configure when the temporary config that set it is cleared', () => {
+    updateConfigExtensionStore('fooExt#id9');
+    temporaryConfigStore.setState({
+      config: { 'other-mod': { extensionSlots: { barSlot: { configure: { 'fooExt#id9': { baz: 'temporary' } } } } } },
+    });
+    expect(getExtensionConfig('barSlot', 'fooExt#id9').getState().config.baz).toBe('temporary');
+
+    // The derived slot config is not part of the extension config cache key, so a released override
+    // is only picked up because that cache also keys on the temporary config it was derived from.
+    temporaryConfigStore.setState({ config: {} });
+    expect(getExtensionConfig('barSlot', 'fooExt#id9').getState().config.baz).toBe('bazzy');
   });
 
   it('validates the extension configure config, with module config schema', () => {

--- a/packages/framework/esm-config/src/module-config/module-config.test.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.test.ts
@@ -1341,6 +1341,83 @@ describe('extension config', () => {
     expect(console.error).not.toHaveBeenCalled();
   });
 
+  it("uses the 'configure' config written by a module other than the one owning the slot", () => {
+    updateConfigExtensionStore('fooExt#id6');
+    // A slot opened by an extension belongs to the module that renders that extension, which is
+    // not the module an implementer configures the slot's contents from. A nav group is the case
+    // in point: the group comes from the primary navigation app, the links in it are configured
+    // by whichever app the group was added to.
+    const configureConfig = {
+      'ext-mod': { bar: 'qux' },
+      'other-mod': {
+        extensionSlots: {
+          barSlot: {
+            configure: { 'fooExt#id6': { baz: 'quiz' } },
+          },
+        },
+      },
+    };
+    Config.provide(configureConfig);
+    const result = getExtensionConfig('barSlot', 'fooExt#id6').getState().config;
+    expect(result).toStrictEqual({
+      bar: 'qux',
+      baz: 'quiz',
+      'Display conditions': { expression: undefined, privileges: [] },
+      'Translation overrides': {},
+    });
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it("prefers the slot-owning module's 'configure' config to another module's", () => {
+    updateConfigExtensionStore('fooExt#id7');
+    const configureConfig = {
+      'other-mod': {
+        extensionSlots: {
+          barSlot: {
+            configure: { 'fooExt#id7': { bar: 'from-other', baz: 'from-other' } },
+          },
+        },
+      },
+      'slot-mod': {
+        extensionSlots: {
+          barSlot: {
+            configure: { 'fooExt#id7': { baz: 'from-owner' } },
+          },
+        },
+      },
+    };
+    Config.provide(configureConfig);
+    const result = getExtensionConfig('barSlot', 'fooExt#id7').getState().config;
+    expect(result).toStrictEqual({
+      bar: 'from-other',
+      baz: 'from-owner',
+      'Display conditions': { expression: undefined, privileges: [] },
+      'Translation overrides': {},
+    });
+    expect(console.error).not.toHaveBeenCalled();
+  });
+
+  it('keeps the slot configuration of every module that configures the slot', () => {
+    updateConfigExtensionStore('fooExt#id8');
+    Config.provide({
+      'adding-mod': { extensionSlots: { barSlot: { add: ['fooExt#id8'] } } },
+      'configuring-mod': {
+        extensionSlots: { barSlot: { configure: { 'fooExt#id8': { baz: 'quiz' } } } },
+      },
+    });
+
+    expect(getExtensionSlotsConfigStore().getState().slots['barSlot'].config).toStrictEqual({
+      add: ['fooExt#id8'],
+      configure: { 'fooExt#id8': { baz: 'quiz' } },
+    });
+    expect(getExtensionConfig('barSlot', 'fooExt#id8').getState().config).toStrictEqual({
+      bar: 'barry',
+      baz: 'quiz',
+      'Display conditions': { expression: undefined, privileges: [] },
+      'Translation overrides': {},
+    });
+  });
+
   it('validates the extension configure config, with module config schema', () => {
     updateConfigExtensionStore('fooExt#id1');
     const badConfig = {

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -32,12 +32,14 @@ import { type TemporaryConfigStore } from '..';
  * Arrays are replaced entirely (not merged by index), matching the
  * behavior of ramda's mergeDeepRight.
  */
+function replaceArrays(_objValue: unknown, srcValue: unknown) {
+  if (Array.isArray(srcValue)) {
+    return srcValue;
+  }
+}
+
 function mergeDeepReplace<T extends object>(left: T, right: Partial<T>): T {
-  return mergeWith({}, left, right, (_objValue: unknown, srcValue: unknown) => {
-    if (Array.isArray(srcValue)) {
-      return srcValue;
-    }
-  }) as T;
+  return mergeWith({}, left, right, replaceArrays) as T;
 }
 
 /**
@@ -748,7 +750,29 @@ function getExtensionSlotConfigs(
   );
 
   validateAllExtensionSlotConfigs(slotConfigPerModule);
-  return mergeConfigs(Object.values(slotConfigPerModule));
+
+  const slotConfigs: Record<string, ExtensionSlotConfig> = {};
+  const configureBlocks: Record<string, Array<NonNullable<ExtensionSlotConfig['configure']>>> = {};
+
+  for (const configBySlotName of Object.values(slotConfigPerModule)) {
+    for (const [slotName, config] of Object.entries(configBySlotName)) {
+      slotConfigs[slotName] = config;
+
+      if (config.configure) {
+        (configureBlocks[slotName] ??= []).push(config.configure);
+      }
+    }
+  }
+
+  for (const [slotName, blocks] of Object.entries(configureBlocks)) {
+    const configure = blocks.length === 1 ? blocks[0] : (mergeConfigs(blocks) as ExtensionSlotConfig['configure']);
+
+    if (slotConfigs[slotName].configure !== configure) {
+      slotConfigs[slotName] = { ...slotConfigs[slotName], configure };
+    }
+  }
+
+  return slotConfigs;
 }
 
 function validateAllExtensionSlotConfigs(slotConfigPerModule: Record<string, Record<string, ExtensionSlotConfig>>) {
@@ -905,8 +929,11 @@ function mergeConfigsFor(moduleName: string, allConfigs: Array<Config>): ConfigO
   return mergeConfigs(allConfigsForModule);
 }
 
+/**
+ * Merges a whole list at once, accumulating into one destination.
+ */
 function mergeConfigs(configs: Array<Config>) {
-  return configs.reduce<Config>((acc, config) => mergeDeepReplace(acc, config), {});
+  return configs.reduce<Config>((acc, config) => mergeWith(acc, config, replaceArrays), {});
 }
 
 /**

--- a/packages/framework/esm-config/src/module-config/module-config.ts
+++ b/packages/framework/esm-config/src/module-config/module-config.ts
@@ -73,8 +73,11 @@ function recomputeAllConfigs() {
   const extensionState = configExtensionStore.getState();
 
   computeModuleConfig(configState, tempConfigState);
-  computeExtensionSlotConfigs(configState, tempConfigState);
-  computeExtensionConfigs(configState, extensionState, tempConfigState);
+
+  const slotConfigs = getExtensionSlotConfigs(configState, tempConfigState);
+  computeExtensionSlotConfigs(slotConfigs);
+  computeExtensionConfigs(configState, extensionState, tempConfigState, slotConfigs);
+
   // Last, because a failure here must not skip the outputs above. Only kept current while the
   // implementer tools are watching it; otherwise derived on read.
   invalidateImplementerToolsConfig();
@@ -185,8 +188,7 @@ function computeModuleConfig(state: ConfigInternalStore, tempState: TemporaryCon
   }
 }
 
-function computeExtensionSlotConfigs(state: ConfigInternalStore, tempState: TemporaryConfigStore) {
-  const slotConfigs = getExtensionSlotConfigs(state, tempState);
+function computeExtensionSlotConfigs(slotConfigs: Record<string, ExtensionSlotConfig>) {
   const slotStore = getExtensionSlotsConfigStore();
   const oldSlots = slotStore.getState().slots;
   const slots: ExtensionSlotsConfigStore['slots'] = {};
@@ -228,6 +230,7 @@ function computeExtensionConfigs(
   configState: ConfigInternalStore,
   extensionState: ConfigExtensionStore,
   tempConfigState: TemporaryConfigStore,
+  slotConfigs: Record<string, ExtensionSlotConfig>,
 ) {
   const extensionsConfigStore = getExtensionsConfigStore();
   const oldConfigs = extensionsConfigStore.getState().configs;
@@ -245,6 +248,7 @@ function computeExtensionConfigs(
       extension.extensionId,
       configState,
       tempConfigState,
+      slotConfigs[extension.slotName],
     );
 
     const previous = oldConfigs[extension.slotName]?.[extension.extensionId];
@@ -555,6 +559,7 @@ const extensionConfigCache = new Map<string, ExtensionConfigCacheEntry>();
  * @param extensionModuleName The name of the module which defines the extension (and therefore the config schema)
  * @param slotName The name of the extension slot where the extension is mounted
  * @param extensionId The ID of the extension in its slot
+ * @param slotConfig The slot's configuration, gathered from every module that configures it
  */
 function computeExtensionConfig(
   slotModuleName: string,
@@ -563,6 +568,7 @@ function computeExtensionConfig(
   extensionId: string,
   configState: ConfigInternalStore,
   tempConfigState: TemporaryConfigStore,
+  slotConfig: ExtensionSlotConfig | undefined,
 ) {
   const extensionName = getExtensionNameFromId(extensionId);
   const extensionConfigSchema = configState.schemas[extensionName];
@@ -582,10 +588,11 @@ function computeExtensionConfig(
 
   const nameOfSchemaSource = extensionConfigSchema ? extensionName : extensionModuleName;
   const providedConfigs = getProvidedConfigs(configState, tempConfigState);
+  const sharedOverride = slotConfig?.configure?.[extensionId] ?? {};
   const slotModuleConfig = mergeConfigsFor(slotModuleName, providedConfigs);
   const configOverride = slotModuleConfig?.extensionSlots?.[slotName]?.configure?.[extensionId] ?? {};
   const extensionConfig = mergeConfigsFor(nameOfSchemaSource, providedConfigs);
-  const combinedConfig = mergeConfigs([extensionConfig, configOverride]);
+  const combinedConfig = mergeConfigs([extensionConfig, sharedOverride, configOverride]);
   const schema = extensionConfigSchema ?? configState.schemas[extensionModuleName];
   validateStructure(schema, combinedConfig, nameOfSchemaSource);
   const config = setDefaults(schema, combinedConfig);
@@ -739,12 +746,9 @@ function getExtensionSlotConfigs(
     },
     {},
   );
+
   validateAllExtensionSlotConfigs(slotConfigPerModule);
-  const slotConfigs = Object.keys(slotConfigPerModule).reduce((obj, key) => {
-    obj = { ...obj, ...slotConfigPerModule[key] };
-    return obj;
-  }, {});
-  return slotConfigs;
+  return mergeConfigs(Object.values(slotConfigPerModule));
 }
 
 function validateAllExtensionSlotConfigs(slotConfigPerModule: Record<string, Record<string, ExtensionSlotConfig>>) {

--- a/packages/framework/esm-framework/docs/functions/defineConfigSchema.md
+++ b/packages/framework/esm-framework/docs/functions/defineConfigSchema.md
@@ -4,7 +4,7 @@
 
 > **defineConfigSchema**(`moduleName`, `schema`): `void`
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:316](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L316)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:318](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L318)
 
 This defines a configuration schema for a module. The schema tells the
 configuration system how the module can be configured. It specifies

--- a/packages/framework/esm-framework/docs/functions/defineConfigSchema.md
+++ b/packages/framework/esm-framework/docs/functions/defineConfigSchema.md
@@ -4,7 +4,7 @@
 
 > **defineConfigSchema**(`moduleName`, `schema`): `void`
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:312](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L312)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:316](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L316)
 
 This defines a configuration schema for a module. The schema tells the
 configuration system how the module can be configured. It specifies

--- a/packages/framework/esm-framework/docs/functions/defineExtensionConfigSchema.md
+++ b/packages/framework/esm-framework/docs/functions/defineExtensionConfigSchema.md
@@ -4,7 +4,7 @@
 
 > **defineExtensionConfigSchema**(`extensionName`, `schema`): `void`
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:388](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L388)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:392](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L392)
 
 This defines a configuration schema for an extension. When a schema is defined
 for an extension, that extension will receive the configuration corresponding

--- a/packages/framework/esm-framework/docs/functions/defineExtensionConfigSchema.md
+++ b/packages/framework/esm-framework/docs/functions/defineExtensionConfigSchema.md
@@ -4,7 +4,7 @@
 
 > **defineExtensionConfigSchema**(`extensionName`, `schema`): `void`
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:392](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L392)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:394](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L394)
 
 This defines a configuration schema for an extension. When a schema is defined
 for an extension, that extension will receive the configuration corresponding

--- a/packages/framework/esm-framework/docs/functions/getConfig.md
+++ b/packages/framework/esm-framework/docs/functions/getConfig.md
@@ -4,7 +4,7 @@
 
 > **getConfig**\<`T`\>(`moduleName`): `Promise`\<`T`\>
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:461](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L461)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:465](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L465)
 
 A promise-based way to access the config as soon as it is fully loaded.
 If it is already loaded, resolves the config in its present state.

--- a/packages/framework/esm-framework/docs/functions/getConfig.md
+++ b/packages/framework/esm-framework/docs/functions/getConfig.md
@@ -4,7 +4,7 @@
 
 > **getConfig**\<`T`\>(`moduleName`): `Promise`\<`T`\>
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:465](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L465)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:467](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L467)
 
 A promise-based way to access the config as soon as it is fully loaded.
 If it is already loaded, resolves the config in its present state.

--- a/packages/framework/esm-framework/docs/functions/provide.md
+++ b/packages/framework/esm-framework/docs/functions/provide.md
@@ -4,7 +4,7 @@
 
 > **provide**(`config`, `sourceName`): `void`
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:418](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L418)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:420](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L420)
 
 Provides configuration values programmatically. This is an alternative to
 providing configuration through the config-file. Configuration provided this

--- a/packages/framework/esm-framework/docs/functions/provide.md
+++ b/packages/framework/esm-framework/docs/functions/provide.md
@@ -4,7 +4,7 @@
 
 > **provide**(`config`, `sourceName`): `void`
 
-Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:414](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L414)
+Defined in: [packages/framework/esm-config/src/module-config/module-config.ts:418](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-config/src/module-config/module-config.ts#L418)
 
 Provides configuration values programmatically. This is an alternative to
 providing configuration through the config-file. Configuration provided this

--- a/packages/framework/esm-react-utils/src/extensions.test.tsx
+++ b/packages/framework/esm-react-utils/src/extensions.test.tsx
@@ -12,11 +12,13 @@ import {
   registerExtension,
   updateInternalExtensionStore,
 } from '@openmrs/esm-extensions';
+import { defineConfigSchema, defineExtensionConfigSchema, provide, Type } from '@openmrs/esm-config';
 import {
   getSyncLifecycle,
   Extension,
   ExtensionSlot,
   openmrsComponentDecorator,
+  useConfig,
   useExtensionSlotMeta,
   useRenderableExtensions,
 } from '.';
@@ -390,6 +392,61 @@ describe('Extension teardown', () => {
     // second render that resolves to null and clears the parcel still coming up.
     expect(consoleWarn).not.toHaveBeenCalledWith(expect.stringContaining('no DOM element was available'));
     consoleWarn.mockRestore();
+  });
+});
+
+describe('a slot opened by an extension from another module', () => {
+  beforeEach(() => {
+    updateInternalExtensionStore(() => ({ slots: {}, extensions: {} }));
+    getExtensionRenderingsStore().setState({ renderings: new Map() });
+  });
+
+  it('configures the extensions in that slot from whichever module configures the slot', async () => {
+    defineConfigSchema('esm-chart-app', {});
+    defineConfigSchema('esm-nav-app', {});
+    defineExtensionConfigSchema('group', { slotName: { _type: Type.String, _default: '' } });
+    defineExtensionConfigSchema('link', { path: { _type: Type.String, _default: '' } });
+
+    function Group() {
+      const { slotName } = useConfig<{ slotName: string }>();
+      return <ExtensionSlot name={slotName} />;
+    }
+
+    function Link() {
+      const { path } = useConfig<{ path: string }>();
+      return <div>path is {path || 'unset'}</div>;
+    }
+
+    registerSimpleExtension('group', 'esm-nav-app', Group);
+    registerSimpleExtension('link', 'esm-nav-app', Link);
+
+    provide(
+      {
+        'esm-chart-app': {
+          extensionSlots: {
+            'chart-slot': {
+              add: ['group#clinical'],
+              configure: { 'group#clinical': { slotName: 'clinical-group-slot' } },
+            },
+            'clinical-group-slot': {
+              add: ['link#ckd'],
+              configure: { 'link#ckd': { path: 'ckd-specific' } },
+            },
+          },
+        },
+      },
+      'test',
+    );
+
+    const App = openmrsComponentDecorator({
+      moduleName: 'esm-chart-app',
+      featureName: 'Chart',
+      disableTranslations: true,
+    })(() => <ExtensionSlot name="chart-slot" />);
+
+    render(<App />);
+
+    expect(await screen.findByText(/path is/)).toHaveTextContent('path is ckd-specific');
   });
 });
 


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [x] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->

#1856 mistakenly only preserved slot-local configurations for the app that defines an extension. This left a gap where an extension might be rendered in a slot belonging to another app and not be able to "see" the slot-local configuration.

Concretely, this broke the nav-group and dashboard extensions provided by the primary-navigation-app. They are supposed to retain the app identity of the slot they are added to (to make configuring them easier), but because cross-app slot configs were not considered, such configurations didn't work as expected.

This commit fixes the issue by propagating the slot-specific configuration as part of the extension configuration and adds regression tests.


## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->

Slack conversation that reported this: https://openmrs.slack.com/archives/C02UNMKFH8V/p1788895511290399
