### PR TITLE
(fix) When using yarn run:shell ensure we serve CSS files

### DIFF
--- a/.changeset/public-snakes-poke.md
+++ b/.changeset/public-snakes-poke.md
@@ -1,0 +1,5 @@
+---
+"@openmrs/esm-app-shell": patch
+---
+
+(fix) When using yarn run:shell ensure we serve CSS files

--- a/packages/shell/esm-app-shell/rspack.config.js
+++ b/packages/shell/esm-app-shell/rspack.config.js
@@ -142,6 +142,20 @@ function escapeRegExp(string) {
   return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
+/** A trailing file extension, which is what separates a request for a file from one of the app's routes. */
+const fileExtension = /\.[a-z0-9]{1,10}$/i;
+
+/**
+ * Whether a request under the SPA path is for a file. Files are proxied as they are; everything else
+ * falls through to `historyApiFallback` and is served the locally built `index.html`.
+ *
+ * @param {string} path
+ * @returns {boolean}
+ */
+function isFileRequest(path) {
+  return fileExtension.test(basename(path.split(/[?#]/)[0]));
+}
+
 /**
  * @param {Record<string, string>} env
  * @param {Array<string>} argv
@@ -281,11 +295,7 @@ module.exports = (env, argv = []) => {
             }
 
             if (path.startsWith(openmrsPublicPath)) {
-              if (basename(path).indexOf('.') >= 0) {
-                return true;
-              } else {
-                return false;
-              }
+              return isFileRequest(path);
             }
 
             if (path.startsWith(openmrsApiUrl)) {
@@ -313,21 +323,6 @@ module.exports = (env, argv = []) => {
             if (proxyRes.headers) {
               delete proxyRes.headers['content-security-policy'];
             }
-          },
-          /**
-           * @param {string} path
-           * @param {Request} req
-           * @returns {string}
-           */
-          pathRewrite(path) {
-            if (path.startsWith(openmrsPublicPath)) {
-              const matcher = /^.*\/([^\/]*\.(?!html|js)[^.]+)$/i.exec(path);
-              if (matcher) {
-                return `${openmrsPublicPath}/${matcher[1]}`;
-              }
-            }
-
-            return path;
           },
         },
       ],

--- a/packages/shell/esm-app-shell/src/dev-server-proxy.test.ts
+++ b/packages/shell/esm-app-shell/src/dev-server-proxy.test.ts
@@ -1,0 +1,83 @@
+// The dev server serves what it builds, proxies files it doesn't have to a real distribution, and falls
+// back to the locally built `index.html` for everything else. That last split is the one worth pinning:
+// misclassify a route as a file and the browser is quietly handed the upstream's shell instead of this one.
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const shellRoot = resolve(__dirname, '..');
+const spaPath = '/openmrs/spa';
+
+/** The directory `openmrs assemble` gives a frontend module, named for the package and its version. */
+const moduleDir = 'openmrs-esm-home-app-11.1.1-pre.9638';
+
+let proxy: Record<string, any> | undefined;
+
+/**
+ * The proxy entry the dev server is actually configured with.
+ *
+ * Loaded from `shellRoot` because the config resolves paths and the styleguide stylesheet relative to
+ * its own directory.
+ */
+function loadProxy() {
+  if (!proxy) {
+    const originalCwd = process.cwd();
+    process.chdir(shellRoot);
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-require-imports
+      const config = require('../rspack.config.js')({}, { mode: 'development' }) as Record<string, any>;
+      proxy = config.devServer.proxy[0];
+    } finally {
+      process.chdir(originalCwd);
+    }
+  }
+
+  return proxy!;
+}
+
+describe('the dev server proxy', () => {
+  it.each([
+    ['a chunk', `${spaPath}/${moduleDir}/4610.js`],
+    ['an extracted stylesheet', `${spaPath}/${moduleDir}/180.css`],
+    ['a source map', `${spaPath}/${moduleDir}/180.css.map`],
+    ['an image', `${spaPath}/${moduleDir}/9a3f2c1d.png`],
+    ['a font', `${spaPath}/${moduleDir}/font.woff2`],
+    ['translations', `${spaPath}/${moduleDir}/en.json`],
+    ['a root-level asset', `${spaPath}/importmap.json`],
+    ['the favicon', `${spaPath}/favicon.ico`],
+    ['an asset with a cache-busting query', `${spaPath}/${moduleDir}/180.css?v=2`],
+  ])('proxies %s', (_, path) => {
+    expect(loadProxy().context(path)).toBe(true);
+  });
+
+  it.each([
+    ['a page', `${spaPath}/81239898/patient-chart`],
+    ['a patient chart', `${spaPath}/patient/2b0f0cba/chart`],
+    ['the home page', `${spaPath}/home`],
+    ['the SPA root', `${spaPath}/`],
+    // `basename()` sees the query, so any dot in one used to make these look like files.
+    ['a search whose query holds a dot', `${spaPath}/search?query=john.doe`],
+    ['a page whose query holds a dot', `${spaPath}/81239898/patient-chart?tab=vitals.summary`],
+  ])('leaves %s to the locally built index.html', (_, path) => {
+    expect(loadProxy().context(path)).toBe(false);
+  });
+
+  it.each([
+    ['the REST API', '/openmrs/ws/rest/v1/session'],
+    ['the FHIR API', '/openmrs/ws/fhir2/R4/Patient?name=john'],
+  ])('proxies %s', (_, path) => {
+    expect(loadProxy().context(path)).toBe(true);
+  });
+
+  it.each([
+    ['an empty path', ''],
+    ['a path it does not own', '/other/thing.js'],
+  ])('ignores %s', (_, path) => {
+    expect(loadProxy().context(path)).toBe(false);
+  });
+
+  // A remote's assets sit under its own directory, so anything but a verbatim path 404s.
+  it('proxies paths verbatim', () => {
+    expect(loadProxy().pathRewrite).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Requirements

- [x] This PR has a title that briefly describes the work done including the ticket number. If there is a ticket, make sure your PR title includes a [conventional commit](https://o3-docs.openmrs.org/en-US/docs/frontend-modules/contributing/#contributing-guidelines) label. See existing PR titles for inspiration.
- [ ] My work is based on designs, which are linked or shown either in the Jira ticket or the description below. (See also: [Styleguide](http://om.rs/o3ui))
- [ ] My work includes tests or is validated by existing tests.
- [ ] I have updated the esm-framework and storybook mocks ([mock.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock.tsx), [mock-jest.tsx](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/framework/esm-framework/mock-jest.tsx), and [storybook mocks](https://github.com/openmrs/openmrs-esm-core/blob/main/packages/tooling/storybook/mocks/)) to reflect any API changes.

## Summary
<!-- Please describe what problems your PR addresses. -->

#1869 accidentally broke `yarn run:shell` because we now serve CSS files from apps.

Previously, we had a weird `pathRewrite` rule to try and figure out if something was matching a file or not because URLs that aren't for a filename should generally be served the single page. That URL only allowed `.html` or `.js`. This switches to a more generic rule where the proxy doesn't touch paths that are requests for files and more closely mirrors how things work in production.

## Screenshots
<!-- Required if you are making UI changes. -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->

## Other
<!-- Anything not covered above -->
